### PR TITLE
feature(index): create repo-derived bundles (#275)

### DIFF
--- a/data/skill-index/Affitor_affiliate-skills.json
+++ b/data/skill-index/Affitor_affiliate-skills.json
@@ -7266,5 +7266,1609 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "affitor-affiliate-skills-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from Affitor/affiliate-skills.",
+      "author": "ASM (Affitor/affiliate-skills)",
+      "createdAt": "2026-05-09T08:10:40.686Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "affitor",
+        "affiliate-skills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/ab-test-generator",
+          "description": "Generate A/B test variants for affiliate content. Triggers on: \"create A/B test\", \"test my headline\", \"optimize my CTA\", \"generate variants\", \"split test ideas\", \"improve click-through rate\", \"test my landing page copy\", \"headline alternatives\", \"CTA variations\", \"which version is better\", \"optimize conversions\", \"test my email subject line\", \"compare approaches\".",
+          "version": "1.0"
+        },
+        {
+          "name": "affiliate-blog-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/affiliate-blog-builder",
+          "description": "Write SEO-optimized affiliate blog articles, product reviews, comparison posts, listicles, and how-to guides. Triggers on: \"write a blog post about\", \"review of [product]\", \"best [category] article\", \"comparison blog\", \"affiliate blog\", \"SEO article\", \"write a review\", \"product roundup\", \"blog content for affiliate\", \"how to use [product] blog post\", \"listicle about [category]\", \"[product] vs [product] blog\", \"content for my affiliate site\".",
+          "version": "1.0"
+        },
+        {
+          "name": "affiliate-program-search",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/affiliate-program-search",
+          "description": "Research and evaluate affiliate programs to find the best ones to promote. Use this skill when the user asks anything about finding affiliate programs, comparing commission rates, evaluating affiliate opportunities, searching for products to promote, picking a niche, or mentions list.affitor.com. Also trigger for: \"which SaaS should I promote\", \"best affiliate programs for X\", \"high commission programs\", \"recurring commission affiliate\", \"compare these affiliate programs\", \"is X affiliate program worth it\", \"find me something to promote\", \"what pays the most\", \"affiliate programs with long cookie duration\".",
+          "version": "1.0"
+        },
+        {
+          "name": "bio-link-deployer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/bio-link-deployer",
+          "description": "Create a Linktree-style bio link hub page as a single self-contained HTML file. Triggers on: \"create a bio link page\", \"make a linktree\", \"link in bio page\", \"bio link\", \"link hub\", \"create my link page\", \"all my links on one page\", \"linktree alternative\", \"build a link page\", \"bio page for my affiliate links\", \"I need a link in bio\", \"make a page with all my links\", \"link aggregator page\".",
+          "version": "1.0"
+        },
+        {
+          "name": "bonus-stack-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/bonus-stack-builder",
+          "description": "Design exclusive bonus packages that make YOUR affiliate link the obvious choice. Triggers on: \"create bonuses for\", \"bonus stack\", \"what bonuses should I offer\", \"bonus ideas for\", \"exclusive bonuses\", \"differentiate my affiliate link\", \"why buy through my link\", \"affiliate bonuses\", \"bonus package\", \"what can I offer as a bonus\", \"design bonuses\", \"build a bonus stack\".",
+          "version": "1.0"
+        },
+        {
+          "name": "category-designer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/category-designer",
+          "description": "Define a new category where your product wins by default. Reframe the buying decision. Triggers on: \"create a category\", \"category design\", \"define my category\", \"category of one\", \"reframe the market\", \"position as category king\", \"new category\", \"category creation\", \"own a category\", \"category strategy\", \"competitive positioning\", \"strategic positioning\", \"market reframing\", \"be the only option\", \"change the buying criteria\", \"category king\".",
+          "version": "1.0"
+        },
+        {
+          "name": "commission-calculator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/commission-calculator",
+          "description": "Calculate realistic affiliate earnings projections before committing to a program. Use this skill when the user asks about affiliate earnings, projecting income, calculating commissions, estimating how much they can make, comparing program payouts, or says \"how much can I make promoting X\", \"calculate my affiliate income\", \"is this commission worth it\", \"how long to first $1000\", \"compare earnings between programs\", \"traffic to income calculator\", \"what conversion rate should I expect\", \"earnings estimate for affiliate program\", \"how many sales do I need\".",
+          "version": "1.0"
+        },
+        {
+          "name": "comparison-post-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/comparison-post-writer",
+          "description": "Write \"X vs Y\" comparison blog posts that help readers choose between two competing products. Triggers on: \"write a comparison post\", \"X vs Y blog post\", \"compare [product A] and [product B]\", \"which is better [A] or [B]\", \"head to head comparison\", \"[product] vs [product] article\", \"comparison review\", \"write a versus article\", \"side by side comparison blog\", \"which should I choose [A] or [B]\", \"compare these two products for my blog\".",
+          "version": "1.0"
+        },
+        {
+          "name": "competitor-spy",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/competitor-spy",
+          "description": "Reverse-engineer successful affiliate strategies from competitors. Use this skill when the user asks about spying on competitors, researching what other affiliates promote, analyzing competitor affiliate sites, understanding how top affiliates in a niche make money, or says \"what programs does X promote\", \"how does [site] make money\", \"what affiliate strategy does this site use\", \"spy on competitor affiliates\", \"reverse engineer affiliate site\", \"copy what works in my niche\", \"who are the top affiliates in X niche\", \"what content gets traffic in my niche\", \"competitor affiliate analysis\".",
+          "version": "1.0"
+        },
+        {
+          "name": "compliance-checker",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/compliance-checker",
+          "description": "Check affiliate content for FTC compliance and platform rules. Triggers on: \"check my content for compliance\", \"FTC disclosure check\", \"is this legal\", \"review for compliance\", \"check affiliate disclosure\", \"am I FTC compliant\", \"audit my content\", \"compliance review\", \"legal check\", \"platform rules check\", \"check before publishing\", \"disclosure audit\", \"review my ad copy\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-angle-ranker",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/content-angle-ranker",
+          "description": "Rank content angles by engagement data, competition level, and platform fit. Data-driven angle selection instead of guesswork. Use this skill when the user has a keyword or product and needs to decide WHAT to create, which angle to take, which format to use, or which platform to target. Triggers on: \"what angle should I use\", \"rank content ideas for [keyword]\", \"best angle for [product]\", \"which content idea will perform best\", \"help me pick an angle\", \"what should I write about\", \"content angle for [topic]\", \"rank my content ideas\", \"which approach will get the most views\", \"data-driven content planning\", \"angle ranker\", \"content scoring\", \"which hook should I use\", \"compare these content ideas\", \"prioritize my content angles\", \"what video should I make\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-decay-detector",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/content-decay-detector",
+          "description": "Monitor existing content for ranking drops and trigger refresh workflows. Triggers on: \"check for content decay\", \"which content needs updating\", \"content refresh\", \"ranking drops\", \"traffic decline\", \"stale content\", \"content audit\", \"what to refresh\", \"outdated content\", \"content performance check\", \"update old articles\", \"declining rankings\", \"content maintenance\", \"refresh priority list\", \"which articles are losing traffic\", \"SEO content audit\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-moat-calculator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/content-moat-calculator",
+          "description": "Estimate pages needed for topical authority. Go/no-go decision before investing months in content. Triggers on: \"how much content do I need\", \"topical authority estimate\", \"content moat\", \"how many articles\", \"content gap analysis\", \"can I compete in this niche\", \"content investment calculator\", \"is this niche worth the effort\", \"SEO feasibility\", \"how many pages to rank\", \"content volume needed\", \"competitive content analysis\", \"moat calculation\", \"authority gap\", \"should I invest in this niche\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-pillar-atomizer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/content-pillar-atomizer",
+          "description": "Take 1 blog post or article and generate 15-30 platform-native micro-content pieces. Not reformatting — re-contextualizing for each platform's culture. Triggers on: \"atomize this content\", \"repurpose my blog post\", \"turn this into social posts\", \"content atomizer\", \"pillar content\", \"one to many content\", \"repurpose content\", \"multiply my content\", \"content explosion\", \"turn article into posts\", \"break down this article\", \"micro content from blog\", \"content pillar strategy\", \"10x my content\", \"platform-native content\", \"atomize\", \"content multiplication\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-repurposer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/content-repurposer",
+          "description": "Repurpose one piece of affiliate content into multiple formats. Triggers on: \"repurpose my content\", \"turn my blog into tweets\", \"cross-post this\", \"content recycling\", \"convert to newsletter\", \"make a tweet thread from this\", \"adapt for TikTok\", \"omnichannel content\", \"scale my content\", \"turn this into a LinkedIn post\", \"repurpose for email\", \"content multiplication\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-research-brief",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/content-research-brief",
+          "description": "Research trending topics, collect source articles, and generate a structured research brief for content creation. Stop writing from thin air — write from real sources. Use this skill when the user wants to research a topic before writing, collect sources for an article, create a research-backed content brief, or says \"research [topic] for me\", \"find sources about [keyword]\", \"content brief for [topic]\", \"what's the latest on [product]\", \"research before writing\", \"collect articles about [keyword]\", \"trending news about [topic]\", \"gather sources for my article\", \"brief me on [topic]\", \"what are people saying about [product]\", \"news roundup for [keyword]\", \"research brief\", \"source collection\", \"content research\", \"prep research for writing\".",
+          "version": "1.0"
+        },
+        {
+          "name": "conversion-tracker",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/conversion-tracker",
+          "description": "Set up affiliate conversion tracking with UTM parameters and link tagging. Triggers on: \"set up tracking\", \"create UTM links\", \"track my affiliate links\", \"tracking pixels\", \"click attribution\", \"organize my links\", \"UTM parameters\", \"tag my links\", \"campaign tracking\", \"link tracking setup\", \"prepare for launch\", \"debug attribution\", \"tracking spreadsheet\".",
+          "version": "1.0"
+        },
+        {
+          "name": "email-automation-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/email-automation-builder",
+          "description": "Build multi-sequence email automation flows with branching logic. Triggers on: \"build email automation\", \"create email funnel\", \"email automation flow\", \"welcome series with branches\", \"conditional email sequence\", \"set up automation\", \"email workflow builder\", \"segmented email flow\", \"advanced email sequence\", \"nurture funnel\", \"cart abandonment sequence\", \"win-back email flow\".",
+          "version": "1.0"
+        },
+        {
+          "name": "email-drip-sequence",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/email-drip-sequence",
+          "description": "Write an email drip sequence for affiliate marketing. Triggers on: \"write me an email sequence\", \"create a drip campaign\", \"email nurture sequence\", \"affiliate email funnel\", \"welcome email series\", \"email onboarding sequence\", \"write emails for my list\", \"set up a drip sequence\", \"email campaign for [product]\", \"nurture my subscribers\", \"email follow-up sequence\", \"build my email funnel\", \"write 5 emails promoting [product]\", \"email automation sequence\".",
+          "version": "1.0"
+        },
+        {
+          "name": "funnel-planner",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/funnel-planner",
+          "description": "Plan a complete affiliate funnel from research to revenue. Triggers on: \"plan my affiliate funnel\", \"create a funnel strategy\", \"affiliate business plan\", \"how to start affiliate marketing\", \"full funnel roadmap\", \"plan from scratch\", \"week by week affiliate plan\", \"chain skills together\", \"build my funnel\", \"affiliate marketing roadmap\", \"step by step affiliate plan\", \"onboarding plan\".",
+          "version": "1.0"
+        },
+        {
+          "name": "github-pages-deployer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/github-pages-deployer",
+          "description": "Deploy affiliate content to GitHub Pages for free hosting. Triggers on: \"deploy to GitHub Pages\", \"host on GitHub Pages\", \"free hosting for my affiliate site\", \"push to GitHub Pages\", \"GitHub Pages setup\", \"deploy my landing page to GitHub\", \"host my bio link on GitHub\", \"free affiliate website hosting\", \"github pages affiliate\", \"set up GitHub Pages for my site\", \"deploy HTML to GitHub\", \"free static hosting\", \"publish my affiliate page for free\", \"github pages custom domain\".",
+          "version": "1.0"
+        },
+        {
+          "name": "grand-slam-offer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/grand-slam-offer",
+          "description": "Design irresistible affiliate offers using the Hormozi Grand Slam framework. Triggers on: \"create an offer for\", \"design my offer\", \"grand slam offer\", \"make an irresistible offer\", \"why should someone buy through my link\", \"offer framework\", \"value proposition for\", \"Hormozi offer\", \"offer stack\", \"make my offer irresistible\", \"craft an offer\", \"what makes my offer different\", \"offer design\", \"increase perceived value\".",
+          "version": "1.0"
+        },
+        {
+          "name": "guarantee-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/guarantee-generator",
+          "description": "Create YOUR personal guarantee on top of the product's guarantee for risk reversal. Triggers on: \"create a guarantee\", \"guarantee for my affiliate\", \"risk reversal\", \"money back guarantee\", \"what guarantee can I offer\", \"reduce buyer risk\", \"guarantee copy\", \"how to guarantee\", \"affiliate guarantee\", \"personal guarantee\", \"risk-free offer\", \"satisfaction guarantee\", \"results guarantee\".",
+          "version": "1.0"
+        },
+        {
+          "name": "how-to-tutorial-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/how-to-tutorial-writer",
+          "description": "Write how-to guides and tutorials that naturally integrate affiliate product recommendations. Triggers on: \"write a how-to guide\", \"tutorial for [task]\", \"step by step guide to [goal]\", \"how to [verb] with [product]\", \"write a tutorial blog post\", \"guide on how to [task]\", \"beginner guide to [topic]\", \"walkthrough for [product]\", \"write an educational article\", \"how do I [task] blog post\", \"write a tutorial that promotes [product]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "infographic-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/infographic-generator",
+          "description": "Generate branded infographic specifications from any content or data. Outputs structured layout, copy, data visualization, and color scheme — ready to render as HTML/CSS, Satori, Canva, or any design tool. Use this skill when the user wants an infographic, data visual, social media image, comparison chart, stat card, or says \"create an infographic for [content]\", \"make a visual for my LinkedIn post\", \"design an image for [topic]\", \"stat graphic for [data]\", \"comparison infographic\", \"branded image\", \"social media graphic\", \"infographic for [blog post]\", \"data visualization\", \"visual content\", \"image for my post\", \"LinkedIn carousel image\", \"feature comparison chart\", \"pricing table image\".",
+          "version": "1.0"
+        },
+        {
+          "name": "internal-linking-optimizer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/internal-linking-optimizer",
+          "description": "Analyze site's internal link structure and optimize for hub-and-spoke SEO architecture. Triggers on: \"optimize internal links\", \"internal linking\", \"link structure\", \"hub and spoke links\", \"orphan pages\", \"link equity\", \"internal link audit\", \"fix my internal links\", \"link architecture\", \"site structure optimization\", \"internal linking strategy\", \"link flow\", \"improve site structure\", \"find orphan pages\", \"maximize link equity\", \"internal link map\".",
+          "version": "1.0"
+        },
+        {
+          "name": "keyword-cluster-architect",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/keyword-cluster-architect",
+          "description": "Map 50-200+ keywords into topical clusters for SEO domination. Build content roadmaps for topical authority. Triggers on: \"keyword research\", \"keyword clustering\", \"topical authority\", \"keyword map\", \"keyword strategy\", \"content roadmap for SEO\", \"keyword grouping\", \"topic clusters\", \"SEO keyword plan\", \"map my keywords\", \"keyword cluster\", \"hub and spoke content\", \"build topical authority\", \"SEO content plan\", \"keyword universe\".",
+          "version": "1.0"
+        },
+        {
+          "name": "landing-page-creator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/landing-page-creator",
+          "description": "Build high-converting affiliate landing pages as single self-contained HTML files. Triggers on: \"create a landing page for\", \"build a landing page\", \"product landing page\", \"affiliate landing page\", \"comparison page for\", \"vs page\", \"single product page\", \"conversion page\", \"sales page for affiliate\", \"landing page HTML\", \"build me a page for\", \"create a page to promote [product]\", \"I need a landing page\", \"make a page for [product]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "list-affitor-program",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/list-affitor-program",
+          "description": "Research an affiliate program and create a verified listing for list.affitor.com. Use this skill when the user asks anything about listing a program, adding an affiliate program to the directory, submitting a program to list, creating a listing, documenting an affiliate program, sharing an affiliate program, writing a program profile, posting a program to list.affitor.com, or contributing a new program. Also trigger for: \"list a program\", \"add affiliate program\", \"submit program to list\", \"create listing for X\", \"document affiliate program\", \"share affiliate program\", \"write a listing\", \"post to list.affitor.com\", \"add X to the directory\", \"register an affiliate program\", \"publish affiliate program\", \"new program listing\", \"profile this affiliate program\", \"catalog this program\".",
+          "version": "1.0"
+        },
+        {
+          "name": "list-affitor-skill",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/list-affitor-skill",
+          "description": "Turn a repeatable AI prompt or workflow into a structured, publish-ready skill for list.affitor.com. Use this skill when the user wants to create a new skill, write a SKILL.md, convert a prompt to a skill, publish a skill to the directory, or document an AI workflow. Also trigger for: \"create a skill\", \"write a skill\", \"make this a skill\", \"turn this into a skill\", \"publish skill\", \"add skill to list\", \"write SKILL.md\", \"skill from prompt\", \"document this workflow\", \"package this as a skill\".",
+          "version": "1.0"
+        },
+        {
+          "name": "listicle-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/listicle-generator",
+          "description": "Write \"Top N best...\" listicle articles for affiliate marketing with mini-reviews, pricing, pros/cons, and CTAs per entry. Triggers on: \"write a best of list\", \"top 10 [category] tools\", \"best [product category] article\", \"roundup post\", \"listicle about [category]\", \"write a top tools article\", \"best [N] alternatives to [product]\", \"product roundup\", \"write a tools comparison list\", \"best software for [use case]\", \"top picks for [category]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "monopoly-niche-finder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/monopoly-niche-finder",
+          "description": "Find intersection niches where you're the ONLY voice. Thiel's \"competition is for losers\" lens. Triggers on: \"find my monopoly niche\", \"blue ocean niche\", \"unique niche\", \"niche intersection\", \"where am I the only one\", \"zero competition niche\", \"untapped niche\", \"category of one\", \"Thiel monopoly\", \"dominate a niche\", \"niche nobody else covers\", \"cross two domains\", \"find a niche with no competition\", \"monopoly positioning\", \"unique angle for affiliate\".",
+          "version": "1.0"
+        },
+        {
+          "name": "multi-program-manager",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/multi-program-manager",
+          "description": "Manage and compare multiple affiliate programs as a portfolio. Triggers on: \"manage my affiliate programs\", \"compare my programs\", \"portfolio overview\", \"which program should I focus on\", \"diversify my affiliate income\", \"program switching\", \"affiliate portfolio\", \"program comparison\", \"revenue allocation\", \"which programs to drop\", \"add new programs\", \"affiliate program strategy\".",
+          "version": "1.0"
+        },
+        {
+          "name": "niche-opportunity-finder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/niche-opportunity-finder",
+          "description": "Find untapped affiliate niches with real earning potential. Use this skill when the user asks about picking a niche, finding a niche to start affiliate marketing, what niche to get into, niche research, niche ideas, beginner niche selection, low competition niches, profitable niches, or says \"I don't know what to promote\", \"help me pick a niche\", \"what niche should I start with\", \"find me a niche with less competition\", \"niche ideas for affiliate\", \"is X a good niche for affiliate marketing\", \"best niches 2024\", \"untapped niches\".",
+          "version": "1.0"
+        },
+        {
+          "name": "paid-ad-copy-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/paid-ad-copy-writer",
+          "description": "Write paid ad copy for affiliate offers across ad platforms. Triggers on: \"write ad copy\", \"Facebook ad for affiliate\", \"Google Ads copy\", \"TikTok ad script\", \"Pinterest ad\", \"paid traffic to affiliate\", \"create ad campaign\", \"ad headlines\", \"ad descriptions\", \"scale with paid ads\", \"run ads for my affiliate link\", \"write Facebook ad\", \"Google Search ad copy\".",
+          "version": "1.0"
+        },
+        {
+          "name": "performance-report",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/performance-report",
+          "description": "Generate affiliate performance reports with KPIs and recommendations. Triggers on: \"show my affiliate report\", \"how are my programs doing\", \"performance review\", \"earnings report\", \"monthly affiliate report\", \"weekly report\", \"analyze my affiliate earnings\", \"which program is best\", \"EPC report\", \"conversion rate analysis\", \"revenue breakdown\", \"campaign performance\".",
+          "version": "1.0"
+        },
+        {
+          "name": "product-showcase-page",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/product-showcase-page",
+          "description": "Build a single-product deep-dive showcase page as a self-contained HTML file. Triggers on: \"build a product showcase page\", \"deep dive landing page for [product]\", \"create a product spotlight page\", \"product feature page\", \"single product page\", \"detailed page about [product]\", \"build a page showing everything about [product]\", \"create a long-form product page\", \"build a sales page for [product]\", \"product deep dive page\", \"make a feature breakdown page for [product]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "proprietary-data-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/proprietary-data-generator",
+          "description": "Create original surveys, benchmarks, and aggregated data nobody else has. Automate data collection for content moats. Triggers on: \"create original data\", \"proprietary data\", \"survey design\", \"benchmark study\", \"original research\", \"data-driven content\", \"create a survey\", \"industry benchmark\", \"aggregated data\", \"unique data\", \"first-party data\", \"data moat\", \"generate research data\", \"create a study\", \"original statistics\", \"data nobody else has\", \"competitive data advantage\".",
+          "version": "1.0"
+        },
+        {
+          "name": "purple-cow-audit",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/purple-cow-audit",
+          "description": "Score product remarkability 1-10 to decide if it's worth promoting. Seth Godin's Purple Cow test. Triggers on: \"is this product worth promoting\", \"should I promote\", \"product audit\", \"purple cow\", \"remarkable product\", \"is it remarkable\", \"rate this product\", \"product quality check\", \"worth my reputation\", \"product evaluation\", \"would I recommend without commission\", \"product remarkability score\", \"evaluate this affiliate product\", \"quality gate for promotion\".",
+          "version": "1.0"
+        },
+        {
+          "name": "reddit-post-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/reddit-post-writer",
+          "description": "Write Reddit posts and comments that recommend affiliate products without getting banned or flagged as spam. Subreddit-native content that adds value first. Use this skill when the user asks about Reddit posts for affiliate marketing, writing Reddit comments that mention products, how to promote affiliate links on Reddit, or says \"write a Reddit post for X\", \"how to mention affiliate on Reddit\", \"Reddit comment promoting product\", \"Reddit-friendly affiliate content\", \"post for r/[subreddit] about X\", \"share affiliate link on Reddit without getting banned\", \"genuine Reddit recommendation\", \"organic Reddit affiliate post\", \"Reddit thread idea for product\".",
+          "version": "1.0"
+        },
+        {
+          "name": "self-improver",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/self-improver",
+          "description": "Review affiliate campaign results and improve strategy. Triggers on: \"review my results\", \"what went wrong\", \"how to improve conversions\", \"analyze my campaign\", \"affiliate retrospective\", \"why am I not converting\", \"improve my strategy\", \"what should I change\", \"campaign review\", \"optimize my approach\", \"learn from my results\", \"post-mortem on my campaign\".",
+          "version": "1.0"
+        },
+        {
+          "name": "seo-audit",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/seo-audit",
+          "description": "Audit affiliate blog posts and landing pages for SEO issues. Triggers on: \"audit my blog post for SEO\", \"check my SEO\", \"SEO review\", \"improve my rankings\", \"SEO checklist\", \"on-page SEO audit\", \"keyword optimization check\", \"why isn't my page ranking\", \"SEO score\", \"content quality audit\", \"check my meta tags\", \"internal linking audit\", \"quick SEO wins\".",
+          "version": "1.0"
+        },
+        {
+          "name": "skill-finder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/skill-finder",
+          "description": "Find the right Affitor skill for your goal. Triggers on: \"which skill should I use\", \"find me a skill\", \"what skills are available\", \"help me choose a skill\", \"skill for SEO\", \"skill for email\", \"explore skills\", \"I'm new to Affitor\", \"what can Affitor do\", \"search skills\", \"skill for blog writing\", \"skill for landing pages\", \"skill for analytics\".",
+          "version": "1.0"
+        },
+        {
+          "name": "social-media-scheduler",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/social-media-scheduler",
+          "description": "Create a 30-day social media content calendar for affiliate marketing. Triggers on: \"create a social media calendar\", \"30-day content plan\", \"social media schedule\", \"content calendar for [product]\", \"plan my social posts\", \"social media strategy\", \"schedule my affiliate posts\", \"content plan for LinkedIn\", \"30 days of content\", \"social posting schedule\", \"what should I post this month\", \"write my social content\", \"create posts for LinkedIn X Facebook\", \"affiliate content calendar\", \"social media plan for my affiliate program\".",
+          "version": "1.0"
+        },
+        {
+          "name": "squeeze-page-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/squeeze-page-builder",
+          "description": "Build email capture landing pages (squeeze pages) as single self-contained HTML files. Triggers on: \"build a squeeze page\", \"email capture page\", \"lead magnet page\", \"create an opt-in page\", \"build an email list page\", \"lead capture landing page\", \"create a freebie page\", \"build a page to collect emails\", \"opt-in landing page\", \"email signup page for [product/niche]\", \"create a lead magnet landing page\", \"build a page that captures emails before sending to affiliate offer\".",
+          "version": "1.0"
+        },
+        {
+          "name": "tiktok-script-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/tiktok-script-writer",
+          "description": "Write short-form video scripts for TikTok, Instagram Reels, and YouTube Shorts that promote affiliate products with strong hooks, demos, and CTAs. Use this skill when the user asks about TikTok scripts, Reels scripts, Shorts scripts, short-form video for affiliate marketing, or says \"write a TikTok for X\", \"script a Reel promoting X\", \"YouTube Shorts script affiliate\", \"60-second video script\", \"hook for TikTok affiliate\", \"write a video promoting X\", \"TikTok script that converts\", \"short video script for product review\", \"viral TikTok affiliate script\", \"how to promote X on TikTok\".",
+          "version": "1.0"
+        },
+        {
+          "name": "traffic-analyzer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/traffic-analyzer",
+          "description": "Analyze website traffic, global rank, engagement metrics, and traffic sources for any domain. Use this skill to evaluate affiliate program websites, compare competitor traffic, assess advertiser strength, or understand where an audience comes from. Triggers on: \"analyze traffic for [domain]\", \"how much traffic does [site] get\", \"compare traffic between [site A] and [site B]\", \"is [program] worth promoting based on traffic\", \"traffic analysis\", \"website analytics for [domain]\", \"where does [site] get traffic\", \"check if [advertiser] is legit\", \"evaluate [program] website health\", \"SimilarWeb analysis\", \"traffic sources for [domain]\", \"how popular is [site]\", \"website rank\", \"domain authority check\", \"compare affiliate program websites\".",
+          "version": "1.0"
+        },
+        {
+          "name": "trending-content-scout",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/trending-content-scout",
+          "description": "Scan social platforms for top-performing content by engagement before you create anything. Use this skill when the user wants to see what content is winning in a niche, find viral content patterns, research what's working on YouTube/TikTok/X/Reddit, benchmark engagement, discover content gaps, or says \"what content is working for [topic]\", \"show me top performing content about [keyword]\", \"what's trending in [niche]\", \"find viral content about [product]\", \"content research for [keyword]\", \"what gets views in [niche]\", \"engagement analysis for [topic]\", \"scout the competition\", \"what videos are getting the most views about [keyword]\", \"social listening for [topic]\", \"trending content in [niche]\", \"top content analysis\", \"what hooks work for [keyword]\", \"content intelligence\", \"find winning formats\".",
+          "version": "1.0"
+        },
+        {
+          "name": "twitter-thread-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/twitter-thread-writer",
+          "description": "Write X/Twitter threads that get bookmarked, shared, and drive affiliate clicks. Use this skill when the user asks about writing Twitter threads, X threads, tweet threads for affiliate marketing, or says \"write a thread about X\", \"Twitter thread promoting X\", \"X thread for affiliate\", \"write tweets that go viral\", \"thread that sells without selling\", \"educational thread with affiliate CTA\", \"Twitter content for affiliate marketing\", \"how to promote X on Twitter\", \"write a thread my audience will bookmark\", \"tweet storm about affiliate product\".",
+          "version": "1.0"
+        },
+        {
+          "name": "value-ladder-architect",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/value-ladder-architect",
+          "description": "Design the complete free-to-premium value ladder for affiliate promotions. Triggers on: \"value ladder\", \"customer journey\", \"upsell path\", \"ascension model\", \"free to paid funnel\", \"tripwire offer\", \"upsell strategy\", \"downsell\", \"product ladder\", \"price ladder\", \"customer ascension\", \"funnel architecture\", \"map my funnel\", \"design my funnel stages\", \"monetization path\".",
+          "version": "1.0"
+        },
+        {
+          "name": "viral-post-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/viral-post-writer",
+          "description": "Write viral social media posts that promote affiliate products naturally. Use this skill when the user asks anything about writing social media content for affiliate marketing, creating posts for LinkedIn/X/Reddit/Facebook, promoting a product on social media, writing affiliate content, or mentions \"viral post\", \"social media post\", \"content for affiliate\". Also trigger for: \"write a post about X\", \"help me promote X on LinkedIn\", \"create a thread about X\", \"make a Reddit post for X\", \"draft tweets for X\", \"social media content for affiliate program\", \"how to promote X on social\", \"write something that goes viral\", \"LinkedIn post for affiliate\", \"X thread about this tool\", \"help me sell X naturally on social media\".",
+          "version": "1.0"
+        },
+        {
+          "name": "webinar-registration-page",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/webinar-registration-page",
+          "description": "Build a webinar or live event registration page as a self-contained HTML file with countdown timer, speaker bio, agenda, and registration form. Triggers on: \"build a webinar registration page\", \"create a webinar sign-up page\", \"event registration landing page\", \"live training registration page\", \"workshop sign-up page\", \"create a webinar page\", \"build an event page\", \"free webinar landing page\", \"live demo registration page\", \"online event page\", \"create a registration page for my webinar\", \"build a training event page\".",
+          "version": "1.0"
+        },
+        {
+          "name": "your-skill-name",
+          "installUrl": "github:Affitor/affiliate-skills:template",
+          "description": "Replace with when the AI should activate this skill. Be pushy — cover multiple phrasings so the AI activates for a wide range of user prompts.",
+          "version": "1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Affitor",
+        "repo": "affiliate-skills",
+        "repoUrl": "https://github.com/Affitor/affiliate-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "affitor-affiliate-skills-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from Affitor/affiliate-skills.",
+      "author": "ASM (Affitor/affiliate-skills)",
+      "createdAt": "2026-05-09T08:10:40.686Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "affitor",
+        "affiliate-skills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/ab-test-generator",
+          "description": "Generate A/B test variants for affiliate content. Triggers on: \"create A/B test\", \"test my headline\", \"optimize my CTA\", \"generate variants\", \"split test ideas\", \"improve click-through rate\", \"test my landing page copy\", \"headline alternatives\", \"CTA variations\", \"which version is better\", \"optimize conversions\", \"test my email subject line\", \"compare approaches\".",
+          "version": "1.0"
+        },
+        {
+          "name": "affiliate-blog-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/affiliate-blog-builder",
+          "description": "Write SEO-optimized affiliate blog articles, product reviews, comparison posts, listicles, and how-to guides. Triggers on: \"write a blog post about\", \"review of [product]\", \"best [category] article\", \"comparison blog\", \"affiliate blog\", \"SEO article\", \"write a review\", \"product roundup\", \"blog content for affiliate\", \"how to use [product] blog post\", \"listicle about [category]\", \"[product] vs [product] blog\", \"content for my affiliate site\".",
+          "version": "1.0"
+        },
+        {
+          "name": "comparison-post-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/comparison-post-writer",
+          "description": "Write \"X vs Y\" comparison blog posts that help readers choose between two competing products. Triggers on: \"write a comparison post\", \"X vs Y blog post\", \"compare [product A] and [product B]\", \"which is better [A] or [B]\", \"head to head comparison\", \"[product] vs [product] article\", \"comparison review\", \"write a versus article\", \"side by side comparison blog\", \"which should I choose [A] or [B]\", \"compare these two products for my blog\".",
+          "version": "1.0"
+        },
+        {
+          "name": "competitor-spy",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/competitor-spy",
+          "description": "Reverse-engineer successful affiliate strategies from competitors. Use this skill when the user asks about spying on competitors, researching what other affiliates promote, analyzing competitor affiliate sites, understanding how top affiliates in a niche make money, or says \"what programs does X promote\", \"how does [site] make money\", \"what affiliate strategy does this site use\", \"spy on competitor affiliates\", \"reverse engineer affiliate site\", \"copy what works in my niche\", \"who are the top affiliates in X niche\", \"what content gets traffic in my niche\", \"competitor affiliate analysis\".",
+          "version": "1.0"
+        },
+        {
+          "name": "compliance-checker",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/compliance-checker",
+          "description": "Check affiliate content for FTC compliance and platform rules. Triggers on: \"check my content for compliance\", \"FTC disclosure check\", \"is this legal\", \"review for compliance\", \"check affiliate disclosure\", \"am I FTC compliant\", \"audit my content\", \"compliance review\", \"legal check\", \"platform rules check\", \"check before publishing\", \"disclosure audit\", \"review my ad copy\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-angle-ranker",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/content-angle-ranker",
+          "description": "Rank content angles by engagement data, competition level, and platform fit. Data-driven angle selection instead of guesswork. Use this skill when the user has a keyword or product and needs to decide WHAT to create, which angle to take, which format to use, or which platform to target. Triggers on: \"what angle should I use\", \"rank content ideas for [keyword]\", \"best angle for [product]\", \"which content idea will perform best\", \"help me pick an angle\", \"what should I write about\", \"content angle for [topic]\", \"rank my content ideas\", \"which approach will get the most views\", \"data-driven content planning\", \"angle ranker\", \"content scoring\", \"which hook should I use\", \"compare these content ideas\", \"prioritize my content angles\", \"what video should I make\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-decay-detector",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/content-decay-detector",
+          "description": "Monitor existing content for ranking drops and trigger refresh workflows. Triggers on: \"check for content decay\", \"which content needs updating\", \"content refresh\", \"ranking drops\", \"traffic decline\", \"stale content\", \"content audit\", \"what to refresh\", \"outdated content\", \"content performance check\", \"update old articles\", \"declining rankings\", \"content maintenance\", \"refresh priority list\", \"which articles are losing traffic\", \"SEO content audit\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-moat-calculator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/content-moat-calculator",
+          "description": "Estimate pages needed for topical authority. Go/no-go decision before investing months in content. Triggers on: \"how much content do I need\", \"topical authority estimate\", \"content moat\", \"how many articles\", \"content gap analysis\", \"can I compete in this niche\", \"content investment calculator\", \"is this niche worth the effort\", \"SEO feasibility\", \"how many pages to rank\", \"content volume needed\", \"competitive content analysis\", \"moat calculation\", \"authority gap\", \"should I invest in this niche\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-pillar-atomizer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/content-pillar-atomizer",
+          "description": "Take 1 blog post or article and generate 15-30 platform-native micro-content pieces. Not reformatting — re-contextualizing for each platform's culture. Triggers on: \"atomize this content\", \"repurpose my blog post\", \"turn this into social posts\", \"content atomizer\", \"pillar content\", \"one to many content\", \"repurpose content\", \"multiply my content\", \"content explosion\", \"turn article into posts\", \"break down this article\", \"micro content from blog\", \"content pillar strategy\", \"10x my content\", \"platform-native content\", \"atomize\", \"content multiplication\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-repurposer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/content-repurposer",
+          "description": "Repurpose one piece of affiliate content into multiple formats. Triggers on: \"repurpose my content\", \"turn my blog into tweets\", \"cross-post this\", \"content recycling\", \"convert to newsletter\", \"make a tweet thread from this\", \"adapt for TikTok\", \"omnichannel content\", \"scale my content\", \"turn this into a LinkedIn post\", \"repurpose for email\", \"content multiplication\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-research-brief",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/content-research-brief",
+          "description": "Research trending topics, collect source articles, and generate a structured research brief for content creation. Stop writing from thin air — write from real sources. Use this skill when the user wants to research a topic before writing, collect sources for an article, create a research-backed content brief, or says \"research [topic] for me\", \"find sources about [keyword]\", \"content brief for [topic]\", \"what's the latest on [product]\", \"research before writing\", \"collect articles about [keyword]\", \"trending news about [topic]\", \"gather sources for my article\", \"brief me on [topic]\", \"what are people saying about [product]\", \"news roundup for [keyword]\", \"research brief\", \"source collection\", \"content research\", \"prep research for writing\".",
+          "version": "1.0"
+        },
+        {
+          "name": "email-drip-sequence",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/email-drip-sequence",
+          "description": "Write an email drip sequence for affiliate marketing. Triggers on: \"write me an email sequence\", \"create a drip campaign\", \"email nurture sequence\", \"affiliate email funnel\", \"welcome email series\", \"email onboarding sequence\", \"write emails for my list\", \"set up a drip sequence\", \"email campaign for [product]\", \"nurture my subscribers\", \"email follow-up sequence\", \"build my email funnel\", \"write 5 emails promoting [product]\", \"email automation sequence\".",
+          "version": "1.0"
+        },
+        {
+          "name": "github-pages-deployer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/github-pages-deployer",
+          "description": "Deploy affiliate content to GitHub Pages for free hosting. Triggers on: \"deploy to GitHub Pages\", \"host on GitHub Pages\", \"free hosting for my affiliate site\", \"push to GitHub Pages\", \"GitHub Pages setup\", \"deploy my landing page to GitHub\", \"host my bio link on GitHub\", \"free affiliate website hosting\", \"github pages affiliate\", \"set up GitHub Pages for my site\", \"deploy HTML to GitHub\", \"free static hosting\", \"publish my affiliate page for free\", \"github pages custom domain\".",
+          "version": "1.0"
+        },
+        {
+          "name": "guarantee-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/guarantee-generator",
+          "description": "Create YOUR personal guarantee on top of the product's guarantee for risk reversal. Triggers on: \"create a guarantee\", \"guarantee for my affiliate\", \"risk reversal\", \"money back guarantee\", \"what guarantee can I offer\", \"reduce buyer risk\", \"guarantee copy\", \"how to guarantee\", \"affiliate guarantee\", \"personal guarantee\", \"risk-free offer\", \"satisfaction guarantee\", \"results guarantee\".",
+          "version": "1.0"
+        },
+        {
+          "name": "how-to-tutorial-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/how-to-tutorial-writer",
+          "description": "Write how-to guides and tutorials that naturally integrate affiliate product recommendations. Triggers on: \"write a how-to guide\", \"tutorial for [task]\", \"step by step guide to [goal]\", \"how to [verb] with [product]\", \"write a tutorial blog post\", \"guide on how to [task]\", \"beginner guide to [topic]\", \"walkthrough for [product]\", \"write an educational article\", \"how do I [task] blog post\", \"write a tutorial that promotes [product]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "infographic-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/infographic-generator",
+          "description": "Generate branded infographic specifications from any content or data. Outputs structured layout, copy, data visualization, and color scheme — ready to render as HTML/CSS, Satori, Canva, or any design tool. Use this skill when the user wants an infographic, data visual, social media image, comparison chart, stat card, or says \"create an infographic for [content]\", \"make a visual for my LinkedIn post\", \"design an image for [topic]\", \"stat graphic for [data]\", \"comparison infographic\", \"branded image\", \"social media graphic\", \"infographic for [blog post]\", \"data visualization\", \"visual content\", \"image for my post\", \"LinkedIn carousel image\", \"feature comparison chart\", \"pricing table image\".",
+          "version": "1.0"
+        },
+        {
+          "name": "keyword-cluster-architect",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/keyword-cluster-architect",
+          "description": "Map 50-200+ keywords into topical clusters for SEO domination. Build content roadmaps for topical authority. Triggers on: \"keyword research\", \"keyword clustering\", \"topical authority\", \"keyword map\", \"keyword strategy\", \"content roadmap for SEO\", \"keyword grouping\", \"topic clusters\", \"SEO keyword plan\", \"map my keywords\", \"keyword cluster\", \"hub and spoke content\", \"build topical authority\", \"SEO content plan\", \"keyword universe\".",
+          "version": "1.0"
+        },
+        {
+          "name": "list-affitor-program",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/list-affitor-program",
+          "description": "Research an affiliate program and create a verified listing for list.affitor.com. Use this skill when the user asks anything about listing a program, adding an affiliate program to the directory, submitting a program to list, creating a listing, documenting an affiliate program, sharing an affiliate program, writing a program profile, posting a program to list.affitor.com, or contributing a new program. Also trigger for: \"list a program\", \"add affiliate program\", \"submit program to list\", \"create listing for X\", \"document affiliate program\", \"share affiliate program\", \"write a listing\", \"post to list.affitor.com\", \"add X to the directory\", \"register an affiliate program\", \"publish affiliate program\", \"new program listing\", \"profile this affiliate program\", \"catalog this program\".",
+          "version": "1.0"
+        },
+        {
+          "name": "list-affitor-skill",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/list-affitor-skill",
+          "description": "Turn a repeatable AI prompt or workflow into a structured, publish-ready skill for list.affitor.com. Use this skill when the user wants to create a new skill, write a SKILL.md, convert a prompt to a skill, publish a skill to the directory, or document an AI workflow. Also trigger for: \"create a skill\", \"write a skill\", \"make this a skill\", \"turn this into a skill\", \"publish skill\", \"add skill to list\", \"write SKILL.md\", \"skill from prompt\", \"document this workflow\", \"package this as a skill\".",
+          "version": "1.0"
+        },
+        {
+          "name": "listicle-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/listicle-generator",
+          "description": "Write \"Top N best...\" listicle articles for affiliate marketing with mini-reviews, pricing, pros/cons, and CTAs per entry. Triggers on: \"write a best of list\", \"top 10 [category] tools\", \"best [product category] article\", \"roundup post\", \"listicle about [category]\", \"write a top tools article\", \"best [N] alternatives to [product]\", \"product roundup\", \"write a tools comparison list\", \"best software for [use case]\", \"top picks for [category]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "paid-ad-copy-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/paid-ad-copy-writer",
+          "description": "Write paid ad copy for affiliate offers across ad platforms. Triggers on: \"write ad copy\", \"Facebook ad for affiliate\", \"Google Ads copy\", \"TikTok ad script\", \"Pinterest ad\", \"paid traffic to affiliate\", \"create ad campaign\", \"ad headlines\", \"ad descriptions\", \"scale with paid ads\", \"run ads for my affiliate link\", \"write Facebook ad\", \"Google Search ad copy\".",
+          "version": "1.0"
+        },
+        {
+          "name": "proprietary-data-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/proprietary-data-generator",
+          "description": "Create original surveys, benchmarks, and aggregated data nobody else has. Automate data collection for content moats. Triggers on: \"create original data\", \"proprietary data\", \"survey design\", \"benchmark study\", \"original research\", \"data-driven content\", \"create a survey\", \"industry benchmark\", \"aggregated data\", \"unique data\", \"first-party data\", \"data moat\", \"generate research data\", \"create a study\", \"original statistics\", \"data nobody else has\", \"competitive data advantage\".",
+          "version": "1.0"
+        },
+        {
+          "name": "reddit-post-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/reddit-post-writer",
+          "description": "Write Reddit posts and comments that recommend affiliate products without getting banned or flagged as spam. Subreddit-native content that adds value first. Use this skill when the user asks about Reddit posts for affiliate marketing, writing Reddit comments that mention products, how to promote affiliate links on Reddit, or says \"write a Reddit post for X\", \"how to mention affiliate on Reddit\", \"Reddit comment promoting product\", \"Reddit-friendly affiliate content\", \"post for r/[subreddit] about X\", \"share affiliate link on Reddit without getting banned\", \"genuine Reddit recommendation\", \"organic Reddit affiliate post\", \"Reddit thread idea for product\".",
+          "version": "1.0"
+        },
+        {
+          "name": "seo-audit",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/seo-audit",
+          "description": "Audit affiliate blog posts and landing pages for SEO issues. Triggers on: \"audit my blog post for SEO\", \"check my SEO\", \"SEO review\", \"improve my rankings\", \"SEO checklist\", \"on-page SEO audit\", \"keyword optimization check\", \"why isn't my page ranking\", \"SEO score\", \"content quality audit\", \"check my meta tags\", \"internal linking audit\", \"quick SEO wins\".",
+          "version": "1.0"
+        },
+        {
+          "name": "skill-finder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/skill-finder",
+          "description": "Find the right Affitor skill for your goal. Triggers on: \"which skill should I use\", \"find me a skill\", \"what skills are available\", \"help me choose a skill\", \"skill for SEO\", \"skill for email\", \"explore skills\", \"I'm new to Affitor\", \"what can Affitor do\", \"search skills\", \"skill for blog writing\", \"skill for landing pages\", \"skill for analytics\".",
+          "version": "1.0"
+        },
+        {
+          "name": "social-media-scheduler",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/social-media-scheduler",
+          "description": "Create a 30-day social media content calendar for affiliate marketing. Triggers on: \"create a social media calendar\", \"30-day content plan\", \"social media schedule\", \"content calendar for [product]\", \"plan my social posts\", \"social media strategy\", \"schedule my affiliate posts\", \"content plan for LinkedIn\", \"30 days of content\", \"social posting schedule\", \"what should I post this month\", \"write my social content\", \"create posts for LinkedIn X Facebook\", \"affiliate content calendar\", \"social media plan for my affiliate program\".",
+          "version": "1.0"
+        },
+        {
+          "name": "tiktok-script-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/tiktok-script-writer",
+          "description": "Write short-form video scripts for TikTok, Instagram Reels, and YouTube Shorts that promote affiliate products with strong hooks, demos, and CTAs. Use this skill when the user asks about TikTok scripts, Reels scripts, Shorts scripts, short-form video for affiliate marketing, or says \"write a TikTok for X\", \"script a Reel promoting X\", \"YouTube Shorts script affiliate\", \"60-second video script\", \"hook for TikTok affiliate\", \"write a video promoting X\", \"TikTok script that converts\", \"short video script for product review\", \"viral TikTok affiliate script\", \"how to promote X on TikTok\".",
+          "version": "1.0"
+        },
+        {
+          "name": "trending-content-scout",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/trending-content-scout",
+          "description": "Scan social platforms for top-performing content by engagement before you create anything. Use this skill when the user wants to see what content is winning in a niche, find viral content patterns, research what's working on YouTube/TikTok/X/Reddit, benchmark engagement, discover content gaps, or says \"what content is working for [topic]\", \"show me top performing content about [keyword]\", \"what's trending in [niche]\", \"find viral content about [product]\", \"content research for [keyword]\", \"what gets views in [niche]\", \"engagement analysis for [topic]\", \"scout the competition\", \"what videos are getting the most views about [keyword]\", \"social listening for [topic]\", \"trending content in [niche]\", \"top content analysis\", \"what hooks work for [keyword]\", \"content intelligence\", \"find winning formats\".",
+          "version": "1.0"
+        },
+        {
+          "name": "twitter-thread-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/twitter-thread-writer",
+          "description": "Write X/Twitter threads that get bookmarked, shared, and drive affiliate clicks. Use this skill when the user asks about writing Twitter threads, X threads, tweet threads for affiliate marketing, or says \"write a thread about X\", \"Twitter thread promoting X\", \"X thread for affiliate\", \"write tweets that go viral\", \"thread that sells without selling\", \"educational thread with affiliate CTA\", \"Twitter content for affiliate marketing\", \"how to promote X on Twitter\", \"write a thread my audience will bookmark\", \"tweet storm about affiliate product\".",
+          "version": "1.0"
+        },
+        {
+          "name": "viral-post-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/viral-post-writer",
+          "description": "Write viral social media posts that promote affiliate products naturally. Use this skill when the user asks anything about writing social media content for affiliate marketing, creating posts for LinkedIn/X/Reddit/Facebook, promoting a product on social media, writing affiliate content, or mentions \"viral post\", \"social media post\", \"content for affiliate\". Also trigger for: \"write a post about X\", \"help me promote X on LinkedIn\", \"create a thread about X\", \"make a Reddit post for X\", \"draft tweets for X\", \"social media content for affiliate program\", \"how to promote X on social\", \"write something that goes viral\", \"LinkedIn post for affiliate\", \"X thread about this tool\", \"help me sell X naturally on social media\".",
+          "version": "1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Affitor",
+        "repo": "affiliate-skills",
+        "repoUrl": "https://github.com/Affitor/affiliate-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "affitor-affiliate-skills-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from Affitor/affiliate-skills.",
+      "author": "ASM (Affitor/affiliate-skills)",
+      "createdAt": "2026-05-09T08:10:40.686Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "affitor",
+        "affiliate-skills"
+      ],
+      "skills": [
+        {
+          "name": "affiliate-blog-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/affiliate-blog-builder",
+          "description": "Write SEO-optimized affiliate blog articles, product reviews, comparison posts, listicles, and how-to guides. Triggers on: \"write a blog post about\", \"review of [product]\", \"best [category] article\", \"comparison blog\", \"affiliate blog\", \"SEO article\", \"write a review\", \"product roundup\", \"blog content for affiliate\", \"how to use [product] blog post\", \"listicle about [category]\", \"[product] vs [product] blog\", \"content for my affiliate site\".",
+          "version": "1.0"
+        },
+        {
+          "name": "affiliate-program-search",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/affiliate-program-search",
+          "description": "Research and evaluate affiliate programs to find the best ones to promote. Use this skill when the user asks anything about finding affiliate programs, comparing commission rates, evaluating affiliate opportunities, searching for products to promote, picking a niche, or mentions list.affitor.com. Also trigger for: \"which SaaS should I promote\", \"best affiliate programs for X\", \"high commission programs\", \"recurring commission affiliate\", \"compare these affiliate programs\", \"is X affiliate program worth it\", \"find me something to promote\", \"what pays the most\", \"affiliate programs with long cookie duration\".",
+          "version": "1.0"
+        },
+        {
+          "name": "commission-calculator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/commission-calculator",
+          "description": "Calculate realistic affiliate earnings projections before committing to a program. Use this skill when the user asks about affiliate earnings, projecting income, calculating commissions, estimating how much they can make, comparing program payouts, or says \"how much can I make promoting X\", \"calculate my affiliate income\", \"is this commission worth it\", \"how long to first $1000\", \"compare earnings between programs\", \"traffic to income calculator\", \"what conversion rate should I expect\", \"earnings estimate for affiliate program\", \"how many sales do I need\".",
+          "version": "1.0"
+        },
+        {
+          "name": "comparison-post-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/comparison-post-writer",
+          "description": "Write \"X vs Y\" comparison blog posts that help readers choose between two competing products. Triggers on: \"write a comparison post\", \"X vs Y blog post\", \"compare [product A] and [product B]\", \"which is better [A] or [B]\", \"head to head comparison\", \"[product] vs [product] article\", \"comparison review\", \"write a versus article\", \"side by side comparison blog\", \"which should I choose [A] or [B]\", \"compare these two products for my blog\".",
+          "version": "1.0"
+        },
+        {
+          "name": "competitor-spy",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/competitor-spy",
+          "description": "Reverse-engineer successful affiliate strategies from competitors. Use this skill when the user asks about spying on competitors, researching what other affiliates promote, analyzing competitor affiliate sites, understanding how top affiliates in a niche make money, or says \"what programs does X promote\", \"how does [site] make money\", \"what affiliate strategy does this site use\", \"spy on competitor affiliates\", \"reverse engineer affiliate site\", \"copy what works in my niche\", \"who are the top affiliates in X niche\", \"what content gets traffic in my niche\", \"competitor affiliate analysis\".",
+          "version": "1.0"
+        },
+        {
+          "name": "compliance-checker",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/compliance-checker",
+          "description": "Check affiliate content for FTC compliance and platform rules. Triggers on: \"check my content for compliance\", \"FTC disclosure check\", \"is this legal\", \"review for compliance\", \"check affiliate disclosure\", \"am I FTC compliant\", \"audit my content\", \"compliance review\", \"legal check\", \"platform rules check\", \"check before publishing\", \"disclosure audit\", \"review my ad copy\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-angle-ranker",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/content-angle-ranker",
+          "description": "Rank content angles by engagement data, competition level, and platform fit. Data-driven angle selection instead of guesswork. Use this skill when the user has a keyword or product and needs to decide WHAT to create, which angle to take, which format to use, or which platform to target. Triggers on: \"what angle should I use\", \"rank content ideas for [keyword]\", \"best angle for [product]\", \"which content idea will perform best\", \"help me pick an angle\", \"what should I write about\", \"content angle for [topic]\", \"rank my content ideas\", \"which approach will get the most views\", \"data-driven content planning\", \"angle ranker\", \"content scoring\", \"which hook should I use\", \"compare these content ideas\", \"prioritize my content angles\", \"what video should I make\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-moat-calculator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/content-moat-calculator",
+          "description": "Estimate pages needed for topical authority. Go/no-go decision before investing months in content. Triggers on: \"how much content do I need\", \"topical authority estimate\", \"content moat\", \"how many articles\", \"content gap analysis\", \"can I compete in this niche\", \"content investment calculator\", \"is this niche worth the effort\", \"SEO feasibility\", \"how many pages to rank\", \"content volume needed\", \"competitive content analysis\", \"moat calculation\", \"authority gap\", \"should I invest in this niche\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-research-brief",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/content-research-brief",
+          "description": "Research trending topics, collect source articles, and generate a structured research brief for content creation. Stop writing from thin air — write from real sources. Use this skill when the user wants to research a topic before writing, collect sources for an article, create a research-backed content brief, or says \"research [topic] for me\", \"find sources about [keyword]\", \"content brief for [topic]\", \"what's the latest on [product]\", \"research before writing\", \"collect articles about [keyword]\", \"trending news about [topic]\", \"gather sources for my article\", \"brief me on [topic]\", \"what are people saying about [product]\", \"news roundup for [keyword]\", \"research brief\", \"source collection\", \"content research\", \"prep research for writing\".",
+          "version": "1.0"
+        },
+        {
+          "name": "funnel-planner",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/funnel-planner",
+          "description": "Plan a complete affiliate funnel from research to revenue. Triggers on: \"plan my affiliate funnel\", \"create a funnel strategy\", \"affiliate business plan\", \"how to start affiliate marketing\", \"full funnel roadmap\", \"plan from scratch\", \"week by week affiliate plan\", \"chain skills together\", \"build my funnel\", \"affiliate marketing roadmap\", \"step by step affiliate plan\", \"onboarding plan\".",
+          "version": "1.0"
+        },
+        {
+          "name": "keyword-cluster-architect",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/keyword-cluster-architect",
+          "description": "Map 50-200+ keywords into topical clusters for SEO domination. Build content roadmaps for topical authority. Triggers on: \"keyword research\", \"keyword clustering\", \"topical authority\", \"keyword map\", \"keyword strategy\", \"content roadmap for SEO\", \"keyword grouping\", \"topic clusters\", \"SEO keyword plan\", \"map my keywords\", \"keyword cluster\", \"hub and spoke content\", \"build topical authority\", \"SEO content plan\", \"keyword universe\".",
+          "version": "1.0"
+        },
+        {
+          "name": "list-affitor-program",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/list-affitor-program",
+          "description": "Research an affiliate program and create a verified listing for list.affitor.com. Use this skill when the user asks anything about listing a program, adding an affiliate program to the directory, submitting a program to list, creating a listing, documenting an affiliate program, sharing an affiliate program, writing a program profile, posting a program to list.affitor.com, or contributing a new program. Also trigger for: \"list a program\", \"add affiliate program\", \"submit program to list\", \"create listing for X\", \"document affiliate program\", \"share affiliate program\", \"write a listing\", \"post to list.affitor.com\", \"add X to the directory\", \"register an affiliate program\", \"publish affiliate program\", \"new program listing\", \"profile this affiliate program\", \"catalog this program\".",
+          "version": "1.0"
+        },
+        {
+          "name": "listicle-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/listicle-generator",
+          "description": "Write \"Top N best...\" listicle articles for affiliate marketing with mini-reviews, pricing, pros/cons, and CTAs per entry. Triggers on: \"write a best of list\", \"top 10 [category] tools\", \"best [product category] article\", \"roundup post\", \"listicle about [category]\", \"write a top tools article\", \"best [N] alternatives to [product]\", \"product roundup\", \"write a tools comparison list\", \"best software for [use case]\", \"top picks for [category]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "monopoly-niche-finder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/monopoly-niche-finder",
+          "description": "Find intersection niches where you're the ONLY voice. Thiel's \"competition is for losers\" lens. Triggers on: \"find my monopoly niche\", \"blue ocean niche\", \"unique niche\", \"niche intersection\", \"where am I the only one\", \"zero competition niche\", \"untapped niche\", \"category of one\", \"Thiel monopoly\", \"dominate a niche\", \"niche nobody else covers\", \"cross two domains\", \"find a niche with no competition\", \"monopoly positioning\", \"unique angle for affiliate\".",
+          "version": "1.0"
+        },
+        {
+          "name": "niche-opportunity-finder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/niche-opportunity-finder",
+          "description": "Find untapped affiliate niches with real earning potential. Use this skill when the user asks about picking a niche, finding a niche to start affiliate marketing, what niche to get into, niche research, niche ideas, beginner niche selection, low competition niches, profitable niches, or says \"I don't know what to promote\", \"help me pick a niche\", \"what niche should I start with\", \"find me a niche with less competition\", \"niche ideas for affiliate\", \"is X a good niche for affiliate marketing\", \"best niches 2024\", \"untapped niches\".",
+          "version": "1.0"
+        },
+        {
+          "name": "performance-report",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/performance-report",
+          "description": "Generate affiliate performance reports with KPIs and recommendations. Triggers on: \"show my affiliate report\", \"how are my programs doing\", \"performance review\", \"earnings report\", \"monthly affiliate report\", \"weekly report\", \"analyze my affiliate earnings\", \"which program is best\", \"EPC report\", \"conversion rate analysis\", \"revenue breakdown\", \"campaign performance\".",
+          "version": "1.0"
+        },
+        {
+          "name": "proprietary-data-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/proprietary-data-generator",
+          "description": "Create original surveys, benchmarks, and aggregated data nobody else has. Automate data collection for content moats. Triggers on: \"create original data\", \"proprietary data\", \"survey design\", \"benchmark study\", \"original research\", \"data-driven content\", \"create a survey\", \"industry benchmark\", \"aggregated data\", \"unique data\", \"first-party data\", \"data moat\", \"generate research data\", \"create a study\", \"original statistics\", \"data nobody else has\", \"competitive data advantage\".",
+          "version": "1.0"
+        },
+        {
+          "name": "purple-cow-audit",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/purple-cow-audit",
+          "description": "Score product remarkability 1-10 to decide if it's worth promoting. Seth Godin's Purple Cow test. Triggers on: \"is this product worth promoting\", \"should I promote\", \"product audit\", \"purple cow\", \"remarkable product\", \"is it remarkable\", \"rate this product\", \"product quality check\", \"worth my reputation\", \"product evaluation\", \"would I recommend without commission\", \"product remarkability score\", \"evaluate this affiliate product\", \"quality gate for promotion\".",
+          "version": "1.0"
+        },
+        {
+          "name": "self-improver",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/self-improver",
+          "description": "Review affiliate campaign results and improve strategy. Triggers on: \"review my results\", \"what went wrong\", \"how to improve conversions\", \"analyze my campaign\", \"affiliate retrospective\", \"why am I not converting\", \"improve my strategy\", \"what should I change\", \"campaign review\", \"optimize my approach\", \"learn from my results\", \"post-mortem on my campaign\".",
+          "version": "1.0"
+        },
+        {
+          "name": "seo-audit",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/seo-audit",
+          "description": "Audit affiliate blog posts and landing pages for SEO issues. Triggers on: \"audit my blog post for SEO\", \"check my SEO\", \"SEO review\", \"improve my rankings\", \"SEO checklist\", \"on-page SEO audit\", \"keyword optimization check\", \"why isn't my page ranking\", \"SEO score\", \"content quality audit\", \"check my meta tags\", \"internal linking audit\", \"quick SEO wins\".",
+          "version": "1.0"
+        },
+        {
+          "name": "tiktok-script-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/tiktok-script-writer",
+          "description": "Write short-form video scripts for TikTok, Instagram Reels, and YouTube Shorts that promote affiliate products with strong hooks, demos, and CTAs. Use this skill when the user asks about TikTok scripts, Reels scripts, Shorts scripts, short-form video for affiliate marketing, or says \"write a TikTok for X\", \"script a Reel promoting X\", \"YouTube Shorts script affiliate\", \"60-second video script\", \"hook for TikTok affiliate\", \"write a video promoting X\", \"TikTok script that converts\", \"short video script for product review\", \"viral TikTok affiliate script\", \"how to promote X on TikTok\".",
+          "version": "1.0"
+        },
+        {
+          "name": "traffic-analyzer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/traffic-analyzer",
+          "description": "Analyze website traffic, global rank, engagement metrics, and traffic sources for any domain. Use this skill to evaluate affiliate program websites, compare competitor traffic, assess advertiser strength, or understand where an audience comes from. Triggers on: \"analyze traffic for [domain]\", \"how much traffic does [site] get\", \"compare traffic between [site A] and [site B]\", \"is [program] worth promoting based on traffic\", \"traffic analysis\", \"website analytics for [domain]\", \"where does [site] get traffic\", \"check if [advertiser] is legit\", \"evaluate [program] website health\", \"SimilarWeb analysis\", \"traffic sources for [domain]\", \"how popular is [site]\", \"website rank\", \"domain authority check\", \"compare affiliate program websites\".",
+          "version": "1.0"
+        },
+        {
+          "name": "trending-content-scout",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/trending-content-scout",
+          "description": "Scan social platforms for top-performing content by engagement before you create anything. Use this skill when the user wants to see what content is winning in a niche, find viral content patterns, research what's working on YouTube/TikTok/X/Reddit, benchmark engagement, discover content gaps, or says \"what content is working for [topic]\", \"show me top performing content about [keyword]\", \"what's trending in [niche]\", \"find viral content about [product]\", \"content research for [keyword]\", \"what gets views in [niche]\", \"engagement analysis for [topic]\", \"scout the competition\", \"what videos are getting the most views about [keyword]\", \"social listening for [topic]\", \"trending content in [niche]\", \"top content analysis\", \"what hooks work for [keyword]\", \"content intelligence\", \"find winning formats\".",
+          "version": "1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Affitor",
+        "repo": "affiliate-skills",
+        "repoUrl": "https://github.com/Affitor/affiliate-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "affitor-affiliate-skills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from Affitor/affiliate-skills.",
+      "author": "ASM (Affitor/affiliate-skills)",
+      "createdAt": "2026-05-09T08:10:40.686Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "affitor",
+        "affiliate-skills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/ab-test-generator",
+          "description": "Generate A/B test variants for affiliate content. Triggers on: \"create A/B test\", \"test my headline\", \"optimize my CTA\", \"generate variants\", \"split test ideas\", \"improve click-through rate\", \"test my landing page copy\", \"headline alternatives\", \"CTA variations\", \"which version is better\", \"optimize conversions\", \"test my email subject line\", \"compare approaches\".",
+          "version": "1.0"
+        },
+        {
+          "name": "affiliate-blog-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/affiliate-blog-builder",
+          "description": "Write SEO-optimized affiliate blog articles, product reviews, comparison posts, listicles, and how-to guides. Triggers on: \"write a blog post about\", \"review of [product]\", \"best [category] article\", \"comparison blog\", \"affiliate blog\", \"SEO article\", \"write a review\", \"product roundup\", \"blog content for affiliate\", \"how to use [product] blog post\", \"listicle about [category]\", \"[product] vs [product] blog\", \"content for my affiliate site\".",
+          "version": "1.0"
+        },
+        {
+          "name": "bio-link-deployer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/bio-link-deployer",
+          "description": "Create a Linktree-style bio link hub page as a single self-contained HTML file. Triggers on: \"create a bio link page\", \"make a linktree\", \"link in bio page\", \"bio link\", \"link hub\", \"create my link page\", \"all my links on one page\", \"linktree alternative\", \"build a link page\", \"bio page for my affiliate links\", \"I need a link in bio\", \"make a page with all my links\", \"link aggregator page\".",
+          "version": "1.0"
+        },
+        {
+          "name": "bonus-stack-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/bonus-stack-builder",
+          "description": "Design exclusive bonus packages that make YOUR affiliate link the obvious choice. Triggers on: \"create bonuses for\", \"bonus stack\", \"what bonuses should I offer\", \"bonus ideas for\", \"exclusive bonuses\", \"differentiate my affiliate link\", \"why buy through my link\", \"affiliate bonuses\", \"bonus package\", \"what can I offer as a bonus\", \"design bonuses\", \"build a bonus stack\".",
+          "version": "1.0"
+        },
+        {
+          "name": "comparison-post-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/comparison-post-writer",
+          "description": "Write \"X vs Y\" comparison blog posts that help readers choose between two competing products. Triggers on: \"write a comparison post\", \"X vs Y blog post\", \"compare [product A] and [product B]\", \"which is better [A] or [B]\", \"head to head comparison\", \"[product] vs [product] article\", \"comparison review\", \"write a versus article\", \"side by side comparison blog\", \"which should I choose [A] or [B]\", \"compare these two products for my blog\".",
+          "version": "1.0"
+        },
+        {
+          "name": "compliance-checker",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/compliance-checker",
+          "description": "Check affiliate content for FTC compliance and platform rules. Triggers on: \"check my content for compliance\", \"FTC disclosure check\", \"is this legal\", \"review for compliance\", \"check affiliate disclosure\", \"am I FTC compliant\", \"audit my content\", \"compliance review\", \"legal check\", \"platform rules check\", \"check before publishing\", \"disclosure audit\", \"review my ad copy\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-decay-detector",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/content-decay-detector",
+          "description": "Monitor existing content for ranking drops and trigger refresh workflows. Triggers on: \"check for content decay\", \"which content needs updating\", \"content refresh\", \"ranking drops\", \"traffic decline\", \"stale content\", \"content audit\", \"what to refresh\", \"outdated content\", \"content performance check\", \"update old articles\", \"declining rankings\", \"content maintenance\", \"refresh priority list\", \"which articles are losing traffic\", \"SEO content audit\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-repurposer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/content-repurposer",
+          "description": "Repurpose one piece of affiliate content into multiple formats. Triggers on: \"repurpose my content\", \"turn my blog into tweets\", \"cross-post this\", \"content recycling\", \"convert to newsletter\", \"make a tweet thread from this\", \"adapt for TikTok\", \"omnichannel content\", \"scale my content\", \"turn this into a LinkedIn post\", \"repurpose for email\", \"content multiplication\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-research-brief",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/content-research-brief",
+          "description": "Research trending topics, collect source articles, and generate a structured research brief for content creation. Stop writing from thin air — write from real sources. Use this skill when the user wants to research a topic before writing, collect sources for an article, create a research-backed content brief, or says \"research [topic] for me\", \"find sources about [keyword]\", \"content brief for [topic]\", \"what's the latest on [product]\", \"research before writing\", \"collect articles about [keyword]\", \"trending news about [topic]\", \"gather sources for my article\", \"brief me on [topic]\", \"what are people saying about [product]\", \"news roundup for [keyword]\", \"research brief\", \"source collection\", \"content research\", \"prep research for writing\".",
+          "version": "1.0"
+        },
+        {
+          "name": "conversion-tracker",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/conversion-tracker",
+          "description": "Set up affiliate conversion tracking with UTM parameters and link tagging. Triggers on: \"set up tracking\", \"create UTM links\", \"track my affiliate links\", \"tracking pixels\", \"click attribution\", \"organize my links\", \"UTM parameters\", \"tag my links\", \"campaign tracking\", \"link tracking setup\", \"prepare for launch\", \"debug attribution\", \"tracking spreadsheet\".",
+          "version": "1.0"
+        },
+        {
+          "name": "email-automation-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/email-automation-builder",
+          "description": "Build multi-sequence email automation flows with branching logic. Triggers on: \"build email automation\", \"create email funnel\", \"email automation flow\", \"welcome series with branches\", \"conditional email sequence\", \"set up automation\", \"email workflow builder\", \"segmented email flow\", \"advanced email sequence\", \"nurture funnel\", \"cart abandonment sequence\", \"win-back email flow\".",
+          "version": "1.0"
+        },
+        {
+          "name": "email-drip-sequence",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/email-drip-sequence",
+          "description": "Write an email drip sequence for affiliate marketing. Triggers on: \"write me an email sequence\", \"create a drip campaign\", \"email nurture sequence\", \"affiliate email funnel\", \"welcome email series\", \"email onboarding sequence\", \"write emails for my list\", \"set up a drip sequence\", \"email campaign for [product]\", \"nurture my subscribers\", \"email follow-up sequence\", \"build my email funnel\", \"write 5 emails promoting [product]\", \"email automation sequence\".",
+          "version": "1.0"
+        },
+        {
+          "name": "funnel-planner",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/funnel-planner",
+          "description": "Plan a complete affiliate funnel from research to revenue. Triggers on: \"plan my affiliate funnel\", \"create a funnel strategy\", \"affiliate business plan\", \"how to start affiliate marketing\", \"full funnel roadmap\", \"plan from scratch\", \"week by week affiliate plan\", \"chain skills together\", \"build my funnel\", \"affiliate marketing roadmap\", \"step by step affiliate plan\", \"onboarding plan\".",
+          "version": "1.0"
+        },
+        {
+          "name": "internal-linking-optimizer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/internal-linking-optimizer",
+          "description": "Analyze site's internal link structure and optimize for hub-and-spoke SEO architecture. Triggers on: \"optimize internal links\", \"internal linking\", \"link structure\", \"hub and spoke links\", \"orphan pages\", \"link equity\", \"internal link audit\", \"fix my internal links\", \"link architecture\", \"site structure optimization\", \"internal linking strategy\", \"link flow\", \"improve site structure\", \"find orphan pages\", \"maximize link equity\", \"internal link map\".",
+          "version": "1.0"
+        },
+        {
+          "name": "keyword-cluster-architect",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/keyword-cluster-architect",
+          "description": "Map 50-200+ keywords into topical clusters for SEO domination. Build content roadmaps for topical authority. Triggers on: \"keyword research\", \"keyword clustering\", \"topical authority\", \"keyword map\", \"keyword strategy\", \"content roadmap for SEO\", \"keyword grouping\", \"topic clusters\", \"SEO keyword plan\", \"map my keywords\", \"keyword cluster\", \"hub and spoke content\", \"build topical authority\", \"SEO content plan\", \"keyword universe\".",
+          "version": "1.0"
+        },
+        {
+          "name": "landing-page-creator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/landing-page-creator",
+          "description": "Build high-converting affiliate landing pages as single self-contained HTML files. Triggers on: \"create a landing page for\", \"build a landing page\", \"product landing page\", \"affiliate landing page\", \"comparison page for\", \"vs page\", \"single product page\", \"conversion page\", \"sales page for affiliate\", \"landing page HTML\", \"build me a page for\", \"create a page to promote [product]\", \"I need a landing page\", \"make a page for [product]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "listicle-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/listicle-generator",
+          "description": "Write \"Top N best...\" listicle articles for affiliate marketing with mini-reviews, pricing, pros/cons, and CTAs per entry. Triggers on: \"write a best of list\", \"top 10 [category] tools\", \"best [product category] article\", \"roundup post\", \"listicle about [category]\", \"write a top tools article\", \"best [N] alternatives to [product]\", \"product roundup\", \"write a tools comparison list\", \"best software for [use case]\", \"top picks for [category]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "performance-report",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/performance-report",
+          "description": "Generate affiliate performance reports with KPIs and recommendations. Triggers on: \"show my affiliate report\", \"how are my programs doing\", \"performance review\", \"earnings report\", \"monthly affiliate report\", \"weekly report\", \"analyze my affiliate earnings\", \"which program is best\", \"EPC report\", \"conversion rate analysis\", \"revenue breakdown\", \"campaign performance\".",
+          "version": "1.0"
+        },
+        {
+          "name": "product-showcase-page",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/product-showcase-page",
+          "description": "Build a single-product deep-dive showcase page as a self-contained HTML file. Triggers on: \"build a product showcase page\", \"deep dive landing page for [product]\", \"create a product spotlight page\", \"product feature page\", \"single product page\", \"detailed page about [product]\", \"build a page showing everything about [product]\", \"create a long-form product page\", \"build a sales page for [product]\", \"product deep dive page\", \"make a feature breakdown page for [product]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "purple-cow-audit",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/purple-cow-audit",
+          "description": "Score product remarkability 1-10 to decide if it's worth promoting. Seth Godin's Purple Cow test. Triggers on: \"is this product worth promoting\", \"should I promote\", \"product audit\", \"purple cow\", \"remarkable product\", \"is it remarkable\", \"rate this product\", \"product quality check\", \"worth my reputation\", \"product evaluation\", \"would I recommend without commission\", \"product remarkability score\", \"evaluate this affiliate product\", \"quality gate for promotion\".",
+          "version": "1.0"
+        },
+        {
+          "name": "self-improver",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/self-improver",
+          "description": "Review affiliate campaign results and improve strategy. Triggers on: \"review my results\", \"what went wrong\", \"how to improve conversions\", \"analyze my campaign\", \"affiliate retrospective\", \"why am I not converting\", \"improve my strategy\", \"what should I change\", \"campaign review\", \"optimize my approach\", \"learn from my results\", \"post-mortem on my campaign\".",
+          "version": "1.0"
+        },
+        {
+          "name": "seo-audit",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/seo-audit",
+          "description": "Audit affiliate blog posts and landing pages for SEO issues. Triggers on: \"audit my blog post for SEO\", \"check my SEO\", \"SEO review\", \"improve my rankings\", \"SEO checklist\", \"on-page SEO audit\", \"keyword optimization check\", \"why isn't my page ranking\", \"SEO score\", \"content quality audit\", \"check my meta tags\", \"internal linking audit\", \"quick SEO wins\".",
+          "version": "1.0"
+        },
+        {
+          "name": "squeeze-page-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/squeeze-page-builder",
+          "description": "Build email capture landing pages (squeeze pages) as single self-contained HTML files. Triggers on: \"build a squeeze page\", \"email capture page\", \"lead magnet page\", \"create an opt-in page\", \"build an email list page\", \"lead capture landing page\", \"create a freebie page\", \"build a page to collect emails\", \"opt-in landing page\", \"email signup page for [product/niche]\", \"create a lead magnet landing page\", \"build a page that captures emails before sending to affiliate offer\".",
+          "version": "1.0"
+        },
+        {
+          "name": "tiktok-script-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/tiktok-script-writer",
+          "description": "Write short-form video scripts for TikTok, Instagram Reels, and YouTube Shorts that promote affiliate products with strong hooks, demos, and CTAs. Use this skill when the user asks about TikTok scripts, Reels scripts, Shorts scripts, short-form video for affiliate marketing, or says \"write a TikTok for X\", \"script a Reel promoting X\", \"YouTube Shorts script affiliate\", \"60-second video script\", \"hook for TikTok affiliate\", \"write a video promoting X\", \"TikTok script that converts\", \"short video script for product review\", \"viral TikTok affiliate script\", \"how to promote X on TikTok\".",
+          "version": "1.0"
+        },
+        {
+          "name": "twitter-thread-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/twitter-thread-writer",
+          "description": "Write X/Twitter threads that get bookmarked, shared, and drive affiliate clicks. Use this skill when the user asks about writing Twitter threads, X threads, tweet threads for affiliate marketing, or says \"write a thread about X\", \"Twitter thread promoting X\", \"X thread for affiliate\", \"write tweets that go viral\", \"thread that sells without selling\", \"educational thread with affiliate CTA\", \"Twitter content for affiliate marketing\", \"how to promote X on Twitter\", \"write a thread my audience will bookmark\", \"tweet storm about affiliate product\".",
+          "version": "1.0"
+        },
+        {
+          "name": "value-ladder-architect",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/value-ladder-architect",
+          "description": "Design the complete free-to-premium value ladder for affiliate promotions. Triggers on: \"value ladder\", \"customer journey\", \"upsell path\", \"ascension model\", \"free to paid funnel\", \"tripwire offer\", \"upsell strategy\", \"downsell\", \"product ladder\", \"price ladder\", \"customer ascension\", \"funnel architecture\", \"map my funnel\", \"design my funnel stages\", \"monetization path\".",
+          "version": "1.0"
+        },
+        {
+          "name": "webinar-registration-page",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/webinar-registration-page",
+          "description": "Build a webinar or live event registration page as a self-contained HTML file with countdown timer, speaker bio, agenda, and registration form. Triggers on: \"build a webinar registration page\", \"create a webinar sign-up page\", \"event registration landing page\", \"live training registration page\", \"workshop sign-up page\", \"create a webinar page\", \"build an event page\", \"free webinar landing page\", \"live demo registration page\", \"online event page\", \"create a registration page for my webinar\", \"build a training event page\".",
+          "version": "1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Affitor",
+        "repo": "affiliate-skills",
+        "repoUrl": "https://github.com/Affitor/affiliate-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "affitor-affiliate-skills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from Affitor/affiliate-skills.",
+      "author": "ASM (Affitor/affiliate-skills)",
+      "createdAt": "2026-05-09T08:10:40.686Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "affitor",
+        "affiliate-skills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/ab-test-generator",
+          "description": "Generate A/B test variants for affiliate content. Triggers on: \"create A/B test\", \"test my headline\", \"optimize my CTA\", \"generate variants\", \"split test ideas\", \"improve click-through rate\", \"test my landing page copy\", \"headline alternatives\", \"CTA variations\", \"which version is better\", \"optimize conversions\", \"test my email subject line\", \"compare approaches\".",
+          "version": "1.0"
+        },
+        {
+          "name": "affiliate-blog-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/affiliate-blog-builder",
+          "description": "Write SEO-optimized affiliate blog articles, product reviews, comparison posts, listicles, and how-to guides. Triggers on: \"write a blog post about\", \"review of [product]\", \"best [category] article\", \"comparison blog\", \"affiliate blog\", \"SEO article\", \"write a review\", \"product roundup\", \"blog content for affiliate\", \"how to use [product] blog post\", \"listicle about [category]\", \"[product] vs [product] blog\", \"content for my affiliate site\".",
+          "version": "1.0"
+        },
+        {
+          "name": "bio-link-deployer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/bio-link-deployer",
+          "description": "Create a Linktree-style bio link hub page as a single self-contained HTML file. Triggers on: \"create a bio link page\", \"make a linktree\", \"link in bio page\", \"bio link\", \"link hub\", \"create my link page\", \"all my links on one page\", \"linktree alternative\", \"build a link page\", \"bio page for my affiliate links\", \"I need a link in bio\", \"make a page with all my links\", \"link aggregator page\".",
+          "version": "1.0"
+        },
+        {
+          "name": "bonus-stack-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/bonus-stack-builder",
+          "description": "Design exclusive bonus packages that make YOUR affiliate link the obvious choice. Triggers on: \"create bonuses for\", \"bonus stack\", \"what bonuses should I offer\", \"bonus ideas for\", \"exclusive bonuses\", \"differentiate my affiliate link\", \"why buy through my link\", \"affiliate bonuses\", \"bonus package\", \"what can I offer as a bonus\", \"design bonuses\", \"build a bonus stack\".",
+          "version": "1.0"
+        },
+        {
+          "name": "category-designer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/category-designer",
+          "description": "Define a new category where your product wins by default. Reframe the buying decision. Triggers on: \"create a category\", \"category design\", \"define my category\", \"category of one\", \"reframe the market\", \"position as category king\", \"new category\", \"category creation\", \"own a category\", \"category strategy\", \"competitive positioning\", \"strategic positioning\", \"market reframing\", \"be the only option\", \"change the buying criteria\", \"category king\".",
+          "version": "1.0"
+        },
+        {
+          "name": "email-automation-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/email-automation-builder",
+          "description": "Build multi-sequence email automation flows with branching logic. Triggers on: \"build email automation\", \"create email funnel\", \"email automation flow\", \"welcome series with branches\", \"conditional email sequence\", \"set up automation\", \"email workflow builder\", \"segmented email flow\", \"advanced email sequence\", \"nurture funnel\", \"cart abandonment sequence\", \"win-back email flow\".",
+          "version": "1.0"
+        },
+        {
+          "name": "email-drip-sequence",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/email-drip-sequence",
+          "description": "Write an email drip sequence for affiliate marketing. Triggers on: \"write me an email sequence\", \"create a drip campaign\", \"email nurture sequence\", \"affiliate email funnel\", \"welcome email series\", \"email onboarding sequence\", \"write emails for my list\", \"set up a drip sequence\", \"email campaign for [product]\", \"nurture my subscribers\", \"email follow-up sequence\", \"build my email funnel\", \"write 5 emails promoting [product]\", \"email automation sequence\".",
+          "version": "1.0"
+        },
+        {
+          "name": "funnel-planner",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/funnel-planner",
+          "description": "Plan a complete affiliate funnel from research to revenue. Triggers on: \"plan my affiliate funnel\", \"create a funnel strategy\", \"affiliate business plan\", \"how to start affiliate marketing\", \"full funnel roadmap\", \"plan from scratch\", \"week by week affiliate plan\", \"chain skills together\", \"build my funnel\", \"affiliate marketing roadmap\", \"step by step affiliate plan\", \"onboarding plan\".",
+          "version": "1.0"
+        },
+        {
+          "name": "github-pages-deployer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/github-pages-deployer",
+          "description": "Deploy affiliate content to GitHub Pages for free hosting. Triggers on: \"deploy to GitHub Pages\", \"host on GitHub Pages\", \"free hosting for my affiliate site\", \"push to GitHub Pages\", \"GitHub Pages setup\", \"deploy my landing page to GitHub\", \"host my bio link on GitHub\", \"free affiliate website hosting\", \"github pages affiliate\", \"set up GitHub Pages for my site\", \"deploy HTML to GitHub\", \"free static hosting\", \"publish my affiliate page for free\", \"github pages custom domain\".",
+          "version": "1.0"
+        },
+        {
+          "name": "grand-slam-offer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/grand-slam-offer",
+          "description": "Design irresistible affiliate offers using the Hormozi Grand Slam framework. Triggers on: \"create an offer for\", \"design my offer\", \"grand slam offer\", \"make an irresistible offer\", \"why should someone buy through my link\", \"offer framework\", \"value proposition for\", \"Hormozi offer\", \"offer stack\", \"make my offer irresistible\", \"craft an offer\", \"what makes my offer different\", \"offer design\", \"increase perceived value\".",
+          "version": "1.0"
+        },
+        {
+          "name": "guarantee-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/guarantee-generator",
+          "description": "Create YOUR personal guarantee on top of the product's guarantee for risk reversal. Triggers on: \"create a guarantee\", \"guarantee for my affiliate\", \"risk reversal\", \"money back guarantee\", \"what guarantee can I offer\", \"reduce buyer risk\", \"guarantee copy\", \"how to guarantee\", \"affiliate guarantee\", \"personal guarantee\", \"risk-free offer\", \"satisfaction guarantee\", \"results guarantee\".",
+          "version": "1.0"
+        },
+        {
+          "name": "how-to-tutorial-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/how-to-tutorial-writer",
+          "description": "Write how-to guides and tutorials that naturally integrate affiliate product recommendations. Triggers on: \"write a how-to guide\", \"tutorial for [task]\", \"step by step guide to [goal]\", \"how to [verb] with [product]\", \"write a tutorial blog post\", \"guide on how to [task]\", \"beginner guide to [topic]\", \"walkthrough for [product]\", \"write an educational article\", \"how do I [task] blog post\", \"write a tutorial that promotes [product]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "infographic-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/infographic-generator",
+          "description": "Generate branded infographic specifications from any content or data. Outputs structured layout, copy, data visualization, and color scheme — ready to render as HTML/CSS, Satori, Canva, or any design tool. Use this skill when the user wants an infographic, data visual, social media image, comparison chart, stat card, or says \"create an infographic for [content]\", \"make a visual for my LinkedIn post\", \"design an image for [topic]\", \"stat graphic for [data]\", \"comparison infographic\", \"branded image\", \"social media graphic\", \"infographic for [blog post]\", \"data visualization\", \"visual content\", \"image for my post\", \"LinkedIn carousel image\", \"feature comparison chart\", \"pricing table image\".",
+          "version": "1.0"
+        },
+        {
+          "name": "internal-linking-optimizer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/internal-linking-optimizer",
+          "description": "Analyze site's internal link structure and optimize for hub-and-spoke SEO architecture. Triggers on: \"optimize internal links\", \"internal linking\", \"link structure\", \"hub and spoke links\", \"orphan pages\", \"link equity\", \"internal link audit\", \"fix my internal links\", \"link architecture\", \"site structure optimization\", \"internal linking strategy\", \"link flow\", \"improve site structure\", \"find orphan pages\", \"maximize link equity\", \"internal link map\".",
+          "version": "1.0"
+        },
+        {
+          "name": "keyword-cluster-architect",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/keyword-cluster-architect",
+          "description": "Map 50-200+ keywords into topical clusters for SEO domination. Build content roadmaps for topical authority. Triggers on: \"keyword research\", \"keyword clustering\", \"topical authority\", \"keyword map\", \"keyword strategy\", \"content roadmap for SEO\", \"keyword grouping\", \"topic clusters\", \"SEO keyword plan\", \"map my keywords\", \"keyword cluster\", \"hub and spoke content\", \"build topical authority\", \"SEO content plan\", \"keyword universe\".",
+          "version": "1.0"
+        },
+        {
+          "name": "landing-page-creator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/landing-page-creator",
+          "description": "Build high-converting affiliate landing pages as single self-contained HTML files. Triggers on: \"create a landing page for\", \"build a landing page\", \"product landing page\", \"affiliate landing page\", \"comparison page for\", \"vs page\", \"single product page\", \"conversion page\", \"sales page for affiliate\", \"landing page HTML\", \"build me a page for\", \"create a page to promote [product]\", \"I need a landing page\", \"make a page for [product]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "product-showcase-page",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/product-showcase-page",
+          "description": "Build a single-product deep-dive showcase page as a self-contained HTML file. Triggers on: \"build a product showcase page\", \"deep dive landing page for [product]\", \"create a product spotlight page\", \"product feature page\", \"single product page\", \"detailed page about [product]\", \"build a page showing everything about [product]\", \"create a long-form product page\", \"build a sales page for [product]\", \"product deep dive page\", \"make a feature breakdown page for [product]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "proprietary-data-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/proprietary-data-generator",
+          "description": "Create original surveys, benchmarks, and aggregated data nobody else has. Automate data collection for content moats. Triggers on: \"create original data\", \"proprietary data\", \"survey design\", \"benchmark study\", \"original research\", \"data-driven content\", \"create a survey\", \"industry benchmark\", \"aggregated data\", \"unique data\", \"first-party data\", \"data moat\", \"generate research data\", \"create a study\", \"original statistics\", \"data nobody else has\", \"competitive data advantage\".",
+          "version": "1.0"
+        },
+        {
+          "name": "reddit-post-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/reddit-post-writer",
+          "description": "Write Reddit posts and comments that recommend affiliate products without getting banned or flagged as spam. Subreddit-native content that adds value first. Use this skill when the user asks about Reddit posts for affiliate marketing, writing Reddit comments that mention products, how to promote affiliate links on Reddit, or says \"write a Reddit post for X\", \"how to mention affiliate on Reddit\", \"Reddit comment promoting product\", \"Reddit-friendly affiliate content\", \"post for r/[subreddit] about X\", \"share affiliate link on Reddit without getting banned\", \"genuine Reddit recommendation\", \"organic Reddit affiliate post\", \"Reddit thread idea for product\".",
+          "version": "1.0"
+        },
+        {
+          "name": "seo-audit",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/seo-audit",
+          "description": "Audit affiliate blog posts and landing pages for SEO issues. Triggers on: \"audit my blog post for SEO\", \"check my SEO\", \"SEO review\", \"improve my rankings\", \"SEO checklist\", \"on-page SEO audit\", \"keyword optimization check\", \"why isn't my page ranking\", \"SEO score\", \"content quality audit\", \"check my meta tags\", \"internal linking audit\", \"quick SEO wins\".",
+          "version": "1.0"
+        },
+        {
+          "name": "skill-finder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/skill-finder",
+          "description": "Find the right Affitor skill for your goal. Triggers on: \"which skill should I use\", \"find me a skill\", \"what skills are available\", \"help me choose a skill\", \"skill for SEO\", \"skill for email\", \"explore skills\", \"I'm new to Affitor\", \"what can Affitor do\", \"search skills\", \"skill for blog writing\", \"skill for landing pages\", \"skill for analytics\".",
+          "version": "1.0"
+        },
+        {
+          "name": "squeeze-page-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/squeeze-page-builder",
+          "description": "Build email capture landing pages (squeeze pages) as single self-contained HTML files. Triggers on: \"build a squeeze page\", \"email capture page\", \"lead magnet page\", \"create an opt-in page\", \"build an email list page\", \"lead capture landing page\", \"create a freebie page\", \"build a page to collect emails\", \"opt-in landing page\", \"email signup page for [product/niche]\", \"create a lead magnet landing page\", \"build a page that captures emails before sending to affiliate offer\".",
+          "version": "1.0"
+        },
+        {
+          "name": "value-ladder-architect",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/value-ladder-architect",
+          "description": "Design the complete free-to-premium value ladder for affiliate promotions. Triggers on: \"value ladder\", \"customer journey\", \"upsell path\", \"ascension model\", \"free to paid funnel\", \"tripwire offer\", \"upsell strategy\", \"downsell\", \"product ladder\", \"price ladder\", \"customer ascension\", \"funnel architecture\", \"map my funnel\", \"design my funnel stages\", \"monetization path\".",
+          "version": "1.0"
+        },
+        {
+          "name": "webinar-registration-page",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/webinar-registration-page",
+          "description": "Build a webinar or live event registration page as a self-contained HTML file with countdown timer, speaker bio, agenda, and registration form. Triggers on: \"build a webinar registration page\", \"create a webinar sign-up page\", \"event registration landing page\", \"live training registration page\", \"workshop sign-up page\", \"create a webinar page\", \"build an event page\", \"free webinar landing page\", \"live demo registration page\", \"online event page\", \"create a registration page for my webinar\", \"build a training event page\".",
+          "version": "1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Affitor",
+        "repo": "affiliate-skills",
+        "repoUrl": "https://github.com/Affitor/affiliate-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "affitor-affiliate-skills-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from Affitor/affiliate-skills.",
+      "author": "ASM (Affitor/affiliate-skills)",
+      "createdAt": "2026-05-09T08:10:40.686Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "affitor",
+        "affiliate-skills"
+      ],
+      "skills": [
+        {
+          "name": "bio-link-deployer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/bio-link-deployer",
+          "description": "Create a Linktree-style bio link hub page as a single self-contained HTML file. Triggers on: \"create a bio link page\", \"make a linktree\", \"link in bio page\", \"bio link\", \"link hub\", \"create my link page\", \"all my links on one page\", \"linktree alternative\", \"build a link page\", \"bio page for my affiliate links\", \"I need a link in bio\", \"make a page with all my links\", \"link aggregator page\".",
+          "version": "1.0"
+        },
+        {
+          "name": "category-designer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/category-designer",
+          "description": "Define a new category where your product wins by default. Reframe the buying decision. Triggers on: \"create a category\", \"category design\", \"define my category\", \"category of one\", \"reframe the market\", \"position as category king\", \"new category\", \"category creation\", \"own a category\", \"category strategy\", \"competitive positioning\", \"strategic positioning\", \"market reframing\", \"be the only option\", \"change the buying criteria\", \"category king\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-angle-ranker",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/content-angle-ranker",
+          "description": "Rank content angles by engagement data, competition level, and platform fit. Data-driven angle selection instead of guesswork. Use this skill when the user has a keyword or product and needs to decide WHAT to create, which angle to take, which format to use, or which platform to target. Triggers on: \"what angle should I use\", \"rank content ideas for [keyword]\", \"best angle for [product]\", \"which content idea will perform best\", \"help me pick an angle\", \"what should I write about\", \"content angle for [topic]\", \"rank my content ideas\", \"which approach will get the most views\", \"data-driven content planning\", \"angle ranker\", \"content scoring\", \"which hook should I use\", \"compare these content ideas\", \"prioritize my content angles\", \"what video should I make\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-decay-detector",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/content-decay-detector",
+          "description": "Monitor existing content for ranking drops and trigger refresh workflows. Triggers on: \"check for content decay\", \"which content needs updating\", \"content refresh\", \"ranking drops\", \"traffic decline\", \"stale content\", \"content audit\", \"what to refresh\", \"outdated content\", \"content performance check\", \"update old articles\", \"declining rankings\", \"content maintenance\", \"refresh priority list\", \"which articles are losing traffic\", \"SEO content audit\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-moat-calculator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/content-moat-calculator",
+          "description": "Estimate pages needed for topical authority. Go/no-go decision before investing months in content. Triggers on: \"how much content do I need\", \"topical authority estimate\", \"content moat\", \"how many articles\", \"content gap analysis\", \"can I compete in this niche\", \"content investment calculator\", \"is this niche worth the effort\", \"SEO feasibility\", \"how many pages to rank\", \"content volume needed\", \"competitive content analysis\", \"moat calculation\", \"authority gap\", \"should I invest in this niche\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-pillar-atomizer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/content-pillar-atomizer",
+          "description": "Take 1 blog post or article and generate 15-30 platform-native micro-content pieces. Not reformatting — re-contextualizing for each platform's culture. Triggers on: \"atomize this content\", \"repurpose my blog post\", \"turn this into social posts\", \"content atomizer\", \"pillar content\", \"one to many content\", \"repurpose content\", \"multiply my content\", \"content explosion\", \"turn article into posts\", \"break down this article\", \"micro content from blog\", \"content pillar strategy\", \"10x my content\", \"platform-native content\", \"atomize\", \"content multiplication\".",
+          "version": "1.0"
+        },
+        {
+          "name": "email-automation-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/email-automation-builder",
+          "description": "Build multi-sequence email automation flows with branching logic. Triggers on: \"build email automation\", \"create email funnel\", \"email automation flow\", \"welcome series with branches\", \"conditional email sequence\", \"set up automation\", \"email workflow builder\", \"segmented email flow\", \"advanced email sequence\", \"nurture funnel\", \"cart abandonment sequence\", \"win-back email flow\".",
+          "version": "1.0"
+        },
+        {
+          "name": "github-pages-deployer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/github-pages-deployer",
+          "description": "Deploy affiliate content to GitHub Pages for free hosting. Triggers on: \"deploy to GitHub Pages\", \"host on GitHub Pages\", \"free hosting for my affiliate site\", \"push to GitHub Pages\", \"GitHub Pages setup\", \"deploy my landing page to GitHub\", \"host my bio link on GitHub\", \"free affiliate website hosting\", \"github pages affiliate\", \"set up GitHub Pages for my site\", \"deploy HTML to GitHub\", \"free static hosting\", \"publish my affiliate page for free\", \"github pages custom domain\".",
+          "version": "1.0"
+        },
+        {
+          "name": "infographic-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/infographic-generator",
+          "description": "Generate branded infographic specifications from any content or data. Outputs structured layout, copy, data visualization, and color scheme — ready to render as HTML/CSS, Satori, Canva, or any design tool. Use this skill when the user wants an infographic, data visual, social media image, comparison chart, stat card, or says \"create an infographic for [content]\", \"make a visual for my LinkedIn post\", \"design an image for [topic]\", \"stat graphic for [data]\", \"comparison infographic\", \"branded image\", \"social media graphic\", \"infographic for [blog post]\", \"data visualization\", \"visual content\", \"image for my post\", \"LinkedIn carousel image\", \"feature comparison chart\", \"pricing table image\".",
+          "version": "1.0"
+        },
+        {
+          "name": "list-affitor-skill",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/list-affitor-skill",
+          "description": "Turn a repeatable AI prompt or workflow into a structured, publish-ready skill for list.affitor.com. Use this skill when the user wants to create a new skill, write a SKILL.md, convert a prompt to a skill, publish a skill to the directory, or document an AI workflow. Also trigger for: \"create a skill\", \"write a skill\", \"make this a skill\", \"turn this into a skill\", \"publish skill\", \"add skill to list\", \"write SKILL.md\", \"skill from prompt\", \"document this workflow\", \"package this as a skill\".",
+          "version": "1.0"
+        },
+        {
+          "name": "listicle-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/listicle-generator",
+          "description": "Write \"Top N best...\" listicle articles for affiliate marketing with mini-reviews, pricing, pros/cons, and CTAs per entry. Triggers on: \"write a best of list\", \"top 10 [category] tools\", \"best [product category] article\", \"roundup post\", \"listicle about [category]\", \"write a top tools article\", \"best [N] alternatives to [product]\", \"product roundup\", \"write a tools comparison list\", \"best software for [use case]\", \"top picks for [category]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "purple-cow-audit",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/purple-cow-audit",
+          "description": "Score product remarkability 1-10 to decide if it's worth promoting. Seth Godin's Purple Cow test. Triggers on: \"is this product worth promoting\", \"should I promote\", \"product audit\", \"purple cow\", \"remarkable product\", \"is it remarkable\", \"rate this product\", \"product quality check\", \"worth my reputation\", \"product evaluation\", \"would I recommend without commission\", \"product remarkability score\", \"evaluate this affiliate product\", \"quality gate for promotion\".",
+          "version": "1.0"
+        },
+        {
+          "name": "social-media-scheduler",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/social-media-scheduler",
+          "description": "Create a 30-day social media content calendar for affiliate marketing. Triggers on: \"create a social media calendar\", \"30-day content plan\", \"social media schedule\", \"content calendar for [product]\", \"plan my social posts\", \"social media strategy\", \"schedule my affiliate posts\", \"content plan for LinkedIn\", \"30 days of content\", \"social posting schedule\", \"what should I post this month\", \"write my social content\", \"create posts for LinkedIn X Facebook\", \"affiliate content calendar\", \"social media plan for my affiliate program\".",
+          "version": "1.0"
+        },
+        {
+          "name": "trending-content-scout",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/trending-content-scout",
+          "description": "Scan social platforms for top-performing content by engagement before you create anything. Use this skill when the user wants to see what content is winning in a niche, find viral content patterns, research what's working on YouTube/TikTok/X/Reddit, benchmark engagement, discover content gaps, or says \"what content is working for [topic]\", \"show me top performing content about [keyword]\", \"what's trending in [niche]\", \"find viral content about [product]\", \"content research for [keyword]\", \"what gets views in [niche]\", \"engagement analysis for [topic]\", \"scout the competition\", \"what videos are getting the most views about [keyword]\", \"social listening for [topic]\", \"trending content in [niche]\", \"top content analysis\", \"what hooks work for [keyword]\", \"content intelligence\", \"find winning formats\".",
+          "version": "1.0"
+        },
+        {
+          "name": "viral-post-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/viral-post-writer",
+          "description": "Write viral social media posts that promote affiliate products naturally. Use this skill when the user asks anything about writing social media content for affiliate marketing, creating posts for LinkedIn/X/Reddit/Facebook, promoting a product on social media, writing affiliate content, or mentions \"viral post\", \"social media post\", \"content for affiliate\". Also trigger for: \"write a post about X\", \"help me promote X on LinkedIn\", \"create a thread about X\", \"make a Reddit post for X\", \"draft tweets for X\", \"social media content for affiliate program\", \"how to promote X on social\", \"write something that goes viral\", \"LinkedIn post for affiliate\", \"X thread about this tool\", \"help me sell X naturally on social media\".",
+          "version": "1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Affitor",
+        "repo": "affiliate-skills",
+        "repoUrl": "https://github.com/Affitor/affiliate-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "affitor-affiliate-skills-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from Affitor/affiliate-skills.",
+      "author": "ASM (Affitor/affiliate-skills)",
+      "createdAt": "2026-05-09T08:10:40.686Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "affitor",
+        "affiliate-skills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/ab-test-generator",
+          "description": "Generate A/B test variants for affiliate content. Triggers on: \"create A/B test\", \"test my headline\", \"optimize my CTA\", \"generate variants\", \"split test ideas\", \"improve click-through rate\", \"test my landing page copy\", \"headline alternatives\", \"CTA variations\", \"which version is better\", \"optimize conversions\", \"test my email subject line\", \"compare approaches\".",
+          "version": "1.0"
+        },
+        {
+          "name": "bio-link-deployer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/bio-link-deployer",
+          "description": "Create a Linktree-style bio link hub page as a single self-contained HTML file. Triggers on: \"create a bio link page\", \"make a linktree\", \"link in bio page\", \"bio link\", \"link hub\", \"create my link page\", \"all my links on one page\", \"linktree alternative\", \"build a link page\", \"bio page for my affiliate links\", \"I need a link in bio\", \"make a page with all my links\", \"link aggregator page\".",
+          "version": "1.0"
+        },
+        {
+          "name": "competitor-spy",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/competitor-spy",
+          "description": "Reverse-engineer successful affiliate strategies from competitors. Use this skill when the user asks about spying on competitors, researching what other affiliates promote, analyzing competitor affiliate sites, understanding how top affiliates in a niche make money, or says \"what programs does X promote\", \"how does [site] make money\", \"what affiliate strategy does this site use\", \"spy on competitor affiliates\", \"reverse engineer affiliate site\", \"copy what works in my niche\", \"who are the top affiliates in X niche\", \"what content gets traffic in my niche\", \"competitor affiliate analysis\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-angle-ranker",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/content-angle-ranker",
+          "description": "Rank content angles by engagement data, competition level, and platform fit. Data-driven angle selection instead of guesswork. Use this skill when the user has a keyword or product and needs to decide WHAT to create, which angle to take, which format to use, or which platform to target. Triggers on: \"what angle should I use\", \"rank content ideas for [keyword]\", \"best angle for [product]\", \"which content idea will perform best\", \"help me pick an angle\", \"what should I write about\", \"content angle for [topic]\", \"rank my content ideas\", \"which approach will get the most views\", \"data-driven content planning\", \"angle ranker\", \"content scoring\", \"which hook should I use\", \"compare these content ideas\", \"prioritize my content angles\", \"what video should I make\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-decay-detector",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/content-decay-detector",
+          "description": "Monitor existing content for ranking drops and trigger refresh workflows. Triggers on: \"check for content decay\", \"which content needs updating\", \"content refresh\", \"ranking drops\", \"traffic decline\", \"stale content\", \"content audit\", \"what to refresh\", \"outdated content\", \"content performance check\", \"update old articles\", \"declining rankings\", \"content maintenance\", \"refresh priority list\", \"which articles are losing traffic\", \"SEO content audit\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-moat-calculator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/content-moat-calculator",
+          "description": "Estimate pages needed for topical authority. Go/no-go decision before investing months in content. Triggers on: \"how much content do I need\", \"topical authority estimate\", \"content moat\", \"how many articles\", \"content gap analysis\", \"can I compete in this niche\", \"content investment calculator\", \"is this niche worth the effort\", \"SEO feasibility\", \"how many pages to rank\", \"content volume needed\", \"competitive content analysis\", \"moat calculation\", \"authority gap\", \"should I invest in this niche\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-repurposer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/content-repurposer",
+          "description": "Repurpose one piece of affiliate content into multiple formats. Triggers on: \"repurpose my content\", \"turn my blog into tweets\", \"cross-post this\", \"content recycling\", \"convert to newsletter\", \"make a tweet thread from this\", \"adapt for TikTok\", \"omnichannel content\", \"scale my content\", \"turn this into a LinkedIn post\", \"repurpose for email\", \"content multiplication\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-research-brief",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/content-research-brief",
+          "description": "Research trending topics, collect source articles, and generate a structured research brief for content creation. Stop writing from thin air — write from real sources. Use this skill when the user wants to research a topic before writing, collect sources for an article, create a research-backed content brief, or says \"research [topic] for me\", \"find sources about [keyword]\", \"content brief for [topic]\", \"what's the latest on [product]\", \"research before writing\", \"collect articles about [keyword]\", \"trending news about [topic]\", \"gather sources for my article\", \"brief me on [topic]\", \"what are people saying about [product]\", \"news roundup for [keyword]\", \"research brief\", \"source collection\", \"content research\", \"prep research for writing\".",
+          "version": "1.0"
+        },
+        {
+          "name": "conversion-tracker",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/conversion-tracker",
+          "description": "Set up affiliate conversion tracking with UTM parameters and link tagging. Triggers on: \"set up tracking\", \"create UTM links\", \"track my affiliate links\", \"tracking pixels\", \"click attribution\", \"organize my links\", \"UTM parameters\", \"tag my links\", \"campaign tracking\", \"link tracking setup\", \"prepare for launch\", \"debug attribution\", \"tracking spreadsheet\".",
+          "version": "1.0"
+        },
+        {
+          "name": "email-automation-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/email-automation-builder",
+          "description": "Build multi-sequence email automation flows with branching logic. Triggers on: \"build email automation\", \"create email funnel\", \"email automation flow\", \"welcome series with branches\", \"conditional email sequence\", \"set up automation\", \"email workflow builder\", \"segmented email flow\", \"advanced email sequence\", \"nurture funnel\", \"cart abandonment sequence\", \"win-back email flow\".",
+          "version": "1.0"
+        },
+        {
+          "name": "email-drip-sequence",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/email-drip-sequence",
+          "description": "Write an email drip sequence for affiliate marketing. Triggers on: \"write me an email sequence\", \"create a drip campaign\", \"email nurture sequence\", \"affiliate email funnel\", \"welcome email series\", \"email onboarding sequence\", \"write emails for my list\", \"set up a drip sequence\", \"email campaign for [product]\", \"nurture my subscribers\", \"email follow-up sequence\", \"build my email funnel\", \"write 5 emails promoting [product]\", \"email automation sequence\".",
+          "version": "1.0"
+        },
+        {
+          "name": "funnel-planner",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/funnel-planner",
+          "description": "Plan a complete affiliate funnel from research to revenue. Triggers on: \"plan my affiliate funnel\", \"create a funnel strategy\", \"affiliate business plan\", \"how to start affiliate marketing\", \"full funnel roadmap\", \"plan from scratch\", \"week by week affiliate plan\", \"chain skills together\", \"build my funnel\", \"affiliate marketing roadmap\", \"step by step affiliate plan\", \"onboarding plan\".",
+          "version": "1.0"
+        },
+        {
+          "name": "github-pages-deployer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/github-pages-deployer",
+          "description": "Deploy affiliate content to GitHub Pages for free hosting. Triggers on: \"deploy to GitHub Pages\", \"host on GitHub Pages\", \"free hosting for my affiliate site\", \"push to GitHub Pages\", \"GitHub Pages setup\", \"deploy my landing page to GitHub\", \"host my bio link on GitHub\", \"free affiliate website hosting\", \"github pages affiliate\", \"set up GitHub Pages for my site\", \"deploy HTML to GitHub\", \"free static hosting\", \"publish my affiliate page for free\", \"github pages custom domain\".",
+          "version": "1.0"
+        },
+        {
+          "name": "infographic-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/infographic-generator",
+          "description": "Generate branded infographic specifications from any content or data. Outputs structured layout, copy, data visualization, and color scheme — ready to render as HTML/CSS, Satori, Canva, or any design tool. Use this skill when the user wants an infographic, data visual, social media image, comparison chart, stat card, or says \"create an infographic for [content]\", \"make a visual for my LinkedIn post\", \"design an image for [topic]\", \"stat graphic for [data]\", \"comparison infographic\", \"branded image\", \"social media graphic\", \"infographic for [blog post]\", \"data visualization\", \"visual content\", \"image for my post\", \"LinkedIn carousel image\", \"feature comparison chart\", \"pricing table image\".",
+          "version": "1.0"
+        },
+        {
+          "name": "internal-linking-optimizer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/internal-linking-optimizer",
+          "description": "Analyze site's internal link structure and optimize for hub-and-spoke SEO architecture. Triggers on: \"optimize internal links\", \"internal linking\", \"link structure\", \"hub and spoke links\", \"orphan pages\", \"link equity\", \"internal link audit\", \"fix my internal links\", \"link architecture\", \"site structure optimization\", \"internal linking strategy\", \"link flow\", \"improve site structure\", \"find orphan pages\", \"maximize link equity\", \"internal link map\".",
+          "version": "1.0"
+        },
+        {
+          "name": "landing-page-creator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/landing-page-creator",
+          "description": "Build high-converting affiliate landing pages as single self-contained HTML files. Triggers on: \"create a landing page for\", \"build a landing page\", \"product landing page\", \"affiliate landing page\", \"comparison page for\", \"vs page\", \"single product page\", \"conversion page\", \"sales page for affiliate\", \"landing page HTML\", \"build me a page for\", \"create a page to promote [product]\", \"I need a landing page\", \"make a page for [product]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "list-affitor-skill",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/list-affitor-skill",
+          "description": "Turn a repeatable AI prompt or workflow into a structured, publish-ready skill for list.affitor.com. Use this skill when the user wants to create a new skill, write a SKILL.md, convert a prompt to a skill, publish a skill to the directory, or document an AI workflow. Also trigger for: \"create a skill\", \"write a skill\", \"make this a skill\", \"turn this into a skill\", \"publish skill\", \"add skill to list\", \"write SKILL.md\", \"skill from prompt\", \"document this workflow\", \"package this as a skill\".",
+          "version": "1.0"
+        },
+        {
+          "name": "monopoly-niche-finder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/monopoly-niche-finder",
+          "description": "Find intersection niches where you're the ONLY voice. Thiel's \"competition is for losers\" lens. Triggers on: \"find my monopoly niche\", \"blue ocean niche\", \"unique niche\", \"niche intersection\", \"where am I the only one\", \"zero competition niche\", \"untapped niche\", \"category of one\", \"Thiel monopoly\", \"dominate a niche\", \"niche nobody else covers\", \"cross two domains\", \"find a niche with no competition\", \"monopoly positioning\", \"unique angle for affiliate\".",
+          "version": "1.0"
+        },
+        {
+          "name": "multi-program-manager",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/multi-program-manager",
+          "description": "Manage and compare multiple affiliate programs as a portfolio. Triggers on: \"manage my affiliate programs\", \"compare my programs\", \"portfolio overview\", \"which program should I focus on\", \"diversify my affiliate income\", \"program switching\", \"affiliate portfolio\", \"program comparison\", \"revenue allocation\", \"which programs to drop\", \"add new programs\", \"affiliate program strategy\".",
+          "version": "1.0"
+        },
+        {
+          "name": "paid-ad-copy-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/paid-ad-copy-writer",
+          "description": "Write paid ad copy for affiliate offers across ad platforms. Triggers on: \"write ad copy\", \"Facebook ad for affiliate\", \"Google Ads copy\", \"TikTok ad script\", \"Pinterest ad\", \"paid traffic to affiliate\", \"create ad campaign\", \"ad headlines\", \"ad descriptions\", \"scale with paid ads\", \"run ads for my affiliate link\", \"write Facebook ad\", \"Google Search ad copy\".",
+          "version": "1.0"
+        },
+        {
+          "name": "performance-report",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/performance-report",
+          "description": "Generate affiliate performance reports with KPIs and recommendations. Triggers on: \"show my affiliate report\", \"how are my programs doing\", \"performance review\", \"earnings report\", \"monthly affiliate report\", \"weekly report\", \"analyze my affiliate earnings\", \"which program is best\", \"EPC report\", \"conversion rate analysis\", \"revenue breakdown\", \"campaign performance\".",
+          "version": "1.0"
+        },
+        {
+          "name": "product-showcase-page",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/product-showcase-page",
+          "description": "Build a single-product deep-dive showcase page as a self-contained HTML file. Triggers on: \"build a product showcase page\", \"deep dive landing page for [product]\", \"create a product spotlight page\", \"product feature page\", \"single product page\", \"detailed page about [product]\", \"build a page showing everything about [product]\", \"create a long-form product page\", \"build a sales page for [product]\", \"product deep dive page\", \"make a feature breakdown page for [product]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "proprietary-data-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/proprietary-data-generator",
+          "description": "Create original surveys, benchmarks, and aggregated data nobody else has. Automate data collection for content moats. Triggers on: \"create original data\", \"proprietary data\", \"survey design\", \"benchmark study\", \"original research\", \"data-driven content\", \"create a survey\", \"industry benchmark\", \"aggregated data\", \"unique data\", \"first-party data\", \"data moat\", \"generate research data\", \"create a study\", \"original statistics\", \"data nobody else has\", \"competitive data advantage\".",
+          "version": "1.0"
+        },
+        {
+          "name": "self-improver",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/self-improver",
+          "description": "Review affiliate campaign results and improve strategy. Triggers on: \"review my results\", \"what went wrong\", \"how to improve conversions\", \"analyze my campaign\", \"affiliate retrospective\", \"why am I not converting\", \"improve my strategy\", \"what should I change\", \"campaign review\", \"optimize my approach\", \"learn from my results\", \"post-mortem on my campaign\".",
+          "version": "1.0"
+        },
+        {
+          "name": "seo-audit",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/seo-audit",
+          "description": "Audit affiliate blog posts and landing pages for SEO issues. Triggers on: \"audit my blog post for SEO\", \"check my SEO\", \"SEO review\", \"improve my rankings\", \"SEO checklist\", \"on-page SEO audit\", \"keyword optimization check\", \"why isn't my page ranking\", \"SEO score\", \"content quality audit\", \"check my meta tags\", \"internal linking audit\", \"quick SEO wins\".",
+          "version": "1.0"
+        },
+        {
+          "name": "skill-finder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/skill-finder",
+          "description": "Find the right Affitor skill for your goal. Triggers on: \"which skill should I use\", \"find me a skill\", \"what skills are available\", \"help me choose a skill\", \"skill for SEO\", \"skill for email\", \"explore skills\", \"I'm new to Affitor\", \"what can Affitor do\", \"search skills\", \"skill for blog writing\", \"skill for landing pages\", \"skill for analytics\".",
+          "version": "1.0"
+        },
+        {
+          "name": "squeeze-page-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/squeeze-page-builder",
+          "description": "Build email capture landing pages (squeeze pages) as single self-contained HTML files. Triggers on: \"build a squeeze page\", \"email capture page\", \"lead magnet page\", \"create an opt-in page\", \"build an email list page\", \"lead capture landing page\", \"create a freebie page\", \"build a page to collect emails\", \"opt-in landing page\", \"email signup page for [product/niche]\", \"create a lead magnet landing page\", \"build a page that captures emails before sending to affiliate offer\".",
+          "version": "1.0"
+        },
+        {
+          "name": "traffic-analyzer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/traffic-analyzer",
+          "description": "Analyze website traffic, global rank, engagement metrics, and traffic sources for any domain. Use this skill to evaluate affiliate program websites, compare competitor traffic, assess advertiser strength, or understand where an audience comes from. Triggers on: \"analyze traffic for [domain]\", \"how much traffic does [site] get\", \"compare traffic between [site A] and [site B]\", \"is [program] worth promoting based on traffic\", \"traffic analysis\", \"website analytics for [domain]\", \"where does [site] get traffic\", \"check if [advertiser] is legit\", \"evaluate [program] website health\", \"SimilarWeb analysis\", \"traffic sources for [domain]\", \"how popular is [site]\", \"website rank\", \"domain authority check\", \"compare affiliate program websites\".",
+          "version": "1.0"
+        },
+        {
+          "name": "trending-content-scout",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/trending-content-scout",
+          "description": "Scan social platforms for top-performing content by engagement before you create anything. Use this skill when the user wants to see what content is winning in a niche, find viral content patterns, research what's working on YouTube/TikTok/X/Reddit, benchmark engagement, discover content gaps, or says \"what content is working for [topic]\", \"show me top performing content about [keyword]\", \"what's trending in [niche]\", \"find viral content about [product]\", \"content research for [keyword]\", \"what gets views in [niche]\", \"engagement analysis for [topic]\", \"scout the competition\", \"what videos are getting the most views about [keyword]\", \"social listening for [topic]\", \"trending content in [niche]\", \"top content analysis\", \"what hooks work for [keyword]\", \"content intelligence\", \"find winning formats\".",
+          "version": "1.0"
+        },
+        {
+          "name": "value-ladder-architect",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/value-ladder-architect",
+          "description": "Design the complete free-to-premium value ladder for affiliate promotions. Triggers on: \"value ladder\", \"customer journey\", \"upsell path\", \"ascension model\", \"free to paid funnel\", \"tripwire offer\", \"upsell strategy\", \"downsell\", \"product ladder\", \"price ladder\", \"customer ascension\", \"funnel architecture\", \"map my funnel\", \"design my funnel stages\", \"monetization path\".",
+          "version": "1.0"
+        },
+        {
+          "name": "webinar-registration-page",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/webinar-registration-page",
+          "description": "Build a webinar or live event registration page as a self-contained HTML file with countdown timer, speaker bio, agenda, and registration form. Triggers on: \"build a webinar registration page\", \"create a webinar sign-up page\", \"event registration landing page\", \"live training registration page\", \"workshop sign-up page\", \"create a webinar page\", \"build an event page\", \"free webinar landing page\", \"live demo registration page\", \"online event page\", \"create a registration page for my webinar\", \"build a training event page\".",
+          "version": "1.0"
+        },
+        {
+          "name": "your-skill-name",
+          "installUrl": "github:Affitor/affiliate-skills:template",
+          "description": "Replace with when the AI should activate this skill. Be pushy — cover multiple phrasings so the AI activates for a wide range of user prompts.",
+          "version": "1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Affitor",
+        "repo": "affiliate-skills",
+        "repoUrl": "https://github.com/Affitor/affiliate-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "affitor-affiliate-skills-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from Affitor/affiliate-skills.",
+      "author": "ASM (Affitor/affiliate-skills)",
+      "createdAt": "2026-05-09T08:10:40.686Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "affitor",
+        "affiliate-skills"
+      ],
+      "skills": [
+        {
+          "name": "affiliate-blog-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/affiliate-blog-builder",
+          "description": "Write SEO-optimized affiliate blog articles, product reviews, comparison posts, listicles, and how-to guides. Triggers on: \"write a blog post about\", \"review of [product]\", \"best [category] article\", \"comparison blog\", \"affiliate blog\", \"SEO article\", \"write a review\", \"product roundup\", \"blog content for affiliate\", \"how to use [product] blog post\", \"listicle about [category]\", \"[product] vs [product] blog\", \"content for my affiliate site\".",
+          "version": "1.0"
+        },
+        {
+          "name": "affiliate-program-search",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/affiliate-program-search",
+          "description": "Research and evaluate affiliate programs to find the best ones to promote. Use this skill when the user asks anything about finding affiliate programs, comparing commission rates, evaluating affiliate opportunities, searching for products to promote, picking a niche, or mentions list.affitor.com. Also trigger for: \"which SaaS should I promote\", \"best affiliate programs for X\", \"high commission programs\", \"recurring commission affiliate\", \"compare these affiliate programs\", \"is X affiliate program worth it\", \"find me something to promote\", \"what pays the most\", \"affiliate programs with long cookie duration\".",
+          "version": "1.0"
+        },
+        {
+          "name": "category-designer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/category-designer",
+          "description": "Define a new category where your product wins by default. Reframe the buying decision. Triggers on: \"create a category\", \"category design\", \"define my category\", \"category of one\", \"reframe the market\", \"position as category king\", \"new category\", \"category creation\", \"own a category\", \"category strategy\", \"competitive positioning\", \"strategic positioning\", \"market reframing\", \"be the only option\", \"change the buying criteria\", \"category king\".",
+          "version": "1.0"
+        },
+        {
+          "name": "commission-calculator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/commission-calculator",
+          "description": "Calculate realistic affiliate earnings projections before committing to a program. Use this skill when the user asks about affiliate earnings, projecting income, calculating commissions, estimating how much they can make, comparing program payouts, or says \"how much can I make promoting X\", \"calculate my affiliate income\", \"is this commission worth it\", \"how long to first $1000\", \"compare earnings between programs\", \"traffic to income calculator\", \"what conversion rate should I expect\", \"earnings estimate for affiliate program\", \"how many sales do I need\".",
+          "version": "1.0"
+        },
+        {
+          "name": "comparison-post-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/comparison-post-writer",
+          "description": "Write \"X vs Y\" comparison blog posts that help readers choose between two competing products. Triggers on: \"write a comparison post\", \"X vs Y blog post\", \"compare [product A] and [product B]\", \"which is better [A] or [B]\", \"head to head comparison\", \"[product] vs [product] article\", \"comparison review\", \"write a versus article\", \"side by side comparison blog\", \"which should I choose [A] or [B]\", \"compare these two products for my blog\".",
+          "version": "1.0"
+        },
+        {
+          "name": "competitor-spy",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/competitor-spy",
+          "description": "Reverse-engineer successful affiliate strategies from competitors. Use this skill when the user asks about spying on competitors, researching what other affiliates promote, analyzing competitor affiliate sites, understanding how top affiliates in a niche make money, or says \"what programs does X promote\", \"how does [site] make money\", \"what affiliate strategy does this site use\", \"spy on competitor affiliates\", \"reverse engineer affiliate site\", \"copy what works in my niche\", \"who are the top affiliates in X niche\", \"what content gets traffic in my niche\", \"competitor affiliate analysis\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-angle-ranker",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/content-angle-ranker",
+          "description": "Rank content angles by engagement data, competition level, and platform fit. Data-driven angle selection instead of guesswork. Use this skill when the user has a keyword or product and needs to decide WHAT to create, which angle to take, which format to use, or which platform to target. Triggers on: \"what angle should I use\", \"rank content ideas for [keyword]\", \"best angle for [product]\", \"which content idea will perform best\", \"help me pick an angle\", \"what should I write about\", \"content angle for [topic]\", \"rank my content ideas\", \"which approach will get the most views\", \"data-driven content planning\", \"angle ranker\", \"content scoring\", \"which hook should I use\", \"compare these content ideas\", \"prioritize my content angles\", \"what video should I make\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-pillar-atomizer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/content-pillar-atomizer",
+          "description": "Take 1 blog post or article and generate 15-30 platform-native micro-content pieces. Not reformatting — re-contextualizing for each platform's culture. Triggers on: \"atomize this content\", \"repurpose my blog post\", \"turn this into social posts\", \"content atomizer\", \"pillar content\", \"one to many content\", \"repurpose content\", \"multiply my content\", \"content explosion\", \"turn article into posts\", \"break down this article\", \"micro content from blog\", \"content pillar strategy\", \"10x my content\", \"platform-native content\", \"atomize\", \"content multiplication\".",
+          "version": "1.0"
+        },
+        {
+          "name": "content-research-brief",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/content-research-brief",
+          "description": "Research trending topics, collect source articles, and generate a structured research brief for content creation. Stop writing from thin air — write from real sources. Use this skill when the user wants to research a topic before writing, collect sources for an article, create a research-backed content brief, or says \"research [topic] for me\", \"find sources about [keyword]\", \"content brief for [topic]\", \"what's the latest on [product]\", \"research before writing\", \"collect articles about [keyword]\", \"trending news about [topic]\", \"gather sources for my article\", \"brief me on [topic]\", \"what are people saying about [product]\", \"news roundup for [keyword]\", \"research brief\", \"source collection\", \"content research\", \"prep research for writing\".",
+          "version": "1.0"
+        },
+        {
+          "name": "email-drip-sequence",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/email-drip-sequence",
+          "description": "Write an email drip sequence for affiliate marketing. Triggers on: \"write me an email sequence\", \"create a drip campaign\", \"email nurture sequence\", \"affiliate email funnel\", \"welcome email series\", \"email onboarding sequence\", \"write emails for my list\", \"set up a drip sequence\", \"email campaign for [product]\", \"nurture my subscribers\", \"email follow-up sequence\", \"build my email funnel\", \"write 5 emails promoting [product]\", \"email automation sequence\".",
+          "version": "1.0"
+        },
+        {
+          "name": "funnel-planner",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/funnel-planner",
+          "description": "Plan a complete affiliate funnel from research to revenue. Triggers on: \"plan my affiliate funnel\", \"create a funnel strategy\", \"affiliate business plan\", \"how to start affiliate marketing\", \"full funnel roadmap\", \"plan from scratch\", \"week by week affiliate plan\", \"chain skills together\", \"build my funnel\", \"affiliate marketing roadmap\", \"step by step affiliate plan\", \"onboarding plan\".",
+          "version": "1.0"
+        },
+        {
+          "name": "guarantee-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/guarantee-generator",
+          "description": "Create YOUR personal guarantee on top of the product's guarantee for risk reversal. Triggers on: \"create a guarantee\", \"guarantee for my affiliate\", \"risk reversal\", \"money back guarantee\", \"what guarantee can I offer\", \"reduce buyer risk\", \"guarantee copy\", \"how to guarantee\", \"affiliate guarantee\", \"personal guarantee\", \"risk-free offer\", \"satisfaction guarantee\", \"results guarantee\".",
+          "version": "1.0"
+        },
+        {
+          "name": "how-to-tutorial-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/how-to-tutorial-writer",
+          "description": "Write how-to guides and tutorials that naturally integrate affiliate product recommendations. Triggers on: \"write a how-to guide\", \"tutorial for [task]\", \"step by step guide to [goal]\", \"how to [verb] with [product]\", \"write a tutorial blog post\", \"guide on how to [task]\", \"beginner guide to [topic]\", \"walkthrough for [product]\", \"write an educational article\", \"how do I [task] blog post\", \"write a tutorial that promotes [product]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "internal-linking-optimizer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/analytics/internal-linking-optimizer",
+          "description": "Analyze site's internal link structure and optimize for hub-and-spoke SEO architecture. Triggers on: \"optimize internal links\", \"internal linking\", \"link structure\", \"hub and spoke links\", \"orphan pages\", \"link equity\", \"internal link audit\", \"fix my internal links\", \"link architecture\", \"site structure optimization\", \"internal linking strategy\", \"link flow\", \"improve site structure\", \"find orphan pages\", \"maximize link equity\", \"internal link map\".",
+          "version": "1.0"
+        },
+        {
+          "name": "keyword-cluster-architect",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/keyword-cluster-architect",
+          "description": "Map 50-200+ keywords into topical clusters for SEO domination. Build content roadmaps for topical authority. Triggers on: \"keyword research\", \"keyword clustering\", \"topical authority\", \"keyword map\", \"keyword strategy\", \"content roadmap for SEO\", \"keyword grouping\", \"topic clusters\", \"SEO keyword plan\", \"map my keywords\", \"keyword cluster\", \"hub and spoke content\", \"build topical authority\", \"SEO content plan\", \"keyword universe\".",
+          "version": "1.0"
+        },
+        {
+          "name": "landing-page-creator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/landing-page-creator",
+          "description": "Build high-converting affiliate landing pages as single self-contained HTML files. Triggers on: \"create a landing page for\", \"build a landing page\", \"product landing page\", \"affiliate landing page\", \"comparison page for\", \"vs page\", \"single product page\", \"conversion page\", \"sales page for affiliate\", \"landing page HTML\", \"build me a page for\", \"create a page to promote [product]\", \"I need a landing page\", \"make a page for [product]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "listicle-generator",
+          "installUrl": "github:Affitor/affiliate-skills:skills/blog/listicle-generator",
+          "description": "Write \"Top N best...\" listicle articles for affiliate marketing with mini-reviews, pricing, pros/cons, and CTAs per entry. Triggers on: \"write a best of list\", \"top 10 [category] tools\", \"best [product category] article\", \"roundup post\", \"listicle about [category]\", \"write a top tools article\", \"best [N] alternatives to [product]\", \"product roundup\", \"write a tools comparison list\", \"best software for [use case]\", \"top picks for [category]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "multi-program-manager",
+          "installUrl": "github:Affitor/affiliate-skills:skills/automation/multi-program-manager",
+          "description": "Manage and compare multiple affiliate programs as a portfolio. Triggers on: \"manage my affiliate programs\", \"compare my programs\", \"portfolio overview\", \"which program should I focus on\", \"diversify my affiliate income\", \"program switching\", \"affiliate portfolio\", \"program comparison\", \"revenue allocation\", \"which programs to drop\", \"add new programs\", \"affiliate program strategy\".",
+          "version": "1.0"
+        },
+        {
+          "name": "niche-opportunity-finder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/niche-opportunity-finder",
+          "description": "Find untapped affiliate niches with real earning potential. Use this skill when the user asks about picking a niche, finding a niche to start affiliate marketing, what niche to get into, niche research, niche ideas, beginner niche selection, low competition niches, profitable niches, or says \"I don't know what to promote\", \"help me pick a niche\", \"what niche should I start with\", \"find me a niche with less competition\", \"niche ideas for affiliate\", \"is X a good niche for affiliate marketing\", \"best niches 2024\", \"untapped niches\".",
+          "version": "1.0"
+        },
+        {
+          "name": "product-showcase-page",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/product-showcase-page",
+          "description": "Build a single-product deep-dive showcase page as a self-contained HTML file. Triggers on: \"build a product showcase page\", \"deep dive landing page for [product]\", \"create a product spotlight page\", \"product feature page\", \"single product page\", \"detailed page about [product]\", \"build a page showing everything about [product]\", \"create a long-form product page\", \"build a sales page for [product]\", \"product deep dive page\", \"make a feature breakdown page for [product]\".",
+          "version": "1.0"
+        },
+        {
+          "name": "purple-cow-audit",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/purple-cow-audit",
+          "description": "Score product remarkability 1-10 to decide if it's worth promoting. Seth Godin's Purple Cow test. Triggers on: \"is this product worth promoting\", \"should I promote\", \"product audit\", \"purple cow\", \"remarkable product\", \"is it remarkable\", \"rate this product\", \"product quality check\", \"worth my reputation\", \"product evaluation\", \"would I recommend without commission\", \"product remarkability score\", \"evaluate this affiliate product\", \"quality gate for promotion\".",
+          "version": "1.0"
+        },
+        {
+          "name": "reddit-post-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/reddit-post-writer",
+          "description": "Write Reddit posts and comments that recommend affiliate products without getting banned or flagged as spam. Subreddit-native content that adds value first. Use this skill when the user asks about Reddit posts for affiliate marketing, writing Reddit comments that mention products, how to promote affiliate links on Reddit, or says \"write a Reddit post for X\", \"how to mention affiliate on Reddit\", \"Reddit comment promoting product\", \"Reddit-friendly affiliate content\", \"post for r/[subreddit] about X\", \"share affiliate link on Reddit without getting banned\", \"genuine Reddit recommendation\", \"organic Reddit affiliate post\", \"Reddit thread idea for product\".",
+          "version": "1.0"
+        },
+        {
+          "name": "self-improver",
+          "installUrl": "github:Affitor/affiliate-skills:skills/meta/self-improver",
+          "description": "Review affiliate campaign results and improve strategy. Triggers on: \"review my results\", \"what went wrong\", \"how to improve conversions\", \"analyze my campaign\", \"affiliate retrospective\", \"why am I not converting\", \"improve my strategy\", \"what should I change\", \"campaign review\", \"optimize my approach\", \"learn from my results\", \"post-mortem on my campaign\".",
+          "version": "1.0"
+        },
+        {
+          "name": "social-media-scheduler",
+          "installUrl": "github:Affitor/affiliate-skills:skills/distribution/social-media-scheduler",
+          "description": "Create a 30-day social media content calendar for affiliate marketing. Triggers on: \"create a social media calendar\", \"30-day content plan\", \"social media schedule\", \"content calendar for [product]\", \"plan my social posts\", \"social media strategy\", \"schedule my affiliate posts\", \"content plan for LinkedIn\", \"30 days of content\", \"social posting schedule\", \"what should I post this month\", \"write my social content\", \"create posts for LinkedIn X Facebook\", \"affiliate content calendar\", \"social media plan for my affiliate program\".",
+          "version": "1.0"
+        },
+        {
+          "name": "squeeze-page-builder",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/squeeze-page-builder",
+          "description": "Build email capture landing pages (squeeze pages) as single self-contained HTML files. Triggers on: \"build a squeeze page\", \"email capture page\", \"lead magnet page\", \"create an opt-in page\", \"build an email list page\", \"lead capture landing page\", \"create a freebie page\", \"build a page to collect emails\", \"opt-in landing page\", \"email signup page for [product/niche]\", \"create a lead magnet landing page\", \"build a page that captures emails before sending to affiliate offer\".",
+          "version": "1.0"
+        },
+        {
+          "name": "tiktok-script-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/tiktok-script-writer",
+          "description": "Write short-form video scripts for TikTok, Instagram Reels, and YouTube Shorts that promote affiliate products with strong hooks, demos, and CTAs. Use this skill when the user asks about TikTok scripts, Reels scripts, Shorts scripts, short-form video for affiliate marketing, or says \"write a TikTok for X\", \"script a Reel promoting X\", \"YouTube Shorts script affiliate\", \"60-second video script\", \"hook for TikTok affiliate\", \"write a video promoting X\", \"TikTok script that converts\", \"short video script for product review\", \"viral TikTok affiliate script\", \"how to promote X on TikTok\".",
+          "version": "1.0"
+        },
+        {
+          "name": "traffic-analyzer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/traffic-analyzer",
+          "description": "Analyze website traffic, global rank, engagement metrics, and traffic sources for any domain. Use this skill to evaluate affiliate program websites, compare competitor traffic, assess advertiser strength, or understand where an audience comes from. Triggers on: \"analyze traffic for [domain]\", \"how much traffic does [site] get\", \"compare traffic between [site A] and [site B]\", \"is [program] worth promoting based on traffic\", \"traffic analysis\", \"website analytics for [domain]\", \"where does [site] get traffic\", \"check if [advertiser] is legit\", \"evaluate [program] website health\", \"SimilarWeb analysis\", \"traffic sources for [domain]\", \"how popular is [site]\", \"website rank\", \"domain authority check\", \"compare affiliate program websites\".",
+          "version": "1.0"
+        },
+        {
+          "name": "trending-content-scout",
+          "installUrl": "github:Affitor/affiliate-skills:skills/research/trending-content-scout",
+          "description": "Scan social platforms for top-performing content by engagement before you create anything. Use this skill when the user wants to see what content is winning in a niche, find viral content patterns, research what's working on YouTube/TikTok/X/Reddit, benchmark engagement, discover content gaps, or says \"what content is working for [topic]\", \"show me top performing content about [keyword]\", \"what's trending in [niche]\", \"find viral content about [product]\", \"content research for [keyword]\", \"what gets views in [niche]\", \"engagement analysis for [topic]\", \"scout the competition\", \"what videos are getting the most views about [keyword]\", \"social listening for [topic]\", \"trending content in [niche]\", \"top content analysis\", \"what hooks work for [keyword]\", \"content intelligence\", \"find winning formats\".",
+          "version": "1.0"
+        },
+        {
+          "name": "twitter-thread-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/twitter-thread-writer",
+          "description": "Write X/Twitter threads that get bookmarked, shared, and drive affiliate clicks. Use this skill when the user asks about writing Twitter threads, X threads, tweet threads for affiliate marketing, or says \"write a thread about X\", \"Twitter thread promoting X\", \"X thread for affiliate\", \"write tweets that go viral\", \"thread that sells without selling\", \"educational thread with affiliate CTA\", \"Twitter content for affiliate marketing\", \"how to promote X on Twitter\", \"write a thread my audience will bookmark\", \"tweet storm about affiliate product\".",
+          "version": "1.0"
+        },
+        {
+          "name": "value-ladder-architect",
+          "installUrl": "github:Affitor/affiliate-skills:skills/landing/value-ladder-architect",
+          "description": "Design the complete free-to-premium value ladder for affiliate promotions. Triggers on: \"value ladder\", \"customer journey\", \"upsell path\", \"ascension model\", \"free to paid funnel\", \"tripwire offer\", \"upsell strategy\", \"downsell\", \"product ladder\", \"price ladder\", \"customer ascension\", \"funnel architecture\", \"map my funnel\", \"design my funnel stages\", \"monetization path\".",
+          "version": "1.0"
+        },
+        {
+          "name": "viral-post-writer",
+          "installUrl": "github:Affitor/affiliate-skills:skills/content/viral-post-writer",
+          "description": "Write viral social media posts that promote affiliate products naturally. Use this skill when the user asks anything about writing social media content for affiliate marketing, creating posts for LinkedIn/X/Reddit/Facebook, promoting a product on social media, writing affiliate content, or mentions \"viral post\", \"social media post\", \"content for affiliate\". Also trigger for: \"write a post about X\", \"help me promote X on LinkedIn\", \"create a thread about X\", \"make a Reddit post for X\", \"draft tweets for X\", \"social media content for affiliate program\", \"how to promote X on social\", \"write something that goes viral\", \"LinkedIn post for affiliate\", \"X thread about this tool\", \"help me sell X naturally on social media\".",
+          "version": "1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Affitor",
+        "repo": "affiliate-skills",
+        "repoUrl": "https://github.com/Affitor/affiliate-skills.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/Eronred_aso-skills.json
+++ b/data/skill-index/Eronred_aso-skills.json
@@ -5485,5 +5485,1249 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "eronred-aso-skills-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from Eronred/aso-skills.",
+      "author": "ASM (Eronred/aso-skills)",
+      "createdAt": "2026-05-09T08:10:44.397Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "eronred",
+        "aso-skills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-store-listing",
+          "installUrl": "github:Eronred/aso-skills:skills/ab-test-store-listing",
+          "description": "When the user wants to A/B test App Store product page elements to improve conversion rate. Also use when the user mentions \"A/B test\", \"product page optimization\", \"test my screenshots\", \"test my icon\", \"conversion rate optimization\", \"CPP\", or \"custom product pages\". For screenshot design, see screenshot-optimization. For metadata optimization, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "android-aso",
+          "installUrl": "github:Eronred/aso-skills:skills/android-aso",
+          "description": "When the user wants to optimize their Google Play Store listing — title, short description, full description, keywords, ratings, or Play Store-specific features. Use when the user mentions \"Google Play\", \"Android\", \"Play Store\", \"Play Console\", \"short description\", \"full description indexed\", \"Google Play ASO\", or wants Google Play-specific keyword, creative, or ratings strategy. For iOS App Store optimization, see aso-audit and metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-analytics",
+          "installUrl": "github:Eronred/aso-skills:skills/app-analytics",
+          "description": "When the user wants to set up, interpret, or improve their app analytics and tracking. Also use when the user mentions \"analytics\", \"tracking\", \"metrics\", \"KPIs\", \"App Store Connect analytics\", \"install tracking\", \"funnel\", \"attribution\", or \"how is my app performing\". For A/B testing, see ab-test-store-listing. For retention metrics, see retention-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-clips",
+          "installUrl": "github:Eronred/aso-skills:skills/app-clips",
+          "description": "When the user wants to implement, optimize, or use App Clips for app discovery and conversion. Use when the user mentions \"App Clip\", \"app clip code\", \"mini app\", \"instant app\", \"App Clip card\", \"App Clip link\", \"no download required\", \"instant experience\", or wants to understand how App Clips appear in App Store search. For general App Store discoverability, see aso-audit. For marketing campaigns, see ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-icon-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/app-icon-optimization",
+          "description": "When the user wants to design, test, or improve their app icon to increase tap-through rate and conversions in App Store search and browse. Use when the user mentions \"app icon\", \"icon design\", \"icon A/B test\", \"icon variants\", \"tap-through rate\", \"icon conversion\", \"icon refresh\", or wants to know what makes a good app icon. For screenshot optimization, see screenshot-optimization. For full listing A/B tests, see ab-test-store-listing.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-launch",
+          "installUrl": "github:Eronred/aso-skills:skills/app-launch",
+          "description": "When the user wants to plan a launch strategy for a new app or major update. Also use when the user mentions \"app launch\", \"launch plan\", \"launch checklist\", \"pre-launch\", \"launch day\", or \"how to launch my app\". For ongoing ASO after launch, see aso-audit. For paid acquisition during launch, see ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-marketing-context",
+          "installUrl": "github:Eronred/aso-skills:skills/app-marketing-context",
+          "description": "When the user wants to create or update their app marketing context document. Also use when the user mentions \"app context\", \"marketing brief\", \"app positioning\", or when starting any ASO or app marketing project. This is the foundation skill — all other skills check for this context first.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-preview-video",
+          "installUrl": "github:Eronred/aso-skills:skills/app-preview-video",
+          "description": "When the user wants to plan, script, produce, or optimize App Store Preview videos or Google Play promo videos — the autoplay videos that show in App Store/Play Store search and product pages. Use when the user mentions \"App Preview\", \"preview video\", \"app store video\", \"promo video\", \"Play Store video\", \"video poster frame\", \"YouTube promo for Play Store\", \"30 second app video\", \"video script\", \"video specs\", or \"should I add a preview video\". For static screenshots, see screenshot-optimization. For A/B testing the video, see ab-test-store-listing. For broader creative briefs, see screenshot-optimization (covers stills).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-rejection-recovery",
+          "installUrl": "github:Eronred/aso-skills:skills/app-rejection-recovery",
+          "description": "When the user's app or update was rejected by Apple App Review or Google Play Review and they need to diagnose why, fix it, and resubmit fast. Use when the user mentions \"app rejected\", \"App Review rejection\", \"guideline violation\", \"Apple rejected my app\", \"Google Play rejected\", \"Play policy violation\", \"Resolution Center\", \"metadata rejection\", \"binary rejection\", \"guideline 2.1\", \"guideline 4.3\", \"guideline 5.1.1\", \"Sign in with Apple required\", \"Apple ID rejection\", \"Play Store suspension\", \"appeal\", \"I need to respond to App Review\", or \"expedited review\". For pre-submission listing health, see aso-audit. For metadata-only fixes, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-store-featured",
+          "installUrl": "github:Eronred/aso-skills:skills/app-store-featured",
+          "description": "When the user wants to get featured on the App Store or understand the editorial process. Also use when the user mentions \"get featured\", \"App Store editorial\", \"App of the Day\", \"Today tab\", \"Apple featuring\", or \"how to get Apple to feature my app\". For launch strategy, see app-launch. For ASO optimization, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "apple-search-ads",
+          "installUrl": "github:Eronred/aso-skills:skills/apple-search-ads",
+          "description": "When the user wants to set up, optimize, or scale Apple Search Ads (ASA) campaigns — including keyword bidding, match types, campaign structure, Creative Product Sets, CPP routing, and ROAS optimization. Use when the user mentions \"Apple Search Ads\", \"ASA\", \"Search Ads\", \"Search tab ads\", \"Today tab ads\", \"CPT\", \"TTR\", \"Search Match\", \"exact match\", \"broad match\", \"CPP in ads\", \"ASA bidding\", or \"Search Ads budget\". For Meta/Google UAC/TikTok paid UA, see ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "asc-metrics",
+          "installUrl": "github:Eronred/aso-skills:skills/asc-metrics",
+          "description": "When the user wants to analyze their own app's actual performance data from App Store Connect — real downloads, revenue, IAP, subscriptions, trials, or country breakdowns synced via Appeeky Connect. Use when the user asks about \"my downloads\", \"my revenue\", \"how is my app performing\", \"ASC data\", \"sales and trends\", \"my subscription numbers\", \"App Store Connect metrics\", or wants to compare periods or top markets. For third-party app estimates, see app-analytics. For subscription analytics depth, see monetization-strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "aso-audit",
+          "installUrl": "github:Eronred/aso-skills:skills/aso-audit",
+          "description": "When the user wants a full ASO health audit, review their App Store listing quality, or diagnose why their app isn't ranking. Also use when the user mentions \"ASO audit\", \"ASO score\", \"why am I not ranking\", \"listing review\", or \"optimize my app store page\". For keyword-specific research, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "aso-router",
+          "installUrl": "github:Eronred/aso-skills:skills/aso-router",
+          "description": "Single entry point that routes any ASO, App Store, Google Play, app marketing, paid UA, monetization, retention, reviews, ratings, market-intel, or app-analytics question to the correct specialist skill in this library. Use FIRST whenever the user mentions an app, App Store, Play Store, keywords, ranking, downloads, revenue, subscriptions, screenshots, icon, reviews, competitors, charts, in-app events, launch, press, or ads — but the right specialized skill is not obvious. Triggers: \"/aso-skill\", \"/aso\", \"aso help\", \"help me with my app\", \"I need ASO\", \"which skill should I use\", or any ambiguous app-marketing request. Skip this router only when the user explicitly invokes a specific skill (e.g. /aso-audit, /keyword-research).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "attribution-setup",
+          "installUrl": "github:Eronred/aso-skills:skills/attribution-setup",
+          "description": "When the user wants to set up, debug, or interpret app install attribution — including SKAdNetwork (SKAN), Apple's AdAttributionKit, Google Play Install Referrer, MMPs (AppsFlyer, Adjust, Singular, Branch, Kochava), deep links, deferred deep links, conversion values, postback windows, or privacy thresholds. Use when the user mentions \"SKAdNetwork\", \"SKAN\", \"SKAN 4\", \"AdAttributionKit\", \"AAK\", \"MMP\", \"AppsFlyer\", \"Adjust\", \"Singular\", \"Branch\", \"attribution\", \"conversion value\", \"postback\", \"Install Referrer\", \"deferred deep link\", \"iOS 14.5\", \"ATT\", \"App Tracking Transparency\", \"IDFA\", or \"I can't measure my ad campaigns\". For paid campaign strategy, see ua-campaign and apple-search-ads. For analytics events, see app-analytics.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "category-positioning",
+          "installUrl": "github:Eronred/aso-skills:skills/category-positioning",
+          "description": "When the user wants to choose, change, or evaluate their App Store / Google Play category and subcategory — including primary vs secondary category trade-offs, chart-rank competitive analysis, category-driven discoverability, and how category choice affects featuring eligibility. Use when the user mentions \"which category\", \"App Store category\", \"primary category\", \"secondary category\", \"change my category\", \"Health & Fitness vs Lifestyle\", \"Productivity vs Utilities\", \"rank higher in a smaller category\", \"category chart\", \"subcategory\", \"Play Store category\", or \"should I switch categories\". For full ASO health beyond category, see aso-audit. For competitor analysis within the chosen category, see competitor-analysis. For chart movements within categories, see market-movers.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitor-analysis",
+          "installUrl": "github:Eronred/aso-skills:skills/competitor-analysis",
+          "description": "When the user wants to analyze competitors' App Store strategy, find keyword gaps, or understand competitive positioning. Also use when the user mentions \"competitor analysis\", \"competitive research\", \"keyword gap\", \"what are my competitors doing\", or \"compare my app to\". For keyword-specific research, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitor-tracking",
+          "installUrl": "github:Eronred/aso-skills:skills/competitor-tracking",
+          "description": "When the user wants to monitor competitor apps on an ongoing basis — tracking metadata changes, keyword shifts, screenshot updates, rating trends, or new features. Use when the user mentions \"competitor monitoring\", \"track competitors\", \"competitor alert\", \"competitor changed their title\", \"watch a competitor app\", \"competitor weekly report\", \"competitive intelligence\", or \"what changed in competitor's listing\". For a one-time deep competitive analysis, see competitor-analysis. For market-wide chart movements, see market-movers.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "crash-analytics",
+          "installUrl": "github:Eronred/aso-skills:skills/crash-analytics",
+          "description": "When the user wants to monitor, triage, or reduce their app's crash rate — including setting up Crashlytics, prioritizing which crashes to fix first, interpreting crash data, and understanding how crashes affect App Store ranking. Use when the user mentions \"crash\", \"crashlytics\", \"crash rate\", \"ANR\", \"app not responding\", \"crash-free sessions\", \"crash-free users\", \"symbolication\", \"stability\", \"firebase crashes\", \"app crashing\", or \"crash report\". For overall analytics setup, see app-analytics.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "creator-ugc-marketing",
+          "installUrl": "github:Eronred/aso-skills:skills/creator-ugc-marketing",
+          "description": "When the user wants to plan, brief, source, or measure organic creator / influencer / UGC marketing for their app — including TikTok creators, Instagram Reels, YouTube Shorts, micro-influencers, paid creator briefs, UGC ad creative for Meta/TikTok, affiliate programs, and seeding strategy. Use when the user mentions \"creators\", \"influencers\", \"TikTok marketing\", \"UGC\", \"user-generated content\", \"creator briefs\", \"creator outreach\", \"influencer marketing\", \"Reels\", \"Shorts\", \"creator gifting\", \"seeding\", \"affiliate\", \"Whop\", \"TikTok Spark Ads\", \"Instagram collab posts\", or \"I want my app to go viral on TikTok\". For paid social ad campaigns (Meta/TikTok ad accounts), see ua-campaign. For PR / press, see press-and-pr. For viral in-app loops, see referral-program.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "custom-product-pages",
+          "installUrl": "github:Eronred/aso-skills:skills/custom-product-pages",
+          "description": "When the user wants to design, deploy, or measure Apple Custom Product Pages (CPP) — the alternate App Store product pages with different screenshots, preview videos, and promo text shown to users coming from specific URLs (typically ad campaigns or social posts). Use when the user mentions \"Custom Product Page\", \"CPP\", \"alternate product page\", \"App Store URL variant\", \"ASA CPP\", \"campaign-specific landing page\", \"product page per audience\", \"App Store Connect CPP\", \"ppoUrl\", \"?cpp=\" parameter, or \"show different screenshots to different ad audiences\". For App Store A/B tests on the default page, see ab-test-store-listing. For paid ad campaigns that route to CPPs, see apple-search-ads or ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "in-app-events",
+          "installUrl": "github:Eronred/aso-skills:skills/in-app-events",
+          "description": "When the user wants to create, plan, or optimize App Store In-App Events — the event cards that appear on the Today tab, search results, and your product page. Use when the user mentions \"in-app event\", \"App Store event\", \"event card\", \"Today tab\", \"live event\", \"challenge\", \"game event\", \"seasonal event card\", or wants visibility beyond organic search. For general ASO, see aso-audit. For seasonal keyword strategy, see seasonal-aso.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "keyword-research",
+          "installUrl": "github:Eronred/aso-skills:skills/keyword-research",
+          "description": "When the user wants to discover, evaluate, or prioritize App Store keywords. Also use when the user mentions \"keyword research\", \"find keywords\", \"search volume\", \"keyword difficulty\", \"keyword ideas\", or \"what keywords should I target\". For implementing keywords into metadata, see metadata-optimization. For auditing current keyword performance, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "localization",
+          "installUrl": "github:Eronred/aso-skills:skills/localization",
+          "description": "When the user wants to localize their App Store listing for international markets. Also use when the user mentions \"localization\", \"translate my app\", \"international markets\", \"expand to new countries\", \"localize metadata\", or \"which countries should I target\". For keyword research in specific markets, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "market-movers",
+          "installUrl": "github:Eronred/aso-skills:skills/market-movers",
+          "description": "When the user wants to track App Store chart rank changes, find top gainers and losers, detect breakout apps entering the top 100, or identify apps dropping out of charts. Also use when the user mentions \"chart movers\", \"rank changes\", \"who's rising\", \"who's falling\", \"new chart entries\", \"top gainers\", or \"market shifts\". For broader market overview, see market-pulse. For competitive keyword analysis, see competitor-analysis.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "market-pulse",
+          "installUrl": "github:Eronred/aso-skills:skills/market-pulse",
+          "description": "When the user wants a comprehensive App Store market overview, daily/weekly market briefing, or combined view of chart movements, trending keywords, featured apps, and new releases. Also use when the user mentions \"market overview\", \"what's happening on the App Store\", \"market briefing\", \"weekly report\", \"market trends\", or \"state of the market\". For chart-specific rank changes only, see market-movers. For keyword trends only, see keyword-research.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "metadata-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/metadata-optimization",
+          "description": "When the user wants to optimize App Store metadata — title, subtitle, keyword field, or description. Also use when the user mentions \"optimize my title\", \"ASO metadata\", \"keyword field\", \"character limits\", \"app description\", or \"write my subtitle\". For keyword discovery, see keyword-research. For full ASO audits, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "monetization-strategy",
+          "installUrl": "github:Eronred/aso-skills:skills/monetization-strategy",
+          "description": "When the user wants to design or optimize their app's monetization — pricing, paywalls, subscriptions, or in-app purchases. Also use when the user mentions \"pricing\", \"paywall\", \"subscription\", \"IAP\", \"how to monetize\", \"revenue optimization\", \"free trial\", or \"conversion to paid\". For retention impact, see retention-optimization. For competitive pricing, see competitor-analysis.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "onboarding-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/onboarding-optimization",
+          "description": "When the user wants to improve their app's onboarding experience, increase activation rate, reduce Day 1 drop-off, or optimize the first-run flow. Use when the user mentions \"onboarding\", \"first-run\", \"activation\", \"tutorial\", \"day 1 retention\", \"new user flow\", \"permission prompts\", \"sign-up conversion\", \"onboarding funnel\", or \"users dropping off early\". For overall retention strategy, see retention-optimization. For paywall placement, see monetization-strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "paywall-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/paywall-optimization",
+          "description": "When the user wants to design, test, or optimize their app's paywall — layout, copy, pricing display, trial offers, plan structure, hard vs soft paywall, paywall placement, or paywall A/B tests. Use when the user mentions \"paywall\", \"paywall design\", \"paywall conversion\", \"trial-to-paid\", \"soft paywall\", \"hard paywall\", \"paywall A/B test\", \"paywall copy\", \"plan picker\", \"annual vs monthly display\", \"best paywall\", \"RevenueCat paywall\", \"Superwall\", \"Adapty\", or \"my paywall isn't converting\". For overall pricing strategy and monetization model choice, see monetization-strategy. For trial nurture, dunning, and churn, see subscription-lifecycle. For where in the onboarding the paywall fires, see onboarding-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "press-and-pr",
+          "installUrl": "github:Eronred/aso-skills:skills/press-and-pr",
+          "description": "When the user wants to get press coverage, media mentions, or editorial features for their app — including writing press releases, pitching journalists, getting on \"best apps\" lists, or building an app press kit. Use when the user mentions \"press\", \"PR\", \"media coverage\", \"TechCrunch\", \"journalist\", \"press release\", \"app press kit\", \"get featured in media\", \"editorial coverage\", \"review from a blogger\", or \"app launch announcement\". For Apple editorial featuring, see app-store-featured. For launch strategy, see app-launch.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "rating-prompt-strategy",
+          "installUrl": "github:Eronred/aso-skills:skills/rating-prompt-strategy",
+          "description": "When the user wants to improve their app's star rating, increase ratings volume, optimize when and how they prompt users for a review, or recover from a bad rating period. Use when the user mentions \"app rating\", \"star rating\", \"review prompt\", \"SKStoreReviewRequest\", \"In-App Review API\", \"ask for review\", \"low rating\", \"rating drop\", \"get more reviews\", or \"recover from 1-star\". For responding to reviews, see review-management. For overall ASO health, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "referral-program",
+          "installUrl": "github:Eronred/aso-skills:skills/referral-program",
+          "description": "When the user wants to design, launch, or optimize an in-app referral / invite / share-to-earn program — including reward structure, mechanics, fraud prevention, deep link setup, and viral coefficient measurement. Use when the user mentions \"referral program\", \"invite a friend\", \"refer and earn\", \"share to earn\", \"viral loop\", \"viral coefficient\", \"K-factor\", \"double-sided rewards\", \"give X get X\", \"referral rewards\", \"invite link\", \"share sheet\", \"Branch referrals\", \"in-app invites\", or \"how to make my app go viral\". For deep link infrastructure that referrals depend on, see attribution-setup. For organic content-driven virality (UGC, creator), see creator-ugc-marketing.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "retention-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/retention-optimization",
+          "description": "When the user wants to reduce churn, improve user engagement, or increase lifetime value. Also use when the user mentions \"retention\", \"churn\", \"users leaving\", \"engagement\", \"DAU/MAU\", \"user activation\", or \"why are users uninstalling\". For onboarding-specific issues, see app-launch. For monetization, see monetization-strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "review-management",
+          "installUrl": "github:Eronred/aso-skills:skills/review-management",
+          "description": "When the user wants to analyze, respond to, or improve their app reviews and ratings. Also use when the user mentions \"reviews\", \"ratings\", \"negative reviews\", \"how to get more reviews\", \"review response\", or \"my rating is dropping\". For broader ASO audit, see aso-audit. For retention issues causing bad reviews, see retention-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "screenshot-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/screenshot-optimization",
+          "description": "When the user wants to design, optimize, or evaluate App Store screenshots and preview videos. Also use when the user mentions \"screenshots\", \"app preview\", \"product page design\", \"screenshot design\", \"creative assets\", or \"what should my screenshots show\". For A/B testing screenshots, see ab-test-store-listing. For full ASO audit, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "seasonal-aso",
+          "installUrl": "github:Eronred/aso-skills:skills/seasonal-aso",
+          "description": "When the user wants to optimize their App Store listing for seasonal events, holidays, or trending moments — including keyword opportunities, metadata updates, screenshot theming, and timing strategy. Use when the user mentions \"seasonal\", \"holiday\", \"Christmas\", \"New Year\", \"Valentine's Day\", \"summer\", \"back to school\", \"seasonal keywords\", \"trending now\", \"limited time\", or wants to capitalize on a calendar event. For general keyword research, see keyword-research. For full metadata rewrites, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "subscription-lifecycle",
+          "installUrl": "github:Eronred/aso-skills:skills/subscription-lifecycle",
+          "description": "When the user wants to optimize their subscription business end-to-end — from trial start through renewal, cancellation, and win-back. Use when the user mentions \"subscription lifecycle\", \"trial conversion\", \"churn\", \"cancellation\", \"win-back\", \"lapsed subscribers\", \"dunning\", \"billing retry\", \"grace period\", \"renewal rate\", \"subscriber LTV\", or \"resubscribe\". For paywall design and pricing strategy, see monetization-strategy. For subscription analytics dashboards, see app-analytics.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ua-campaign",
+          "installUrl": "github:Eronred/aso-skills:skills/ua-campaign",
+          "description": "When the user wants to plan or optimize paid user acquisition campaigns. Also use when the user mentions \"Apple Search Ads\", \"user acquisition\", \"paid ads\", \"UA\", \"ad campaign\", \"install campaign\", \"Facebook ads for apps\", \"TikTok ads\", or \"cost per install\". For organic growth, see aso-audit. For launch-specific UA, see app-launch.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "web-to-app-funnel",
+          "installUrl": "github:Eronred/aso-skills:skills/web-to-app-funnel",
+          "description": "When the user wants to design or optimize the funnel that takes web visitors into installing and onboarding the app — including smart app banners, web-to-app deep links, deferred deep links, web onboarding (Stripe-paid web flow before app install), QR codes, \"open in app\" CTAs, and the trade-off between paying on web vs in-app. Use when the user mentions \"web to app\", \"smart app banner\", \"Stripe before app\", \"web paywall before install\", \"Branch web SDK\", \"web funnel for app\", \"AppsFlyer OneLink web\", \"Universal Links\", \"App Links\", \"QR code to app\", \"open in app\", \"deferred deep link from web\", or \"should I sell on web first then push to app\". For pure in-app onboarding, see onboarding-optimization. For deep link infra, see attribution-setup.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Eronred",
+        "repo": "aso-skills",
+        "repoUrl": "https://github.com/Eronred/aso-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "eronred-aso-skills-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from Eronred/aso-skills.",
+      "author": "ASM (Eronred/aso-skills)",
+      "createdAt": "2026-05-09T08:10:44.397Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "eronred",
+        "aso-skills"
+      ],
+      "skills": [
+        {
+          "name": "aso-audit",
+          "installUrl": "github:Eronred/aso-skills:skills/aso-audit",
+          "description": "When the user wants a full ASO health audit, review their App Store listing quality, or diagnose why their app isn't ranking. Also use when the user mentions \"ASO audit\", \"ASO score\", \"why am I not ranking\", \"listing review\", or \"optimize my app store page\". For keyword-specific research, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitor-analysis",
+          "installUrl": "github:Eronred/aso-skills:skills/competitor-analysis",
+          "description": "When the user wants to analyze competitors' App Store strategy, find keyword gaps, or understand competitive positioning. Also use when the user mentions \"competitor analysis\", \"competitive research\", \"keyword gap\", \"what are my competitors doing\", or \"compare my app to\". For keyword-specific research, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "creator-ugc-marketing",
+          "installUrl": "github:Eronred/aso-skills:skills/creator-ugc-marketing",
+          "description": "When the user wants to plan, brief, source, or measure organic creator / influencer / UGC marketing for their app — including TikTok creators, Instagram Reels, YouTube Shorts, micro-influencers, paid creator briefs, UGC ad creative for Meta/TikTok, affiliate programs, and seeding strategy. Use when the user mentions \"creators\", \"influencers\", \"TikTok marketing\", \"UGC\", \"user-generated content\", \"creator briefs\", \"creator outreach\", \"influencer marketing\", \"Reels\", \"Shorts\", \"creator gifting\", \"seeding\", \"affiliate\", \"Whop\", \"TikTok Spark Ads\", \"Instagram collab posts\", or \"I want my app to go viral on TikTok\". For paid social ad campaigns (Meta/TikTok ad accounts), see ua-campaign. For PR / press, see press-and-pr. For viral in-app loops, see referral-program.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "localization",
+          "installUrl": "github:Eronred/aso-skills:skills/localization",
+          "description": "When the user wants to localize their App Store listing for international markets. Also use when the user mentions \"localization\", \"translate my app\", \"international markets\", \"expand to new countries\", \"localize metadata\", or \"which countries should I target\". For keyword research in specific markets, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "metadata-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/metadata-optimization",
+          "description": "When the user wants to optimize App Store metadata — title, subtitle, keyword field, or description. Also use when the user mentions \"optimize my title\", \"ASO metadata\", \"keyword field\", \"character limits\", \"app description\", or \"write my subtitle\". For keyword discovery, see keyword-research. For full ASO audits, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "paywall-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/paywall-optimization",
+          "description": "When the user wants to design, test, or optimize their app's paywall — layout, copy, pricing display, trial offers, plan structure, hard vs soft paywall, paywall placement, or paywall A/B tests. Use when the user mentions \"paywall\", \"paywall design\", \"paywall conversion\", \"trial-to-paid\", \"soft paywall\", \"hard paywall\", \"paywall A/B test\", \"paywall copy\", \"plan picker\", \"annual vs monthly display\", \"best paywall\", \"RevenueCat paywall\", \"Superwall\", \"Adapty\", or \"my paywall isn't converting\". For overall pricing strategy and monetization model choice, see monetization-strategy. For trial nurture, dunning, and churn, see subscription-lifecycle. For where in the onboarding the paywall fires, see onboarding-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "press-and-pr",
+          "installUrl": "github:Eronred/aso-skills:skills/press-and-pr",
+          "description": "When the user wants to get press coverage, media mentions, or editorial features for their app — including writing press releases, pitching journalists, getting on \"best apps\" lists, or building an app press kit. Use when the user mentions \"press\", \"PR\", \"media coverage\", \"TechCrunch\", \"journalist\", \"press release\", \"app press kit\", \"get featured in media\", \"editorial coverage\", \"review from a blogger\", or \"app launch announcement\". For Apple editorial featuring, see app-store-featured. For launch strategy, see app-launch.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "referral-program",
+          "installUrl": "github:Eronred/aso-skills:skills/referral-program",
+          "description": "When the user wants to design, launch, or optimize an in-app referral / invite / share-to-earn program — including reward structure, mechanics, fraud prevention, deep link setup, and viral coefficient measurement. Use when the user mentions \"referral program\", \"invite a friend\", \"refer and earn\", \"share to earn\", \"viral loop\", \"viral coefficient\", \"K-factor\", \"double-sided rewards\", \"give X get X\", \"referral rewards\", \"invite link\", \"share sheet\", \"Branch referrals\", \"in-app invites\", or \"how to make my app go viral\". For deep link infrastructure that referrals depend on, see attribution-setup. For organic content-driven virality (UGC, creator), see creator-ugc-marketing.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "seasonal-aso",
+          "installUrl": "github:Eronred/aso-skills:skills/seasonal-aso",
+          "description": "When the user wants to optimize their App Store listing for seasonal events, holidays, or trending moments — including keyword opportunities, metadata updates, screenshot theming, and timing strategy. Use when the user mentions \"seasonal\", \"holiday\", \"Christmas\", \"New Year\", \"Valentine's Day\", \"summer\", \"back to school\", \"seasonal keywords\", \"trending now\", \"limited time\", or wants to capitalize on a calendar event. For general keyword research, see keyword-research. For full metadata rewrites, see metadata-optimization.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Eronred",
+        "repo": "aso-skills",
+        "repoUrl": "https://github.com/Eronred/aso-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "eronred-aso-skills-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from Eronred/aso-skills.",
+      "author": "ASM (Eronred/aso-skills)",
+      "createdAt": "2026-05-09T08:10:44.397Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "eronred",
+        "aso-skills"
+      ],
+      "skills": [
+        {
+          "name": "app-preview-video",
+          "installUrl": "github:Eronred/aso-skills:skills/app-preview-video",
+          "description": "When the user wants to plan, script, produce, or optimize App Store Preview videos or Google Play promo videos — the autoplay videos that show in App Store/Play Store search and product pages. Use when the user mentions \"App Preview\", \"preview video\", \"app store video\", \"promo video\", \"Play Store video\", \"video poster frame\", \"YouTube promo for Play Store\", \"30 second app video\", \"video script\", \"video specs\", or \"should I add a preview video\". For static screenshots, see screenshot-optimization. For A/B testing the video, see ab-test-store-listing. For broader creative briefs, see screenshot-optimization (covers stills).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-rejection-recovery",
+          "installUrl": "github:Eronred/aso-skills:skills/app-rejection-recovery",
+          "description": "When the user's app or update was rejected by Apple App Review or Google Play Review and they need to diagnose why, fix it, and resubmit fast. Use when the user mentions \"app rejected\", \"App Review rejection\", \"guideline violation\", \"Apple rejected my app\", \"Google Play rejected\", \"Play policy violation\", \"Resolution Center\", \"metadata rejection\", \"binary rejection\", \"guideline 2.1\", \"guideline 4.3\", \"guideline 5.1.1\", \"Sign in with Apple required\", \"Apple ID rejection\", \"Play Store suspension\", \"appeal\", \"I need to respond to App Review\", or \"expedited review\". For pre-submission listing health, see aso-audit. For metadata-only fixes, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "aso-audit",
+          "installUrl": "github:Eronred/aso-skills:skills/aso-audit",
+          "description": "When the user wants a full ASO health audit, review their App Store listing quality, or diagnose why their app isn't ranking. Also use when the user mentions \"ASO audit\", \"ASO score\", \"why am I not ranking\", \"listing review\", or \"optimize my app store page\". For keyword-specific research, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "aso-router",
+          "installUrl": "github:Eronred/aso-skills:skills/aso-router",
+          "description": "Single entry point that routes any ASO, App Store, Google Play, app marketing, paid UA, monetization, retention, reviews, ratings, market-intel, or app-analytics question to the correct specialist skill in this library. Use FIRST whenever the user mentions an app, App Store, Play Store, keywords, ranking, downloads, revenue, subscriptions, screenshots, icon, reviews, competitors, charts, in-app events, launch, press, or ads — but the right specialized skill is not obvious. Triggers: \"/aso-skill\", \"/aso\", \"aso help\", \"help me with my app\", \"I need ASO\", \"which skill should I use\", or any ambiguous app-marketing request. Skip this router only when the user explicitly invokes a specific skill (e.g. /aso-audit, /keyword-research).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "category-positioning",
+          "installUrl": "github:Eronred/aso-skills:skills/category-positioning",
+          "description": "When the user wants to choose, change, or evaluate their App Store / Google Play category and subcategory — including primary vs secondary category trade-offs, chart-rank competitive analysis, category-driven discoverability, and how category choice affects featuring eligibility. Use when the user mentions \"which category\", \"App Store category\", \"primary category\", \"secondary category\", \"change my category\", \"Health & Fitness vs Lifestyle\", \"Productivity vs Utilities\", \"rank higher in a smaller category\", \"category chart\", \"subcategory\", \"Play Store category\", or \"should I switch categories\". For full ASO health beyond category, see aso-audit. For competitor analysis within the chosen category, see competitor-analysis. For chart movements within categories, see market-movers.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitor-analysis",
+          "installUrl": "github:Eronred/aso-skills:skills/competitor-analysis",
+          "description": "When the user wants to analyze competitors' App Store strategy, find keyword gaps, or understand competitive positioning. Also use when the user mentions \"competitor analysis\", \"competitive research\", \"keyword gap\", \"what are my competitors doing\", or \"compare my app to\". For keyword-specific research, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitor-tracking",
+          "installUrl": "github:Eronred/aso-skills:skills/competitor-tracking",
+          "description": "When the user wants to monitor competitor apps on an ongoing basis — tracking metadata changes, keyword shifts, screenshot updates, rating trends, or new features. Use when the user mentions \"competitor monitoring\", \"track competitors\", \"competitor alert\", \"competitor changed their title\", \"watch a competitor app\", \"competitor weekly report\", \"competitive intelligence\", or \"what changed in competitor's listing\". For a one-time deep competitive analysis, see competitor-analysis. For market-wide chart movements, see market-movers.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "custom-product-pages",
+          "installUrl": "github:Eronred/aso-skills:skills/custom-product-pages",
+          "description": "When the user wants to design, deploy, or measure Apple Custom Product Pages (CPP) — the alternate App Store product pages with different screenshots, preview videos, and promo text shown to users coming from specific URLs (typically ad campaigns or social posts). Use when the user mentions \"Custom Product Page\", \"CPP\", \"alternate product page\", \"App Store URL variant\", \"ASA CPP\", \"campaign-specific landing page\", \"product page per audience\", \"App Store Connect CPP\", \"ppoUrl\", \"?cpp=\" parameter, or \"show different screenshots to different ad audiences\". For App Store A/B tests on the default page, see ab-test-store-listing. For paid ad campaigns that route to CPPs, see apple-search-ads or ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "keyword-research",
+          "installUrl": "github:Eronred/aso-skills:skills/keyword-research",
+          "description": "When the user wants to discover, evaluate, or prioritize App Store keywords. Also use when the user mentions \"keyword research\", \"find keywords\", \"search volume\", \"keyword difficulty\", \"keyword ideas\", or \"what keywords should I target\". For implementing keywords into metadata, see metadata-optimization. For auditing current keyword performance, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "localization",
+          "installUrl": "github:Eronred/aso-skills:skills/localization",
+          "description": "When the user wants to localize their App Store listing for international markets. Also use when the user mentions \"localization\", \"translate my app\", \"international markets\", \"expand to new countries\", \"localize metadata\", or \"which countries should I target\". For keyword research in specific markets, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "market-movers",
+          "installUrl": "github:Eronred/aso-skills:skills/market-movers",
+          "description": "When the user wants to track App Store chart rank changes, find top gainers and losers, detect breakout apps entering the top 100, or identify apps dropping out of charts. Also use when the user mentions \"chart movers\", \"rank changes\", \"who's rising\", \"who's falling\", \"new chart entries\", \"top gainers\", or \"market shifts\". For broader market overview, see market-pulse. For competitive keyword analysis, see competitor-analysis.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "market-pulse",
+          "installUrl": "github:Eronred/aso-skills:skills/market-pulse",
+          "description": "When the user wants a comprehensive App Store market overview, daily/weekly market briefing, or combined view of chart movements, trending keywords, featured apps, and new releases. Also use when the user mentions \"market overview\", \"what's happening on the App Store\", \"market briefing\", \"weekly report\", \"market trends\", or \"state of the market\". For chart-specific rank changes only, see market-movers. For keyword trends only, see keyword-research.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "metadata-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/metadata-optimization",
+          "description": "When the user wants to optimize App Store metadata — title, subtitle, keyword field, or description. Also use when the user mentions \"optimize my title\", \"ASO metadata\", \"keyword field\", \"character limits\", \"app description\", or \"write my subtitle\". For keyword discovery, see keyword-research. For full ASO audits, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "monetization-strategy",
+          "installUrl": "github:Eronred/aso-skills:skills/monetization-strategy",
+          "description": "When the user wants to design or optimize their app's monetization — pricing, paywalls, subscriptions, or in-app purchases. Also use when the user mentions \"pricing\", \"paywall\", \"subscription\", \"IAP\", \"how to monetize\", \"revenue optimization\", \"free trial\", or \"conversion to paid\". For retention impact, see retention-optimization. For competitive pricing, see competitor-analysis.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "press-and-pr",
+          "installUrl": "github:Eronred/aso-skills:skills/press-and-pr",
+          "description": "When the user wants to get press coverage, media mentions, or editorial features for their app — including writing press releases, pitching journalists, getting on \"best apps\" lists, or building an app press kit. Use when the user mentions \"press\", \"PR\", \"media coverage\", \"TechCrunch\", \"journalist\", \"press release\", \"app press kit\", \"get featured in media\", \"editorial coverage\", \"review from a blogger\", or \"app launch announcement\". For Apple editorial featuring, see app-store-featured. For launch strategy, see app-launch.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "rating-prompt-strategy",
+          "installUrl": "github:Eronred/aso-skills:skills/rating-prompt-strategy",
+          "description": "When the user wants to improve their app's star rating, increase ratings volume, optimize when and how they prompt users for a review, or recover from a bad rating period. Use when the user mentions \"app rating\", \"star rating\", \"review prompt\", \"SKStoreReviewRequest\", \"In-App Review API\", \"ask for review\", \"low rating\", \"rating drop\", \"get more reviews\", or \"recover from 1-star\". For responding to reviews, see review-management. For overall ASO health, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "review-management",
+          "installUrl": "github:Eronred/aso-skills:skills/review-management",
+          "description": "When the user wants to analyze, respond to, or improve their app reviews and ratings. Also use when the user mentions \"reviews\", \"ratings\", \"negative reviews\", \"how to get more reviews\", \"review response\", or \"my rating is dropping\". For broader ASO audit, see aso-audit. For retention issues causing bad reviews, see retention-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "screenshot-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/screenshot-optimization",
+          "description": "When the user wants to design, optimize, or evaluate App Store screenshots and preview videos. Also use when the user mentions \"screenshots\", \"app preview\", \"product page design\", \"screenshot design\", \"creative assets\", or \"what should my screenshots show\". For A/B testing screenshots, see ab-test-store-listing. For full ASO audit, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "seasonal-aso",
+          "installUrl": "github:Eronred/aso-skills:skills/seasonal-aso",
+          "description": "When the user wants to optimize their App Store listing for seasonal events, holidays, or trending moments — including keyword opportunities, metadata updates, screenshot theming, and timing strategy. Use when the user mentions \"seasonal\", \"holiday\", \"Christmas\", \"New Year\", \"Valentine's Day\", \"summer\", \"back to school\", \"seasonal keywords\", \"trending now\", \"limited time\", or wants to capitalize on a calendar event. For general keyword research, see keyword-research. For full metadata rewrites, see metadata-optimization.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Eronred",
+        "repo": "aso-skills",
+        "repoUrl": "https://github.com/Eronred/aso-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "eronred-aso-skills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from Eronred/aso-skills.",
+      "author": "ASM (Eronred/aso-skills)",
+      "createdAt": "2026-05-09T08:10:44.397Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "eronred",
+        "aso-skills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-store-listing",
+          "installUrl": "github:Eronred/aso-skills:skills/ab-test-store-listing",
+          "description": "When the user wants to A/B test App Store product page elements to improve conversion rate. Also use when the user mentions \"A/B test\", \"product page optimization\", \"test my screenshots\", \"test my icon\", \"conversion rate optimization\", \"CPP\", or \"custom product pages\". For screenshot design, see screenshot-optimization. For metadata optimization, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-analytics",
+          "installUrl": "github:Eronred/aso-skills:skills/app-analytics",
+          "description": "When the user wants to set up, interpret, or improve their app analytics and tracking. Also use when the user mentions \"analytics\", \"tracking\", \"metrics\", \"KPIs\", \"App Store Connect analytics\", \"install tracking\", \"funnel\", \"attribution\", or \"how is my app performing\". For A/B testing, see ab-test-store-listing. For retention metrics, see retention-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-clips",
+          "installUrl": "github:Eronred/aso-skills:skills/app-clips",
+          "description": "When the user wants to implement, optimize, or use App Clips for app discovery and conversion. Use when the user mentions \"App Clip\", \"app clip code\", \"mini app\", \"instant app\", \"App Clip card\", \"App Clip link\", \"no download required\", \"instant experience\", or wants to understand how App Clips appear in App Store search. For general App Store discoverability, see aso-audit. For marketing campaigns, see ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-icon-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/app-icon-optimization",
+          "description": "When the user wants to design, test, or improve their app icon to increase tap-through rate and conversions in App Store search and browse. Use when the user mentions \"app icon\", \"icon design\", \"icon A/B test\", \"icon variants\", \"tap-through rate\", \"icon conversion\", \"icon refresh\", or wants to know what makes a good app icon. For screenshot optimization, see screenshot-optimization. For full listing A/B tests, see ab-test-store-listing.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-preview-video",
+          "installUrl": "github:Eronred/aso-skills:skills/app-preview-video",
+          "description": "When the user wants to plan, script, produce, or optimize App Store Preview videos or Google Play promo videos — the autoplay videos that show in App Store/Play Store search and product pages. Use when the user mentions \"App Preview\", \"preview video\", \"app store video\", \"promo video\", \"Play Store video\", \"video poster frame\", \"YouTube promo for Play Store\", \"30 second app video\", \"video script\", \"video specs\", or \"should I add a preview video\". For static screenshots, see screenshot-optimization. For A/B testing the video, see ab-test-store-listing. For broader creative briefs, see screenshot-optimization (covers stills).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-rejection-recovery",
+          "installUrl": "github:Eronred/aso-skills:skills/app-rejection-recovery",
+          "description": "When the user's app or update was rejected by Apple App Review or Google Play Review and they need to diagnose why, fix it, and resubmit fast. Use when the user mentions \"app rejected\", \"App Review rejection\", \"guideline violation\", \"Apple rejected my app\", \"Google Play rejected\", \"Play policy violation\", \"Resolution Center\", \"metadata rejection\", \"binary rejection\", \"guideline 2.1\", \"guideline 4.3\", \"guideline 5.1.1\", \"Sign in with Apple required\", \"Apple ID rejection\", \"Play Store suspension\", \"appeal\", \"I need to respond to App Review\", or \"expedited review\". For pre-submission listing health, see aso-audit. For metadata-only fixes, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "aso-audit",
+          "installUrl": "github:Eronred/aso-skills:skills/aso-audit",
+          "description": "When the user wants a full ASO health audit, review their App Store listing quality, or diagnose why their app isn't ranking. Also use when the user mentions \"ASO audit\", \"ASO score\", \"why am I not ranking\", \"listing review\", or \"optimize my app store page\". For keyword-specific research, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "aso-router",
+          "installUrl": "github:Eronred/aso-skills:skills/aso-router",
+          "description": "Single entry point that routes any ASO, App Store, Google Play, app marketing, paid UA, monetization, retention, reviews, ratings, market-intel, or app-analytics question to the correct specialist skill in this library. Use FIRST whenever the user mentions an app, App Store, Play Store, keywords, ranking, downloads, revenue, subscriptions, screenshots, icon, reviews, competitors, charts, in-app events, launch, press, or ads — but the right specialized skill is not obvious. Triggers: \"/aso-skill\", \"/aso\", \"aso help\", \"help me with my app\", \"I need ASO\", \"which skill should I use\", or any ambiguous app-marketing request. Skip this router only when the user explicitly invokes a specific skill (e.g. /aso-audit, /keyword-research).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "attribution-setup",
+          "installUrl": "github:Eronred/aso-skills:skills/attribution-setup",
+          "description": "When the user wants to set up, debug, or interpret app install attribution — including SKAdNetwork (SKAN), Apple's AdAttributionKit, Google Play Install Referrer, MMPs (AppsFlyer, Adjust, Singular, Branch, Kochava), deep links, deferred deep links, conversion values, postback windows, or privacy thresholds. Use when the user mentions \"SKAdNetwork\", \"SKAN\", \"SKAN 4\", \"AdAttributionKit\", \"AAK\", \"MMP\", \"AppsFlyer\", \"Adjust\", \"Singular\", \"Branch\", \"attribution\", \"conversion value\", \"postback\", \"Install Referrer\", \"deferred deep link\", \"iOS 14.5\", \"ATT\", \"App Tracking Transparency\", \"IDFA\", or \"I can't measure my ad campaigns\". For paid campaign strategy, see ua-campaign and apple-search-ads. For analytics events, see app-analytics.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "custom-product-pages",
+          "installUrl": "github:Eronred/aso-skills:skills/custom-product-pages",
+          "description": "When the user wants to design, deploy, or measure Apple Custom Product Pages (CPP) — the alternate App Store product pages with different screenshots, preview videos, and promo text shown to users coming from specific URLs (typically ad campaigns or social posts). Use when the user mentions \"Custom Product Page\", \"CPP\", \"alternate product page\", \"App Store URL variant\", \"ASA CPP\", \"campaign-specific landing page\", \"product page per audience\", \"App Store Connect CPP\", \"ppoUrl\", \"?cpp=\" parameter, or \"show different screenshots to different ad audiences\". For App Store A/B tests on the default page, see ab-test-store-listing. For paid ad campaigns that route to CPPs, see apple-search-ads or ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "paywall-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/paywall-optimization",
+          "description": "When the user wants to design, test, or optimize their app's paywall — layout, copy, pricing display, trial offers, plan structure, hard vs soft paywall, paywall placement, or paywall A/B tests. Use when the user mentions \"paywall\", \"paywall design\", \"paywall conversion\", \"trial-to-paid\", \"soft paywall\", \"hard paywall\", \"paywall A/B test\", \"paywall copy\", \"plan picker\", \"annual vs monthly display\", \"best paywall\", \"RevenueCat paywall\", \"Superwall\", \"Adapty\", or \"my paywall isn't converting\". For overall pricing strategy and monetization model choice, see monetization-strategy. For trial nurture, dunning, and churn, see subscription-lifecycle. For where in the onboarding the paywall fires, see onboarding-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "press-and-pr",
+          "installUrl": "github:Eronred/aso-skills:skills/press-and-pr",
+          "description": "When the user wants to get press coverage, media mentions, or editorial features for their app — including writing press releases, pitching journalists, getting on \"best apps\" lists, or building an app press kit. Use when the user mentions \"press\", \"PR\", \"media coverage\", \"TechCrunch\", \"journalist\", \"press release\", \"app press kit\", \"get featured in media\", \"editorial coverage\", \"review from a blogger\", or \"app launch announcement\". For Apple editorial featuring, see app-store-featured. For launch strategy, see app-launch.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "rating-prompt-strategy",
+          "installUrl": "github:Eronred/aso-skills:skills/rating-prompt-strategy",
+          "description": "When the user wants to improve their app's star rating, increase ratings volume, optimize when and how they prompt users for a review, or recover from a bad rating period. Use when the user mentions \"app rating\", \"star rating\", \"review prompt\", \"SKStoreReviewRequest\", \"In-App Review API\", \"ask for review\", \"low rating\", \"rating drop\", \"get more reviews\", or \"recover from 1-star\". For responding to reviews, see review-management. For overall ASO health, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "review-management",
+          "installUrl": "github:Eronred/aso-skills:skills/review-management",
+          "description": "When the user wants to analyze, respond to, or improve their app reviews and ratings. Also use when the user mentions \"reviews\", \"ratings\", \"negative reviews\", \"how to get more reviews\", \"review response\", or \"my rating is dropping\". For broader ASO audit, see aso-audit. For retention issues causing bad reviews, see retention-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "screenshot-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/screenshot-optimization",
+          "description": "When the user wants to design, optimize, or evaluate App Store screenshots and preview videos. Also use when the user mentions \"screenshots\", \"app preview\", \"product page design\", \"screenshot design\", \"creative assets\", or \"what should my screenshots show\". For A/B testing screenshots, see ab-test-store-listing. For full ASO audit, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "seasonal-aso",
+          "installUrl": "github:Eronred/aso-skills:skills/seasonal-aso",
+          "description": "When the user wants to optimize their App Store listing for seasonal events, holidays, or trending moments — including keyword opportunities, metadata updates, screenshot theming, and timing strategy. Use when the user mentions \"seasonal\", \"holiday\", \"Christmas\", \"New Year\", \"Valentine's Day\", \"summer\", \"back to school\", \"seasonal keywords\", \"trending now\", \"limited time\", or wants to capitalize on a calendar event. For general keyword research, see keyword-research. For full metadata rewrites, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "web-to-app-funnel",
+          "installUrl": "github:Eronred/aso-skills:skills/web-to-app-funnel",
+          "description": "When the user wants to design or optimize the funnel that takes web visitors into installing and onboarding the app — including smart app banners, web-to-app deep links, deferred deep links, web onboarding (Stripe-paid web flow before app install), QR codes, \"open in app\" CTAs, and the trade-off between paying on web vs in-app. Use when the user mentions \"web to app\", \"smart app banner\", \"Stripe before app\", \"web paywall before install\", \"Branch web SDK\", \"web funnel for app\", \"AppsFlyer OneLink web\", \"Universal Links\", \"App Links\", \"QR code to app\", \"open in app\", \"deferred deep link from web\", or \"should I sell on web first then push to app\". For pure in-app onboarding, see onboarding-optimization. For deep link infra, see attribution-setup.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Eronred",
+        "repo": "aso-skills",
+        "repoUrl": "https://github.com/Eronred/aso-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "eronred-aso-skills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from Eronred/aso-skills.",
+      "author": "ASM (Eronred/aso-skills)",
+      "createdAt": "2026-05-09T08:10:44.397Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "eronred",
+        "aso-skills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-store-listing",
+          "installUrl": "github:Eronred/aso-skills:skills/ab-test-store-listing",
+          "description": "When the user wants to A/B test App Store product page elements to improve conversion rate. Also use when the user mentions \"A/B test\", \"product page optimization\", \"test my screenshots\", \"test my icon\", \"conversion rate optimization\", \"CPP\", or \"custom product pages\". For screenshot design, see screenshot-optimization. For metadata optimization, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-clips",
+          "installUrl": "github:Eronred/aso-skills:skills/app-clips",
+          "description": "When the user wants to implement, optimize, or use App Clips for app discovery and conversion. Use when the user mentions \"App Clip\", \"app clip code\", \"mini app\", \"instant app\", \"App Clip card\", \"App Clip link\", \"no download required\", \"instant experience\", or wants to understand how App Clips appear in App Store search. For general App Store discoverability, see aso-audit. For marketing campaigns, see ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-icon-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/app-icon-optimization",
+          "description": "When the user wants to design, test, or improve their app icon to increase tap-through rate and conversions in App Store search and browse. Use when the user mentions \"app icon\", \"icon design\", \"icon A/B test\", \"icon variants\", \"tap-through rate\", \"icon conversion\", \"icon refresh\", or wants to know what makes a good app icon. For screenshot optimization, see screenshot-optimization. For full listing A/B tests, see ab-test-store-listing.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-launch",
+          "installUrl": "github:Eronred/aso-skills:skills/app-launch",
+          "description": "When the user wants to plan a launch strategy for a new app or major update. Also use when the user mentions \"app launch\", \"launch plan\", \"launch checklist\", \"pre-launch\", \"launch day\", or \"how to launch my app\". For ongoing ASO after launch, see aso-audit. For paid acquisition during launch, see ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-rejection-recovery",
+          "installUrl": "github:Eronred/aso-skills:skills/app-rejection-recovery",
+          "description": "When the user's app or update was rejected by Apple App Review or Google Play Review and they need to diagnose why, fix it, and resubmit fast. Use when the user mentions \"app rejected\", \"App Review rejection\", \"guideline violation\", \"Apple rejected my app\", \"Google Play rejected\", \"Play policy violation\", \"Resolution Center\", \"metadata rejection\", \"binary rejection\", \"guideline 2.1\", \"guideline 4.3\", \"guideline 5.1.1\", \"Sign in with Apple required\", \"Apple ID rejection\", \"Play Store suspension\", \"appeal\", \"I need to respond to App Review\", or \"expedited review\". For pre-submission listing health, see aso-audit. For metadata-only fixes, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "custom-product-pages",
+          "installUrl": "github:Eronred/aso-skills:skills/custom-product-pages",
+          "description": "When the user wants to design, deploy, or measure Apple Custom Product Pages (CPP) — the alternate App Store product pages with different screenshots, preview videos, and promo text shown to users coming from specific URLs (typically ad campaigns or social posts). Use when the user mentions \"Custom Product Page\", \"CPP\", \"alternate product page\", \"App Store URL variant\", \"ASA CPP\", \"campaign-specific landing page\", \"product page per audience\", \"App Store Connect CPP\", \"ppoUrl\", \"?cpp=\" parameter, or \"show different screenshots to different ad audiences\". For App Store A/B tests on the default page, see ab-test-store-listing. For paid ad campaigns that route to CPPs, see apple-search-ads or ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "monetization-strategy",
+          "installUrl": "github:Eronred/aso-skills:skills/monetization-strategy",
+          "description": "When the user wants to design or optimize their app's monetization — pricing, paywalls, subscriptions, or in-app purchases. Also use when the user mentions \"pricing\", \"paywall\", \"subscription\", \"IAP\", \"how to monetize\", \"revenue optimization\", \"free trial\", or \"conversion to paid\". For retention impact, see retention-optimization. For competitive pricing, see competitor-analysis.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "paywall-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/paywall-optimization",
+          "description": "When the user wants to design, test, or optimize their app's paywall — layout, copy, pricing display, trial offers, plan structure, hard vs soft paywall, paywall placement, or paywall A/B tests. Use when the user mentions \"paywall\", \"paywall design\", \"paywall conversion\", \"trial-to-paid\", \"soft paywall\", \"hard paywall\", \"paywall A/B test\", \"paywall copy\", \"plan picker\", \"annual vs monthly display\", \"best paywall\", \"RevenueCat paywall\", \"Superwall\", \"Adapty\", or \"my paywall isn't converting\". For overall pricing strategy and monetization model choice, see monetization-strategy. For trial nurture, dunning, and churn, see subscription-lifecycle. For where in the onboarding the paywall fires, see onboarding-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "press-and-pr",
+          "installUrl": "github:Eronred/aso-skills:skills/press-and-pr",
+          "description": "When the user wants to get press coverage, media mentions, or editorial features for their app — including writing press releases, pitching journalists, getting on \"best apps\" lists, or building an app press kit. Use when the user mentions \"press\", \"PR\", \"media coverage\", \"TechCrunch\", \"journalist\", \"press release\", \"app press kit\", \"get featured in media\", \"editorial coverage\", \"review from a blogger\", or \"app launch announcement\". For Apple editorial featuring, see app-store-featured. For launch strategy, see app-launch.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "referral-program",
+          "installUrl": "github:Eronred/aso-skills:skills/referral-program",
+          "description": "When the user wants to design, launch, or optimize an in-app referral / invite / share-to-earn program — including reward structure, mechanics, fraud prevention, deep link setup, and viral coefficient measurement. Use when the user mentions \"referral program\", \"invite a friend\", \"refer and earn\", \"share to earn\", \"viral loop\", \"viral coefficient\", \"K-factor\", \"double-sided rewards\", \"give X get X\", \"referral rewards\", \"invite link\", \"share sheet\", \"Branch referrals\", \"in-app invites\", or \"how to make my app go viral\". For deep link infrastructure that referrals depend on, see attribution-setup. For organic content-driven virality (UGC, creator), see creator-ugc-marketing.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "screenshot-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/screenshot-optimization",
+          "description": "When the user wants to design, optimize, or evaluate App Store screenshots and preview videos. Also use when the user mentions \"screenshots\", \"app preview\", \"product page design\", \"screenshot design\", \"creative assets\", or \"what should my screenshots show\". For A/B testing screenshots, see ab-test-store-listing. For full ASO audit, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "subscription-lifecycle",
+          "installUrl": "github:Eronred/aso-skills:skills/subscription-lifecycle",
+          "description": "When the user wants to optimize their subscription business end-to-end — from trial start through renewal, cancellation, and win-back. Use when the user mentions \"subscription lifecycle\", \"trial conversion\", \"churn\", \"cancellation\", \"win-back\", \"lapsed subscribers\", \"dunning\", \"billing retry\", \"grace period\", \"renewal rate\", \"subscriber LTV\", or \"resubscribe\". For paywall design and pricing strategy, see monetization-strategy. For subscription analytics dashboards, see app-analytics.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ua-campaign",
+          "installUrl": "github:Eronred/aso-skills:skills/ua-campaign",
+          "description": "When the user wants to plan or optimize paid user acquisition campaigns. Also use when the user mentions \"Apple Search Ads\", \"user acquisition\", \"paid ads\", \"UA\", \"ad campaign\", \"install campaign\", \"Facebook ads for apps\", \"TikTok ads\", or \"cost per install\". For organic growth, see aso-audit. For launch-specific UA, see app-launch.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "web-to-app-funnel",
+          "installUrl": "github:Eronred/aso-skills:skills/web-to-app-funnel",
+          "description": "When the user wants to design or optimize the funnel that takes web visitors into installing and onboarding the app — including smart app banners, web-to-app deep links, deferred deep links, web onboarding (Stripe-paid web flow before app install), QR codes, \"open in app\" CTAs, and the trade-off between paying on web vs in-app. Use when the user mentions \"web to app\", \"smart app banner\", \"Stripe before app\", \"web paywall before install\", \"Branch web SDK\", \"web funnel for app\", \"AppsFlyer OneLink web\", \"Universal Links\", \"App Links\", \"QR code to app\", \"open in app\", \"deferred deep link from web\", or \"should I sell on web first then push to app\". For pure in-app onboarding, see onboarding-optimization. For deep link infra, see attribution-setup.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Eronred",
+        "repo": "aso-skills",
+        "repoUrl": "https://github.com/Eronred/aso-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "eronred-aso-skills-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from Eronred/aso-skills.",
+      "author": "ASM (Eronred/aso-skills)",
+      "createdAt": "2026-05-09T08:10:44.397Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "eronred",
+        "aso-skills"
+      ],
+      "skills": [
+        {
+          "name": "android-aso",
+          "installUrl": "github:Eronred/aso-skills:skills/android-aso",
+          "description": "When the user wants to optimize their Google Play Store listing — title, short description, full description, keywords, ratings, or Play Store-specific features. Use when the user mentions \"Google Play\", \"Android\", \"Play Store\", \"Play Console\", \"short description\", \"full description indexed\", \"Google Play ASO\", or wants Google Play-specific keyword, creative, or ratings strategy. For iOS App Store optimization, see aso-audit and metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "aso-audit",
+          "installUrl": "github:Eronred/aso-skills:skills/aso-audit",
+          "description": "When the user wants a full ASO health audit, review their App Store listing quality, or diagnose why their app isn't ranking. Also use when the user mentions \"ASO audit\", \"ASO score\", \"why am I not ranking\", \"listing review\", or \"optimize my app store page\". For keyword-specific research, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "aso-router",
+          "installUrl": "github:Eronred/aso-skills:skills/aso-router",
+          "description": "Single entry point that routes any ASO, App Store, Google Play, app marketing, paid UA, monetization, retention, reviews, ratings, market-intel, or app-analytics question to the correct specialist skill in this library. Use FIRST whenever the user mentions an app, App Store, Play Store, keywords, ranking, downloads, revenue, subscriptions, screenshots, icon, reviews, competitors, charts, in-app events, launch, press, or ads — but the right specialized skill is not obvious. Triggers: \"/aso-skill\", \"/aso\", \"aso help\", \"help me with my app\", \"I need ASO\", \"which skill should I use\", or any ambiguous app-marketing request. Skip this router only when the user explicitly invokes a specific skill (e.g. /aso-audit, /keyword-research).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitor-analysis",
+          "installUrl": "github:Eronred/aso-skills:skills/competitor-analysis",
+          "description": "When the user wants to analyze competitors' App Store strategy, find keyword gaps, or understand competitive positioning. Also use when the user mentions \"competitor analysis\", \"competitive research\", \"keyword gap\", \"what are my competitors doing\", or \"compare my app to\". For keyword-specific research, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "creator-ugc-marketing",
+          "installUrl": "github:Eronred/aso-skills:skills/creator-ugc-marketing",
+          "description": "When the user wants to plan, brief, source, or measure organic creator / influencer / UGC marketing for their app — including TikTok creators, Instagram Reels, YouTube Shorts, micro-influencers, paid creator briefs, UGC ad creative for Meta/TikTok, affiliate programs, and seeding strategy. Use when the user mentions \"creators\", \"influencers\", \"TikTok marketing\", \"UGC\", \"user-generated content\", \"creator briefs\", \"creator outreach\", \"influencer marketing\", \"Reels\", \"Shorts\", \"creator gifting\", \"seeding\", \"affiliate\", \"Whop\", \"TikTok Spark Ads\", \"Instagram collab posts\", or \"I want my app to go viral on TikTok\". For paid social ad campaigns (Meta/TikTok ad accounts), see ua-campaign. For PR / press, see press-and-pr. For viral in-app loops, see referral-program.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "custom-product-pages",
+          "installUrl": "github:Eronred/aso-skills:skills/custom-product-pages",
+          "description": "When the user wants to design, deploy, or measure Apple Custom Product Pages (CPP) — the alternate App Store product pages with different screenshots, preview videos, and promo text shown to users coming from specific URLs (typically ad campaigns or social posts). Use when the user mentions \"Custom Product Page\", \"CPP\", \"alternate product page\", \"App Store URL variant\", \"ASA CPP\", \"campaign-specific landing page\", \"product page per audience\", \"App Store Connect CPP\", \"ppoUrl\", \"?cpp=\" parameter, or \"show different screenshots to different ad audiences\". For App Store A/B tests on the default page, see ab-test-store-listing. For paid ad campaigns that route to CPPs, see apple-search-ads or ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "localization",
+          "installUrl": "github:Eronred/aso-skills:skills/localization",
+          "description": "When the user wants to localize their App Store listing for international markets. Also use when the user mentions \"localization\", \"translate my app\", \"international markets\", \"expand to new countries\", \"localize metadata\", or \"which countries should I target\". For keyword research in specific markets, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "market-pulse",
+          "installUrl": "github:Eronred/aso-skills:skills/market-pulse",
+          "description": "When the user wants a comprehensive App Store market overview, daily/weekly market briefing, or combined view of chart movements, trending keywords, featured apps, and new releases. Also use when the user mentions \"market overview\", \"what's happening on the App Store\", \"market briefing\", \"weekly report\", \"market trends\", or \"state of the market\". For chart-specific rank changes only, see market-movers. For keyword trends only, see keyword-research.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "monetization-strategy",
+          "installUrl": "github:Eronred/aso-skills:skills/monetization-strategy",
+          "description": "When the user wants to design or optimize their app's monetization — pricing, paywalls, subscriptions, or in-app purchases. Also use when the user mentions \"pricing\", \"paywall\", \"subscription\", \"IAP\", \"how to monetize\", \"revenue optimization\", \"free trial\", or \"conversion to paid\". For retention impact, see retention-optimization. For competitive pricing, see competitor-analysis.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "paywall-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/paywall-optimization",
+          "description": "When the user wants to design, test, or optimize their app's paywall — layout, copy, pricing display, trial offers, plan structure, hard vs soft paywall, paywall placement, or paywall A/B tests. Use when the user mentions \"paywall\", \"paywall design\", \"paywall conversion\", \"trial-to-paid\", \"soft paywall\", \"hard paywall\", \"paywall A/B test\", \"paywall copy\", \"plan picker\", \"annual vs monthly display\", \"best paywall\", \"RevenueCat paywall\", \"Superwall\", \"Adapty\", or \"my paywall isn't converting\". For overall pricing strategy and monetization model choice, see monetization-strategy. For trial nurture, dunning, and churn, see subscription-lifecycle. For where in the onboarding the paywall fires, see onboarding-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "press-and-pr",
+          "installUrl": "github:Eronred/aso-skills:skills/press-and-pr",
+          "description": "When the user wants to get press coverage, media mentions, or editorial features for their app — including writing press releases, pitching journalists, getting on \"best apps\" lists, or building an app press kit. Use when the user mentions \"press\", \"PR\", \"media coverage\", \"TechCrunch\", \"journalist\", \"press release\", \"app press kit\", \"get featured in media\", \"editorial coverage\", \"review from a blogger\", or \"app launch announcement\". For Apple editorial featuring, see app-store-featured. For launch strategy, see app-launch.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "referral-program",
+          "installUrl": "github:Eronred/aso-skills:skills/referral-program",
+          "description": "When the user wants to design, launch, or optimize an in-app referral / invite / share-to-earn program — including reward structure, mechanics, fraud prevention, deep link setup, and viral coefficient measurement. Use when the user mentions \"referral program\", \"invite a friend\", \"refer and earn\", \"share to earn\", \"viral loop\", \"viral coefficient\", \"K-factor\", \"double-sided rewards\", \"give X get X\", \"referral rewards\", \"invite link\", \"share sheet\", \"Branch referrals\", \"in-app invites\", or \"how to make my app go viral\". For deep link infrastructure that referrals depend on, see attribution-setup. For organic content-driven virality (UGC, creator), see creator-ugc-marketing.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "retention-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/retention-optimization",
+          "description": "When the user wants to reduce churn, improve user engagement, or increase lifetime value. Also use when the user mentions \"retention\", \"churn\", \"users leaving\", \"engagement\", \"DAU/MAU\", \"user activation\", or \"why are users uninstalling\". For onboarding-specific issues, see app-launch. For monetization, see monetization-strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "subscription-lifecycle",
+          "installUrl": "github:Eronred/aso-skills:skills/subscription-lifecycle",
+          "description": "When the user wants to optimize their subscription business end-to-end — from trial start through renewal, cancellation, and win-back. Use when the user mentions \"subscription lifecycle\", \"trial conversion\", \"churn\", \"cancellation\", \"win-back\", \"lapsed subscribers\", \"dunning\", \"billing retry\", \"grace period\", \"renewal rate\", \"subscriber LTV\", or \"resubscribe\". For paywall design and pricing strategy, see monetization-strategy. For subscription analytics dashboards, see app-analytics.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ua-campaign",
+          "installUrl": "github:Eronred/aso-skills:skills/ua-campaign",
+          "description": "When the user wants to plan or optimize paid user acquisition campaigns. Also use when the user mentions \"Apple Search Ads\", \"user acquisition\", \"paid ads\", \"UA\", \"ad campaign\", \"install campaign\", \"Facebook ads for apps\", \"TikTok ads\", or \"cost per install\". For organic growth, see aso-audit. For launch-specific UA, see app-launch.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "web-to-app-funnel",
+          "installUrl": "github:Eronred/aso-skills:skills/web-to-app-funnel",
+          "description": "When the user wants to design or optimize the funnel that takes web visitors into installing and onboarding the app — including smart app banners, web-to-app deep links, deferred deep links, web onboarding (Stripe-paid web flow before app install), QR codes, \"open in app\" CTAs, and the trade-off between paying on web vs in-app. Use when the user mentions \"web to app\", \"smart app banner\", \"Stripe before app\", \"web paywall before install\", \"Branch web SDK\", \"web funnel for app\", \"AppsFlyer OneLink web\", \"Universal Links\", \"App Links\", \"QR code to app\", \"open in app\", \"deferred deep link from web\", or \"should I sell on web first then push to app\". For pure in-app onboarding, see onboarding-optimization. For deep link infra, see attribution-setup.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Eronred",
+        "repo": "aso-skills",
+        "repoUrl": "https://github.com/Eronred/aso-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "eronred-aso-skills-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from Eronred/aso-skills.",
+      "author": "ASM (Eronred/aso-skills)",
+      "createdAt": "2026-05-09T08:10:44.397Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "eronred",
+        "aso-skills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-store-listing",
+          "installUrl": "github:Eronred/aso-skills:skills/ab-test-store-listing",
+          "description": "When the user wants to A/B test App Store product page elements to improve conversion rate. Also use when the user mentions \"A/B test\", \"product page optimization\", \"test my screenshots\", \"test my icon\", \"conversion rate optimization\", \"CPP\", or \"custom product pages\". For screenshot design, see screenshot-optimization. For metadata optimization, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "android-aso",
+          "installUrl": "github:Eronred/aso-skills:skills/android-aso",
+          "description": "When the user wants to optimize their Google Play Store listing — title, short description, full description, keywords, ratings, or Play Store-specific features. Use when the user mentions \"Google Play\", \"Android\", \"Play Store\", \"Play Console\", \"short description\", \"full description indexed\", \"Google Play ASO\", or wants Google Play-specific keyword, creative, or ratings strategy. For iOS App Store optimization, see aso-audit and metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-analytics",
+          "installUrl": "github:Eronred/aso-skills:skills/app-analytics",
+          "description": "When the user wants to set up, interpret, or improve their app analytics and tracking. Also use when the user mentions \"analytics\", \"tracking\", \"metrics\", \"KPIs\", \"App Store Connect analytics\", \"install tracking\", \"funnel\", \"attribution\", or \"how is my app performing\". For A/B testing, see ab-test-store-listing. For retention metrics, see retention-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-clips",
+          "installUrl": "github:Eronred/aso-skills:skills/app-clips",
+          "description": "When the user wants to implement, optimize, or use App Clips for app discovery and conversion. Use when the user mentions \"App Clip\", \"app clip code\", \"mini app\", \"instant app\", \"App Clip card\", \"App Clip link\", \"no download required\", \"instant experience\", or wants to understand how App Clips appear in App Store search. For general App Store discoverability, see aso-audit. For marketing campaigns, see ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-launch",
+          "installUrl": "github:Eronred/aso-skills:skills/app-launch",
+          "description": "When the user wants to plan a launch strategy for a new app or major update. Also use when the user mentions \"app launch\", \"launch plan\", \"launch checklist\", \"pre-launch\", \"launch day\", or \"how to launch my app\". For ongoing ASO after launch, see aso-audit. For paid acquisition during launch, see ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-rejection-recovery",
+          "installUrl": "github:Eronred/aso-skills:skills/app-rejection-recovery",
+          "description": "When the user's app or update was rejected by Apple App Review or Google Play Review and they need to diagnose why, fix it, and resubmit fast. Use when the user mentions \"app rejected\", \"App Review rejection\", \"guideline violation\", \"Apple rejected my app\", \"Google Play rejected\", \"Play policy violation\", \"Resolution Center\", \"metadata rejection\", \"binary rejection\", \"guideline 2.1\", \"guideline 4.3\", \"guideline 5.1.1\", \"Sign in with Apple required\", \"Apple ID rejection\", \"Play Store suspension\", \"appeal\", \"I need to respond to App Review\", or \"expedited review\". For pre-submission listing health, see aso-audit. For metadata-only fixes, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "apple-search-ads",
+          "installUrl": "github:Eronred/aso-skills:skills/apple-search-ads",
+          "description": "When the user wants to set up, optimize, or scale Apple Search Ads (ASA) campaigns — including keyword bidding, match types, campaign structure, Creative Product Sets, CPP routing, and ROAS optimization. Use when the user mentions \"Apple Search Ads\", \"ASA\", \"Search Ads\", \"Search tab ads\", \"Today tab ads\", \"CPT\", \"TTR\", \"Search Match\", \"exact match\", \"broad match\", \"CPP in ads\", \"ASA bidding\", or \"Search Ads budget\". For Meta/Google UAC/TikTok paid UA, see ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "asc-metrics",
+          "installUrl": "github:Eronred/aso-skills:skills/asc-metrics",
+          "description": "When the user wants to analyze their own app's actual performance data from App Store Connect — real downloads, revenue, IAP, subscriptions, trials, or country breakdowns synced via Appeeky Connect. Use when the user asks about \"my downloads\", \"my revenue\", \"how is my app performing\", \"ASC data\", \"sales and trends\", \"my subscription numbers\", \"App Store Connect metrics\", or wants to compare periods or top markets. For third-party app estimates, see app-analytics. For subscription analytics depth, see monetization-strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "aso-audit",
+          "installUrl": "github:Eronred/aso-skills:skills/aso-audit",
+          "description": "When the user wants a full ASO health audit, review their App Store listing quality, or diagnose why their app isn't ranking. Also use when the user mentions \"ASO audit\", \"ASO score\", \"why am I not ranking\", \"listing review\", or \"optimize my app store page\". For keyword-specific research, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "aso-router",
+          "installUrl": "github:Eronred/aso-skills:skills/aso-router",
+          "description": "Single entry point that routes any ASO, App Store, Google Play, app marketing, paid UA, monetization, retention, reviews, ratings, market-intel, or app-analytics question to the correct specialist skill in this library. Use FIRST whenever the user mentions an app, App Store, Play Store, keywords, ranking, downloads, revenue, subscriptions, screenshots, icon, reviews, competitors, charts, in-app events, launch, press, or ads — but the right specialized skill is not obvious. Triggers: \"/aso-skill\", \"/aso\", \"aso help\", \"help me with my app\", \"I need ASO\", \"which skill should I use\", or any ambiguous app-marketing request. Skip this router only when the user explicitly invokes a specific skill (e.g. /aso-audit, /keyword-research).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "attribution-setup",
+          "installUrl": "github:Eronred/aso-skills:skills/attribution-setup",
+          "description": "When the user wants to set up, debug, or interpret app install attribution — including SKAdNetwork (SKAN), Apple's AdAttributionKit, Google Play Install Referrer, MMPs (AppsFlyer, Adjust, Singular, Branch, Kochava), deep links, deferred deep links, conversion values, postback windows, or privacy thresholds. Use when the user mentions \"SKAdNetwork\", \"SKAN\", \"SKAN 4\", \"AdAttributionKit\", \"AAK\", \"MMP\", \"AppsFlyer\", \"Adjust\", \"Singular\", \"Branch\", \"attribution\", \"conversion value\", \"postback\", \"Install Referrer\", \"deferred deep link\", \"iOS 14.5\", \"ATT\", \"App Tracking Transparency\", \"IDFA\", or \"I can't measure my ad campaigns\". For paid campaign strategy, see ua-campaign and apple-search-ads. For analytics events, see app-analytics.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "category-positioning",
+          "installUrl": "github:Eronred/aso-skills:skills/category-positioning",
+          "description": "When the user wants to choose, change, or evaluate their App Store / Google Play category and subcategory — including primary vs secondary category trade-offs, chart-rank competitive analysis, category-driven discoverability, and how category choice affects featuring eligibility. Use when the user mentions \"which category\", \"App Store category\", \"primary category\", \"secondary category\", \"change my category\", \"Health & Fitness vs Lifestyle\", \"Productivity vs Utilities\", \"rank higher in a smaller category\", \"category chart\", \"subcategory\", \"Play Store category\", or \"should I switch categories\". For full ASO health beyond category, see aso-audit. For competitor analysis within the chosen category, see competitor-analysis. For chart movements within categories, see market-movers.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitor-analysis",
+          "installUrl": "github:Eronred/aso-skills:skills/competitor-analysis",
+          "description": "When the user wants to analyze competitors' App Store strategy, find keyword gaps, or understand competitive positioning. Also use when the user mentions \"competitor analysis\", \"competitive research\", \"keyword gap\", \"what are my competitors doing\", or \"compare my app to\". For keyword-specific research, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitor-tracking",
+          "installUrl": "github:Eronred/aso-skills:skills/competitor-tracking",
+          "description": "When the user wants to monitor competitor apps on an ongoing basis — tracking metadata changes, keyword shifts, screenshot updates, rating trends, or new features. Use when the user mentions \"competitor monitoring\", \"track competitors\", \"competitor alert\", \"competitor changed their title\", \"watch a competitor app\", \"competitor weekly report\", \"competitive intelligence\", or \"what changed in competitor's listing\". For a one-time deep competitive analysis, see competitor-analysis. For market-wide chart movements, see market-movers.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "crash-analytics",
+          "installUrl": "github:Eronred/aso-skills:skills/crash-analytics",
+          "description": "When the user wants to monitor, triage, or reduce their app's crash rate — including setting up Crashlytics, prioritizing which crashes to fix first, interpreting crash data, and understanding how crashes affect App Store ranking. Use when the user mentions \"crash\", \"crashlytics\", \"crash rate\", \"ANR\", \"app not responding\", \"crash-free sessions\", \"crash-free users\", \"symbolication\", \"stability\", \"firebase crashes\", \"app crashing\", or \"crash report\". For overall analytics setup, see app-analytics.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "creator-ugc-marketing",
+          "installUrl": "github:Eronred/aso-skills:skills/creator-ugc-marketing",
+          "description": "When the user wants to plan, brief, source, or measure organic creator / influencer / UGC marketing for their app — including TikTok creators, Instagram Reels, YouTube Shorts, micro-influencers, paid creator briefs, UGC ad creative for Meta/TikTok, affiliate programs, and seeding strategy. Use when the user mentions \"creators\", \"influencers\", \"TikTok marketing\", \"UGC\", \"user-generated content\", \"creator briefs\", \"creator outreach\", \"influencer marketing\", \"Reels\", \"Shorts\", \"creator gifting\", \"seeding\", \"affiliate\", \"Whop\", \"TikTok Spark Ads\", \"Instagram collab posts\", or \"I want my app to go viral on TikTok\". For paid social ad campaigns (Meta/TikTok ad accounts), see ua-campaign. For PR / press, see press-and-pr. For viral in-app loops, see referral-program.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "custom-product-pages",
+          "installUrl": "github:Eronred/aso-skills:skills/custom-product-pages",
+          "description": "When the user wants to design, deploy, or measure Apple Custom Product Pages (CPP) — the alternate App Store product pages with different screenshots, preview videos, and promo text shown to users coming from specific URLs (typically ad campaigns or social posts). Use when the user mentions \"Custom Product Page\", \"CPP\", \"alternate product page\", \"App Store URL variant\", \"ASA CPP\", \"campaign-specific landing page\", \"product page per audience\", \"App Store Connect CPP\", \"ppoUrl\", \"?cpp=\" parameter, or \"show different screenshots to different ad audiences\". For App Store A/B tests on the default page, see ab-test-store-listing. For paid ad campaigns that route to CPPs, see apple-search-ads or ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "keyword-research",
+          "installUrl": "github:Eronred/aso-skills:skills/keyword-research",
+          "description": "When the user wants to discover, evaluate, or prioritize App Store keywords. Also use when the user mentions \"keyword research\", \"find keywords\", \"search volume\", \"keyword difficulty\", \"keyword ideas\", or \"what keywords should I target\". For implementing keywords into metadata, see metadata-optimization. For auditing current keyword performance, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "localization",
+          "installUrl": "github:Eronred/aso-skills:skills/localization",
+          "description": "When the user wants to localize their App Store listing for international markets. Also use when the user mentions \"localization\", \"translate my app\", \"international markets\", \"expand to new countries\", \"localize metadata\", or \"which countries should I target\". For keyword research in specific markets, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "market-movers",
+          "installUrl": "github:Eronred/aso-skills:skills/market-movers",
+          "description": "When the user wants to track App Store chart rank changes, find top gainers and losers, detect breakout apps entering the top 100, or identify apps dropping out of charts. Also use when the user mentions \"chart movers\", \"rank changes\", \"who's rising\", \"who's falling\", \"new chart entries\", \"top gainers\", or \"market shifts\". For broader market overview, see market-pulse. For competitive keyword analysis, see competitor-analysis.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "market-pulse",
+          "installUrl": "github:Eronred/aso-skills:skills/market-pulse",
+          "description": "When the user wants a comprehensive App Store market overview, daily/weekly market briefing, or combined view of chart movements, trending keywords, featured apps, and new releases. Also use when the user mentions \"market overview\", \"what's happening on the App Store\", \"market briefing\", \"weekly report\", \"market trends\", or \"state of the market\". For chart-specific rank changes only, see market-movers. For keyword trends only, see keyword-research.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "metadata-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/metadata-optimization",
+          "description": "When the user wants to optimize App Store metadata — title, subtitle, keyword field, or description. Also use when the user mentions \"optimize my title\", \"ASO metadata\", \"keyword field\", \"character limits\", \"app description\", or \"write my subtitle\". For keyword discovery, see keyword-research. For full ASO audits, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "monetization-strategy",
+          "installUrl": "github:Eronred/aso-skills:skills/monetization-strategy",
+          "description": "When the user wants to design or optimize their app's monetization — pricing, paywalls, subscriptions, or in-app purchases. Also use when the user mentions \"pricing\", \"paywall\", \"subscription\", \"IAP\", \"how to monetize\", \"revenue optimization\", \"free trial\", or \"conversion to paid\". For retention impact, see retention-optimization. For competitive pricing, see competitor-analysis.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "onboarding-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/onboarding-optimization",
+          "description": "When the user wants to improve their app's onboarding experience, increase activation rate, reduce Day 1 drop-off, or optimize the first-run flow. Use when the user mentions \"onboarding\", \"first-run\", \"activation\", \"tutorial\", \"day 1 retention\", \"new user flow\", \"permission prompts\", \"sign-up conversion\", \"onboarding funnel\", or \"users dropping off early\". For overall retention strategy, see retention-optimization. For paywall placement, see monetization-strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "paywall-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/paywall-optimization",
+          "description": "When the user wants to design, test, or optimize their app's paywall — layout, copy, pricing display, trial offers, plan structure, hard vs soft paywall, paywall placement, or paywall A/B tests. Use when the user mentions \"paywall\", \"paywall design\", \"paywall conversion\", \"trial-to-paid\", \"soft paywall\", \"hard paywall\", \"paywall A/B test\", \"paywall copy\", \"plan picker\", \"annual vs monthly display\", \"best paywall\", \"RevenueCat paywall\", \"Superwall\", \"Adapty\", or \"my paywall isn't converting\". For overall pricing strategy and monetization model choice, see monetization-strategy. For trial nurture, dunning, and churn, see subscription-lifecycle. For where in the onboarding the paywall fires, see onboarding-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "rating-prompt-strategy",
+          "installUrl": "github:Eronred/aso-skills:skills/rating-prompt-strategy",
+          "description": "When the user wants to improve their app's star rating, increase ratings volume, optimize when and how they prompt users for a review, or recover from a bad rating period. Use when the user mentions \"app rating\", \"star rating\", \"review prompt\", \"SKStoreReviewRequest\", \"In-App Review API\", \"ask for review\", \"low rating\", \"rating drop\", \"get more reviews\", or \"recover from 1-star\". For responding to reviews, see review-management. For overall ASO health, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "seasonal-aso",
+          "installUrl": "github:Eronred/aso-skills:skills/seasonal-aso",
+          "description": "When the user wants to optimize their App Store listing for seasonal events, holidays, or trending moments — including keyword opportunities, metadata updates, screenshot theming, and timing strategy. Use when the user mentions \"seasonal\", \"holiday\", \"Christmas\", \"New Year\", \"Valentine's Day\", \"summer\", \"back to school\", \"seasonal keywords\", \"trending now\", \"limited time\", or wants to capitalize on a calendar event. For general keyword research, see keyword-research. For full metadata rewrites, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "subscription-lifecycle",
+          "installUrl": "github:Eronred/aso-skills:skills/subscription-lifecycle",
+          "description": "When the user wants to optimize their subscription business end-to-end — from trial start through renewal, cancellation, and win-back. Use when the user mentions \"subscription lifecycle\", \"trial conversion\", \"churn\", \"cancellation\", \"win-back\", \"lapsed subscribers\", \"dunning\", \"billing retry\", \"grace period\", \"renewal rate\", \"subscriber LTV\", or \"resubscribe\". For paywall design and pricing strategy, see monetization-strategy. For subscription analytics dashboards, see app-analytics.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ua-campaign",
+          "installUrl": "github:Eronred/aso-skills:skills/ua-campaign",
+          "description": "When the user wants to plan or optimize paid user acquisition campaigns. Also use when the user mentions \"Apple Search Ads\", \"user acquisition\", \"paid ads\", \"UA\", \"ad campaign\", \"install campaign\", \"Facebook ads for apps\", \"TikTok ads\", or \"cost per install\". For organic growth, see aso-audit. For launch-specific UA, see app-launch.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "web-to-app-funnel",
+          "installUrl": "github:Eronred/aso-skills:skills/web-to-app-funnel",
+          "description": "When the user wants to design or optimize the funnel that takes web visitors into installing and onboarding the app — including smart app banners, web-to-app deep links, deferred deep links, web onboarding (Stripe-paid web flow before app install), QR codes, \"open in app\" CTAs, and the trade-off between paying on web vs in-app. Use when the user mentions \"web to app\", \"smart app banner\", \"Stripe before app\", \"web paywall before install\", \"Branch web SDK\", \"web funnel for app\", \"AppsFlyer OneLink web\", \"Universal Links\", \"App Links\", \"QR code to app\", \"open in app\", \"deferred deep link from web\", or \"should I sell on web first then push to app\". For pure in-app onboarding, see onboarding-optimization. For deep link infra, see attribution-setup.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Eronred",
+        "repo": "aso-skills",
+        "repoUrl": "https://github.com/Eronred/aso-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "eronred-aso-skills-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from Eronred/aso-skills.",
+      "author": "ASM (Eronred/aso-skills)",
+      "createdAt": "2026-05-09T08:10:44.397Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "eronred",
+        "aso-skills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-store-listing",
+          "installUrl": "github:Eronred/aso-skills:skills/ab-test-store-listing",
+          "description": "When the user wants to A/B test App Store product page elements to improve conversion rate. Also use when the user mentions \"A/B test\", \"product page optimization\", \"test my screenshots\", \"test my icon\", \"conversion rate optimization\", \"CPP\", or \"custom product pages\". For screenshot design, see screenshot-optimization. For metadata optimization, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "android-aso",
+          "installUrl": "github:Eronred/aso-skills:skills/android-aso",
+          "description": "When the user wants to optimize their Google Play Store listing — title, short description, full description, keywords, ratings, or Play Store-specific features. Use when the user mentions \"Google Play\", \"Android\", \"Play Store\", \"Play Console\", \"short description\", \"full description indexed\", \"Google Play ASO\", or wants Google Play-specific keyword, creative, or ratings strategy. For iOS App Store optimization, see aso-audit and metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-clips",
+          "installUrl": "github:Eronred/aso-skills:skills/app-clips",
+          "description": "When the user wants to implement, optimize, or use App Clips for app discovery and conversion. Use when the user mentions \"App Clip\", \"app clip code\", \"mini app\", \"instant app\", \"App Clip card\", \"App Clip link\", \"no download required\", \"instant experience\", or wants to understand how App Clips appear in App Store search. For general App Store discoverability, see aso-audit. For marketing campaigns, see ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-launch",
+          "installUrl": "github:Eronred/aso-skills:skills/app-launch",
+          "description": "When the user wants to plan a launch strategy for a new app or major update. Also use when the user mentions \"app launch\", \"launch plan\", \"launch checklist\", \"pre-launch\", \"launch day\", or \"how to launch my app\". For ongoing ASO after launch, see aso-audit. For paid acquisition during launch, see ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-marketing-context",
+          "installUrl": "github:Eronred/aso-skills:skills/app-marketing-context",
+          "description": "When the user wants to create or update their app marketing context document. Also use when the user mentions \"app context\", \"marketing brief\", \"app positioning\", or when starting any ASO or app marketing project. This is the foundation skill — all other skills check for this context first.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-preview-video",
+          "installUrl": "github:Eronred/aso-skills:skills/app-preview-video",
+          "description": "When the user wants to plan, script, produce, or optimize App Store Preview videos or Google Play promo videos — the autoplay videos that show in App Store/Play Store search and product pages. Use when the user mentions \"App Preview\", \"preview video\", \"app store video\", \"promo video\", \"Play Store video\", \"video poster frame\", \"YouTube promo for Play Store\", \"30 second app video\", \"video script\", \"video specs\", or \"should I add a preview video\". For static screenshots, see screenshot-optimization. For A/B testing the video, see ab-test-store-listing. For broader creative briefs, see screenshot-optimization (covers stills).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-store-featured",
+          "installUrl": "github:Eronred/aso-skills:skills/app-store-featured",
+          "description": "When the user wants to get featured on the App Store or understand the editorial process. Also use when the user mentions \"get featured\", \"App Store editorial\", \"App of the Day\", \"Today tab\", \"Apple featuring\", or \"how to get Apple to feature my app\". For launch strategy, see app-launch. For ASO optimization, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "apple-search-ads",
+          "installUrl": "github:Eronred/aso-skills:skills/apple-search-ads",
+          "description": "When the user wants to set up, optimize, or scale Apple Search Ads (ASA) campaigns — including keyword bidding, match types, campaign structure, Creative Product Sets, CPP routing, and ROAS optimization. Use when the user mentions \"Apple Search Ads\", \"ASA\", \"Search Ads\", \"Search tab ads\", \"Today tab ads\", \"CPT\", \"TTR\", \"Search Match\", \"exact match\", \"broad match\", \"CPP in ads\", \"ASA bidding\", or \"Search Ads budget\". For Meta/Google UAC/TikTok paid UA, see ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "asc-metrics",
+          "installUrl": "github:Eronred/aso-skills:skills/asc-metrics",
+          "description": "When the user wants to analyze their own app's actual performance data from App Store Connect — real downloads, revenue, IAP, subscriptions, trials, or country breakdowns synced via Appeeky Connect. Use when the user asks about \"my downloads\", \"my revenue\", \"how is my app performing\", \"ASC data\", \"sales and trends\", \"my subscription numbers\", \"App Store Connect metrics\", or wants to compare periods or top markets. For third-party app estimates, see app-analytics. For subscription analytics depth, see monetization-strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "aso-router",
+          "installUrl": "github:Eronred/aso-skills:skills/aso-router",
+          "description": "Single entry point that routes any ASO, App Store, Google Play, app marketing, paid UA, monetization, retention, reviews, ratings, market-intel, or app-analytics question to the correct specialist skill in this library. Use FIRST whenever the user mentions an app, App Store, Play Store, keywords, ranking, downloads, revenue, subscriptions, screenshots, icon, reviews, competitors, charts, in-app events, launch, press, or ads — but the right specialized skill is not obvious. Triggers: \"/aso-skill\", \"/aso\", \"aso help\", \"help me with my app\", \"I need ASO\", \"which skill should I use\", or any ambiguous app-marketing request. Skip this router only when the user explicitly invokes a specific skill (e.g. /aso-audit, /keyword-research).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "attribution-setup",
+          "installUrl": "github:Eronred/aso-skills:skills/attribution-setup",
+          "description": "When the user wants to set up, debug, or interpret app install attribution — including SKAdNetwork (SKAN), Apple's AdAttributionKit, Google Play Install Referrer, MMPs (AppsFlyer, Adjust, Singular, Branch, Kochava), deep links, deferred deep links, conversion values, postback windows, or privacy thresholds. Use when the user mentions \"SKAdNetwork\", \"SKAN\", \"SKAN 4\", \"AdAttributionKit\", \"AAK\", \"MMP\", \"AppsFlyer\", \"Adjust\", \"Singular\", \"Branch\", \"attribution\", \"conversion value\", \"postback\", \"Install Referrer\", \"deferred deep link\", \"iOS 14.5\", \"ATT\", \"App Tracking Transparency\", \"IDFA\", or \"I can't measure my ad campaigns\". For paid campaign strategy, see ua-campaign and apple-search-ads. For analytics events, see app-analytics.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "category-positioning",
+          "installUrl": "github:Eronred/aso-skills:skills/category-positioning",
+          "description": "When the user wants to choose, change, or evaluate their App Store / Google Play category and subcategory — including primary vs secondary category trade-offs, chart-rank competitive analysis, category-driven discoverability, and how category choice affects featuring eligibility. Use when the user mentions \"which category\", \"App Store category\", \"primary category\", \"secondary category\", \"change my category\", \"Health & Fitness vs Lifestyle\", \"Productivity vs Utilities\", \"rank higher in a smaller category\", \"category chart\", \"subcategory\", \"Play Store category\", or \"should I switch categories\". For full ASO health beyond category, see aso-audit. For competitor analysis within the chosen category, see competitor-analysis. For chart movements within categories, see market-movers.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitor-analysis",
+          "installUrl": "github:Eronred/aso-skills:skills/competitor-analysis",
+          "description": "When the user wants to analyze competitors' App Store strategy, find keyword gaps, or understand competitive positioning. Also use when the user mentions \"competitor analysis\", \"competitive research\", \"keyword gap\", \"what are my competitors doing\", or \"compare my app to\". For keyword-specific research, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitor-tracking",
+          "installUrl": "github:Eronred/aso-skills:skills/competitor-tracking",
+          "description": "When the user wants to monitor competitor apps on an ongoing basis — tracking metadata changes, keyword shifts, screenshot updates, rating trends, or new features. Use when the user mentions \"competitor monitoring\", \"track competitors\", \"competitor alert\", \"competitor changed their title\", \"watch a competitor app\", \"competitor weekly report\", \"competitive intelligence\", or \"what changed in competitor's listing\". For a one-time deep competitive analysis, see competitor-analysis. For market-wide chart movements, see market-movers.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "creator-ugc-marketing",
+          "installUrl": "github:Eronred/aso-skills:skills/creator-ugc-marketing",
+          "description": "When the user wants to plan, brief, source, or measure organic creator / influencer / UGC marketing for their app — including TikTok creators, Instagram Reels, YouTube Shorts, micro-influencers, paid creator briefs, UGC ad creative for Meta/TikTok, affiliate programs, and seeding strategy. Use when the user mentions \"creators\", \"influencers\", \"TikTok marketing\", \"UGC\", \"user-generated content\", \"creator briefs\", \"creator outreach\", \"influencer marketing\", \"Reels\", \"Shorts\", \"creator gifting\", \"seeding\", \"affiliate\", \"Whop\", \"TikTok Spark Ads\", \"Instagram collab posts\", or \"I want my app to go viral on TikTok\". For paid social ad campaigns (Meta/TikTok ad accounts), see ua-campaign. For PR / press, see press-and-pr. For viral in-app loops, see referral-program.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "custom-product-pages",
+          "installUrl": "github:Eronred/aso-skills:skills/custom-product-pages",
+          "description": "When the user wants to design, deploy, or measure Apple Custom Product Pages (CPP) — the alternate App Store product pages with different screenshots, preview videos, and promo text shown to users coming from specific URLs (typically ad campaigns or social posts). Use when the user mentions \"Custom Product Page\", \"CPP\", \"alternate product page\", \"App Store URL variant\", \"ASA CPP\", \"campaign-specific landing page\", \"product page per audience\", \"App Store Connect CPP\", \"ppoUrl\", \"?cpp=\" parameter, or \"show different screenshots to different ad audiences\". For App Store A/B tests on the default page, see ab-test-store-listing. For paid ad campaigns that route to CPPs, see apple-search-ads or ua-campaign.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "in-app-events",
+          "installUrl": "github:Eronred/aso-skills:skills/in-app-events",
+          "description": "When the user wants to create, plan, or optimize App Store In-App Events — the event cards that appear on the Today tab, search results, and your product page. Use when the user mentions \"in-app event\", \"App Store event\", \"event card\", \"Today tab\", \"live event\", \"challenge\", \"game event\", \"seasonal event card\", or wants visibility beyond organic search. For general ASO, see aso-audit. For seasonal keyword strategy, see seasonal-aso.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "localization",
+          "installUrl": "github:Eronred/aso-skills:skills/localization",
+          "description": "When the user wants to localize their App Store listing for international markets. Also use when the user mentions \"localization\", \"translate my app\", \"international markets\", \"expand to new countries\", \"localize metadata\", or \"which countries should I target\". For keyword research in specific markets, see keyword-research. For metadata writing, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "market-movers",
+          "installUrl": "github:Eronred/aso-skills:skills/market-movers",
+          "description": "When the user wants to track App Store chart rank changes, find top gainers and losers, detect breakout apps entering the top 100, or identify apps dropping out of charts. Also use when the user mentions \"chart movers\", \"rank changes\", \"who's rising\", \"who's falling\", \"new chart entries\", \"top gainers\", or \"market shifts\". For broader market overview, see market-pulse. For competitive keyword analysis, see competitor-analysis.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "market-pulse",
+          "installUrl": "github:Eronred/aso-skills:skills/market-pulse",
+          "description": "When the user wants a comprehensive App Store market overview, daily/weekly market briefing, or combined view of chart movements, trending keywords, featured apps, and new releases. Also use when the user mentions \"market overview\", \"what's happening on the App Store\", \"market briefing\", \"weekly report\", \"market trends\", or \"state of the market\". For chart-specific rank changes only, see market-movers. For keyword trends only, see keyword-research.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "monetization-strategy",
+          "installUrl": "github:Eronred/aso-skills:skills/monetization-strategy",
+          "description": "When the user wants to design or optimize their app's monetization — pricing, paywalls, subscriptions, or in-app purchases. Also use when the user mentions \"pricing\", \"paywall\", \"subscription\", \"IAP\", \"how to monetize\", \"revenue optimization\", \"free trial\", or \"conversion to paid\". For retention impact, see retention-optimization. For competitive pricing, see competitor-analysis.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "onboarding-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/onboarding-optimization",
+          "description": "When the user wants to improve their app's onboarding experience, increase activation rate, reduce Day 1 drop-off, or optimize the first-run flow. Use when the user mentions \"onboarding\", \"first-run\", \"activation\", \"tutorial\", \"day 1 retention\", \"new user flow\", \"permission prompts\", \"sign-up conversion\", \"onboarding funnel\", or \"users dropping off early\". For overall retention strategy, see retention-optimization. For paywall placement, see monetization-strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "paywall-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/paywall-optimization",
+          "description": "When the user wants to design, test, or optimize their app's paywall — layout, copy, pricing display, trial offers, plan structure, hard vs soft paywall, paywall placement, or paywall A/B tests. Use when the user mentions \"paywall\", \"paywall design\", \"paywall conversion\", \"trial-to-paid\", \"soft paywall\", \"hard paywall\", \"paywall A/B test\", \"paywall copy\", \"plan picker\", \"annual vs monthly display\", \"best paywall\", \"RevenueCat paywall\", \"Superwall\", \"Adapty\", or \"my paywall isn't converting\". For overall pricing strategy and monetization model choice, see monetization-strategy. For trial nurture, dunning, and churn, see subscription-lifecycle. For where in the onboarding the paywall fires, see onboarding-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "press-and-pr",
+          "installUrl": "github:Eronred/aso-skills:skills/press-and-pr",
+          "description": "When the user wants to get press coverage, media mentions, or editorial features for their app — including writing press releases, pitching journalists, getting on \"best apps\" lists, or building an app press kit. Use when the user mentions \"press\", \"PR\", \"media coverage\", \"TechCrunch\", \"journalist\", \"press release\", \"app press kit\", \"get featured in media\", \"editorial coverage\", \"review from a blogger\", or \"app launch announcement\". For Apple editorial featuring, see app-store-featured. For launch strategy, see app-launch.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "rating-prompt-strategy",
+          "installUrl": "github:Eronred/aso-skills:skills/rating-prompt-strategy",
+          "description": "When the user wants to improve their app's star rating, increase ratings volume, optimize when and how they prompt users for a review, or recover from a bad rating period. Use when the user mentions \"app rating\", \"star rating\", \"review prompt\", \"SKStoreReviewRequest\", \"In-App Review API\", \"ask for review\", \"low rating\", \"rating drop\", \"get more reviews\", or \"recover from 1-star\". For responding to reviews, see review-management. For overall ASO health, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "referral-program",
+          "installUrl": "github:Eronred/aso-skills:skills/referral-program",
+          "description": "When the user wants to design, launch, or optimize an in-app referral / invite / share-to-earn program — including reward structure, mechanics, fraud prevention, deep link setup, and viral coefficient measurement. Use when the user mentions \"referral program\", \"invite a friend\", \"refer and earn\", \"share to earn\", \"viral loop\", \"viral coefficient\", \"K-factor\", \"double-sided rewards\", \"give X get X\", \"referral rewards\", \"invite link\", \"share sheet\", \"Branch referrals\", \"in-app invites\", or \"how to make my app go viral\". For deep link infrastructure that referrals depend on, see attribution-setup. For organic content-driven virality (UGC, creator), see creator-ugc-marketing.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "retention-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/retention-optimization",
+          "description": "When the user wants to reduce churn, improve user engagement, or increase lifetime value. Also use when the user mentions \"retention\", \"churn\", \"users leaving\", \"engagement\", \"DAU/MAU\", \"user activation\", or \"why are users uninstalling\". For onboarding-specific issues, see app-launch. For monetization, see monetization-strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "screenshot-optimization",
+          "installUrl": "github:Eronred/aso-skills:skills/screenshot-optimization",
+          "description": "When the user wants to design, optimize, or evaluate App Store screenshots and preview videos. Also use when the user mentions \"screenshots\", \"app preview\", \"product page design\", \"screenshot design\", \"creative assets\", or \"what should my screenshots show\". For A/B testing screenshots, see ab-test-store-listing. For full ASO audit, see aso-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "seasonal-aso",
+          "installUrl": "github:Eronred/aso-skills:skills/seasonal-aso",
+          "description": "When the user wants to optimize their App Store listing for seasonal events, holidays, or trending moments — including keyword opportunities, metadata updates, screenshot theming, and timing strategy. Use when the user mentions \"seasonal\", \"holiday\", \"Christmas\", \"New Year\", \"Valentine's Day\", \"summer\", \"back to school\", \"seasonal keywords\", \"trending now\", \"limited time\", or wants to capitalize on a calendar event. For general keyword research, see keyword-research. For full metadata rewrites, see metadata-optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "subscription-lifecycle",
+          "installUrl": "github:Eronred/aso-skills:skills/subscription-lifecycle",
+          "description": "When the user wants to optimize their subscription business end-to-end — from trial start through renewal, cancellation, and win-back. Use when the user mentions \"subscription lifecycle\", \"trial conversion\", \"churn\", \"cancellation\", \"win-back\", \"lapsed subscribers\", \"dunning\", \"billing retry\", \"grace period\", \"renewal rate\", \"subscriber LTV\", or \"resubscribe\". For paywall design and pricing strategy, see monetization-strategy. For subscription analytics dashboards, see app-analytics.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Eronred",
+        "repo": "aso-skills",
+        "repoUrl": "https://github.com/Eronred/aso-skills.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/GPTomics_bioSkills.json
+++ b/data/skill-index/GPTomics_bioSkills.json
@@ -60148,5 +60148,3175 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "gptomics-bioskills-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from GPTomics/bioSkills.",
+      "author": "ASM (GPTomics/bioSkills)",
+      "createdAt": "2026-05-09T08:10:51.349Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "gptomics",
+        "bioskills"
+      ],
+      "skills": [
+        {
+          "name": "bio-atac-seq-motif-deviation",
+          "installUrl": "github:GPTomics/bioSkills:atac-seq/motif-deviation",
+          "description": "Analyze transcription factor motif accessibility variability using chromVAR. Use when identifying which TF motifs show variable accessibility across samples or conditions in ATAC-seq data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-batch-processing",
+          "installUrl": "github:GPTomics/bioSkills:sequence-io/batch-processing",
+          "description": "Process multiple sequence files in batch using Biopython. Use when working with many files, merging/splitting sequences, or automating file operations across directories.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-bedgraph-handling",
+          "installUrl": "github:GPTomics/bioSkills:genome-intervals/bedgraph-handling",
+          "description": "Create, manipulate, and convert bedGraph files for genome browser visualization. Covers bedGraph format, conversion to/from bigWig, normalization, and signal processing. Use when handling coverage and signal tracks from ChIP-seq, ATAC-seq, or RNA-seq.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-chipseq-qc",
+          "installUrl": "github:GPTomics/bioSkills:chip-seq/chipseq-qc",
+          "description": "ChIP-seq quality control metrics including FRiP (Fraction of Reads in Peaks), cross-correlation analysis (NSC/RSC), library complexity, and IDR (Irreproducibility Discovery Rate) for replicate concordance. Use to assess experiment quality before downstream analysis. Use when assessing ChIP-seq data quality metrics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-effect-measures",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/effect-measures",
+          "description": "Computes and interprets treatment effect measures including odds ratios, risk ratios, number needed to treat, and confidence intervals from clinical trial data. Covers crude and adjusted measures, non-collapsibility of odds ratios, and forest plot visualization. Use when reporting treatment effects or comparing effect sizes across clinical studies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-subgroup-analysis",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/subgroup-analysis",
+          "description": "Performs stratified and subgroup analyses for clinical trial data. Covers Mantel-Haenszel pooling, Breslow-Day homogeneity testing, interaction terms in regression, multiple comparisons correction, and forest plot visualization. Use when analyzing treatment effects across patient subgroups or controlling for stratification variables.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-dbsnp-queries",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/dbsnp-queries",
+          "description": "Query dbSNP for rsID lookups, variant annotations, and cross-references to other databases. Use when mapping between rsIDs and genomic coordinates or retrieving basic variant information.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clip-seq-clip-alignment",
+          "installUrl": "github:GPTomics/bioSkills:clip-seq/clip-alignment",
+          "description": "Align CLIP-seq reads to the genome with crosslink site awareness. Use when mapping preprocessed CLIP reads for peak calling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-comparative-genomics-ortholog-inference",
+          "installUrl": "github:GPTomics/bioSkills:comparative-genomics/ortholog-inference",
+          "description": "Infer orthologous gene groups across species using OrthoFinder and ProteinOrtho. Identify orthologs, paralogs, and co-orthologs for comparative genomics and functional annotation transfer. Use when identifying gene orthologs across species or building orthogroups for evolutionary analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-cnv-annotation",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/cnv-annotation",
+          "description": "Annotate CNVs with genes, pathways, and clinical significance. Use when interpreting CNV calls or identifying affected genes from copy number analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-cnv-visualization",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/cnv-visualization",
+          "description": "Visualize copy number profiles, segments, and compare across samples. Create publication-quality plots of CNV data from CNVkit, GATK, or other callers. Use when creating genome-wide CNV plots, sample heatmaps, or chromosome-level visualizations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-cnvkit-analysis",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/cnvkit-analysis",
+          "description": "Detect copy number variants from targeted/exome sequencing using CNVkit. Supports tumor-normal pairs, tumor-only, and germline CNV calling. Use when detecting CNVs from WES or targeted panel sequencing data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-gatk-cnv",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/gatk-cnv",
+          "description": "Call copy number variants using GATK best practices workflow. Supports both somatic (tumor-normal) and germline CNV detection from WGS or WES data. Use when following GATK best practices or integrating CNV calling with other GATK variant pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-crispr-screens-batch-correction",
+          "installUrl": "github:GPTomics/bioSkills:crispr-screens/batch-correction",
+          "description": "Batch effect correction for CRISPR screens. Covers normalization across batches, technical replicate handling, and batch-aware analysis. Use when combining screens from multiple batches or correcting systematic technical variation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-crispr-screens-jacks-analysis",
+          "installUrl": "github:GPTomics/bioSkills:crispr-screens/jacks-analysis",
+          "description": "JACKS (Joint Analysis of CRISPR/Cas9 Knockout Screens) for modeling sgRNA efficacy and gene essentiality. Use when analyzing multiple CRISPR screens simultaneously or when accounting for variable sgRNA efficiency across experiments.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-heatmaps-clustering",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/heatmaps-clustering",
+          "description": "Create clustered heatmaps with row/column annotations using ComplexHeatmap, pheatmap, and seaborn for gene expression and omics data visualization. Use when visualizing expression patterns across samples or identifying co-expressed gene clusters.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-biodiversity-metrics",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/biodiversity-metrics",
+          "description": "Calculates species richness, diversity, and turnover using the Hill number framework with iNEXT coverage-based rarefaction/extrapolation, asymptotic diversity estimation, and beta diversity partitioning (betapart turnover vs nestedness). Compares assemblages using coverage-standardized rather than size-standardized rarefaction. Use when quantifying biodiversity from species abundance or incidence data, comparing diversity across sites, or constructing rarefaction curves. Not for clinical 16S microbiome alpha/beta diversity (see microbiome/diversity-analysis).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-community-ecology",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/community-ecology",
+          "description": "Analyzes community composition using constrained ordination (CCA, RDA, db-RDA), variance partitioning (varpart), indicator species analysis (indicspecies multipatt), and distance-based environmental gradient methods with vegan. Links species composition to environmental explanatory variables. Use when testing how environmental gradients structure species communities, identifying habitat indicator taxa, or partitioning explained variation among predictors. Not for basic unconstrained ordination and PERMANOVA (see microbiome/diversity-analysis).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-conservation-genetics",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/conservation-genetics",
+          "description": "Assesses genetic health of populations for conservation using effective population size estimation (GONE2 for recent Ne trajectory, NeEstimator for contemporary Ne, Stairway Plot 2 and PSMC for historical Ne), F-statistics (hierfstat), runs of homozygosity (detectRUNS), and genetic diversity metrics. Use when estimating effective population size, detecting inbreeding or bottlenecks, or assessing genetic diversity in threatened species from microsatellite or SNP data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-edna-metabarcoding",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/edna-metabarcoding",
+          "description": "Processes environmental DNA metabarcoding data from raw amplicon reads to species occurrence tables using OBITools3, DADA2, and taxonomic assignment against BOLD, MIDORI2, or MitoFish databases. Handles COI, 12S, rbcL, and ITS barcode regions with primer removal, denoising, chimera detection, and contamination filtering via decontam. Includes occupancy modeling (occumb) for detection probability correction. Use when analyzing eDNA from water, soil, or bulk samples for biodiversity monitoring. Not for 16S human microbiome (see microbiome/amplicon-processing).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-landscape-genomics",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/landscape-genomics",
+          "description": "Tests genotype-environment associations and identifies loci under local adaptation using LFMM2 (LEA), pcadapt outlier detection, OutFLANK Fst-based selection scans, and redundancy analysis. Detects adaptive genetic variation correlated with environmental variables while controlling for population structure. Use when identifying adaptive loci across environmental gradients, testing for signatures of local adaptation, or predicting genetic vulnerability to climate change with gradientForest.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-entrez-link",
+          "installUrl": "github:GPTomics/bioSkills:database-access/entrez-link",
+          "description": "Find cross-references between NCBI databases using Biopython Bio.Entrez. Use when navigating from genes to proteins, sequences to publications, finding related records, or discovering database relationships.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-entrez-search",
+          "installUrl": "github:GPTomics/bioSkills:database-access/entrez-search",
+          "description": "Search NCBI databases using Biopython Bio.Entrez. Use when finding records by keyword, building complex search queries, discovering database structure, or getting global query counts across databases.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-epidemiological-genomics-amr-surveillance",
+          "installUrl": "github:GPTomics/bioSkills:epidemiological-genomics/amr-surveillance",
+          "description": "Detect and track antimicrobial resistance genes using AMRFinderPlus and ResFinder with epidemiological context. Monitor resistance trends and identify emerging resistance patterns. Use when screening genomes for AMR genes or tracking resistance in surveillance programs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-flow-cytometry-bead-normalization",
+          "installUrl": "github:GPTomics/bioSkills:flow-cytometry/bead-normalization",
+          "description": "Bead-based normalization for CyTOF and high-parameter flow cytometry. Covers EQ bead normalization, signal drift correction, and batch normalization. Use when correcting instrument drift in CyTOF or harmonizing data across batches.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-format-conversion",
+          "installUrl": "github:GPTomics/bioSkills:sequence-io/format-conversion",
+          "description": "Convert between sequence file formats (FASTA, FASTQ, GenBank, EMBL) using Biopython Bio.SeqIO. Use when changing file formats or preparing data for different tools.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-annotation-annotation-transfer",
+          "installUrl": "github:GPTomics/bioSkills:genome-annotation/annotation-transfer",
+          "description": "Transfer gene annotations between genome assemblies using Liftoff for same-species annotation liftover and MiniProt for cross-species protein-to-genome alignment. Enables rapid annotation of new assemblies using existing reference annotations. Use when annotating a new assembly of a species with an existing reference annotation or mapping annotations across related species.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-assembly-metagenome-assembly",
+          "installUrl": "github:GPTomics/bioSkills:genome-assembly/metagenome-assembly",
+          "description": "Metagenome assembly from long reads using metaFlye and metaSPAdes with binning strategies. Use when reconstructing genomes from microbial communities, recovering metagenome-assembled genomes (MAGs), or resolving strain-level variation in complex samples.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-engineering-base-editing-design",
+          "installUrl": "github:GPTomics/bioSkills:genome-engineering/base-editing-design",
+          "description": "Design guides for cytosine and adenine base editing using editing window optimization and BE-Hive outcome prediction. Select optimal positions for C-to-T or A-to-G conversions without double-strand breaks. Use when designing base editor experiments for precise nucleotide changes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-intervals-bed-file-basics",
+          "installUrl": "github:GPTomics/bioSkills:genome-intervals/bed-file-basics",
+          "description": "BED file format fundamentals, creation, validation, and basic operations. Covers BED3 through BED12 formats, coordinate systems, sorting, and format conversion using bedtools and pybedtools. Use when working with genomic coordinates or preparing interval files for downstream tools.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-intervals-coverage-analysis",
+          "installUrl": "github:GPTomics/bioSkills:genome-intervals/coverage-analysis",
+          "description": "Calculate read depth and coverage across genomic intervals using bedtools genomecov and coverage. Generate bedGraph files, compute per-base depth, and summarize coverage statistics. Use when assessing sequencing depth, creating coverage tracks, or evaluating target capture efficiency.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-geo-data",
+          "installUrl": "github:GPTomics/bioSkills:database-access/geo-data",
+          "description": "Query NCBI Gene Expression Omnibus (GEO) for expression datasets using Biopython Bio.Entrez. Use when finding microarray/RNA-seq datasets, downloading expression data, or linking GEO series to SRA runs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-long-read-sequencing-nanopore-methylation",
+          "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/nanopore-methylation",
+          "description": "Calls DNA methylation from Oxford Nanopore sequencing data using signal-level analysis. Use when detecting 5mC or 6mA modifications directly from nanopore reads without bisulfite conversion.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-machine-learning-model-validation",
+          "installUrl": "github:GPTomics/bioSkills:machine-learning/model-validation",
+          "description": "Implements nested cross-validation and stratified splits for unbiased model evaluation on biomedical datasets. Prevents data leakage and overfitting in biomarker discovery. Use when validating classifiers or optimizing hyperparameters on omics data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-metagenomics-amr-detection",
+          "installUrl": "github:GPTomics/bioSkills:metagenomics/amr-detection",
+          "description": "Detect antimicrobial resistance genes using AMRFinderPlus, ResFinder, and CARD. Screen isolates and metagenomes for resistance determinants. Use when characterizing resistance profiles in clinical isolates, surveillance samples, or metagenomic data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-metagenomics-visualization",
+          "installUrl": "github:GPTomics/bioSkills:metagenomics/metagenome-visualization",
+          "description": "Visualize metagenomic profiles using R (phyloseq, microbiome) and Python (matplotlib, seaborn). Create stacked bar plots, heatmaps, PCA plots, and diversity analyses. Use when creating publication-quality figures from MetaPhlAn, Bracken, or other taxonomic profiling output.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-microbiome-amplicon-processing",
+          "installUrl": "github:GPTomics/bioSkills:microbiome/amplicon-processing",
+          "description": "Amplicon sequence variant (ASV) inference from 16S rRNA or ITS amplicon sequencing using DADA2. Covers quality filtering, error learning, denoising, and chimera removal. Use when processing demultiplexed amplicon FASTQ files to generate an ASV table for downstream analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-microbiome-differential-abundance",
+          "installUrl": "github:GPTomics/bioSkills:microbiome/differential-abundance",
+          "description": "Differential abundance testing for microbiome data using compositionally-aware methods like ALDEx2, ANCOM-BC2, and MaAsLin2. Use when identifying taxa that differ between experimental groups while accounting for the compositional nature of microbiome data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-microbiome-diversity-analysis",
+          "installUrl": "github:GPTomics/bioSkills:microbiome/diversity-analysis",
+          "description": "Alpha and beta diversity analysis for microbiome data. Calculate within-sample richness, evenness, and between-sample dissimilarity with phyloseq and vegan. Use when comparing community composition across samples or testing for group differences in microbiome structure.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-microbiome-functional-prediction",
+          "installUrl": "github:GPTomics/bioSkills:microbiome/functional-prediction",
+          "description": "Predict metagenome functional content from 16S rRNA marker gene data using PICRUSt2. Infer KEGG, MetaCyc, and EC abundances from ASV tables. Use when functional profiling is needed from 16S data without shotgun metagenomics sequencing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-microbiome-qiime2-workflow",
+          "installUrl": "github:GPTomics/bioSkills:microbiome/qiime2-workflow",
+          "description": "QIIME2 command-line workflow for 16S/ITS amplicon analysis. Alternative to DADA2/phyloseq R workflow with built-in provenance tracking. Use when preferring CLI over R, needing reproducible provenance, or working within QIIME2 ecosystem.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-microbiome-taxonomy-assignment",
+          "installUrl": "github:GPTomics/bioSkills:microbiome/taxonomy-assignment",
+          "description": "Taxonomic classification of ASVs using reference databases like SILVA, GTDB, or UNITE. Covers naive Bayes classifiers (DADA2, IDTAXA) and exact matching approaches. Use when assigning taxonomy to ASVs after DADA2 amplicon processing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-multi-omics-data-harmonization",
+          "installUrl": "github:GPTomics/bioSkills:multi-omics-integration/data-harmonization",
+          "description": "Preprocessing and harmonization of multi-omics data before integration. Covers normalization, batch correction, feature alignment, and missing value handling across data types. Use when preparing multi-omics datasets for integration analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-multi-omics-mofa-integration",
+          "installUrl": "github:GPTomics/bioSkills:multi-omics-integration/mofa-integration",
+          "description": "Multi-Omics Factor Analysis (MOFA2) for unsupervised integration of multiple data modalities. Identifies shared and view-specific sources of variation. Use when integrating RNA-seq, proteomics, methylation, or other omics to discover latent factors driving biological variation across modalities.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-phasing-imputation-genotype-imputation",
+          "installUrl": "github:GPTomics/bioSkills:phasing-imputation/genotype-imputation",
+          "description": "Impute missing genotypes using reference panels with Beagle or Minimac4. Use when increasing variant density for GWAS, harmonizing data across genotyping platforms, or inferring variants not directly typed in array data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-phylo-divergence-dating",
+          "installUrl": "github:GPTomics/bioSkills:phylogenetics/divergence-dating",
+          "description": "Estimate divergence times using molecular clock models with BEAST2, MCMCTree, and TreePL. Use when dating speciation events, calibrating phylogenies with fossils, choosing between strict and relaxed clock models, or estimating evolutionary rates across lineages.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-population-genetics-plink-basics",
+          "installUrl": "github:GPTomics/bioSkills:population-genetics/plink-basics",
+          "description": "PLINK file formats, format conversion, and quality control filtering for population genetics. Convert between VCF, BED/BIM/FAM, and PED/MAP formats, apply MAF, genotyping rate, and HWE filters using PLINK 1.9 and 2.0. Use when working with PLINK format files or running QC.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-read-qc-contamination-screening",
+          "installUrl": "github:GPTomics/bioSkills:read-qc/contamination-screening",
+          "description": "Detect sample contamination and cross-species reads using FastQ Screen. Screen reads against multiple reference genomes to identify bacterial, viral, adapter, or sample swap contamination. Use when suspecting cross-contamination or working with samples prone to microbial contamination.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-reporting-automated-qc-reports",
+          "installUrl": "github:GPTomics/bioSkills:reporting/automated-qc-reports",
+          "description": "Generates standardized quality control reports by aggregating metrics from FastQC, alignment, and other tools using MultiQC. Use when summarizing QC metrics across samples, creating shareable quality reports, or building automated QC pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-reporting-figure-export",
+          "installUrl": "github:GPTomics/bioSkills:reporting/figure-export",
+          "description": "Exports publication-ready figures in various formats with proper resolution, sizing, and typography. Use when preparing figures for journal submission, creating vector graphics for presentations, or ensuring consistent figure styling across analyses.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-rna-structure-secondary-structure-prediction",
+          "installUrl": "github:GPTomics/bioSkills:rna-structure/secondary-structure-prediction",
+          "description": "Predicts RNA secondary structures using minimum free energy folding and partition function analysis with ViennaRNA (RNAfold, RNAalifold, RNAcofold). Computes base-pair probabilities, centroid structures, and consensus structures from alignments. Use when predicting RNA folding, evaluating structural stability, or comparing structures across homologs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-single-cell-metabolite-communication",
+          "installUrl": "github:GPTomics/bioSkills:single-cell/metabolite-communication",
+          "description": "Analyze metabolite-mediated cell-cell communication using MeboCost for metabolic signaling inference between cell types. Predict metabolite secretion and sensing patterns from scRNA-seq data. Use when studying metabolic crosstalk between cell populations or metabolite-receptor interactions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-single-cell-perturb-seq",
+          "installUrl": "github:GPTomics/bioSkills:single-cell/perturb-seq",
+          "description": "Analyze Perturb-seq and CROP-seq CRISPR screening data integrated with scRNA-seq. Use when identifying gene function through pooled genetic perturbations in single cells.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-structural-biology-modern-structure-prediction",
+          "installUrl": "github:GPTomics/bioSkills:structural-biology/modern-structure-prediction",
+          "description": "Predict protein structures using modern ML models including AlphaFold3, ESMFold, Chai-1, and Boltz-1. Use when predicting structures for novel proteins, protein complexes, or when comparing predictions across multiple methods.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-systems-biology-flux-balance-analysis",
+          "installUrl": "github:GPTomics/bioSkills:systems-biology/flux-balance-analysis",
+          "description": "Perform flux balance analysis (FBA) and flux variability analysis (FVA) on genome-scale metabolic models using COBRApy. Predict growth rates, metabolic fluxes, and optimal resource utilization. Use when predicting metabolic phenotypes or optimizing flux distributions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-temporal-genomics-temporal-clustering",
+          "installUrl": "github:GPTomics/bioSkills:temporal-genomics/temporal-clustering",
+          "description": "Clusters genes by temporal expression profile shape using Mfuzz soft clustering, TCseq, and DEGreport degPatterns. Groups co-regulated genes into shared trajectory patterns via fuzzy c-means or hierarchical approaches. Use when categorizing temporally dynamic genes into response groups or identifying co-expression modules across time points. Requires temporally variable genes identified first (see differential-expression/timeseries-de).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-temporal-genomics-temporal-grn",
+          "installUrl": "github:GPTomics/bioSkills:temporal-genomics/temporal-grn",
+          "description": "Infers dynamic gene regulatory networks from bulk time-series expression data using Granger causality (statsmodels), dynGENIE3 (Extra-Trees on ODE-derived expression derivatives), and dynamic Bayesian networks (bnlearn). Identifies time-delayed regulatory relationships and tracks network rewiring across conditions. Use when inferring causal regulatory relationships from bulk temporal expression data or detecting TF influence propagation over time. Not for static co-expression networks (see gene-regulatory-networks/coexpression-networks).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-temporal-genomics-trajectory-modeling",
+          "installUrl": "github:GPTomics/bioSkills:temporal-genomics/trajectory-modeling",
+          "description": "Models continuous temporal trajectories from bulk or time-resolved omics data using generalized additive models (mgcv), spline regression, and changepoint detection (segmented, ruptures). Fits smooth gene expression curves and tests trajectory differences between conditions. Use when fitting non-linear temporal models to bulk time-series data or comparing developmental trajectories across conditions. Not for single-cell pseudotime (see single-cell/trajectory-inference).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-tumor-fraction-estimation",
+          "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/tumor-fraction-estimation",
+          "description": "Estimates circulating tumor DNA fraction from shallow whole-genome sequencing using ichorCNA. Detects copy number alterations via HMM segmentation and calculates ctDNA percentage. Requires 0.1-1x sWGS coverage. Use when quantifying tumor burden from liquid biopsy or monitoring treatment response.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-variant-calling-joint-calling",
+          "installUrl": "github:GPTomics/bioSkills:variant-calling/joint-calling",
+          "description": "Joint genotype calling across multiple samples using GATK CombineGVCFs and GenotypeGVCFs. Essential for cohort studies, population genetics, and leveraging VQSR. Use when performing joint genotyping across multiple samples.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-workflow-management-cwl-workflows",
+          "installUrl": "github:GPTomics/bioSkills:workflow-management/cwl-workflows",
+          "description": "Create portable, standards-based bioinformatics pipelines with Common Workflow Language (CWL). Use when building workflows that need maximum portability across execution platforms, sharing pipelines with collaborators using different systems, or contributing to community workflow registries.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-workflow-management-wdl-workflows",
+          "installUrl": "github:GPTomics/bioSkills:workflow-management/wdl-workflows",
+          "description": "Create portable bioinformatics pipelines with Workflow Description Language (WDL) using Cromwell or miniwdl execution engines. Use when running GATK best practices pipelines, working with Terra/AnVIL platforms, or building workflows for cloud execution on Google Cloud or AWS.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-workflows-cnv-pipeline",
+          "installUrl": "github:GPTomics/bioSkills:workflows/cnv-pipeline",
+          "description": "End-to-end copy number variant detection workflow from BAM files. Covers CNVkit analysis for exome/targeted sequencing with visualization and annotation. Use when detecting copy number alterations from sequencing data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-workflows-microbiome-pipeline",
+          "installUrl": "github:GPTomics/bioSkills:workflows/microbiome-pipeline",
+          "description": "End-to-end 16S amplicon workflow from FASTQ reads to differential abundance. Orchestrates DADA2 ASV inference, taxonomy assignment, diversity analysis, and compositional testing with ALDEx2. Use when processing 16S/ITS amplicon data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-workflows-multi-omics-pipeline",
+          "installUrl": "github:GPTomics/bioSkills:workflows/multi-omics-pipeline",
+          "description": "End-to-end multi-omics integration workflow. Orchestrates data harmonization, MOFA/mixOmics integration, factor interpretation, and downstream analysis across transcriptomics, proteomics, metabolomics, and other modalities. Use when integrating multiple omics datasets.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "GPTomics",
+        "repo": "bioSkills",
+        "repoUrl": "https://github.com/GPTomics/bioSkills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "gptomics-bioskills-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from GPTomics/bioSkills.",
+      "author": "ASM (GPTomics/bioSkills)",
+      "createdAt": "2026-05-09T08:10:51.349Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "gptomics",
+        "bioskills"
+      ],
+      "skills": [
+        {
+          "name": "bio-alignment-io",
+          "installUrl": "github:GPTomics/bioSkills:alignment/alignment-io",
+          "description": "Read, write, and convert multiple sequence alignment files using Biopython Bio.AlignIO. Supports Clustal, PHYLIP, Stockholm, FASTA, Nexus, and other alignment formats for phylogenetics and conservation analysis. Use when reading, writing, or converting alignment file formats.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-compressed-files",
+          "installUrl": "github:GPTomics/bioSkills:sequence-io/compressed-files",
+          "description": "Read and write compressed sequence files (gzip, bzip2, BGZF) using Biopython. Use when working with .gz or .bz2 sequence files. Use BGZF for indexable compressed files.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-cnv-annotation",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/cnv-annotation",
+          "description": "Annotate CNVs with genes, pathways, and clinical significance. Use when interpreting CNV calls or identifying affected genes from copy number analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-cnv-visualization",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/cnv-visualization",
+          "description": "Visualize copy number profiles, segments, and compare across samples. Create publication-quality plots of CNV data from CNVkit, GATK, or other callers. Use when creating genome-wide CNV plots, sample heatmaps, or chromosome-level visualizations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-cnvkit-analysis",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/cnvkit-analysis",
+          "description": "Detect copy number variants from targeted/exome sequencing using CNVkit. Supports tumor-normal pairs, tumor-only, and germline CNV calling. Use when detecting CNVs from WES or targeted panel sequencing data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-gatk-cnv",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/gatk-cnv",
+          "description": "Call copy number variants using GATK best practices workflow. Supports both somatic (tumor-normal) and germline CNV detection from WGS or WES data. Use when following GATK best practices or integrating CNV calling with other GATK variant pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-ggplot2-fundamentals",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/ggplot2-fundamentals",
+          "description": "Create publication-quality scientific figures with ggplot2 including scatter plots, boxplots, heatmaps, and multi-panel layouts. Use when creating static figures for papers, presentations, or reports in R.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-experimental-design-sample-size",
+          "installUrl": "github:GPTomics/bioSkills:experimental-design/sample-size",
+          "description": "Estimates required sample sizes for differential expression, ChIP-seq, methylation, and proteomics studies. Use when budgeting experiments, writing grant proposals, or determining minimum replicates needed to achieve statistical significance for expected effect sizes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-filter-sequences",
+          "installUrl": "github:GPTomics/bioSkills:sequence-io/filter-sequences",
+          "description": "Filter and select sequences by criteria (length, ID, GC content, patterns) using Biopython. Use when subsetting sequences, removing unwanted records, or selecting by specific criteria.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-microbiome-functional-prediction",
+          "installUrl": "github:GPTomics/bioSkills:microbiome/functional-prediction",
+          "description": "Predict metagenome functional content from 16S rRNA marker gene data using PICRUSt2. Infer KEGG, MetaCyc, and EC abundances from ASV tables. Use when functional profiling is needed from 16S data without shotgun metagenomics sequencing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-molecular-io",
+          "installUrl": "github:GPTomics/bioSkills:chemoinformatics/molecular-io",
+          "description": "Reads, writes, and converts molecular file formats (SMILES, SDF, MOL2, PDB) using RDKit and Open Babel. Handles structure parsing, canonicalization, and full standardization pipeline including sanitization, normalization, and tautomer canonicalization. Use when loading chemical libraries, converting formats, or preparing molecules for analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-pdb-structure-io",
+          "installUrl": "github:GPTomics/bioSkills:structural-biology/structure-io",
+          "description": "Parse and write protein structure files using Biopython Bio.PDB. Use when reading PDB, mmCIF, and MMTF files, downloading structures from RCSB PDB, or writing structures to various formats.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-phylo-tree-io",
+          "installUrl": "github:GPTomics/bioSkills:phylogenetics/tree-io",
+          "description": "Read, write, and convert phylogenetic tree files using Biopython Bio.Phylo. Use when parsing Newick, Nexus, PhyloXML, or NeXML tree formats, converting between formats, or handling multiple trees.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-read-qc-quality-filtering",
+          "installUrl": "github:GPTomics/bioSkills:read-qc/quality-filtering",
+          "description": "Filter reads by quality scores, length, and N content using Trimmomatic and fastp. Apply sliding window trimming, remove low-quality bases from read ends, and discard reads below thresholds. Use when reads have poor quality tails or require minimum quality for downstream analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-read-qc-quality-reports",
+          "installUrl": "github:GPTomics/bioSkills:read-qc/quality-reports",
+          "description": "Generate and interpret quality reports from FASTQ files using FastQC and MultiQC. Assess per-base quality, adapter content, GC bias, duplication levels, and overrepresented sequences. Use when performing initial QC on raw sequencing data or validating preprocessing results.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-reporting-jupyter-reports",
+          "installUrl": "github:GPTomics/bioSkills:reporting/jupyter-reports",
+          "description": "Creates reproducible Jupyter notebooks for bioinformatics analysis with parameterization using papermill. Use when generating automated analysis reports, running notebook-based pipelines, or creating shareable computational notebooks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-sequence-properties",
+          "installUrl": "github:GPTomics/bioSkills:sequence-manipulation/sequence-properties",
+          "description": "Calculate sequence properties like GC content, molecular weight, isoelectric point, and GC skew using Biopython. Use when analyzing sequence composition, computing physical properties, or comparing sequences.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-sequence-statistics",
+          "installUrl": "github:GPTomics/bioSkills:sequence-io/sequence-statistics",
+          "description": "Calculate sequence statistics (N50, length distribution, GC content, summary reports) using Biopython. Use when analyzing sequence datasets, generating QC reports, or comparing assemblies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-single-cell-data-io",
+          "installUrl": "github:GPTomics/bioSkills:single-cell/data-io",
+          "description": "Read, write, and create single-cell data objects using Seurat (R) and Scanpy (Python). Use for loading 10X Genomics data, importing/exporting h5ad and RDS files, creating Seurat objects and AnnData objects, and converting between formats. Use when loading, saving, or converting single-cell data formats.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-systems-biology-metabolic-reconstruction",
+          "installUrl": "github:GPTomics/bioSkills:systems-biology/metabolic-reconstruction",
+          "description": "Build genome-scale metabolic models from genome sequences using CarveMe and gapseq for automated reconstruction. Generate draft models ready for curation and analysis. Use when creating metabolic models for organisms without existing models.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-systems-biology-model-curation",
+          "installUrl": "github:GPTomics/bioSkills:systems-biology/model-curation",
+          "description": "Validate, gap-fill, and curate genome-scale metabolic models using memote for quality scores and COBRApy for manual curation. Ensure models meet SBML standards and produce biologically meaningful predictions. Use when improving draft models or preparing models for publication.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-tumor-fraction-estimation",
+          "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/tumor-fraction-estimation",
+          "description": "Estimates circulating tumor DNA fraction from shallow whole-genome sequencing using ichorCNA. Detects copy number alterations via HMM segmentation and calculates ctDNA percentage. Requires 0.1-1x sWGS coverage. Use when quantifying tumor burden from liquid biopsy or monitoring treatment response.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-vcf-statistics",
+          "installUrl": "github:GPTomics/bioSkills:variant-calling/vcf-statistics",
+          "description": "Generate variant statistics, sample concordance, and quality metrics using bcftools stats and gtcheck. Use when evaluating variant quality, comparing samples, or summarizing VCF contents.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-workflows-cnv-pipeline",
+          "installUrl": "github:GPTomics/bioSkills:workflows/cnv-pipeline",
+          "description": "End-to-end copy number variant detection workflow from BAM files. Covers CNVkit analysis for exome/targeted sequencing with visualization and annotation. Use when detecting copy number alterations from sequencing data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-write-sequences",
+          "installUrl": "github:GPTomics/bioSkills:sequence-io/write-sequences",
+          "description": "Write biological sequences to files (FASTA, FASTQ, GenBank, EMBL) using Biopython Bio.SeqIO. Use when saving sequences, creating new sequence files, or outputting modified records.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "GPTomics",
+        "repo": "bioSkills",
+        "repoUrl": "https://github.com/GPTomics/bioSkills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "gptomics-bioskills-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from GPTomics/bioSkills.",
+      "author": "ASM (GPTomics/bioSkills)",
+      "createdAt": "2026-05-09T08:10:51.349Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "gptomics",
+        "bioskills"
+      ],
+      "skills": [
+        {
+          "name": "bio-alignment-io",
+          "installUrl": "github:GPTomics/bioSkills:alignment/alignment-io",
+          "description": "Read, write, and convert multiple sequence alignment files using Biopython Bio.AlignIO. Supports Clustal, PHYLIP, Stockholm, FASTA, Nexus, and other alignment formats for phylogenetics and conservation analysis. Use when reading, writing, or converting alignment file formats.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-alignment-msa-parsing",
+          "installUrl": "github:GPTomics/bioSkills:alignment/msa-parsing",
+          "description": "Parse and analyze multiple sequence alignments using Biopython. Extract sequences, identify conserved regions, analyze gaps, work with annotations, and manipulate alignment data for downstream analysis. Use when parsing or manipulating multiple sequence alignments.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-alignment-multiple",
+          "installUrl": "github:GPTomics/bioSkills:alignment/multiple-alignment",
+          "description": "Perform multiple sequence alignment using MAFFT, MUSCLE5, ClustalOmega, or T-Coffee. Guides tool and algorithm selection based on dataset size, sequence divergence, and downstream application. Use when aligning three or more homologous sequences for phylogenetics, conservation analysis, or evolutionary studies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-alignment-sorting",
+          "installUrl": "github:GPTomics/bioSkills:alignment-files/alignment-sorting",
+          "description": "Sort alignment files by coordinate or read name using samtools and pysam. Use when preparing BAM files for indexing, variant calling, or paired-end analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-alignment-validation",
+          "installUrl": "github:GPTomics/bioSkills:alignment-files/alignment-validation",
+          "description": "Validate alignment quality with insert size distribution, proper pairing rates, GC bias, strand balance, and other post-alignment metrics. Use when verifying alignment data quality before variant calling or quantification.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-atac-seq-footprinting",
+          "installUrl": "github:GPTomics/bioSkills:atac-seq/footprinting",
+          "description": "Detect transcription factor binding sites through footprinting analysis in ATAC-seq data using TOBIAS. Use when identifying TF occupancy patterns within accessible regions, as TF binding protects DNA from Tn5 cutting.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-atac-seq-nucleosome-positioning",
+          "installUrl": "github:GPTomics/bioSkills:atac-seq/nucleosome-positioning",
+          "description": "Extract nucleosome positions from ATAC-seq data using NucleoATAC, ATACseqQC, and fragment analysis. Use when analyzing chromatin organization, identifying nucleosome-free regions at promoters, or characterizing nucleosome occupancy patterns from ATAC-seq fragment size distributions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-causal-genomics-colocalization-analysis",
+          "installUrl": "github:GPTomics/bioSkills:causal-genomics/colocalization-analysis",
+          "description": "Test whether two traits share a causal variant at a genomic locus using Bayesian colocalization with coloc. Computes posterior probabilities for shared vs distinct causal variants between GWAS and eQTL signals. Use when determining if a GWAS signal and an eQTL share the same causal variant.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-causal-genomics-mediation-analysis",
+          "installUrl": "github:GPTomics/bioSkills:causal-genomics/mediation-analysis",
+          "description": "Decompose genetic effects into direct and indirect paths through mediating variables using the mediation R package. Tests whether gene expression, methylation, or other molecular phenotypes mediate the effect of genetic variants on disease. Use when testing whether a molecular phenotype mediates the genotype-to-phenotype relationship.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-causal-genomics-mendelian-randomization",
+          "installUrl": "github:GPTomics/bioSkills:causal-genomics/mendelian-randomization",
+          "description": "Estimate causal effects between exposures and outcomes using genetic variants as instrumental variables with TwoSampleMR. Implements IVW, MR-Egger, weighted median, and MR-PRESSO methods for robust causal inference from GWAS summary statistics. Use when testing whether an exposure causally affects an outcome using genetic instruments.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-cfdna-preprocessing",
+          "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/cfdna-preprocessing",
+          "description": "Preprocesses cell-free DNA sequencing data including adapter trimming, alignment optimized for short fragments, and UMI-aware duplicate removal using fgbio. Applies cfDNA-specific quality thresholds and fragment length filtering. Use when processing plasma cfDNA sequencing data before downstream analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-chipseq-motif-analysis",
+          "installUrl": "github:GPTomics/bioSkills:chip-seq/motif-analysis",
+          "description": "De novo motif discovery and known motif enrichment analysis using HOMER and MEME-ChIP. Identify transcription factor binding motifs in ChIP-seq, ATAC-seq, or other genomic peak data. Use when finding enriched DNA motifs in peak sequences.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-chipseq-qc",
+          "installUrl": "github:GPTomics/bioSkills:chip-seq/chipseq-qc",
+          "description": "ChIP-seq quality control metrics including FRiP (Fraction of Reads in Peaks), cross-correlation analysis (NSC/RSC), library complexity, and IDR (Irreproducibility Discovery Rate) for replicate concordance. Use to assess experiment quality before downstream analysis. Use when assessing ChIP-seq data quality metrics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-cdisc-data",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/cdisc-data-handling",
+          "description": "Reads and prepares CDISC SDTM clinical trial data for analysis. Handles domain tables (DM, AE, EX, VS, LB), USUBJID-based joins, event-to-subject aggregation, and SUPPQUAL pivoting. Use when working with clinical trial datasets in CDISC/SDTM format or .xpt files.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-subgroup-analysis",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/subgroup-analysis",
+          "description": "Performs stratified and subgroup analyses for clinical trial data. Covers Mantel-Haenszel pooling, Breslow-Day homogeneity testing, interaction terms in regression, multiple comparisons correction, and forest plot visualization. Use when analyzing treatment effects across patient subgroups or controlling for stratification variables.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-trial-reporting",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/trial-reporting",
+          "description": "Prepares statistical tables and reports for clinical trials following regulatory standards. Generates Table 1 baseline characteristics, defines analysis populations (ITT, per-protocol, safety), performs multiple imputation for missing data, and follows CONSORT and ICH E9 guidelines. Use when creating analysis reports, handling missing data, or preparing regulatory submissions from clinical trials.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-clinvar-lookup",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/clinvar-lookup",
+          "description": "Query ClinVar for variant pathogenicity classifications, review status, and disease associations via REST API or local VCF. Use when determining clinical significance of variants for diagnostic or research purposes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-gnomad-frequencies",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/gnomad-frequencies",
+          "description": "Query gnomAD for population allele frequencies to assess variant rarity. Use when filtering variants by population frequency for rare disease analysis or determining if a variant is common in the general population.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-polygenic-risk",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/polygenic-risk",
+          "description": "Calculate polygenic risk scores using PRSice-2, LDpred2, or PRS-CS from GWAS summary statistics. Use when predicting disease risk from genome-wide genetic variants.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-variant-prioritization",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/variant-prioritization",
+          "description": "Filter and prioritize variants by pathogenicity, population frequency, and clinical evidence for rare disease analysis. Use when identifying candidate disease-causing variants from exome or genome sequencing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clip-seq-clip-motif-analysis",
+          "installUrl": "github:GPTomics/bioSkills:clip-seq/clip-motif-analysis",
+          "description": "Identify enriched sequence motifs at CLIP-seq binding sites for RBP binding specificity. Use when characterizing the sequence preferences of an RNA-binding protein.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-codon-usage",
+          "installUrl": "github:GPTomics/bioSkills:sequence-manipulation/codon-usage",
+          "description": "Analyze codon usage, calculate CAI (Codon Adaptation Index), and examine synonymous codon bias using Biopython. Use when analyzing coding sequences for expression optimization or evolutionary analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-comparative-genomics-hgt-detection",
+          "installUrl": "github:GPTomics/bioSkills:comparative-genomics/hgt-detection",
+          "description": "Detect horizontal gene transfer events using HGTector, compositional analysis, and phylogenetic incongruence methods. Identify foreign genes in bacterial and archaeal genomes from anomalous composition or unexpected phylogenetic placement. Use when searching for horizontally transferred genes or analyzing genome evolution in prokaryotes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-comparative-genomics-ortholog-inference",
+          "installUrl": "github:GPTomics/bioSkills:comparative-genomics/ortholog-inference",
+          "description": "Infer orthologous gene groups across species using OrthoFinder and ProteinOrtho. Identify orthologs, paralogs, and co-orthologs for comparative genomics and functional annotation transfer. Use when identifying gene orthologs across species or building orthogroups for evolutionary analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-comparative-genomics-synteny-analysis",
+          "installUrl": "github:GPTomics/bioSkills:comparative-genomics/synteny-analysis",
+          "description": "Analyze genome collinearity and syntenic blocks using MCScanX, SyRI, and JCVI for comparative genomics. Detect conserved gene order, chromosomal rearrangements, and whole-genome duplications. Use when comparing genome structure between species or identifying conserved genomic regions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-cnv-annotation",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/cnv-annotation",
+          "description": "Annotate CNVs with genes, pathways, and clinical significance. Use when interpreting CNV calls or identifying affected genes from copy number analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-cnvkit-analysis",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/cnvkit-analysis",
+          "description": "Detect copy number variants from targeted/exome sequencing using CNVkit. Supports tumor-normal pairs, tumor-only, and germline CNV calling. Use when detecting CNVs from WES or targeted panel sequencing data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-crispr-screens-base-editing-analysis",
+          "installUrl": "github:GPTomics/bioSkills:crispr-screens/base-editing-analysis",
+          "description": "Analyzes base editing and prime editing outcomes including editing efficiency, bystander edits, and indel frequencies. Use when quantifying CRISPR base editor results, comparing ABE vs CBE efficiency, or assessing prime editing fidelity.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-crispr-screens-batch-correction",
+          "installUrl": "github:GPTomics/bioSkills:crispr-screens/batch-correction",
+          "description": "Batch effect correction for CRISPR screens. Covers normalization across batches, technical replicate handling, and batch-aware analysis. Use when combining screens from multiple batches or correcting systematic technical variation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-crispr-screens-jacks-analysis",
+          "installUrl": "github:GPTomics/bioSkills:crispr-screens/jacks-analysis",
+          "description": "JACKS (Joint Analysis of CRISPR/Cas9 Knockout Screens) for modeling sgRNA efficacy and gene essentiality. Use when analyzing multiple CRISPR screens simultaneously or when accounting for variable sgRNA efficiency across experiments.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-crispr-screens-mageck-analysis",
+          "installUrl": "github:GPTomics/bioSkills:crispr-screens/mageck-analysis",
+          "description": "MAGeCK (Model-based Analysis of Genome-wide CRISPR-Cas9 Knockout) for pooled CRISPR screen analysis. Covers count normalization, gene ranking, and pathway analysis. Use when identifying essential genes, drug targets, or resistance mechanisms from dropout or enrichment screens.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-ggplot2-fundamentals",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/ggplot2-fundamentals",
+          "description": "Create publication-quality scientific figures with ggplot2 including scatter plots, boxplots, heatmaps, and multi-panel layouts. Use when creating static figures for papers, presentations, or reports in R.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-interactive-visualization",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/interactive-visualization",
+          "description": "Create interactive HTML plots with plotly and bokeh for exploratory data analysis and web-based sharing of omics visualizations. Use when building zoomable, hoverable plots for data exploration or web dashboards.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-de-deseq2-basics",
+          "installUrl": "github:GPTomics/bioSkills:differential-expression/deseq2-basics",
+          "description": "Perform differential expression analysis using DESeq2 in R/Bioconductor. Use for analyzing RNA-seq count data, creating DESeqDataSet objects, running the DESeq workflow, and extracting results with log fold change shrinkage. Use when performing DE analysis with DESeq2.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-de-edger-basics",
+          "installUrl": "github:GPTomics/bioSkills:differential-expression/edger-basics",
+          "description": "Perform differential expression analysis using edgeR in R/Bioconductor. Use for analyzing RNA-seq count data with the quasi-likelihood F-test framework, creating DGEList objects, normalization, dispersion estimation, and statistical testing. Use when performing DE analysis with edgeR.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-de-results",
+          "installUrl": "github:GPTomics/bioSkills:differential-expression/de-results",
+          "description": "Extract, filter, annotate, and export differential expression results from DESeq2 or edgeR. Use for identifying significant genes, applying multiple testing corrections, adding gene annotations, and preparing results for downstream analysis. Use when filtering and exporting DE analysis results.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-duplicate-handling",
+          "installUrl": "github:GPTomics/bioSkills:alignment-files/duplicate-handling",
+          "description": "Mark and remove PCR/optical duplicates using samtools fixmate and markdup. Use when preparing alignments for variant calling or when duplicate reads would bias analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-biodiversity-metrics",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/biodiversity-metrics",
+          "description": "Calculates species richness, diversity, and turnover using the Hill number framework with iNEXT coverage-based rarefaction/extrapolation, asymptotic diversity estimation, and beta diversity partitioning (betapart turnover vs nestedness). Compares assemblages using coverage-standardized rather than size-standardized rarefaction. Use when quantifying biodiversity from species abundance or incidence data, comparing diversity across sites, or constructing rarefaction curves. Not for clinical 16S microbiome alpha/beta diversity (see microbiome/diversity-analysis).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-community-ecology",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/community-ecology",
+          "description": "Analyzes community composition using constrained ordination (CCA, RDA, db-RDA), variance partitioning (varpart), indicator species analysis (indicspecies multipatt), and distance-based environmental gradient methods with vegan. Links species composition to environmental explanatory variables. Use when testing how environmental gradients structure species communities, identifying habitat indicator taxa, or partitioning explained variation among predictors. Not for basic unconstrained ordination and PERMANOVA (see microbiome/diversity-analysis).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-landscape-genomics",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/landscape-genomics",
+          "description": "Tests genotype-environment associations and identifies loci under local adaptation using LFMM2 (LEA), pcadapt outlier detection, OutFLANK Fst-based selection scans, and redundancy analysis. Detects adaptive genetic variation correlated with environmental variables while controlling for population structure. Use when identifying adaptive loci across environmental gradients, testing for signatures of local adaptation, or predicting genetic vulnerability to climate change with gradientForest.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-entrez-fetch",
+          "installUrl": "github:GPTomics/bioSkills:database-access/entrez-fetch",
+          "description": "Retrieve records from NCBI databases using Biopython Bio.Entrez. Use when downloading sequences, fetching GenBank records, getting document summaries, or parsing NCBI data into Biopython objects.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-epidemiological-genomics-phylodynamics",
+          "installUrl": "github:GPTomics/bioSkills:epidemiological-genomics/phylodynamics",
+          "description": "Construct time-scaled phylogenies and infer evolutionary dynamics using TreeTime and BEAST2 for outbreak analysis. Estimate divergence times, molecular clock rates, and ancestral states. Use when dating outbreak origins, estimating transmission rates, or building time-calibrated trees.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-epitranscriptomics-m6anet-analysis",
+          "installUrl": "github:GPTomics/bioSkills:epitranscriptomics/m6anet-analysis",
+          "description": "Detect m6A modifications from Oxford Nanopore direct RNA sequencing using m6Anet. Use when analyzing epitranscriptomic modifications from long-read RNA data without immunoprecipitation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-epitranscriptomics-merip-preprocessing",
+          "installUrl": "github:GPTomics/bioSkills:epitranscriptomics/merip-preprocessing",
+          "description": "Align and QC MeRIP-seq IP and input samples for m6A analysis. Use when preparing MeRIP-seq data for peak calling or differential methylation analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-experimental-design-power-analysis",
+          "installUrl": "github:GPTomics/bioSkills:experimental-design/power-analysis",
+          "description": "Calculates statistical power and minimum sample sizes for RNA-seq, ATAC-seq, and other sequencing experiments. Use when planning experiments, determining how many replicates are needed, or assessing whether a study is adequately powered to detect expected effect sizes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-expression-matrix-counts-ingest",
+          "installUrl": "github:GPTomics/bioSkills:expression-matrix/counts-ingest",
+          "description": "Load gene expression count matrices from various formats including CSV, TSV, featureCounts, Salmon, kallisto, and 10X. Use when importing quantification results for downstream analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-expression-matrix-gene-id-mapping",
+          "installUrl": "github:GPTomics/bioSkills:expression-matrix/gene-id-mapping",
+          "description": "Convert between gene identifier systems including Ensembl, Entrez, HGNC symbols, and UniProt. Use when mapping IDs for pathway analysis or matching different data sources.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-expression-matrix-metadata-joins",
+          "installUrl": "github:GPTomics/bioSkills:expression-matrix/metadata-joins",
+          "description": "Merge sample metadata with count matrices and add gene annotations. Use when preparing data for differential expression analysis or visualization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-flow-cytometry-compensation-transformation",
+          "installUrl": "github:GPTomics/bioSkills:flow-cytometry/compensation-transformation",
+          "description": "Spillover compensation and data transformation for flow cytometry. Covers compensation matrix calculation, application, and biexponential/arcsinh transforms. Use when correcting spectral overlap between fluorophores or transforming data for analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-flow-cytometry-cytometry-qc",
+          "installUrl": "github:GPTomics/bioSkills:flow-cytometry/cytometry-qc",
+          "description": "Comprehensive quality control for flow cytometry and CyTOF data. Covers flow rate stability, signal drift, margin events, dead cell exclusion, and batch QC. Use when assessing acquisition quality or identifying problematic samples before analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-flow-cytometry-differential-analysis",
+          "installUrl": "github:GPTomics/bioSkills:flow-cytometry/differential-analysis",
+          "description": "Differential abundance and state analysis for cytometry data. Compare cell populations between conditions using statistical methods. Use when testing for significant changes in cell frequencies or marker expression between groups.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-flow-cytometry-doublet-detection",
+          "installUrl": "github:GPTomics/bioSkills:flow-cytometry/doublet-detection",
+          "description": "Detect and remove doublets from flow and mass cytometry data. Covers FSC/SSC gating and computational doublet detection methods. Use when filtering out cell aggregates before clustering or quantitative analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-flow-cytometry-gating-analysis",
+          "installUrl": "github:GPTomics/bioSkills:flow-cytometry/gating-analysis",
+          "description": "Manual and automated gating for defining cell populations in flow cytometry. Covers rectangular, polygon, and data-driven gates. Use when identifying cell populations through hierarchical gating strategies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-fragment-analysis",
+          "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/fragment-analysis",
+          "description": "Analyzes cfDNA fragment size distributions and fragmentomics features using FinaleToolkit or Griffin. Extracts nucleosome positioning patterns, fragment ratios, and DELFI-style fragmentation profiles for cancer detection. Use when leveraging fragment patterns for tumor detection or tissue-of-origin analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-annotation-functional-annotation",
+          "installUrl": "github:GPTomics/bioSkills:genome-annotation/functional-annotation",
+          "description": "Assign GO terms, KEGG orthologs, Pfam domains, and EC numbers to predicted proteins using eggNOG-mapper and InterProScan. Produces functional summaries for downstream pathway and enrichment analysis. Use when adding functional annotation to predicted genes or characterizing protein functions in a new genome.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-intervals-coverage-analysis",
+          "installUrl": "github:GPTomics/bioSkills:genome-intervals/coverage-analysis",
+          "description": "Calculate read depth and coverage across genomic intervals using bedtools genomecov and coverage. Generate bedGraph files, compute per-base depth, and summarize coverage statistics. Use when assessing sequencing depth, creating coverage tracks, or evaluating target capture efficiency.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-intervals-proximity-operations",
+          "installUrl": "github:GPTomics/bioSkills:genome-intervals/proximity-operations",
+          "description": "Find nearest features, search within windows, and extend intervals using closest, window, flank, and slop operations. Use when performing TSS proximity analysis, assigning enhancers to genes, defining promoter regions, or finding nearby genomic features.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-hi-c-analysis-compartment-analysis",
+          "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/compartment-analysis",
+          "description": "Detect A/B compartments from Hi-C data using cooltools and eigenvector decomposition. Identify active (A) and inactive (B) chromatin compartments from contact matrices. Use when identifying A/B compartments from Hi-C data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-hi-c-analysis-contact-pairs",
+          "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/contact-pairs",
+          "description": "Process Hi-C read pairs using pairtools. Parse alignments, filter duplicates, classify pairs, and generate contact statistics from Hi-C sequencing data. Use when processing raw Hi-C read pairs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-hi-c-analysis-hic-data-io",
+          "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/hic-data-io",
+          "description": "Load, convert, and manipulate Hi-C contact matrices using cooler format. Read .cool/.mcool files, convert from .hic format, access matrix data, and export to different formats. Use when loading or converting Hi-C contact matrices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-hi-c-analysis-hic-differential",
+          "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/hic-differential",
+          "description": "Compare Hi-C contact matrices between conditions to identify differential chromatin interactions. Compute log2 fold changes, statistical significance, and visualize differential contact maps. Use when comparing Hi-C contacts between conditions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-hi-c-analysis-hic-visualization",
+          "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/hic-visualization",
+          "description": "Visualize Hi-C contact matrices, TADs, loops, and genomic features using matplotlib, cooltools, and HiCExplorer. Create triangle plots, virtual 4C, and multi-track figures. Use when visualizing contact matrices or genomic features.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-hi-c-analysis-loop-calling",
+          "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/loop-calling",
+          "description": "Detect chromatin loops and point interactions from Hi-C data using cooltools, chromosight, and HiCCUPS-like methods. Identify CTCF-mediated loops and enhancer-promoter contacts. Use when detecting chromatin loops from Hi-C data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-hi-c-analysis-matrix-operations",
+          "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/matrix-operations",
+          "description": "Balance, normalize, and transform Hi-C contact matrices using cooler and cooltools. Apply iterative correction (ICE), compute expected values, and generate observed/expected matrices. Use when normalizing or transforming Hi-C matrices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-hi-c-analysis-tad-detection",
+          "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/tad-detection",
+          "description": "Call topologically associating domains (TADs) from Hi-C data using insulation score, HiCExplorer, and other methods. Identify domain boundaries and hierarchical domain structure. Use when calling TADs from Hi-C insulation scores.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-imaging-mass-cytometry-data-preprocessing",
+          "installUrl": "github:GPTomics/bioSkills:imaging-mass-cytometry/data-preprocessing",
+          "description": "Load and preprocess imaging mass cytometry (IMC) and MIBI data. Covers MCD/TIFF handling, hot pixel removal, and image normalization. Use when starting IMC analysis from raw MCD files or preparing images for segmentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-imaging-mass-cytometry-quality-metrics",
+          "installUrl": "github:GPTomics/bioSkills:imaging-mass-cytometry/quality-metrics",
+          "description": "Quality metrics for IMC data including signal-to-noise, channel correlation, tissue integrity, and acquisition QC. Use when assessing data quality before analysis or troubleshooting problematic acquisitions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-imaging-mass-cytometry-spatial-analysis",
+          "installUrl": "github:GPTomics/bioSkills:imaging-mass-cytometry/spatial-analysis",
+          "description": "Spatial analysis of cell neighborhoods and interactions in IMC data. Covers neighbor graphs, spatial statistics, and interaction testing. Use when analyzing spatial relationships between cell types, testing for neighborhood enrichment, or identifying cell-cell interaction patterns in imaging mass cytometry data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-liquid-biopsy-pipeline",
+          "installUrl": "github:GPTomics/bioSkills:workflows/liquid-biopsy-pipeline",
+          "description": "Cell-free DNA analysis pipeline from plasma sequencing to tumor monitoring. Preprocesses cfDNA reads, analyzes fragment patterns, estimates tumor fraction from sWGS, and optionally detects mutations from targeted panels. Use when analyzing liquid biopsy samples for cancer detection or monitoring.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-local-blast",
+          "installUrl": "github:GPTomics/bioSkills:database-access/local-blast",
+          "description": "Run local BLAST searches using BLAST+ command-line tools. Use when running fast unlimited searches, building custom databases, performing large-scale analysis, or when NCBI servers are slow or unavailable.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-long-read-sequencing-clair3-variants",
+          "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/clair3-variants",
+          "description": "Deep learning-based variant calling from long reads using Clair3 for SNPs and small indels. Use when calling germline variants from ONT or PacBio alignments, particularly when high accuracy is needed for clinical or research applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-long-read-sequencing-isoseq-analysis",
+          "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/isoseq-analysis",
+          "description": "Analyze PacBio Iso-Seq data for full-length isoform discovery and quantification. Use when characterizing transcript diversity or identifying novel splice variants.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-long-read-sequencing-nanopore-methylation",
+          "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/nanopore-methylation",
+          "description": "Calls DNA methylation from Oxford Nanopore sequencing data using signal-level analysis. Use when detecting 5mC or 6mA modifications directly from nanopore reads without bisulfite conversion.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-longread-alignment",
+          "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/long-read-alignment",
+          "description": "Align long reads using minimap2 for Oxford Nanopore and PacBio data. Supports various presets for different read types and applications. Use when aligning ONT or PacBio reads to a reference genome for variant calling, SV detection, or coverage analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-machine-learning-survival-analysis",
+          "installUrl": "github:GPTomics/bioSkills:machine-learning/survival-analysis",
+          "description": "Analyzes time-to-event data using Kaplan-Meier curves, log-rank tests, and Cox proportional hazards regression with lifelines. Builds survival models from clinical and omics features. Use when predicting patient survival or modeling time-to-event outcomes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-metabolomics-lipidomics",
+          "installUrl": "github:GPTomics/bioSkills:metabolomics/lipidomics",
+          "description": "Specialized lipidomics analysis for lipid identification, quantification, and pathway interpretation. Covers LC-MS lipidomics with LipidSearch, MS-DIAL, and LipidMaps annotation. Use when analyzing lipid classes, chain composition, or lipid-specific pathways.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-metabolomics-msdial-preprocessing",
+          "installUrl": "github:GPTomics/bioSkills:metabolomics/msdial-preprocessing",
+          "description": "MS-DIAL-based metabolomics preprocessing as alternative to XCMS. Covers peak detection, alignment, annotation, and export for downstream analysis. Use when processing MS-DIAL output files for R/Python analysis or when preferring GUI-based preprocessing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-metabolomics-normalization-qc",
+          "installUrl": "github:GPTomics/bioSkills:metabolomics/normalization-qc",
+          "description": "Quality control and normalization for metabolomics data. Covers QC-based correction, batch effect removal, and data transformation methods. Use when correcting technical variation in metabolomics data before statistical analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-metabolomics-pathway-mapping",
+          "installUrl": "github:GPTomics/bioSkills:metabolomics/pathway-mapping",
+          "description": "Map metabolites to biological pathways using KEGG, Reactome, and MetaboAnalyst. Perform pathway enrichment and topology analysis. Use when interpreting metabolomics results in the context of biochemical pathways.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-metabolomics-statistical-analysis",
+          "installUrl": "github:GPTomics/bioSkills:metabolomics/statistical-analysis",
+          "description": "Statistical analysis for metabolomics data. Covers preprocessing (log2 transformation, normalization), limma moderated testing with empirical Bayes, Welch's t-tests with BH correction, fold change estimation, and multivariate methods (PCA, PLS-DA, OPLS-DA). Use when identifying differentially abundant metabolites or building classification models.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "GPTomics",
+        "repo": "bioSkills",
+        "repoUrl": "https://github.com/GPTomics/bioSkills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "gptomics-bioskills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from GPTomics/bioSkills.",
+      "author": "ASM (GPTomics/bioSkills)",
+      "createdAt": "2026-05-09T08:10:51.349Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "gptomics",
+        "bioskills"
+      ],
+      "skills": [
+        {
+          "name": "bio-admet-prediction",
+          "installUrl": "github:GPTomics/bioSkills:chemoinformatics/admet-prediction",
+          "description": "Predicts ADMET properties using ADMETlab 3.0 API or DeepChem models. Estimates bioavailability, CYP inhibition, hERG liability, and 119 toxicity endpoints with uncertainty quantification. Filters for PAINS and other structural alerts. Use when filtering compounds for drug-likeness or prioritizing leads by predicted safety.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-alignment-files-bam-statistics",
+          "installUrl": "github:GPTomics/bioSkills:alignment-files/bam-statistics",
+          "description": "Generate alignment statistics using samtools flagstat, stats, depth, and coverage. Use when assessing alignment quality, calculating coverage, or generating QC reports.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-alignment-io",
+          "installUrl": "github:GPTomics/bioSkills:alignment/alignment-io",
+          "description": "Read, write, and convert multiple sequence alignment files using Biopython Bio.AlignIO. Supports Clustal, PHYLIP, Stockholm, FASTA, Nexus, and other alignment formats for phylogenetics and conservation analysis. Use when reading, writing, or converting alignment file formats.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-alignment-msa-parsing",
+          "installUrl": "github:GPTomics/bioSkills:alignment/msa-parsing",
+          "description": "Parse and analyze multiple sequence alignments using Biopython. Extract sequences, identify conserved regions, analyze gaps, work with annotations, and manipulate alignment data for downstream analysis. Use when parsing or manipulating multiple sequence alignments.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-alignment-pairwise",
+          "installUrl": "github:GPTomics/bioSkills:alignment/pairwise-alignment",
+          "description": "Perform pairwise sequence alignment using Biopython Bio.Align.PairwiseAligner. Use when comparing two sequences, finding optimal alignments, scoring similarity, and identifying local or global matches between DNA, RNA, or protein sequences.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-batch-processing",
+          "installUrl": "github:GPTomics/bioSkills:sequence-io/batch-processing",
+          "description": "Process multiple sequence files in batch using Biopython. Use when working with many files, merging/splitting sequences, or automating file operations across directories.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-bedgraph-handling",
+          "installUrl": "github:GPTomics/bioSkills:genome-intervals/bedgraph-handling",
+          "description": "Create, manipulate, and convert bedGraph files for genome browser visualization. Covers bedGraph format, conversion to/from bigWig, normalization, and signal processing. Use when handling coverage and signal tracks from ChIP-seq, ATAC-seq, or RNA-seq.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-blast-searches",
+          "installUrl": "github:GPTomics/bioSkills:database-access/blast-searches",
+          "description": "Run remote BLAST searches against NCBI databases using Biopython Bio.Blast. Use when identifying unknown sequences, finding homologs, or searching for sequence similarity against NCBI's nr/nt databases.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-causal-genomics-colocalization-analysis",
+          "installUrl": "github:GPTomics/bioSkills:causal-genomics/colocalization-analysis",
+          "description": "Test whether two traits share a causal variant at a genomic locus using Bayesian colocalization with coloc. Computes posterior probabilities for shared vs distinct causal variants between GWAS and eQTL signals. Use when determining if a GWAS signal and an eQTL share the same causal variant.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-causal-genomics-fine-mapping",
+          "installUrl": "github:GPTomics/bioSkills:causal-genomics/fine-mapping",
+          "description": "Identify likely causal variants within GWAS loci using SuSiE for sum of single effects regression and FINEMAP for shotgun stochastic search. Computes posterior inclusion probabilities and credible sets to prioritize variants for functional follow-up. Use when narrowing GWAS association signals to candidate causal variants or building credible sets for functional validation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-causal-genomics-mediation-analysis",
+          "installUrl": "github:GPTomics/bioSkills:causal-genomics/mediation-analysis",
+          "description": "Decompose genetic effects into direct and indirect paths through mediating variables using the mediation R package. Tests whether gene expression, methylation, or other molecular phenotypes mediate the effect of genetic variants on disease. Use when testing whether a molecular phenotype mediates the genotype-to-phenotype relationship.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-causal-genomics-mendelian-randomization",
+          "installUrl": "github:GPTomics/bioSkills:causal-genomics/mendelian-randomization",
+          "description": "Estimate causal effects between exposures and outcomes using genetic variants as instrumental variables with TwoSampleMR. Implements IVW, MR-Egger, weighted median, and MR-PRESSO methods for robust causal inference from GWAS summary statistics. Use when testing whether an exposure causally affects an outcome using genetic instruments.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-chipseq-differential-binding",
+          "installUrl": "github:GPTomics/bioSkills:chip-seq/differential-binding",
+          "description": "Identifies differentially bound ChIP-seq regions between conditions using DiffBind (from BAMs), DESeq2, or PyDESeq2 (from count matrices). Handles normalization, statistical testing, and fold-change estimation with ChIP-seq-specific considerations. Use when comparing ChIP-seq binding between experimental conditions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-chipseq-peak-annotation",
+          "installUrl": "github:GPTomics/bioSkills:chip-seq/peak-annotation",
+          "description": "Annotate ChIP-seq peaks to genomic features and nearest genes. Classify peaks as promoter, exon, intron, or intergenic using ChIPseeker (R), HOMER annotatePeaks.pl (CLI), or Python (pandas/pyranges). Supports pre-built annotation databases and custom GTF files. Handles promoter definition, feature priority, category collapsing, and signed distance-to-TSS. Use when assigning genomic context to ChIP-seq peaks or linking peaks to target genes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-categorical-tests",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/categorical-tests",
+          "description": "Tests associations between categorical variables in clinical data using chi-square, Fisher's exact, and Cochran-Mantel-Haenszel tests. Computes effect sizes and post-hoc pairwise comparisons. Use when analyzing categorical outcomes or testing treatment-outcome independence in clinical trials.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-cdisc-data",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/cdisc-data-handling",
+          "description": "Reads and prepares CDISC SDTM clinical trial data for analysis. Handles domain tables (DM, AE, EX, VS, LB), USUBJID-based joins, event-to-subject aggregation, and SUPPQUAL pivoting. Use when working with clinical trial datasets in CDISC/SDTM format or .xpt files.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-effect-measures",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/effect-measures",
+          "description": "Computes and interprets treatment effect measures including odds ratios, risk ratios, number needed to treat, and confidence intervals from clinical trial data. Covers crude and adjusted measures, non-collapsibility of odds ratios, and forest plot visualization. Use when reporting treatment effects or comparing effect sizes across clinical studies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-logistic-regression",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/logistic-regression",
+          "description": "Performs logistic regression for clinical trial outcomes including binary, ordinal, and multinomial models. Extracts odds ratios with confidence intervals, handles covariate adjustment, and provides Firth penalized regression for rare events or separation. Use when modeling binary or ordinal endpoints from clinical data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-subgroup-analysis",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/subgroup-analysis",
+          "description": "Performs stratified and subgroup analyses for clinical trial data. Covers Mantel-Haenszel pooling, Breslow-Day homogeneity testing, interaction terms in regression, multiple comparisons correction, and forest plot visualization. Use when analyzing treatment effects across patient subgroups or controlling for stratification variables.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-trial-reporting",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/trial-reporting",
+          "description": "Prepares statistical tables and reports for clinical trials following regulatory standards. Generates Table 1 baseline characteristics, defines analysis populations (ITT, per-protocol, safety), performs multiple imputation for missing data, and follows CONSORT and ICH E9 guidelines. Use when creating analysis reports, handling missing data, or preparing regulatory submissions from clinical trials.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-clinvar-lookup",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/clinvar-lookup",
+          "description": "Query ClinVar for variant pathogenicity classifications, review status, and disease associations via REST API or local VCF. Use when determining clinical significance of variants for diagnostic or research purposes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-dbsnp-queries",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/dbsnp-queries",
+          "description": "Query dbSNP for rsID lookups, variant annotations, and cross-references to other databases. Use when mapping between rsIDs and genomic coordinates or retrieving basic variant information.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-gnomad-frequencies",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/gnomad-frequencies",
+          "description": "Query gnomAD for population allele frequencies to assess variant rarity. Use when filtering variants by population frequency for rare disease analysis or determining if a variant is common in the general population.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-hla-typing",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/hla-typing",
+          "description": "Call HLA alleles from NGS data using OptiType, HLA-HD, or arcasHLA for immunogenomics applications. Use when determining HLA genotype for transplant matching, neoantigen prediction, or pharmacogenomic screening.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-myvariant-queries",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/myvariant-queries",
+          "description": "Query myvariant.info API for aggregated variant annotations from multiple databases (ClinVar, gnomAD, dbSNP, COSMIC, etc.) in a single request. Use when annotating variants with clinical and population data from multiple sources simultaneously.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-pharmacogenomics",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/pharmacogenomics",
+          "description": "Query PharmGKB and CPIC for drug-gene interactions, pharmacogenomic annotations, and dosing guidelines. Use when predicting drug response from genetic variants or implementing clinical pharmacogenomics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-polygenic-risk",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/polygenic-risk",
+          "description": "Calculate polygenic risk scores using PRSice-2, LDpred2, or PRS-CS from GWAS summary statistics. Use when predicting disease risk from genome-wide genetic variants.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-somatic-signatures",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/somatic-signatures",
+          "description": "Extract and analyze mutational signatures from somatic variants using SigProfiler or MutationalPatterns to characterize mutagenic processes. Use when identifying DNA damage mechanisms or etiology in cancer genomes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-tumor-mutational-burden",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/tumor-mutational-burden",
+          "description": "Calculate tumor mutational burden from panel or WES data with proper normalization and clinical thresholds. Use when assessing immunotherapy eligibility or characterizing tumor immunogenicity.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-variant-prioritization",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/variant-prioritization",
+          "description": "Filter and prioritize variants by pathogenicity, population frequency, and clinical evidence for rare disease analysis. Use when identifying candidate disease-causing variants from exome or genome sequencing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clip-seq-binding-site-annotation",
+          "installUrl": "github:GPTomics/bioSkills:clip-seq/binding-site-annotation",
+          "description": "Annotate CLIP-seq binding sites to genomic features including 3'UTR, 5'UTR, CDS, introns, and ncRNAs. Use when characterizing where an RBP binds in transcripts.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clip-seq-clip-alignment",
+          "installUrl": "github:GPTomics/bioSkills:clip-seq/clip-alignment",
+          "description": "Align CLIP-seq reads to the genome with crosslink site awareness. Use when mapping preprocessed CLIP reads for peak calling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clip-seq-clip-motif-analysis",
+          "installUrl": "github:GPTomics/bioSkills:clip-seq/clip-motif-analysis",
+          "description": "Identify enriched sequence motifs at CLIP-seq binding sites for RBP binding specificity. Use when characterizing the sequence preferences of an RNA-binding protein.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clip-seq-clip-peak-calling",
+          "installUrl": "github:GPTomics/bioSkills:clip-seq/clip-peak-calling",
+          "description": "Call protein-RNA binding site peaks from CLIP-seq data using CLIPper, PureCLIP, or Piranha. Use when identifying RBP binding sites from aligned CLIP reads.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clip-seq-clip-preprocessing",
+          "installUrl": "github:GPTomics/bioSkills:clip-seq/clip-preprocessing",
+          "description": "Preprocess CLIP-seq data including adapter trimming, UMI extraction, and PCR duplicate removal. Use when preparing raw CLIP, iCLIP, or eCLIP reads for peak calling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-codon-usage",
+          "installUrl": "github:GPTomics/bioSkills:sequence-manipulation/codon-usage",
+          "description": "Analyze codon usage, calculate CAI (Codon Adaptation Index), and examine synonymous codon bias using Biopython. Use when analyzing coding sequences for expression optimization or evolutionary analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-comparative-genomics-ortholog-inference",
+          "installUrl": "github:GPTomics/bioSkills:comparative-genomics/ortholog-inference",
+          "description": "Infer orthologous gene groups across species using OrthoFinder and ProteinOrtho. Identify orthologs, paralogs, and co-orthologs for comparative genomics and functional annotation transfer. Use when identifying gene orthologs across species or building orthogroups for evolutionary analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-comparative-genomics-positive-selection",
+          "installUrl": "github:GPTomics/bioSkills:comparative-genomics/positive-selection",
+          "description": "Detect positive selection using dN/dS (omega) tests with PAML codeml and HyPhy. Identify sites and branches under adaptive evolution through codon models and branch-site tests. Use when testing for adaptive evolution in gene families or identifying positively selected sites.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-compressed-files",
+          "installUrl": "github:GPTomics/bioSkills:sequence-io/compressed-files",
+          "description": "Read and write compressed sequence files (gzip, bzip2, BGZF) using Biopython. Use when working with .gz or .bz2 sequence files. Use BGZF for indexable compressed files.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-cnv-annotation",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/cnv-annotation",
+          "description": "Annotate CNVs with genes, pathways, and clinical significance. Use when interpreting CNV calls or identifying affected genes from copy number analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-genome-tracks",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/genome-tracks",
+          "description": "Create genome browser-style visualizations showing multiple data tracks (coverage, peaks, genes) using pyGenomeTracks, Gviz, and IGV. Use when visualizing genomic data at specific loci with multiple aligned tracks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-interactive-visualization",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/interactive-visualization",
+          "description": "Create interactive HTML plots with plotly and bokeh for exploratory data analysis and web-based sharing of omics visualizations. Use when building zoomable, hoverable plots for data exploration or web dashboards.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-de-edger-basics",
+          "installUrl": "github:GPTomics/bioSkills:differential-expression/edger-basics",
+          "description": "Perform differential expression analysis using edgeR in R/Bioconductor. Use for analyzing RNA-seq count data with the quasi-likelihood F-test framework, creating DGEList objects, normalization, dispersion estimation, and statistical testing. Use when performing DE analysis with edgeR.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-de-results",
+          "installUrl": "github:GPTomics/bioSkills:differential-expression/de-results",
+          "description": "Extract, filter, annotate, and export differential expression results from DESeq2 or edgeR. Use for identifying significant genes, applying multiple testing corrections, adding gene annotations, and preparing results for downstream analysis. Use when filtering and exporting DE analysis results.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-biodiversity-metrics",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/biodiversity-metrics",
+          "description": "Calculates species richness, diversity, and turnover using the Hill number framework with iNEXT coverage-based rarefaction/extrapolation, asymptotic diversity estimation, and beta diversity partitioning (betapart turnover vs nestedness). Compares assemblages using coverage-standardized rather than size-standardized rarefaction. Use when quantifying biodiversity from species abundance or incidence data, comparing diversity across sites, or constructing rarefaction curves. Not for clinical 16S microbiome alpha/beta diversity (see microbiome/diversity-analysis).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-community-ecology",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/community-ecology",
+          "description": "Analyzes community composition using constrained ordination (CCA, RDA, db-RDA), variance partitioning (varpart), indicator species analysis (indicspecies multipatt), and distance-based environmental gradient methods with vegan. Links species composition to environmental explanatory variables. Use when testing how environmental gradients structure species communities, identifying habitat indicator taxa, or partitioning explained variation among predictors. Not for basic unconstrained ordination and PERMANOVA (see microbiome/diversity-analysis).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-edna-metabarcoding",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/edna-metabarcoding",
+          "description": "Processes environmental DNA metabarcoding data from raw amplicon reads to species occurrence tables using OBITools3, DADA2, and taxonomic assignment against BOLD, MIDORI2, or MitoFish databases. Handles COI, 12S, rbcL, and ITS barcode regions with primer removal, denoising, chimera detection, and contamination filtering via decontam. Includes occupancy modeling (occumb) for detection probability correction. Use when analyzing eDNA from water, soil, or bulk samples for biodiversity monitoring. Not for 16S human microbiome (see microbiome/amplicon-processing).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-landscape-genomics",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/landscape-genomics",
+          "description": "Tests genotype-environment associations and identifies loci under local adaptation using LFMM2 (LEA), pcadapt outlier detection, OutFLANK Fst-based selection scans, and redundancy analysis. Detects adaptive genetic variation correlated with environmental variables while controlling for population structure. Use when identifying adaptive loci across environmental gradients, testing for signatures of local adaptation, or predicting genetic vulnerability to climate change with gradientForest.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-species-delimitation",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/species-delimitation",
+          "description": "Delimits species boundaries from molecular data using distance-based (ASAP), tree-based (bPTP, GMYC), and coalescent (BPP) methods. Compares multiple delimitation results with delimtools. Use when delineating putative species from DNA barcoding data, resolving cryptic species complexes, or validating taxonomic assignments. Emphasizes multi-method consensus following integrative taxonomy best practice.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-entrez-fetch",
+          "installUrl": "github:GPTomics/bioSkills:database-access/entrez-fetch",
+          "description": "Retrieve records from NCBI databases using Biopython Bio.Entrez. Use when downloading sequences, fetching GenBank records, getting document summaries, or parsing NCBI data into Biopython objects.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-entrez-link",
+          "installUrl": "github:GPTomics/bioSkills:database-access/entrez-link",
+          "description": "Find cross-references between NCBI databases using Biopython Bio.Entrez. Use when navigating from genes to proteins, sequences to publications, finding related records, or discovering database relationships.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-entrez-search",
+          "installUrl": "github:GPTomics/bioSkills:database-access/entrez-search",
+          "description": "Search NCBI databases using Biopython Bio.Entrez. Use when finding records by keyword, building complex search queries, discovering database structure, or getting global query counts across databases.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-epidemiological-genomics-phylodynamics",
+          "installUrl": "github:GPTomics/bioSkills:epidemiological-genomics/phylodynamics",
+          "description": "Construct time-scaled phylogenies and infer evolutionary dynamics using TreeTime and BEAST2 for outbreak analysis. Estimate divergence times, molecular clock rates, and ancestral states. Use when dating outbreak origins, estimating transmission rates, or building time-calibrated trees.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-experimental-design-multiple-testing",
+          "installUrl": "github:GPTomics/bioSkills:experimental-design/multiple-testing",
+          "description": "Applies multiple testing correction methods including FDR, Bonferroni, and q-value for genomics data. Use when filtering differential expression results, setting significance thresholds, or choosing between correction methods for different study designs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-fastq-quality",
+          "installUrl": "github:GPTomics/bioSkills:sequence-io/fastq-quality",
+          "description": "Work with FASTQ quality scores using Biopython. Use when analyzing read quality, filtering by quality, trimming low-quality bases, or generating quality reports.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-filter-sequences",
+          "installUrl": "github:GPTomics/bioSkills:sequence-io/filter-sequences",
+          "description": "Filter and select sequences by criteria (length, ID, GC content, patterns) using Biopython. Use when subsetting sequences, removing unwanted records, or selecting by specific criteria.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-flow-cytometry-differential-analysis",
+          "installUrl": "github:GPTomics/bioSkills:flow-cytometry/differential-analysis",
+          "description": "Differential abundance and state analysis for cytometry data. Compare cell populations between conditions using statistical methods. Use when testing for significant changes in cell frequencies or marker expression between groups.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-format-conversion",
+          "installUrl": "github:GPTomics/bioSkills:sequence-io/format-conversion",
+          "description": "Convert between sequence file formats (FASTA, FASTQ, GenBank, EMBL) using Biopython Bio.SeqIO. Use when changing file formats or preparing data for different tools.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-gene-regulatory-networks-coexpression-networks",
+          "installUrl": "github:GPTomics/bioSkills:gene-regulatory-networks/coexpression-networks",
+          "description": "Build weighted gene co-expression networks to identify modules of co-regulated genes and relate them to phenotypes using WGCNA and CEMiTool. Detects hub genes and module-trait relationships from bulk or single-cell expression data. Use when finding co-expression modules, identifying hub genes, or relating gene networks to clinical or experimental variables.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-gene-regulatory-networks-multiomics-grn",
+          "installUrl": "github:GPTomics/bioSkills:gene-regulatory-networks/multiomics-grn",
+          "description": "Build enhancer-driven gene regulatory networks by integrating single-cell RNA-seq and ATAC-seq data using SCENIC+ to identify eRegulons linking transcription factors to enhancers and target genes. Use when analyzing 10x multiome or paired scRNA+scATAC data to infer cis-regulatory GRNs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-annotation-annotation-transfer",
+          "installUrl": "github:GPTomics/bioSkills:genome-annotation/annotation-transfer",
+          "description": "Transfer gene annotations between genome assemblies using Liftoff for same-species annotation liftover and MiniProt for cross-species protein-to-genome alignment. Enables rapid annotation of new assemblies using existing reference annotations. Use when annotating a new assembly of a species with an existing reference annotation or mapping annotations across related species.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-annotation-eukaryotic-gene-prediction",
+          "installUrl": "github:GPTomics/bioSkills:genome-annotation/eukaryotic-gene-prediction",
+          "description": "Predict protein-coding genes in eukaryotic genomes using BRAKER3 for combined RNA-seq and protein evidence, or GALBA for protein-only evidence. Runs Augustus with trained parameters for accurate gene models. Use when annotating a newly assembled eukaryotic genome or improving existing gene predictions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-annotation-ncrna-annotation",
+          "installUrl": "github:GPTomics/bioSkills:genome-annotation/ncrna-annotation",
+          "description": "Identify non-coding RNAs including tRNAs, rRNAs, snoRNAs, and regulatory RNAs using Infernal covariance model searches against Rfam and tRNAscan-SE for tRNA prediction. Use when performing genome-wide ncRNA annotation with assembly input producing GFF output.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-assembly-hifi-assembly",
+          "installUrl": "github:GPTomics/bioSkills:genome-assembly/hifi-assembly",
+          "description": "High-quality genome assembly from PacBio HiFi reads using hifiasm with phasing support. Use when building reference-quality diploid assemblies from HiFi data, especially with trio or Hi-C phasing for fully resolved haplotypes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-intervals-bigwig-tracks",
+          "installUrl": "github:GPTomics/bioSkills:genome-intervals/bigwig-tracks",
+          "description": "Create and read bigWig browser tracks for visualizing continuous genomic data. Convert bedGraph to bigWig, extract signal values, and generate coverage tracks using UCSC tools and pyBigWig. Use when preparing coverage tracks for genome browsers or extracting signal at specific regions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-intervals-coverage-analysis",
+          "installUrl": "github:GPTomics/bioSkills:genome-intervals/coverage-analysis",
+          "description": "Calculate read depth and coverage across genomic intervals using bedtools genomecov and coverage. Generate bedGraph files, compute per-base depth, and summarize coverage statistics. Use when assessing sequencing depth, creating coverage tracks, or evaluating target capture efficiency.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-geo-data",
+          "installUrl": "github:GPTomics/bioSkills:database-access/geo-data",
+          "description": "Query NCBI Gene Expression Omnibus (GEO) for expression datasets using Biopython Bio.Entrez. Use when finding microarray/RNA-seq datasets, downloading expression data, or linking GEO series to SRA runs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-imaging-mass-cytometry-spatial-analysis",
+          "installUrl": "github:GPTomics/bioSkills:imaging-mass-cytometry/spatial-analysis",
+          "description": "Spatial analysis of cell neighborhoods and interactions in IMC data. Covers neighbor graphs, spatial statistics, and interaction testing. Use when analyzing spatial relationships between cell types, testing for neighborhood enrichment, or identifying cell-cell interaction patterns in imaging mass cytometry data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-interaction-databases",
+          "installUrl": "github:GPTomics/bioSkills:database-access/interaction-databases",
+          "description": "Query protein-protein and gene interaction databases including STRING, BioGRID, and IntAct via their REST APIs and Python clients. Retrieve interaction networks, confidence scores, and functional enrichment. Use when building protein interaction networks, contextualizing gene lists with known interactions, or retrieving pathway-level interaction data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-isoform-switching",
+          "installUrl": "github:GPTomics/bioSkills:alternative-splicing/isoform-switching",
+          "description": "Analyzes isoform switching events and functional consequences using IsoformSwitchAnalyzeR. Predicts protein domain changes, NMD sensitivity, ORF alterations, and coding potential shifts between conditions. Use when investigating how splicing changes affect protein function.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-local-blast",
+          "installUrl": "github:GPTomics/bioSkills:database-access/local-blast",
+          "description": "Run local BLAST searches using BLAST+ command-line tools. Use when running fast unlimited searches, building custom databases, performing large-scale analysis, or when NCBI servers are slow or unavailable.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-long-read-sequencing-clair3-variants",
+          "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/clair3-variants",
+          "description": "Deep learning-based variant calling from long reads using Clair3 for SNPs and small indels. Use when calling germline variants from ONT or PacBio alignments, particularly when high accuracy is needed for clinical or research applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-longitudinal-monitoring",
+          "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/longitudinal-monitoring",
+          "description": "Tracks ctDNA dynamics over time for treatment response monitoring using serial liquid biopsy samples. Analyzes tumor fraction trends, mutation clearance kinetics, and defines molecular response criteria. Use when monitoring patients during therapy or detecting molecular relapse before clinical progression.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-longread-alignment",
+          "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/long-read-alignment",
+          "description": "Align long reads using minimap2 for Oxford Nanopore and PacBio data. Supports various presets for different read types and applications. Use when aligning ONT or PacBio reads to a reference genome for variant calling, SV detection, or coverage analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-machine-learning-omics-classifiers",
+          "installUrl": "github:GPTomics/bioSkills:machine-learning/omics-classifiers",
+          "description": "Builds classification models for omics data using RandomForest, XGBoost, and logistic regression with sklearn-compatible APIs. Includes proper preprocessing and evaluation metrics for biomarker classifiers. Use when building diagnostic or prognostic classifiers from expression or variant data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-machine-learning-survival-analysis",
+          "installUrl": "github:GPTomics/bioSkills:machine-learning/survival-analysis",
+          "description": "Analyzes time-to-event data using Kaplan-Meier curves, log-rank tests, and Cox proportional hazards regression with lifelines. Builds survival models from clinical and omics features. Use when predicting patient survival or modeling time-to-event outcomes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-metabolomics-msdial-preprocessing",
+          "installUrl": "github:GPTomics/bioSkills:metabolomics/msdial-preprocessing",
+          "description": "MS-DIAL-based metabolomics preprocessing as alternative to XCMS. Covers peak detection, alignment, annotation, and export for downstream analysis. Use when processing MS-DIAL output files for R/Python analysis or when preferring GUI-based preprocessing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-metabolomics-statistical-analysis",
+          "installUrl": "github:GPTomics/bioSkills:metabolomics/statistical-analysis",
+          "description": "Statistical analysis for metabolomics data. Covers preprocessing (log2 transformation, normalization), limma moderated testing with empirical Bayes, Welch's t-tests with BH correction, fold change estimation, and multivariate methods (PCA, PLS-DA, OPLS-DA). Use when identifying differentially abundant metabolites or building classification models.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-metagenomics-amr-detection",
+          "installUrl": "github:GPTomics/bioSkills:metagenomics/amr-detection",
+          "description": "Detect antimicrobial resistance genes using AMRFinderPlus, ResFinder, and CARD. Screen isolates and metagenomes for resistance determinants. Use when characterizing resistance profiles in clinical isolates, surveillance samples, or metagenomic data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-metagenomics-visualization",
+          "installUrl": "github:GPTomics/bioSkills:metagenomics/metagenome-visualization",
+          "description": "Visualize metagenomic profiles using R (phyloseq, microbiome) and Python (matplotlib, seaborn). Create stacked bar plots, heatmaps, PCA plots, and diversity analyses. Use when creating publication-quality figures from MetaPhlAn, Bracken, or other taxonomic profiling output.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "GPTomics",
+        "repo": "bioSkills",
+        "repoUrl": "https://github.com/GPTomics/bioSkills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "gptomics-bioskills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from GPTomics/bioSkills.",
+      "author": "ASM (GPTomics/bioSkills)",
+      "createdAt": "2026-05-09T08:10:51.349Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "gptomics",
+        "bioskills"
+      ],
+      "skills": [
+        {
+          "name": "bio-alignment-multiple",
+          "installUrl": "github:GPTomics/bioSkills:alignment/multiple-alignment",
+          "description": "Perform multiple sequence alignment using MAFFT, MUSCLE5, ClustalOmega, or T-Coffee. Guides tool and algorithm selection based on dataset size, sequence divergence, and downstream application. Use when aligning three or more homologous sequences for phylogenetics, conservation analysis, or evolutionary studies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-bedgraph-handling",
+          "installUrl": "github:GPTomics/bioSkills:genome-intervals/bedgraph-handling",
+          "description": "Create, manipulate, and convert bedGraph files for genome browser visualization. Covers bedGraph format, conversion to/from bigWig, normalization, and signal processing. Use when handling coverage and signal tracks from ChIP-seq, ATAC-seq, or RNA-seq.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-causal-genomics-fine-mapping",
+          "installUrl": "github:GPTomics/bioSkills:causal-genomics/fine-mapping",
+          "description": "Identify likely causal variants within GWAS loci using SuSiE for sum of single effects regression and FINEMAP for shotgun stochastic search. Computes posterior inclusion probabilities and credible sets to prioritize variants for functional follow-up. Use when narrowing GWAS association signals to candidate causal variants or building credible sets for functional validation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-cfdna-preprocessing",
+          "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/cfdna-preprocessing",
+          "description": "Preprocesses cell-free DNA sequencing data including adapter trimming, alignment optimized for short fragments, and UMI-aware duplicate removal using fgbio. Applies cfDNA-specific quality thresholds and fragment length filtering. Use when processing plasma cfDNA sequencing data before downstream analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-chipseq-peak-annotation",
+          "installUrl": "github:GPTomics/bioSkills:chip-seq/peak-annotation",
+          "description": "Annotate ChIP-seq peaks to genomic features and nearest genes. Classify peaks as promoter, exon, intron, or intergenic using ChIPseeker (R), HOMER annotatePeaks.pl (CLI), or Python (pandas/pyranges). Supports pre-built annotation databases and custom GTF files. Handles promoter definition, feature priority, category collapsing, and signed distance-to-TSS. Use when assigning genomic context to ChIP-seq peaks or linking peaks to target genes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-chipseq-visualization",
+          "installUrl": "github:GPTomics/bioSkills:chip-seq/chipseq-visualization",
+          "description": "Visualize ChIP-seq data using deepTools, Gviz, and ChIPseeker. Create heatmaps, profile plots, and genome browser tracks. Visualize signal around peaks, TSS, or custom regions. Use when visualizing ChIP-seq signal and peaks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-effect-measures",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/effect-measures",
+          "description": "Computes and interprets treatment effect measures including odds ratios, risk ratios, number needed to treat, and confidence intervals from clinical trial data. Covers crude and adjusted measures, non-collapsibility of odds ratios, and forest plot visualization. Use when reporting treatment effects or comparing effect sizes across clinical studies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-subgroup-analysis",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/subgroup-analysis",
+          "description": "Performs stratified and subgroup analyses for clinical trial data. Covers Mantel-Haenszel pooling, Breslow-Day homogeneity testing, interaction terms in regression, multiple comparisons correction, and forest plot visualization. Use when analyzing treatment effects across patient subgroups or controlling for stratification variables.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-trial-reporting",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/trial-reporting",
+          "description": "Prepares statistical tables and reports for clinical trials following regulatory standards. Generates Table 1 baseline characteristics, defines analysis populations (ITT, per-protocol, safety), performs multiple imputation for missing data, and follows CONSORT and ICH E9 guidelines. Use when creating analysis reports, handling missing data, or preparing regulatory submissions from clinical trials.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-pharmacogenomics",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/pharmacogenomics",
+          "description": "Query PharmGKB and CPIC for drug-gene interactions, pharmacogenomic annotations, and dosing guidelines. Use when predicting drug response from genetic variants or implementing clinical pharmacogenomics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-comparative-genomics-ortholog-inference",
+          "installUrl": "github:GPTomics/bioSkills:comparative-genomics/ortholog-inference",
+          "description": "Infer orthologous gene groups across species using OrthoFinder and ProteinOrtho. Identify orthologs, paralogs, and co-orthologs for comparative genomics and functional annotation transfer. Use when identifying gene orthologs across species or building orthogroups for evolutionary analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-cnv-visualization",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/cnv-visualization",
+          "description": "Visualize copy number profiles, segments, and compare across samples. Create publication-quality plots of CNV data from CNVkit, GATK, or other callers. Use when creating genome-wide CNV plots, sample heatmaps, or chromosome-level visualizations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-crispr-screens-library-design",
+          "installUrl": "github:GPTomics/bioSkills:crispr-screens/library-design",
+          "description": "CRISPR library design for genetic screens. Covers sgRNA selection, library composition, control design, and oligo ordering. Use when designing custom sgRNA libraries for knockout, activation, or interference screens.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ctdna-mutation-detection",
+          "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/ctdna-mutation-detection",
+          "description": "Detects somatic mutations in circulating tumor DNA using variant callers optimized for low allele fractions with UMI-based error suppression. Reliably detects mutations at VAF above 0.5 percent using consensus-based approaches. Use when identifying tumor mutations from plasma DNA or tracking specific variants.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-circos-plots",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/circos-plots",
+          "description": "Create circular genome visualizations with Circos and pyCircos. Display multi-track data including ideograms, genes, variants, CNVs, and interaction arcs. Use when creating circular genome visualizations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-color-palettes",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/color-palettes",
+          "description": "Select and apply colorblind-friendly palettes for scientific figures using viridis, RColorBrewer, and custom color schemes. Use when selecting colorblind-friendly palettes for figures.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-genome-browser-tracks",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/genome-browser-tracks",
+          "description": "Generate genome browser visualizations using pyGenomeTracks or IGV batch scripting for publication figures. Use when creating publication figures of genomic regions with multiple data tracks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-genome-tracks",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/genome-tracks",
+          "description": "Create genome browser-style visualizations showing multiple data tracks (coverage, peaks, genes) using pyGenomeTracks, Gviz, and IGV. Use when visualizing genomic data at specific loci with multiple aligned tracks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-ggplot2-fundamentals",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/ggplot2-fundamentals",
+          "description": "Create publication-quality scientific figures with ggplot2 including scatter plots, boxplots, heatmaps, and multi-panel layouts. Use when creating static figures for papers, presentations, or reports in R.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-heatmaps-clustering",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/heatmaps-clustering",
+          "description": "Create clustered heatmaps with row/column annotations using ComplexHeatmap, pheatmap, and seaborn for gene expression and omics data visualization. Use when visualizing expression patterns across samples or identifying co-expressed gene clusters.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-interactive-visualization",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/interactive-visualization",
+          "description": "Create interactive HTML plots with plotly and bokeh for exploratory data analysis and web-based sharing of omics visualizations. Use when building zoomable, hoverable plots for data exploration or web dashboards.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-multipanel-figures",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/multipanel-figures",
+          "description": "Combine multiple plots into publication-ready multi-panel figures using patchwork, cowplot, or matplotlib GridSpec with shared legends and panel labels. Use when combining multiple plots into publication figures.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-network-visualization",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/network-visualization",
+          "description": "Visualize biological networks including gene regulatory networks, protein interaction networks, and co-expression modules using NetworkX, PyVis, and Cytoscape automation. Produces interactive and publication-quality network figures. Use when creating network diagrams from interaction data, GRN results, or co-expression modules.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-specialized-omics-plots",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/specialized-omics-plots",
+          "description": "Reusable plotting functions for common omics visualizations. Custom ggplot2/matplotlib implementations of volcano, MA, PCA, enrichment dotplots, boxplots, and survival curves. Use when creating volcano, MA, or enrichment plots.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-upset-plots",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/upset-plots",
+          "description": "Create UpSet plots to visualize set intersections as an alternative to Venn diagrams using UpSetR or upsetplot. Use when comparing overlapping gene sets, peak sets, or sample groups with more than 3 sets.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-volcano-customization",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/volcano-customization",
+          "description": "Create publication-ready volcano plots with custom thresholds, gene labels, and highlighting using ggplot2, EnhancedVolcano, or matplotlib. Use when visualizing differential expression or association results with gene annotations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-de-visualization",
+          "installUrl": "github:GPTomics/bioSkills:differential-expression/de-visualization",
+          "description": "Visualize differential expression results using DESeq2/edgeR built-in functions. Covers plotMA, plotDispEsts, plotCounts, plotBCV, sample distance heatmaps, and p-value histograms. Use when visualizing differential expression results.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-entrez-search",
+          "installUrl": "github:GPTomics/bioSkills:database-access/entrez-search",
+          "description": "Search NCBI databases using Biopython Bio.Entrez. Use when finding records by keyword, building complex search queries, discovering database structure, or getting global query counts across databases.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-epidemiological-genomics-phylodynamics",
+          "installUrl": "github:GPTomics/bioSkills:epidemiological-genomics/phylodynamics",
+          "description": "Construct time-scaled phylogenies and infer evolutionary dynamics using TreeTime and BEAST2 for outbreak analysis. Estimate divergence times, molecular clock rates, and ancestral states. Use when dating outbreak origins, estimating transmission rates, or building time-calibrated trees.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-epitranscriptomics-modification-visualization",
+          "installUrl": "github:GPTomics/bioSkills:epitranscriptomics/modification-visualization",
+          "description": "Create metagene plots and browser tracks for RNA modification data. Use when visualizing m6A distribution patterns around genomic features like stop codons.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-experimental-design-batch-design",
+          "installUrl": "github:GPTomics/bioSkills:experimental-design/batch-design",
+          "description": "Designs experiments to minimize and account for batch effects using balanced layouts and blocking strategies. Use when planning multi-batch experiments, assigning samples to sequencing lanes, or designing studies where technical variation could confound biological signals.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-experimental-design-multiple-testing",
+          "installUrl": "github:GPTomics/bioSkills:experimental-design/multiple-testing",
+          "description": "Applies multiple testing correction methods including FDR, Bonferroni, and q-value for genomics data. Use when filtering differential expression results, setting significance thresholds, or choosing between correction methods for different study designs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-experimental-design-power-analysis",
+          "installUrl": "github:GPTomics/bioSkills:experimental-design/power-analysis",
+          "description": "Calculates statistical power and minimum sample sizes for RNA-seq, ATAC-seq, and other sequencing experiments. Use when planning experiments, determining how many replicates are needed, or assessing whether a study is adequately powered to detect expected effect sizes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-experimental-design-sample-size",
+          "installUrl": "github:GPTomics/bioSkills:experimental-design/sample-size",
+          "description": "Estimates required sample sizes for differential expression, ChIP-seq, methylation, and proteomics studies. Use when budgeting experiments, writing grant proposals, or determining minimum replicates needed to achieve statistical significance for expected effect sizes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-expression-matrix-metadata-joins",
+          "installUrl": "github:GPTomics/bioSkills:expression-matrix/metadata-joins",
+          "description": "Merge sample metadata with count matrices and add gene annotations. Use when preparing data for differential expression analysis or visualization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-expression-matrix-normalization",
+          "installUrl": "github:GPTomics/bioSkills:expression-matrix/normalization",
+          "description": "Normalize and transform RNA-seq count matrices for differential expression, visualization, and clustering. Covers between-sample (TMM, RLE, upper quartile), within-sample (TPM, FPKM), variance-stabilizing (VST, rlog), and single-cell (scran) methods. Use when choosing or applying normalization to expression data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-flow-cytometry-cytometry-qc",
+          "installUrl": "github:GPTomics/bioSkills:flow-cytometry/cytometry-qc",
+          "description": "Comprehensive quality control for flow cytometry and CyTOF data. Covers flow rate stability, signal drift, margin events, dead cell exclusion, and batch QC. Use when assessing acquisition quality or identifying problematic samples before analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-fragment-analysis",
+          "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/fragment-analysis",
+          "description": "Analyzes cfDNA fragment size distributions and fragmentomics features using FinaleToolkit or Griffin. Extracts nucleosome positioning patterns, fragment ratios, and DELFI-style fragmentation profiles for cancer detection. Use when leveraging fragment patterns for tumor detection or tissue-of-origin analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-gene-regulatory-networks-coexpression-networks",
+          "installUrl": "github:GPTomics/bioSkills:gene-regulatory-networks/coexpression-networks",
+          "description": "Build weighted gene co-expression networks to identify modules of co-regulated genes and relate them to phenotypes using WGCNA and CEMiTool. Detects hub genes and module-trait relationships from bulk or single-cell expression data. Use when finding co-expression modules, identifying hub genes, or relating gene networks to clinical or experimental variables.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-gene-regulatory-networks-multiomics-grn",
+          "installUrl": "github:GPTomics/bioSkills:gene-regulatory-networks/multiomics-grn",
+          "description": "Build enhancer-driven gene regulatory networks by integrating single-cell RNA-seq and ATAC-seq data using SCENIC+ to identify eRegulons linking transcription factors to enhancers and target genes. Use when analyzing 10x multiome or paired scRNA+scATAC data to infer cis-regulatory GRNs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-assembly-assembly-qc",
+          "installUrl": "github:GPTomics/bioSkills:genome-assembly/assembly-qc",
+          "description": "Assess genome assembly quality using QUAST for contiguity metrics and BUSCO for completeness. Essential for evaluating assembly success and comparing assemblers. Use when evaluating assembly completeness and quality.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-assembly-hifi-assembly",
+          "installUrl": "github:GPTomics/bioSkills:genome-assembly/hifi-assembly",
+          "description": "High-quality genome assembly from PacBio HiFi reads using hifiasm with phasing support. Use when building reference-quality diploid assemblies from HiFi data, especially with trio or Hi-C phasing for fully resolved haplotypes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-assembly-long-read-assembly",
+          "installUrl": "github:GPTomics/bioSkills:genome-assembly/long-read-assembly",
+          "description": "De novo genome assembly from Oxford Nanopore or PacBio long reads using Flye and Canu. Produces highly contiguous assemblies suitable for complete bacterial genomes and resolving complex regions. Use when assembling genomes from ONT or PacBio reads.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-engineering-base-editing-design",
+          "installUrl": "github:GPTomics/bioSkills:genome-engineering/base-editing-design",
+          "description": "Design guides for cytosine and adenine base editing using editing window optimization and BE-Hive outcome prediction. Select optimal positions for C-to-T or A-to-G conversions without double-strand breaks. Use when designing base editor experiments for precise nucleotide changes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-engineering-grna-design",
+          "installUrl": "github:GPTomics/bioSkills:genome-engineering/grna-design",
+          "description": "Design guide RNAs for CRISPR-Cas9/Cas12a experiments using CRISPRscan and local scoring algorithms. Score guides for on-target activity using Rule Set 2 and Azimuth models. Use when designing sgRNAs for gene knockout, activation, or repression experiments.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-engineering-hdr-template-design",
+          "installUrl": "github:GPTomics/bioSkills:genome-engineering/hdr-template-design",
+          "description": "Design homology-directed repair donor templates for CRISPR knock-ins using primer3-py. Create ssODN, dsDNA, or plasmid templates with optimized homology arms. Use when designing donor templates for precise insertions, tagging, or allele replacement.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-engineering-off-target-prediction",
+          "installUrl": "github:GPTomics/bioSkills:genome-engineering/off-target-prediction",
+          "description": "Predict CRISPR off-target sites using Cas-OFFinder and CFD scoring algorithms. Identify potential unintended cleavage sites genome-wide and assess guide specificity. Use when evaluating guide RNA specificity or selecting guides with minimal off-target risk.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-engineering-prime-editing-design",
+          "installUrl": "github:GPTomics/bioSkills:genome-engineering/prime-editing-design",
+          "description": "Design pegRNAs for prime editing using PrimeDesign algorithms. Generate spacer, PBS, and RT template sequences for precise genomic modifications without double-strand breaks. Use when designing prime editing experiments for precise insertions, deletions, or point mutations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-intervals-bigwig-tracks",
+          "installUrl": "github:GPTomics/bioSkills:genome-intervals/bigwig-tracks",
+          "description": "Create and read bigWig browser tracks for visualizing continuous genomic data. Convert bedGraph to bigWig, extract signal values, and generate coverage tracks using UCSC tools and pyBigWig. Use when preparing coverage tracks for genome browsers or extracting signal at specific regions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-hi-c-analysis-hic-differential",
+          "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/hic-differential",
+          "description": "Compare Hi-C contact matrices between conditions to identify differential chromatin interactions. Compute log2 fold changes, statistical significance, and visualize differential contact maps. Use when comparing Hi-C contacts between conditions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-hi-c-analysis-hic-visualization",
+          "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/hic-visualization",
+          "description": "Visualize Hi-C contact matrices, TADs, loops, and genomic features using matplotlib, cooltools, and HiCExplorer. Create triangle plots, virtual 4C, and multi-track figures. Use when visualizing contact matrices or genomic features.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-imaging-mass-cytometry-interactive-annotation",
+          "installUrl": "github:GPTomics/bioSkills:imaging-mass-cytometry/interactive-annotation",
+          "description": "Interactive cell type annotation for IMC data. Covers napari-based annotation, marker-guided labeling, training data generation, and annotation validation. Use when manually annotating cell types for training classifiers or validating automated phenotyping results.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-imaging-mass-cytometry-quality-metrics",
+          "installUrl": "github:GPTomics/bioSkills:imaging-mass-cytometry/quality-metrics",
+          "description": "Quality metrics for IMC data including signal-to-noise, channel correlation, tissue integrity, and acquisition QC. Use when assessing data quality before analysis or troubleshooting problematic acquisitions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-immunoinformatics-epitope-prediction",
+          "installUrl": "github:GPTomics/bioSkills:immunoinformatics/epitope-prediction",
+          "description": "Predict B-cell and T-cell epitopes using BepiPred, IEDB tools, and structure-based methods for vaccine and antibody design. Identify immunogenic regions in antigens. Use when designing vaccines, mapping antibody binding sites, or predicting immunogenic peptides.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-immunoinformatics-immunogenicity-scoring",
+          "installUrl": "github:GPTomics/bioSkills:immunoinformatics/immunogenicity-scoring",
+          "description": "Score and prioritize neoantigens and epitopes for immunogenicity using multi-factor models combining MHC binding, processing, expression, and sequence features. Rank candidates for vaccine design. Use when prioritizing epitopes for vaccine development or identifying the most immunogenic neoantigens.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-immunoinformatics-mhc-binding-prediction",
+          "installUrl": "github:GPTomics/bioSkills:immunoinformatics/mhc-binding-prediction",
+          "description": "Predict peptide-MHC class I and II binding affinity using MHCflurry and NetMHCpan neural network models. Identify potential T-cell epitopes from protein sequences. Use when predicting MHC binding for vaccine design or neoantigen identification.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-immunoinformatics-tcr-epitope-binding",
+          "installUrl": "github:GPTomics/bioSkills:immunoinformatics/tcr-epitope-binding",
+          "description": "Predict TCR-epitope specificity using ERGO-II and deep learning models for T-cell receptor antigen recognition. Match TCRs to their cognate epitopes or predict TCR targets. Use when analyzing TCR repertoire specificity or identifying antigen-reactive T-cells.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-interaction-databases",
+          "installUrl": "github:GPTomics/bioSkills:database-access/interaction-databases",
+          "description": "Query protein-protein and gene interaction databases including STRING, BioGRID, and IntAct via their REST APIs and Python clients. Retrieve interaction networks, confidence scores, and functional enrichment. Use when building protein interaction networks, contextualizing gene lists with known interactions, or retrieving pathway-level interaction data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-liquid-biopsy-pipeline",
+          "installUrl": "github:GPTomics/bioSkills:workflows/liquid-biopsy-pipeline",
+          "description": "Cell-free DNA analysis pipeline from plasma sequencing to tumor monitoring. Preprocesses cfDNA reads, analyzes fragment patterns, estimates tumor fraction from sWGS, and optionally detects mutations from targeted panels. Use when analyzing liquid biopsy samples for cancer detection or monitoring.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-local-blast",
+          "installUrl": "github:GPTomics/bioSkills:database-access/local-blast",
+          "description": "Run local BLAST searches using BLAST+ command-line tools. Use when running fast unlimited searches, building custom databases, performing large-scale analysis, or when NCBI servers are slow or unavailable.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-longitudinal-monitoring",
+          "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/longitudinal-monitoring",
+          "description": "Tracks ctDNA dynamics over time for treatment response monitoring using serial liquid biopsy samples. Analyzes tumor fraction trends, mutation clearance kinetics, and defines molecular response criteria. Use when monitoring patients during therapy or detecting molecular relapse before clinical progression.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-longread-qc",
+          "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/long-read-qc",
+          "description": "Quality control for long-read sequencing data using NanoPlot, NanoStat, and chopper. Generate QC reports, filter reads by length and quality, and visualize read characteristics. Use when assessing ONT or PacBio run quality or filtering reads before assembly or alignment.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-machine-learning-omics-classifiers",
+          "installUrl": "github:GPTomics/bioSkills:machine-learning/omics-classifiers",
+          "description": "Builds classification models for omics data using RandomForest, XGBoost, and logistic regression with sklearn-compatible APIs. Includes proper preprocessing and evaluation metrics for biomarker classifiers. Use when building diagnostic or prognostic classifiers from expression or variant data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-machine-learning-survival-analysis",
+          "installUrl": "github:GPTomics/bioSkills:machine-learning/survival-analysis",
+          "description": "Analyzes time-to-event data using Kaplan-Meier curves, log-rank tests, and Cox proportional hazards regression with lifelines. Builds survival models from clinical and omics features. Use when predicting patient survival or modeling time-to-event outcomes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-metabolomics-msdial-preprocessing",
+          "installUrl": "github:GPTomics/bioSkills:metabolomics/msdial-preprocessing",
+          "description": "MS-DIAL-based metabolomics preprocessing as alternative to XCMS. Covers peak detection, alignment, annotation, and export for downstream analysis. Use when processing MS-DIAL output files for R/Python analysis or when preferring GUI-based preprocessing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-metabolomics-pathway-mapping",
+          "installUrl": "github:GPTomics/bioSkills:metabolomics/pathway-mapping",
+          "description": "Map metabolites to biological pathways using KEGG, Reactome, and MetaboAnalyst. Perform pathway enrichment and topology analysis. Use when interpreting metabolomics results in the context of biochemical pathways.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-metabolomics-statistical-analysis",
+          "installUrl": "github:GPTomics/bioSkills:metabolomics/statistical-analysis",
+          "description": "Statistical analysis for metabolomics data. Covers preprocessing (log2 transformation, normalization), limma moderated testing with empirical Bayes, Welch's t-tests with BH correction, fold change estimation, and multivariate methods (PCA, PLS-DA, OPLS-DA). Use when identifying differentially abundant metabolites or building classification models.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-metagenomics-visualization",
+          "installUrl": "github:GPTomics/bioSkills:metagenomics/metagenome-visualization",
+          "description": "Visualize metagenomic profiles using R (phyloseq, microbiome) and Python (matplotlib, seaborn). Create stacked bar plots, heatmaps, PCA plots, and diversity analyses. Use when creating publication-quality figures from MetaPhlAn, Bracken, or other taxonomic profiling output.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-methylation-based-detection",
+          "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/methylation-based-detection",
+          "description": "Analyzes cfDNA methylation patterns for cancer detection using cfMeDIP-seq or bisulfite sequencing with MethylDackel. Identifies cancer-specific methylation signatures and performs tissue-of-origin deconvolution. Use when using methylation biomarkers for early cancer detection or minimal residual disease.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-microbiome-qiime2-workflow",
+          "installUrl": "github:GPTomics/bioSkills:microbiome/qiime2-workflow",
+          "description": "QIIME2 command-line workflow for 16S/ITS amplicon analysis. Alternative to DADA2/phyloseq R workflow with built-in provenance tracking. Use when preferring CLI over R, needing reproducible provenance, or working within QIIME2 ecosystem.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-pathway-enrichment-visualization",
+          "installUrl": "github:GPTomics/bioSkills:pathway-analysis/enrichment-visualization",
+          "description": "Visualize enrichment results using enrichplot package functions. Use when creating publication-quality figures from clusterProfiler results. Covers dotplot, barplot, cnetplot, emapplot, gseaplot2, ridgeplot, and treeplot.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-pathway-reactome",
+          "installUrl": "github:GPTomics/bioSkills:pathway-analysis/reactome-pathways",
+          "description": "Reactome pathway enrichment using ReactomePA package. Use when analyzing gene lists against Reactome's curated peer-reviewed pathway database. Performs over-representation analysis and GSEA with visualization and pathway hierarchy exploration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-pdb-structure-modification",
+          "installUrl": "github:GPTomics/bioSkills:structural-biology/structure-modification",
+          "description": "Modify protein structures using Biopython Bio.PDB. Use when transforming coordinates, removing atoms or residues, adding new entities, modifying B-factors and occupancies, or building structures programmatically.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-phasing-imputation-haplotype-phasing",
+          "installUrl": "github:GPTomics/bioSkills:phasing-imputation/haplotype-phasing",
+          "description": "Phase genotypes into haplotypes using Beagle or SHAPEIT. Resolves which alleles are inherited together on each chromosome. Use when preparing VCF files for imputation, HLA typing, or population genetic analyses requiring phased haplotypes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-phylo-distance-calculations",
+          "installUrl": "github:GPTomics/bioSkills:phylogenetics/distance-calculations",
+          "description": "Compute evolutionary distances and build phylogenetic trees using Biopython Bio.Phylo.TreeConstruction. Use when creating distance matrices from alignments, building NJ/UPGMA trees, generating bootstrap consensus, or needing quick exploratory phylogenies before running full ML analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-phylo-modern-tree-inference",
+          "installUrl": "github:GPTomics/bioSkills:phylogenetics/modern-tree-inference",
+          "description": "Build maximum likelihood phylogenetic trees using IQ-TREE2 and RAxML-NG with expert model selection, branch support assessment, and topology testing. Use when inferring publication-quality ML trees, selecting substitution models, interpreting bootstrap and concordance factor support, or running partitioned phylogenomic analyses.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-phylo-tree-manipulation",
+          "installUrl": "github:GPTomics/bioSkills:phylogenetics/tree-manipulation",
+          "description": "Modify phylogenetic tree structure using Biopython Bio.Phylo. Use when rooting trees with outgroups, midpoint, or MAD methods, pruning taxa, collapsing clades, ladderizing branches, or extracting subtrees. Includes rooting method decision guidance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-phylo-tree-visualization",
+          "installUrl": "github:GPTomics/bioSkills:phylogenetics/tree-visualization",
+          "description": "Draw and export phylogenetic trees using Biopython Bio.Phylo with matplotlib and modern alternatives. Use when creating tree figures, customizing colors and labels, exporting to image formats, or choosing between Bio.Phylo, ggtree, ETE4, and iTOL for publication.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-population-genetics-association-testing",
+          "installUrl": "github:GPTomics/bioSkills:population-genetics/association-testing",
+          "description": "Genome-wide association studies (GWAS) with PLINK. Perform case-control and quantitative trait association testing using logistic/linear regression with covariates, generate Manhattan and QQ plots for result visualization. Use when running GWAS or association tests.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-population-genetics-linkage-disequilibrium",
+          "installUrl": "github:GPTomics/bioSkills:population-genetics/linkage-disequilibrium",
+          "description": "Calculate linkage disequilibrium statistics (r², D'), perform LD pruning for population structure analysis, identify haplotype blocks, and visualize LD patterns using PLINK, scikit-allel, and LDBlockShow. Use when calculating LD or pruning variants.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "GPTomics",
+        "repo": "bioSkills",
+        "repoUrl": "https://github.com/GPTomics/bioSkills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "gptomics-bioskills-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from GPTomics/bioSkills.",
+      "author": "ASM (GPTomics/bioSkills)",
+      "createdAt": "2026-05-09T08:10:51.349Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "gptomics",
+        "bioskills"
+      ],
+      "skills": [
+        {
+          "name": "bio-admet-prediction",
+          "installUrl": "github:GPTomics/bioSkills:chemoinformatics/admet-prediction",
+          "description": "Predicts ADMET properties using ADMETlab 3.0 API or DeepChem models. Estimates bioavailability, CYP inhibition, hERG liability, and 119 toxicity endpoints with uncertainty quantification. Filters for PAINS and other structural alerts. Use when filtering compounds for drug-likeness or prioritizing leads by predicted safety.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-alignment-filtering",
+          "installUrl": "github:GPTomics/bioSkills:alignment-files/alignment-filtering",
+          "description": "Filter alignments by flags, mapping quality, and regions using samtools view and pysam. Use when extracting specific reads, removing low-quality alignments, or subsetting to target regions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-alignment-indexing",
+          "installUrl": "github:GPTomics/bioSkills:alignment-files/alignment-indexing",
+          "description": "Create and use BAI/CSI indices for BAM/CRAM files using samtools and pysam. Use when enabling random access to alignment files or fetching specific genomic regions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-atac-seq-atac-peak-calling",
+          "installUrl": "github:GPTomics/bioSkills:atac-seq/atac-peak-calling",
+          "description": "Call accessible chromatin regions from ATAC-seq data using MACS3 with ATAC-specific parameters. Use when identifying open chromatin regions from aligned ATAC-seq BAM files, different from ChIP-seq peak calling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-basecalling",
+          "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/basecalling",
+          "description": "Convert raw Nanopore signal data (FAST5/POD5) to nucleotide sequences using Dorado basecaller. Covers model selection, GPU acceleration, modified base detection, and quality filtering. Use when processing raw Nanopore data before alignment. Note: Guppy is deprecated; use Dorado for all new analyses.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-batch-downloads",
+          "installUrl": "github:GPTomics/bioSkills:database-access/batch-downloads",
+          "description": "Download large datasets from NCBI efficiently using history server, batching, and rate limiting. Use when performing bulk sequence downloads, handling large query results, or production-scale data retrieval.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-causal-genomics-fine-mapping",
+          "installUrl": "github:GPTomics/bioSkills:causal-genomics/fine-mapping",
+          "description": "Identify likely causal variants within GWAS loci using SuSiE for sum of single effects regression and FINEMAP for shotgun stochastic search. Computes posterior inclusion probabilities and credible sets to prioritize variants for functional follow-up. Use when narrowing GWAS association signals to candidate causal variants or building credible sets for functional validation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-cfdna-preprocessing",
+          "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/cfdna-preprocessing",
+          "description": "Preprocesses cell-free DNA sequencing data including adapter trimming, alignment optimized for short fragments, and UMI-aware duplicate removal using fgbio. Applies cfDNA-specific quality thresholds and fragment length filtering. Use when processing plasma cfDNA sequencing data before downstream analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-chipseq-differential-binding",
+          "installUrl": "github:GPTomics/bioSkills:chip-seq/differential-binding",
+          "description": "Identifies differentially bound ChIP-seq regions between conditions using DiffBind (from BAMs), DESeq2, or PyDESeq2 (from count matrices). Handles normalization, statistical testing, and fold-change estimation with ChIP-seq-specific considerations. Use when comparing ChIP-seq binding between experimental conditions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-chipseq-qc",
+          "installUrl": "github:GPTomics/bioSkills:chip-seq/chipseq-qc",
+          "description": "ChIP-seq quality control metrics including FRiP (Fraction of Reads in Peaks), cross-correlation analysis (NSC/RSC), library complexity, and IDR (Irreproducibility Discovery Rate) for replicate concordance. Use to assess experiment quality before downstream analysis. Use when assessing ChIP-seq data quality metrics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-chipseq-super-enhancers",
+          "installUrl": "github:GPTomics/bioSkills:chip-seq/super-enhancers",
+          "description": "Identifies super-enhancers from H3K27ac ChIP-seq data using ROSE and related tools. Use when studying cell identity genes, cancer-associated regulatory elements, or master transcription factor binding regions that cluster into large enhancer domains.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-categorical-tests",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/categorical-tests",
+          "description": "Tests associations between categorical variables in clinical data using chi-square, Fisher's exact, and Cochran-Mantel-Haenszel tests. Computes effect sizes and post-hoc pairwise comparisons. Use when analyzing categorical outcomes or testing treatment-outcome independence in clinical trials.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-cdisc-data",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/cdisc-data-handling",
+          "description": "Reads and prepares CDISC SDTM clinical trial data for analysis. Handles domain tables (DM, AE, EX, VS, LB), USUBJID-based joins, event-to-subject aggregation, and SUPPQUAL pivoting. Use when working with clinical trial datasets in CDISC/SDTM format or .xpt files.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-clinvar-lookup",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/clinvar-lookup",
+          "description": "Query ClinVar for variant pathogenicity classifications, review status, and disease associations via REST API or local VCF. Use when determining clinical significance of variants for diagnostic or research purposes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-gnomad-frequencies",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/gnomad-frequencies",
+          "description": "Query gnomAD for population allele frequencies to assess variant rarity. Use when filtering variants by population frequency for rare disease analysis or determining if a variant is common in the general population.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-tumor-mutational-burden",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/tumor-mutational-burden",
+          "description": "Calculate tumor mutational burden from panel or WES data with proper normalization and clinical thresholds. Use when assessing immunotherapy eligibility or characterizing tumor immunogenicity.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-variant-prioritization",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/variant-prioritization",
+          "description": "Filter and prioritize variants by pathogenicity, population frequency, and clinical evidence for rare disease analysis. Use when identifying candidate disease-causing variants from exome or genome sequencing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clip-seq-binding-site-annotation",
+          "installUrl": "github:GPTomics/bioSkills:clip-seq/binding-site-annotation",
+          "description": "Annotate CLIP-seq binding sites to genomic features including 3'UTR, 5'UTR, CDS, introns, and ncRNAs. Use when characterizing where an RBP binds in transcripts.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clip-seq-clip-motif-analysis",
+          "installUrl": "github:GPTomics/bioSkills:clip-seq/clip-motif-analysis",
+          "description": "Identify enriched sequence motifs at CLIP-seq binding sites for RBP binding specificity. Use when characterizing the sequence preferences of an RNA-binding protein.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-comparative-genomics-ancestral-reconstruction",
+          "installUrl": "github:GPTomics/bioSkills:comparative-genomics/ancestral-reconstruction",
+          "description": "Reconstruct ancestral sequences at phylogenetic nodes using PAML and IQ-TREE marginal likelihood methods. Infer ancient protein sequences and trace evolutionary trajectories through sequence history. Use when inferring ancestral states for protein resurrection or tracing evolutionary history.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-comparative-genomics-ortholog-inference",
+          "installUrl": "github:GPTomics/bioSkills:comparative-genomics/ortholog-inference",
+          "description": "Infer orthologous gene groups across species using OrthoFinder and ProteinOrtho. Identify orthologs, paralogs, and co-orthologs for comparative genomics and functional annotation transfer. Use when identifying gene orthologs across species or building orthogroups for evolutionary analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-comparative-genomics-synteny-analysis",
+          "installUrl": "github:GPTomics/bioSkills:comparative-genomics/synteny-analysis",
+          "description": "Analyze genome collinearity and syntenic blocks using MCScanX, SyRI, and JCVI for comparative genomics. Detect conserved gene order, chromosomal rearrangements, and whole-genome duplications. Use when comparing genome structure between species or identifying conserved genomic regions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-consensus-sequences",
+          "installUrl": "github:GPTomics/bioSkills:variant-calling/consensus-sequences",
+          "description": "Generate consensus FASTA sequences by applying VCF variants to a reference using bcftools consensus. Use when creating sample-specific reference sequences or reconstructing haplotypes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-cnvkit-analysis",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/cnvkit-analysis",
+          "description": "Detect copy number variants from targeted/exome sequencing using CNVkit. Supports tumor-normal pairs, tumor-only, and germline CNV calling. Use when detecting CNVs from WES or targeted panel sequencing data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-gatk-cnv",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/gatk-cnv",
+          "description": "Call copy number variants using GATK best practices workflow. Supports both somatic (tumor-normal) and germline CNV detection from WGS or WES data. Use when following GATK best practices or integrating CNV calling with other GATK variant pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-crispr-screens-base-editing-analysis",
+          "installUrl": "github:GPTomics/bioSkills:crispr-screens/base-editing-analysis",
+          "description": "Analyzes base editing and prime editing outcomes including editing efficiency, bystander edits, and indel frequencies. Use when quantifying CRISPR base editor results, comparing ABE vs CBE efficiency, or assessing prime editing fidelity.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-crispr-screens-crispresso-editing",
+          "installUrl": "github:GPTomics/bioSkills:crispr-screens/crispresso-editing",
+          "description": "CRISPResso2 for analyzing CRISPR gene editing outcomes. Quantifies indels, HDR efficiency, and generates comprehensive editing reports. Use when analyzing amplicon sequencing data from CRISPR editing experiments to assess editing efficiency.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-crispr-screens-jacks-analysis",
+          "installUrl": "github:GPTomics/bioSkills:crispr-screens/jacks-analysis",
+          "description": "JACKS (Joint Analysis of CRISPR/Cas9 Knockout Screens) for modeling sgRNA efficacy and gene essentiality. Use when analyzing multiple CRISPR screens simultaneously or when accounting for variable sgRNA efficiency across experiments.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ctdna-mutation-detection",
+          "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/ctdna-mutation-detection",
+          "description": "Detects somatic mutations in circulating tumor DNA using variant callers optimized for low allele fractions with UMI-based error suppression. Reliably detects mutations at VAF above 0.5 percent using consensus-based approaches. Use when identifying tumor mutations from plasma DNA or tracking specific variants.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-circos-plots",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/circos-plots",
+          "description": "Create circular genome visualizations with Circos and pyCircos. Display multi-track data including ideograms, genes, variants, CNVs, and interaction arcs. Use when creating circular genome visualizations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-color-palettes",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/color-palettes",
+          "description": "Select and apply colorblind-friendly palettes for scientific figures using viridis, RColorBrewer, and custom color schemes. Use when selecting colorblind-friendly palettes for figures.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-genome-tracks",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/genome-tracks",
+          "description": "Create genome browser-style visualizations showing multiple data tracks (coverage, peaks, genes) using pyGenomeTracks, Gviz, and IGV. Use when visualizing genomic data at specific loci with multiple aligned tracks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-ggplot2-fundamentals",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/ggplot2-fundamentals",
+          "description": "Create publication-quality scientific figures with ggplot2 including scatter plots, boxplots, heatmaps, and multi-panel layouts. Use when creating static figures for papers, presentations, or reports in R.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-specialized-omics-plots",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/specialized-omics-plots",
+          "description": "Reusable plotting functions for common omics visualizations. Custom ggplot2/matplotlib implementations of volcano, MA, PCA, enrichment dotplots, boxplots, and survival curves. Use when creating volcano, MA, or enrichment plots.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-volcano-customization",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/volcano-customization",
+          "description": "Create publication-ready volcano plots with custom thresholds, gene labels, and highlighting using ggplot2, EnhancedVolcano, or matplotlib. Use when visualizing differential expression or association results with gene annotations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-de-deseq2-basics",
+          "installUrl": "github:GPTomics/bioSkills:differential-expression/deseq2-basics",
+          "description": "Perform differential expression analysis using DESeq2 in R/Bioconductor. Use for analyzing RNA-seq count data, creating DESeqDataSet objects, running the DESeq workflow, and extracting results with log fold change shrinkage. Use when performing DE analysis with DESeq2.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-differential-splicing",
+          "installUrl": "github:GPTomics/bioSkills:alternative-splicing/differential-splicing",
+          "description": "Detects differential alternative splicing between conditions using rMATS-turbo (BAM-based) or SUPPA2 diffSplice (TPM-based). Reports events with FDR-corrected significance and delta PSI effect sizes. Use when comparing splicing patterns between treatment groups, tissues, or disease states.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-biodiversity-metrics",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/biodiversity-metrics",
+          "description": "Calculates species richness, diversity, and turnover using the Hill number framework with iNEXT coverage-based rarefaction/extrapolation, asymptotic diversity estimation, and beta diversity partitioning (betapart turnover vs nestedness). Compares assemblages using coverage-standardized rather than size-standardized rarefaction. Use when quantifying biodiversity from species abundance or incidence data, comparing diversity across sites, or constructing rarefaction curves. Not for clinical 16S microbiome alpha/beta diversity (see microbiome/diversity-analysis).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-community-ecology",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/community-ecology",
+          "description": "Analyzes community composition using constrained ordination (CCA, RDA, db-RDA), variance partitioning (varpart), indicator species analysis (indicspecies multipatt), and distance-based environmental gradient methods with vegan. Links species composition to environmental explanatory variables. Use when testing how environmental gradients structure species communities, identifying habitat indicator taxa, or partitioning explained variation among predictors. Not for basic unconstrained ordination and PERMANOVA (see microbiome/diversity-analysis).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-conservation-genetics",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/conservation-genetics",
+          "description": "Assesses genetic health of populations for conservation using effective population size estimation (GONE2 for recent Ne trajectory, NeEstimator for contemporary Ne, Stairway Plot 2 and PSMC for historical Ne), F-statistics (hierfstat), runs of homozygosity (detectRUNS), and genetic diversity metrics. Use when estimating effective population size, detecting inbreeding or bottlenecks, or assessing genetic diversity in threatened species from microsatellite or SNP data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-edna-metabarcoding",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/edna-metabarcoding",
+          "description": "Processes environmental DNA metabarcoding data from raw amplicon reads to species occurrence tables using OBITools3, DADA2, and taxonomic assignment against BOLD, MIDORI2, or MitoFish databases. Handles COI, 12S, rbcL, and ITS barcode regions with primer removal, denoising, chimera detection, and contamination filtering via decontam. Includes occupancy modeling (occumb) for detection probability correction. Use when analyzing eDNA from water, soil, or bulk samples for biodiversity monitoring. Not for 16S human microbiome (see microbiome/amplicon-processing).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-landscape-genomics",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/landscape-genomics",
+          "description": "Tests genotype-environment associations and identifies loci under local adaptation using LFMM2 (LEA), pcadapt outlier detection, OutFLANK Fst-based selection scans, and redundancy analysis. Detects adaptive genetic variation correlated with environmental variables while controlling for population structure. Use when identifying adaptive loci across environmental gradients, testing for signatures of local adaptation, or predicting genetic vulnerability to climate change with gradientForest.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-species-delimitation",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/species-delimitation",
+          "description": "Delimits species boundaries from molecular data using distance-based (ASAP), tree-based (bPTP, GMYC), and coalescent (BPP) methods. Compares multiple delimitation results with delimtools. Use when delineating putative species from DNA barcoding data, resolving cryptic species complexes, or validating taxonomic assignments. Emphasizes multi-method consensus following integrative taxonomy best practice.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-epitranscriptomics-m6a-peak-calling",
+          "installUrl": "github:GPTomics/bioSkills:epitranscriptomics/m6a-peak-calling",
+          "description": "Call m6A peaks from MeRIP-seq IP vs input comparisons. Use when identifying m6A modification sites from methylated RNA immunoprecipitation data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-epitranscriptomics-m6anet-analysis",
+          "installUrl": "github:GPTomics/bioSkills:epitranscriptomics/m6anet-analysis",
+          "description": "Detect m6A modifications from Oxford Nanopore direct RNA sequencing using m6Anet. Use when analyzing epitranscriptomic modifications from long-read RNA data without immunoprecipitation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-experimental-design-batch-design",
+          "installUrl": "github:GPTomics/bioSkills:experimental-design/batch-design",
+          "description": "Designs experiments to minimize and account for batch effects using balanced layouts and blocking strategies. Use when planning multi-batch experiments, assigning samples to sequencing lanes, or designing studies where technical variation could confound biological signals.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-experimental-design-power-analysis",
+          "installUrl": "github:GPTomics/bioSkills:experimental-design/power-analysis",
+          "description": "Calculates statistical power and minimum sample sizes for RNA-seq, ATAC-seq, and other sequencing experiments. Use when planning experiments, determining how many replicates are needed, or assessing whether a study is adequately powered to detect expected effect sizes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-expression-matrix-sparse-handling",
+          "installUrl": "github:GPTomics/bioSkills:expression-matrix/sparse-handling",
+          "description": "Work with sparse matrices for memory-efficient storage of count data. Use when dealing with single-cell data or large bulk RNA-seq datasets where most values are zero.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-filter-sequences",
+          "installUrl": "github:GPTomics/bioSkills:sequence-io/filter-sequences",
+          "description": "Filter and select sequences by criteria (length, ID, GC content, patterns) using Biopython. Use when subsetting sequences, removing unwanted records, or selecting by specific criteria.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-flow-cytometry-clustering-phenotyping",
+          "installUrl": "github:GPTomics/bioSkills:flow-cytometry/clustering-phenotyping",
+          "description": "Unsupervised clustering and cell type identification for flow/mass cytometry. Covers FlowSOM, Phenograph, and CATALYST workflows. Use when discovering cell populations in high-dimensional cytometry data without predefined gates.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-flow-cytometry-differential-analysis",
+          "installUrl": "github:GPTomics/bioSkills:flow-cytometry/differential-analysis",
+          "description": "Differential abundance and state analysis for cytometry data. Compare cell populations between conditions using statistical methods. Use when testing for significant changes in cell frequencies or marker expression between groups.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-gatk-variant-calling",
+          "installUrl": "github:GPTomics/bioSkills:variant-calling/gatk-variant-calling",
+          "description": "Variant calling with GATK HaplotypeCaller following best practices. Covers germline SNP/indel calling, GVCF workflow for cohorts, joint genotyping, and variant quality score recalibration (VQSR). Use when calling variants with GATK HaplotypeCaller.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-gene-regulatory-networks-multiomics-grn",
+          "installUrl": "github:GPTomics/bioSkills:gene-regulatory-networks/multiomics-grn",
+          "description": "Build enhancer-driven gene regulatory networks by integrating single-cell RNA-seq and ATAC-seq data using SCENIC+ to identify eRegulons linking transcription factors to enhancers and target genes. Use when analyzing 10x multiome or paired scRNA+scATAC data to infer cis-regulatory GRNs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-gene-regulatory-networks-scenic-regulons",
+          "installUrl": "github:GPTomics/bioSkills:gene-regulatory-networks/scenic-regulons",
+          "description": "Infer gene regulatory networks and identify transcription factor regulons from single-cell RNA-seq data using pySCENIC. Discovers co-expression modules with GRNBoost2, prunes by cis-regulatory motif enrichment, and scores regulon activity per cell with AUCell. Use when identifying transcription factor regulons, scoring TF activity in single cells, or finding master regulators of cell identity.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-annotation-annotation-transfer",
+          "installUrl": "github:GPTomics/bioSkills:genome-annotation/annotation-transfer",
+          "description": "Transfer gene annotations between genome assemblies using Liftoff for same-species annotation liftover and MiniProt for cross-species protein-to-genome alignment. Enables rapid annotation of new assemblies using existing reference annotations. Use when annotating a new assembly of a species with an existing reference annotation or mapping annotations across related species.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-annotation-ncrna-annotation",
+          "installUrl": "github:GPTomics/bioSkills:genome-annotation/ncrna-annotation",
+          "description": "Identify non-coding RNAs including tRNAs, rRNAs, snoRNAs, and regulatory RNAs using Infernal covariance model searches against Rfam and tRNAscan-SE for tRNA prediction. Use when performing genome-wide ncRNA annotation with assembly input producing GFF output.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-assembly-assembly-polishing",
+          "installUrl": "github:GPTomics/bioSkills:genome-assembly/assembly-polishing",
+          "description": "Polish genome assemblies to reduce errors using short reads (Pilon), long reads (Racon), or ONT-specific tools (medaka). Essential for improving long-read assembly accuracy. Use when improving assembly accuracy with polishing tools.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-assembly-hifi-assembly",
+          "installUrl": "github:GPTomics/bioSkills:genome-assembly/hifi-assembly",
+          "description": "High-quality genome assembly from PacBio HiFi reads using hifiasm with phasing support. Use when building reference-quality diploid assemblies from HiFi data, especially with trio or Hi-C phasing for fully resolved haplotypes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-engineering-base-editing-design",
+          "installUrl": "github:GPTomics/bioSkills:genome-engineering/base-editing-design",
+          "description": "Design guides for cytosine and adenine base editing using editing window optimization and BE-Hive outcome prediction. Select optimal positions for C-to-T or A-to-G conversions without double-strand breaks. Use when designing base editor experiments for precise nucleotide changes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-engineering-hdr-template-design",
+          "installUrl": "github:GPTomics/bioSkills:genome-engineering/hdr-template-design",
+          "description": "Design homology-directed repair donor templates for CRISPR knock-ins using primer3-py. Create ssODN, dsDNA, or plasmid templates with optimized homology arms. Use when designing donor templates for precise insertions, tagging, or allele replacement.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-engineering-off-target-prediction",
+          "installUrl": "github:GPTomics/bioSkills:genome-engineering/off-target-prediction",
+          "description": "Predict CRISPR off-target sites using Cas-OFFinder and CFD scoring algorithms. Identify potential unintended cleavage sites genome-wide and assess guide specificity. Use when evaluating guide RNA specificity or selecting guides with minimal off-target risk.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-engineering-prime-editing-design",
+          "installUrl": "github:GPTomics/bioSkills:genome-engineering/prime-editing-design",
+          "description": "Design pegRNAs for prime editing using PrimeDesign algorithms. Generate spacer, PBS, and RT template sequences for precise genomic modifications without double-strand breaks. Use when designing prime editing experiments for precise insertions, deletions, or point mutations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-intervals-bigwig-tracks",
+          "installUrl": "github:GPTomics/bioSkills:genome-intervals/bigwig-tracks",
+          "description": "Create and read bigWig browser tracks for visualizing continuous genomic data. Convert bedGraph to bigWig, extract signal values, and generate coverage tracks using UCSC tools and pyBigWig. Use when preparing coverage tracks for genome browsers or extracting signal at specific regions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-intervals-coverage-analysis",
+          "installUrl": "github:GPTomics/bioSkills:genome-intervals/coverage-analysis",
+          "description": "Calculate read depth and coverage across genomic intervals using bedtools genomecov and coverage. Generate bedGraph files, compute per-base depth, and summarize coverage statistics. Use when assessing sequencing depth, creating coverage tracks, or evaluating target capture efficiency.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-genome-intervals-gtf-gff-handling",
+          "installUrl": "github:GPTomics/bioSkills:genome-intervals/gtf-gff-handling",
+          "description": "Parse, query, and convert GTF and GFF3 annotation files. Extract gene, transcript, and exon coordinates using gffread, gtfparse, and gffutils. Use when extracting specific features from gene annotations or converting between annotation formats.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-hi-c-analysis-contact-pairs",
+          "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/contact-pairs",
+          "description": "Process Hi-C read pairs using pairtools. Parse alignments, filter duplicates, classify pairs, and generate contact statistics from Hi-C sequencing data. Use when processing raw Hi-C read pairs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-hi-c-analysis-tad-detection",
+          "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/tad-detection",
+          "description": "Call topologically associating domains (TADs) from Hi-C data using insulation score, HiCExplorer, and other methods. Identify domain boundaries and hierarchical domain structure. Use when calling TADs from Hi-C insulation scores.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-imaging-mass-cytometry-data-preprocessing",
+          "installUrl": "github:GPTomics/bioSkills:imaging-mass-cytometry/data-preprocessing",
+          "description": "Load and preprocess imaging mass cytometry (IMC) and MIBI data. Covers MCD/TIFF handling, hot pixel removal, and image normalization. Use when starting IMC analysis from raw MCD files or preparing images for segmentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-immunoinformatics-epitope-prediction",
+          "installUrl": "github:GPTomics/bioSkills:immunoinformatics/epitope-prediction",
+          "description": "Predict B-cell and T-cell epitopes using BepiPred, IEDB tools, and structure-based methods for vaccine and antibody design. Identify immunogenic regions in antigens. Use when designing vaccines, mapping antibody binding sites, or predicting immunogenic peptides.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-immunoinformatics-immunogenicity-scoring",
+          "installUrl": "github:GPTomics/bioSkills:immunoinformatics/immunogenicity-scoring",
+          "description": "Score and prioritize neoantigens and epitopes for immunogenicity using multi-factor models combining MHC binding, processing, expression, and sequence features. Rank candidates for vaccine design. Use when prioritizing epitopes for vaccine development or identifying the most immunogenic neoantigens.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-immunoinformatics-mhc-binding-prediction",
+          "installUrl": "github:GPTomics/bioSkills:immunoinformatics/mhc-binding-prediction",
+          "description": "Predict peptide-MHC class I and II binding affinity using MHCflurry and NetMHCpan neural network models. Identify potential T-cell epitopes from protein sequences. Use when predicting MHC binding for vaccine design or neoantigen identification.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-immunoinformatics-neoantigen-prediction",
+          "installUrl": "github:GPTomics/bioSkills:immunoinformatics/neoantigen-prediction",
+          "description": "Identify tumor neoantigens from somatic mutations using pVACtools for personalized cancer immunotherapy. Predict mutant peptides that bind patient HLA and may elicit T-cell responses. Use when identifying vaccine targets or checkpoint inhibitor response biomarkers from tumor sequencing data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-immunoinformatics-tcr-epitope-binding",
+          "installUrl": "github:GPTomics/bioSkills:immunoinformatics/tcr-epitope-binding",
+          "description": "Predict TCR-epitope specificity using ERGO-II and deep learning models for T-cell receptor antigen recognition. Match TCRs to their cognate epitopes or predict TCR targets. Use when analyzing TCR repertoire specificity or identifying antigen-reactive T-cells.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-isoform-switching",
+          "installUrl": "github:GPTomics/bioSkills:alternative-splicing/isoform-switching",
+          "description": "Analyzes isoform switching events and functional consequences using IsoformSwitchAnalyzeR. Predicts protein domain changes, NMD sensitivity, ORF alterations, and coding potential shifts between conditions. Use when investigating how splicing changes affect protein function.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-liquid-biopsy-pipeline",
+          "installUrl": "github:GPTomics/bioSkills:workflows/liquid-biopsy-pipeline",
+          "description": "Cell-free DNA analysis pipeline from plasma sequencing to tumor monitoring. Preprocesses cfDNA reads, analyzes fragment patterns, estimates tumor fraction from sWGS, and optionally detects mutations from targeted panels. Use when analyzing liquid biopsy samples for cancer detection or monitoring.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-long-read-sequencing-clair3-variants",
+          "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/clair3-variants",
+          "description": "Deep learning-based variant calling from long reads using Clair3 for SNPs and small indels. Use when calling germline variants from ONT or PacBio alignments, particularly when high accuracy is needed for clinical or research applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-long-read-sequencing-isoseq-analysis",
+          "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/isoseq-analysis",
+          "description": "Analyze PacBio Iso-Seq data for full-length isoform discovery and quantification. Use when characterizing transcript diversity or identifying novel splice variants.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-long-read-sequencing-nanopore-methylation",
+          "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/nanopore-methylation",
+          "description": "Calls DNA methylation from Oxford Nanopore sequencing data using signal-level analysis. Use when detecting 5mC or 6mA modifications directly from nanopore reads without bisulfite conversion.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-longread-alignment",
+          "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/long-read-alignment",
+          "description": "Align long reads using minimap2 for Oxford Nanopore and PacBio data. Supports various presets for different read types and applications. Use when aligning ONT or PacBio reads to a reference genome for variant calling, SV detection, or coverage analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-longread-medaka",
+          "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/medaka-polishing",
+          "description": "Polish assemblies and call variants from Oxford Nanopore data using medaka. Uses neural networks trained on specific basecaller versions. Use when improving ONT-only assemblies or calling variants from Nanopore data without short-read polishing.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "GPTomics",
+        "repo": "bioSkills",
+        "repoUrl": "https://github.com/GPTomics/bioSkills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "gptomics-bioskills-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from GPTomics/bioSkills.",
+      "author": "ASM (GPTomics/bioSkills)",
+      "createdAt": "2026-05-09T08:10:51.349Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "gptomics",
+        "bioskills"
+      ],
+      "skills": [
+        {
+          "name": "bio-admet-prediction",
+          "installUrl": "github:GPTomics/bioSkills:chemoinformatics/admet-prediction",
+          "description": "Predicts ADMET properties using ADMETlab 3.0 API or DeepChem models. Estimates bioavailability, CYP inhibition, hERG liability, and 119 toxicity endpoints with uncertainty quantification. Filters for PAINS and other structural alerts. Use when filtering compounds for drug-likeness or prioritizing leads by predicted safety.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-alignment-indexing",
+          "installUrl": "github:GPTomics/bioSkills:alignment-files/alignment-indexing",
+          "description": "Create and use BAI/CSI indices for BAM/CRAM files using samtools and pysam. Use when enabling random access to alignment files or fetching specific genomic regions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-alignment-io",
+          "installUrl": "github:GPTomics/bioSkills:alignment/alignment-io",
+          "description": "Read, write, and convert multiple sequence alignment files using Biopython Bio.AlignIO. Supports Clustal, PHYLIP, Stockholm, FASTA, Nexus, and other alignment formats for phylogenetics and conservation analysis. Use when reading, writing, or converting alignment file formats.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-alignment-msa-parsing",
+          "installUrl": "github:GPTomics/bioSkills:alignment/msa-parsing",
+          "description": "Parse and analyze multiple sequence alignments using Biopython. Extract sequences, identify conserved regions, analyze gaps, work with annotations, and manipulate alignment data for downstream analysis. Use when parsing or manipulating multiple sequence alignments.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-alignment-multiple",
+          "installUrl": "github:GPTomics/bioSkills:alignment/multiple-alignment",
+          "description": "Perform multiple sequence alignment using MAFFT, MUSCLE5, ClustalOmega, or T-Coffee. Guides tool and algorithm selection based on dataset size, sequence divergence, and downstream application. Use when aligning three or more homologous sequences for phylogenetics, conservation analysis, or evolutionary studies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-alignment-pairwise",
+          "installUrl": "github:GPTomics/bioSkills:alignment/pairwise-alignment",
+          "description": "Perform pairwise sequence alignment using Biopython Bio.Align.PairwiseAligner. Use when comparing two sequences, finding optimal alignments, scoring similarity, and identifying local or global matches between DNA, RNA, or protein sequences.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-alignment-sorting",
+          "installUrl": "github:GPTomics/bioSkills:alignment-files/alignment-sorting",
+          "description": "Sort alignment files by coordinate or read name using samtools and pysam. Use when preparing BAM files for indexing, variant calling, or paired-end analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-alignment-validation",
+          "installUrl": "github:GPTomics/bioSkills:alignment-files/alignment-validation",
+          "description": "Validate alignment quality with insert size distribution, proper pairing rates, GC bias, strand balance, and other post-alignment metrics. Use when verifying alignment data quality before variant calling or quantification.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-atac-seq-atac-peak-calling",
+          "installUrl": "github:GPTomics/bioSkills:atac-seq/atac-peak-calling",
+          "description": "Call accessible chromatin regions from ATAC-seq data using MACS3 with ATAC-specific parameters. Use when identifying open chromatin regions from aligned ATAC-seq BAM files, different from ChIP-seq peak calling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-atac-seq-atac-qc",
+          "installUrl": "github:GPTomics/bioSkills:atac-seq/atac-qc",
+          "description": "Quality control metrics for ATAC-seq data including fragment size distribution, TSS enrichment, FRiP, and library complexity. Use when assessing ATAC-seq library quality before or after peak calling to identify problematic samples.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-atac-seq-footprinting",
+          "installUrl": "github:GPTomics/bioSkills:atac-seq/footprinting",
+          "description": "Detect transcription factor binding sites through footprinting analysis in ATAC-seq data using TOBIAS. Use when identifying TF occupancy patterns within accessible regions, as TF binding protects DNA from Tn5 cutting.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-atac-seq-motif-deviation",
+          "installUrl": "github:GPTomics/bioSkills:atac-seq/motif-deviation",
+          "description": "Analyze transcription factor motif accessibility variability using chromVAR. Use when identifying which TF motifs show variable accessibility across samples or conditions in ATAC-seq data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-atac-seq-nucleosome-positioning",
+          "installUrl": "github:GPTomics/bioSkills:atac-seq/nucleosome-positioning",
+          "description": "Extract nucleosome positions from ATAC-seq data using NucleoATAC, ATACseqQC, and fragment analysis. Use when analyzing chromatin organization, identifying nucleosome-free regions at promoters, or characterizing nucleosome occupancy patterns from ATAC-seq fragment size distributions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-basecalling",
+          "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/basecalling",
+          "description": "Convert raw Nanopore signal data (FAST5/POD5) to nucleotide sequences using Dorado basecaller. Covers model selection, GPU acceleration, modified base detection, and quality filtering. Use when processing raw Nanopore data before alignment. Note: Guppy is deprecated; use Dorado for all new analyses.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-batch-downloads",
+          "installUrl": "github:GPTomics/bioSkills:database-access/batch-downloads",
+          "description": "Download large datasets from NCBI efficiently using history server, batching, and rate limiting. Use when performing bulk sequence downloads, handling large query results, or production-scale data retrieval.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-blast-searches",
+          "installUrl": "github:GPTomics/bioSkills:database-access/blast-searches",
+          "description": "Run remote BLAST searches against NCBI databases using Biopython Bio.Blast. Use when identifying unknown sequences, finding homologs, or searching for sequence similarity against NCBI's nr/nt databases.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-causal-genomics-colocalization-analysis",
+          "installUrl": "github:GPTomics/bioSkills:causal-genomics/colocalization-analysis",
+          "description": "Test whether two traits share a causal variant at a genomic locus using Bayesian colocalization with coloc. Computes posterior probabilities for shared vs distinct causal variants between GWAS and eQTL signals. Use when determining if a GWAS signal and an eQTL share the same causal variant.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-causal-genomics-mediation-analysis",
+          "installUrl": "github:GPTomics/bioSkills:causal-genomics/mediation-analysis",
+          "description": "Decompose genetic effects into direct and indirect paths through mediating variables using the mediation R package. Tests whether gene expression, methylation, or other molecular phenotypes mediate the effect of genetic variants on disease. Use when testing whether a molecular phenotype mediates the genotype-to-phenotype relationship.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-cfdna-preprocessing",
+          "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/cfdna-preprocessing",
+          "description": "Preprocesses cell-free DNA sequencing data including adapter trimming, alignment optimized for short fragments, and UMI-aware duplicate removal using fgbio. Applies cfDNA-specific quality thresholds and fragment length filtering. Use when processing plasma cfDNA sequencing data before downstream analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-chipseq-motif-analysis",
+          "installUrl": "github:GPTomics/bioSkills:chip-seq/motif-analysis",
+          "description": "De novo motif discovery and known motif enrichment analysis using HOMER and MEME-ChIP. Identify transcription factor binding motifs in ChIP-seq, ATAC-seq, or other genomic peak data. Use when finding enriched DNA motifs in peak sequences.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-chipseq-peak-annotation",
+          "installUrl": "github:GPTomics/bioSkills:chip-seq/peak-annotation",
+          "description": "Annotate ChIP-seq peaks to genomic features and nearest genes. Classify peaks as promoter, exon, intron, or intergenic using ChIPseeker (R), HOMER annotatePeaks.pl (CLI), or Python (pandas/pyranges). Supports pre-built annotation databases and custom GTF files. Handles promoter definition, feature priority, category collapsing, and signed distance-to-TSS. Use when assigning genomic context to ChIP-seq peaks or linking peaks to target genes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-chipseq-peak-calling",
+          "installUrl": "github:GPTomics/bioSkills:chip-seq/peak-calling",
+          "description": "ChIP-seq peak calling using MACS3 and HOMER findPeaks. Call narrow peaks for transcription factors or broad peaks for histone modifications. Supports single-caller and multi-caller consensus approaches, input control, fragment size modeling, and various output formats. Use when calling peaks from ChIP-seq alignments.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-chipseq-qc",
+          "installUrl": "github:GPTomics/bioSkills:chip-seq/chipseq-qc",
+          "description": "ChIP-seq quality control metrics including FRiP (Fraction of Reads in Peaks), cross-correlation analysis (NSC/RSC), library complexity, and IDR (Irreproducibility Discovery Rate) for replicate concordance. Use to assess experiment quality before downstream analysis. Use when assessing ChIP-seq data quality metrics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-chipseq-super-enhancers",
+          "installUrl": "github:GPTomics/bioSkills:chip-seq/super-enhancers",
+          "description": "Identifies super-enhancers from H3K27ac ChIP-seq data using ROSE and related tools. Use when studying cell identity genes, cancer-associated regulatory elements, or master transcription factor binding regions that cluster into large enhancer domains.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-chipseq-visualization",
+          "installUrl": "github:GPTomics/bioSkills:chip-seq/chipseq-visualization",
+          "description": "Visualize ChIP-seq data using deepTools, Gviz, and ChIPseeker. Create heatmaps, profile plots, and genome browser tracks. Visualize signal around peaks, TSS, or custom regions. Use when visualizing ChIP-seq signal and peaks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-categorical-tests",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/categorical-tests",
+          "description": "Tests associations between categorical variables in clinical data using chi-square, Fisher's exact, and Cochran-Mantel-Haenszel tests. Computes effect sizes and post-hoc pairwise comparisons. Use when analyzing categorical outcomes or testing treatment-outcome independence in clinical trials.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-cdisc-data",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/cdisc-data-handling",
+          "description": "Reads and prepares CDISC SDTM clinical trial data for analysis. Handles domain tables (DM, AE, EX, VS, LB), USUBJID-based joins, event-to-subject aggregation, and SUPPQUAL pivoting. Use when working with clinical trial datasets in CDISC/SDTM format or .xpt files.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-effect-measures",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/effect-measures",
+          "description": "Computes and interprets treatment effect measures including odds ratios, risk ratios, number needed to treat, and confidence intervals from clinical trial data. Covers crude and adjusted measures, non-collapsibility of odds ratios, and forest plot visualization. Use when reporting treatment effects or comparing effect sizes across clinical studies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-logistic-regression",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/logistic-regression",
+          "description": "Performs logistic regression for clinical trial outcomes including binary, ordinal, and multinomial models. Extracts odds ratios with confidence intervals, handles covariate adjustment, and provides Firth penalized regression for rare events or separation. Use when modeling binary or ordinal endpoints from clinical data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-subgroup-analysis",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/subgroup-analysis",
+          "description": "Performs stratified and subgroup analyses for clinical trial data. Covers Mantel-Haenszel pooling, Breslow-Day homogeneity testing, interaction terms in regression, multiple comparisons correction, and forest plot visualization. Use when analyzing treatment effects across patient subgroups or controlling for stratification variables.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-biostatistics-trial-reporting",
+          "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/trial-reporting",
+          "description": "Prepares statistical tables and reports for clinical trials following regulatory standards. Generates Table 1 baseline characteristics, defines analysis populations (ITT, per-protocol, safety), performs multiple imputation for missing data, and follows CONSORT and ICH E9 guidelines. Use when creating analysis reports, handling missing data, or preparing regulatory submissions from clinical trials.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-clinvar-lookup",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/clinvar-lookup",
+          "description": "Query ClinVar for variant pathogenicity classifications, review status, and disease associations via REST API or local VCF. Use when determining clinical significance of variants for diagnostic or research purposes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-dbsnp-queries",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/dbsnp-queries",
+          "description": "Query dbSNP for rsID lookups, variant annotations, and cross-references to other databases. Use when mapping between rsIDs and genomic coordinates or retrieving basic variant information.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-gnomad-frequencies",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/gnomad-frequencies",
+          "description": "Query gnomAD for population allele frequencies to assess variant rarity. Use when filtering variants by population frequency for rare disease analysis or determining if a variant is common in the general population.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-hla-typing",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/hla-typing",
+          "description": "Call HLA alleles from NGS data using OptiType, HLA-HD, or arcasHLA for immunogenomics applications. Use when determining HLA genotype for transplant matching, neoantigen prediction, or pharmacogenomic screening.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-myvariant-queries",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/myvariant-queries",
+          "description": "Query myvariant.info API for aggregated variant annotations from multiple databases (ClinVar, gnomAD, dbSNP, COSMIC, etc.) in a single request. Use when annotating variants with clinical and population data from multiple sources simultaneously.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-pharmacogenomics",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/pharmacogenomics",
+          "description": "Query PharmGKB and CPIC for drug-gene interactions, pharmacogenomic annotations, and dosing guidelines. Use when predicting drug response from genetic variants or implementing clinical pharmacogenomics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-polygenic-risk",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/polygenic-risk",
+          "description": "Calculate polygenic risk scores using PRSice-2, LDpred2, or PRS-CS from GWAS summary statistics. Use when predicting disease risk from genome-wide genetic variants.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-somatic-signatures",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/somatic-signatures",
+          "description": "Extract and analyze mutational signatures from somatic variants using SigProfiler or MutationalPatterns to characterize mutagenic processes. Use when identifying DNA damage mechanisms or etiology in cancer genomes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-tumor-mutational-burden",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/tumor-mutational-burden",
+          "description": "Calculate tumor mutational burden from panel or WES data with proper normalization and clinical thresholds. Use when assessing immunotherapy eligibility or characterizing tumor immunogenicity.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clinical-databases-variant-prioritization",
+          "installUrl": "github:GPTomics/bioSkills:clinical-databases/variant-prioritization",
+          "description": "Filter and prioritize variants by pathogenicity, population frequency, and clinical evidence for rare disease analysis. Use when identifying candidate disease-causing variants from exome or genome sequencing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clip-seq-clip-motif-analysis",
+          "installUrl": "github:GPTomics/bioSkills:clip-seq/clip-motif-analysis",
+          "description": "Identify enriched sequence motifs at CLIP-seq binding sites for RBP binding specificity. Use when characterizing the sequence preferences of an RNA-binding protein.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clip-seq-clip-peak-calling",
+          "installUrl": "github:GPTomics/bioSkills:clip-seq/clip-peak-calling",
+          "description": "Call protein-RNA binding site peaks from CLIP-seq data using CLIPper, PureCLIP, or Piranha. Use when identifying RBP binding sites from aligned CLIP reads.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-clip-seq-clip-preprocessing",
+          "installUrl": "github:GPTomics/bioSkills:clip-seq/clip-preprocessing",
+          "description": "Preprocess CLIP-seq data including adapter trimming, UMI extraction, and PCR duplicate removal. Use when preparing raw CLIP, iCLIP, or eCLIP reads for peak calling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-codon-usage",
+          "installUrl": "github:GPTomics/bioSkills:sequence-manipulation/codon-usage",
+          "description": "Analyze codon usage, calculate CAI (Codon Adaptation Index), and examine synonymous codon bias using Biopython. Use when analyzing coding sequences for expression optimization or evolutionary analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-comparative-genomics-hgt-detection",
+          "installUrl": "github:GPTomics/bioSkills:comparative-genomics/hgt-detection",
+          "description": "Detect horizontal gene transfer events using HGTector, compositional analysis, and phylogenetic incongruence methods. Identify foreign genes in bacterial and archaeal genomes from anomalous composition or unexpected phylogenetic placement. Use when searching for horizontally transferred genes or analyzing genome evolution in prokaryotes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-comparative-genomics-ortholog-inference",
+          "installUrl": "github:GPTomics/bioSkills:comparative-genomics/ortholog-inference",
+          "description": "Infer orthologous gene groups across species using OrthoFinder and ProteinOrtho. Identify orthologs, paralogs, and co-orthologs for comparative genomics and functional annotation transfer. Use when identifying gene orthologs across species or building orthogroups for evolutionary analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-comparative-genomics-positive-selection",
+          "installUrl": "github:GPTomics/bioSkills:comparative-genomics/positive-selection",
+          "description": "Detect positive selection using dN/dS (omega) tests with PAML codeml and HyPhy. Identify sites and branches under adaptive evolution through codon models and branch-site tests. Use when testing for adaptive evolution in gene families or identifying positively selected sites.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-comparative-genomics-synteny-analysis",
+          "installUrl": "github:GPTomics/bioSkills:comparative-genomics/synteny-analysis",
+          "description": "Analyze genome collinearity and syntenic blocks using MCScanX, SyRI, and JCVI for comparative genomics. Detect conserved gene order, chromosomal rearrangements, and whole-genome duplications. Use when comparing genome structure between species or identifying conserved genomic regions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-cnv-annotation",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/cnv-annotation",
+          "description": "Annotate CNVs with genes, pathways, and clinical significance. Use when interpreting CNV calls or identifying affected genes from copy number analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-cnv-visualization",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/cnv-visualization",
+          "description": "Visualize copy number profiles, segments, and compare across samples. Create publication-quality plots of CNV data from CNVkit, GATK, or other callers. Use when creating genome-wide CNV plots, sample heatmaps, or chromosome-level visualizations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-cnvkit-analysis",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/cnvkit-analysis",
+          "description": "Detect copy number variants from targeted/exome sequencing using CNVkit. Supports tumor-normal pairs, tumor-only, and germline CNV calling. Use when detecting CNVs from WES or targeted panel sequencing data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-copy-number-gatk-cnv",
+          "installUrl": "github:GPTomics/bioSkills:copy-number/gatk-cnv",
+          "description": "Call copy number variants using GATK best practices workflow. Supports both somatic (tumor-normal) and germline CNV detection from WGS or WES data. Use when following GATK best practices or integrating CNV calling with other GATK variant pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-crispr-screens-base-editing-analysis",
+          "installUrl": "github:GPTomics/bioSkills:crispr-screens/base-editing-analysis",
+          "description": "Analyzes base editing and prime editing outcomes including editing efficiency, bystander edits, and indel frequencies. Use when quantifying CRISPR base editor results, comparing ABE vs CBE efficiency, or assessing prime editing fidelity.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-crispr-screens-batch-correction",
+          "installUrl": "github:GPTomics/bioSkills:crispr-screens/batch-correction",
+          "description": "Batch effect correction for CRISPR screens. Covers normalization across batches, technical replicate handling, and batch-aware analysis. Use when combining screens from multiple batches or correcting systematic technical variation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-crispr-screens-crispresso-editing",
+          "installUrl": "github:GPTomics/bioSkills:crispr-screens/crispresso-editing",
+          "description": "CRISPResso2 for analyzing CRISPR gene editing outcomes. Quantifies indels, HDR efficiency, and generates comprehensive editing reports. Use when analyzing amplicon sequencing data from CRISPR editing experiments to assess editing efficiency.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-crispr-screens-hit-calling",
+          "installUrl": "github:GPTomics/bioSkills:crispr-screens/hit-calling",
+          "description": "Statistical methods for calling hits in CRISPR screens. Covers MAGeCK, BAGEL2, drugZ, and custom approaches for identifying essential and resistance genes. Use when identifying significant genes from screen count data after QC passes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-crispr-screens-jacks-analysis",
+          "installUrl": "github:GPTomics/bioSkills:crispr-screens/jacks-analysis",
+          "description": "JACKS (Joint Analysis of CRISPR/Cas9 Knockout Screens) for modeling sgRNA efficacy and gene essentiality. Use when analyzing multiple CRISPR screens simultaneously or when accounting for variable sgRNA efficiency across experiments.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-crispr-screens-mageck-analysis",
+          "installUrl": "github:GPTomics/bioSkills:crispr-screens/mageck-analysis",
+          "description": "MAGeCK (Model-based Analysis of Genome-wide CRISPR-Cas9 Knockout) for pooled CRISPR screen analysis. Covers count normalization, gene ranking, and pathway analysis. Use when identifying essential genes, drug targets, or resistance mechanisms from dropout or enrichment screens.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-circos-plots",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/circos-plots",
+          "description": "Create circular genome visualizations with Circos and pyCircos. Display multi-track data including ideograms, genes, variants, CNVs, and interaction arcs. Use when creating circular genome visualizations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-color-palettes",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/color-palettes",
+          "description": "Select and apply colorblind-friendly palettes for scientific figures using viridis, RColorBrewer, and custom color schemes. Use when selecting colorblind-friendly palettes for figures.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-genome-browser-tracks",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/genome-browser-tracks",
+          "description": "Generate genome browser visualizations using pyGenomeTracks or IGV batch scripting for publication figures. Use when creating publication figures of genomic regions with multiple data tracks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-genome-tracks",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/genome-tracks",
+          "description": "Create genome browser-style visualizations showing multiple data tracks (coverage, peaks, genes) using pyGenomeTracks, Gviz, and IGV. Use when visualizing genomic data at specific loci with multiple aligned tracks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-ggplot2-fundamentals",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/ggplot2-fundamentals",
+          "description": "Create publication-quality scientific figures with ggplot2 including scatter plots, boxplots, heatmaps, and multi-panel layouts. Use when creating static figures for papers, presentations, or reports in R.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-heatmaps-clustering",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/heatmaps-clustering",
+          "description": "Create clustered heatmaps with row/column annotations using ComplexHeatmap, pheatmap, and seaborn for gene expression and omics data visualization. Use when visualizing expression patterns across samples or identifying co-expressed gene clusters.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-interactive-visualization",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/interactive-visualization",
+          "description": "Create interactive HTML plots with plotly and bokeh for exploratory data analysis and web-based sharing of omics visualizations. Use when building zoomable, hoverable plots for data exploration or web dashboards.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-multipanel-figures",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/multipanel-figures",
+          "description": "Combine multiple plots into publication-ready multi-panel figures using patchwork, cowplot, or matplotlib GridSpec with shared legends and panel labels. Use when combining multiple plots into publication figures.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-network-visualization",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/network-visualization",
+          "description": "Visualize biological networks including gene regulatory networks, protein interaction networks, and co-expression modules using NetworkX, PyVis, and Cytoscape automation. Produces interactive and publication-quality network figures. Use when creating network diagrams from interaction data, GRN results, or co-expression modules.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-specialized-omics-plots",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/specialized-omics-plots",
+          "description": "Reusable plotting functions for common omics visualizations. Custom ggplot2/matplotlib implementations of volcano, MA, PCA, enrichment dotplots, boxplots, and survival curves. Use when creating volcano, MA, or enrichment plots.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-upset-plots",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/upset-plots",
+          "description": "Create UpSet plots to visualize set intersections as an alternative to Venn diagrams using UpSetR or upsetplot. Use when comparing overlapping gene sets, peak sets, or sample groups with more than 3 sets.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-data-visualization-volcano-customization",
+          "installUrl": "github:GPTomics/bioSkills:data-visualization/volcano-customization",
+          "description": "Create publication-ready volcano plots with custom thresholds, gene labels, and highlighting using ggplot2, EnhancedVolcano, or matplotlib. Use when visualizing differential expression or association results with gene annotations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-de-deseq2-basics",
+          "installUrl": "github:GPTomics/bioSkills:differential-expression/deseq2-basics",
+          "description": "Perform differential expression analysis using DESeq2 in R/Bioconductor. Use for analyzing RNA-seq count data, creating DESeqDataSet objects, running the DESeq workflow, and extracting results with log fold change shrinkage. Use when performing DE analysis with DESeq2.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-de-edger-basics",
+          "installUrl": "github:GPTomics/bioSkills:differential-expression/edger-basics",
+          "description": "Perform differential expression analysis using edgeR in R/Bioconductor. Use for analyzing RNA-seq count data with the quasi-likelihood F-test framework, creating DGEList objects, normalization, dispersion estimation, and statistical testing. Use when performing DE analysis with edgeR.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-de-results",
+          "installUrl": "github:GPTomics/bioSkills:differential-expression/de-results",
+          "description": "Extract, filter, annotate, and export differential expression results from DESeq2 or edgeR. Use for identifying significant genes, applying multiple testing corrections, adding gene annotations, and preparing results for downstream analysis. Use when filtering and exporting DE analysis results.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-differential-expression-batch-correction",
+          "installUrl": "github:GPTomics/bioSkills:differential-expression/batch-correction",
+          "description": "Remove batch effects from RNA-seq data using ComBat, ComBat-Seq, limma removeBatchEffect, and SVA for unknown batch variables. Use when correcting batch effects in expression data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-differential-expression-timeseries-de",
+          "installUrl": "github:GPTomics/bioSkills:differential-expression/timeseries-de",
+          "description": "Analyze time-series RNA-seq data using limma voom with splines, maSigPro, and ImpulseDE2. Identify genes with dynamic expression patterns. Use when analyzing time-series or longitudinal expression data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-duplicate-handling",
+          "installUrl": "github:GPTomics/bioSkills:alignment-files/duplicate-handling",
+          "description": "Mark and remove PCR/optical duplicates using samtools fixmate and markdup. Use when preparing alignments for variant calling or when duplicate reads would bias analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-biodiversity-metrics",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/biodiversity-metrics",
+          "description": "Calculates species richness, diversity, and turnover using the Hill number framework with iNEXT coverage-based rarefaction/extrapolation, asymptotic diversity estimation, and beta diversity partitioning (betapart turnover vs nestedness). Compares assemblages using coverage-standardized rather than size-standardized rarefaction. Use when quantifying biodiversity from species abundance or incidence data, comparing diversity across sites, or constructing rarefaction curves. Not for clinical 16S microbiome alpha/beta diversity (see microbiome/diversity-analysis).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-community-ecology",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/community-ecology",
+          "description": "Analyzes community composition using constrained ordination (CCA, RDA, db-RDA), variance partitioning (varpart), indicator species analysis (indicspecies multipatt), and distance-based environmental gradient methods with vegan. Links species composition to environmental explanatory variables. Use when testing how environmental gradients structure species communities, identifying habitat indicator taxa, or partitioning explained variation among predictors. Not for basic unconstrained ordination and PERMANOVA (see microbiome/diversity-analysis).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-ecological-genomics-conservation-genetics",
+          "installUrl": "github:GPTomics/bioSkills:ecological-genomics/conservation-genetics",
+          "description": "Assesses genetic health of populations for conservation using effective population size estimation (GONE2 for recent Ne trajectory, NeEstimator for contemporary Ne, Stairway Plot 2 and PSMC for historical Ne), F-statistics (hierfstat), runs of homozygosity (detectRUNS), and genetic diversity metrics. Use when estimating effective population size, detecting inbreeding or bottlenecks, or assessing genetic diversity in threatened species from microsatellite or SNP data.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "GPTomics",
+        "repo": "bioSkills",
+        "repoUrl": "https://github.com/GPTomics/bioSkills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "gptomics-bioskills-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from GPTomics/bioSkills.",
+      "author": "ASM (GPTomics/bioSkills)",
+      "createdAt": "2026-05-09T08:10:51.349Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "gptomics",
+        "bioskills"
+      ],
+      "skills": [
+        {
+          "name": "bio-batch-downloads",
+          "installUrl": "github:GPTomics/bioSkills:database-access/batch-downloads",
+          "description": "Download large datasets from NCBI efficiently using history server, batching, and rate limiting. Use when performing bulk sequence downloads, handling large query results, or production-scale data retrieval.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-experimental-design-batch-design",
+          "installUrl": "github:GPTomics/bioSkills:experimental-design/batch-design",
+          "description": "Designs experiments to minimize and account for batch effects using balanced layouts and blocking strategies. Use when planning multi-batch experiments, assigning samples to sequencing lanes, or designing studies where technical variation could confound biological signals.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-experimental-design-power-analysis",
+          "installUrl": "github:GPTomics/bioSkills:experimental-design/power-analysis",
+          "description": "Calculates statistical power and minimum sample sizes for RNA-seq, ATAC-seq, and other sequencing experiments. Use when planning experiments, determining how many replicates are needed, or assessing whether a study is adequately powered to detect expected effect sizes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-gene-regulatory-networks-perturbation-simulation",
+          "installUrl": "github:GPTomics/bioSkills:gene-regulatory-networks/perturbation-simulation",
+          "description": "Simulate transcription factor perturbation effects on cell state using CellOracle, which integrates GRN inference with in silico knockout and overexpression modeling. Predicts cell identity shifts and differentiation trajectory changes from TF perturbations. Use when predicting the effect of transcription factor knockouts, planning perturbation experiments, or identifying driver TFs for cell fate transitions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-primer-design-primer-basics",
+          "installUrl": "github:GPTomics/bioSkills:primer-design/primer-basics",
+          "description": "Design PCR primers for a target sequence using primer3-py. Specify target regions, product size, melting temperature, and other constraints. Returns ranked primer pairs with quality metrics. Use when designing standard PCR primers.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bio-reaction-enumeration",
+          "installUrl": "github:GPTomics/bioSkills:chemoinformatics/reaction-enumeration",
+          "description": "Enumerates chemical libraries through reaction SMARTS transformations using RDKit. Generates virtual compound libraries from building blocks using defined chemical reactions with product validation. Use when creating combinatorial libraries or enumerating products from synthetic routes.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "GPTomics",
+        "repo": "bioSkills",
+        "repoUrl": "https://github.com/GPTomics/bioSkills.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/Galaxy-Dawn_claude-scholar.json
+++ b/data/skill-index/Galaxy-Dawn_claude-scholar.json
@@ -5348,5 +5348,1141 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "galaxy-dawn-claude-scholar-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from Galaxy-Dawn/claude-scholar.",
+      "author": "ASM (Galaxy-Dawn/claude-scholar)",
+      "createdAt": "2026-05-09T08:10:46.497Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "galaxy-dawn",
+        "claude-scholar"
+      ],
+      "skills": [
+        {
+          "name": "kaggle-learner",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/kaggle-learner",
+          "description": "This skill should be used when the user asks to \"learn from Kaggle\", \"study Kaggle solutions\", \"analyze Kaggle competitions\", or mentions Kaggle competition URLs. Provides access to extracted knowledge from winning Kaggle solutions across NLP, CV, time series, tabular, and multimodal domains.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "skill-quality-reviewer",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/skill-quality-reviewer",
+          "description": "This skill should be used when the user asks to \"analyze skill quality\", \"evaluate this skill\", \"review skill quality\", \"check my skill\", or \"generate quality report\". Evaluates local skills across description quality, content organization, writing style, and structural integrity.",
+          "version": "0.1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Galaxy-Dawn",
+        "repo": "claude-scholar",
+        "repoUrl": "https://github.com/Galaxy-Dawn/claude-scholar.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "galaxy-dawn-claude-scholar-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from Galaxy-Dawn/claude-scholar.",
+      "author": "ASM (Galaxy-Dawn/claude-scholar)",
+      "createdAt": "2026-05-09T08:10:46.497Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "galaxy-dawn",
+        "claude-scholar"
+      ],
+      "skills": [
+        {
+          "name": "citation-verification",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/citation-verification",
+          "description": "This skill provides reference guidance for citation verification in academic writing. Use when the user asks about \"citation verification best practices\", \"how to verify references\", \"preventing fake citations\", or needs guidance on citation accuracy. This skill supports ml-paper-writing by providing detailed verification principles and common error patterns.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "code-review-excellence",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/code-review-excellence",
+          "description": "This skill should be used when the user asks to review a diff or pull request, write review comments, audit code quality, establish review standards, or improve how a team performs code review.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "command-development",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/command-development",
+          "description": "This skill should be used when the user asks to \"create a slash command\", \"add a command\", \"write a custom command\", \"define command arguments\", \"use command frontmatter\", \"organize commands\", \"create command with file references\", \"interactive command\", \"use AskUserQuestion in command\", or needs guidance on slash command structure, YAML frontmatter fields, dynamic arguments, bash execution in commands, user interaction patterns, or command development best practices for Claude Code.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "daily-coding",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/daily-coding",
+          "description": "Use for everyday coding tasks that involve writing or modifying source code.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "daily-paper-generator",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/daily-paper-generator",
+          "description": "Use when the user asks to generate daily paper digests on a general topic. This skill supports both arXiv and bioRxiv (or either one), then produces structured Chinese/English summaries for selected papers.",
+          "version": "0.5.1"
+        },
+        {
+          "name": "doc-coauthoring",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/doc-coauthoring",
+          "description": "This skill should be used when the user asks to co-author documentation, draft a proposal, write a technical spec, create a decision doc or RFC, or structure a substantial document through iterative collaboration and reader testing.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "ml-paper-writing",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/ml-paper-writing",
+          "description": "Write publication-ready ML/AI papers for NeurIPS, ICML, ICLR, ACL, AAAI, COLM. Use when drafting papers from research repos, conducting literature reviews, finding related work, verifying citations, or preparing camera-ready submissions. Includes LaTeX templates, citation verification workflows, and paper discovery/evaluation criteria.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "obsidian-literature-workflow",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-literature-workflow",
+          "description": "Use this skill for project-scoped literature review built on Sources/Papers, with synthesis landing in Knowledge, writing handoff in Writing, and the default literature canvas under Maps/literature.canvas.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "obsidian-source-ingestion",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-source-ingestion",
+          "description": "Use this skill to ingest external materials into the current project-scoped Obsidian KB as source notes under Sources/Papers, Sources/Web, Sources/Docs, Sources/Data, Sources/Interviews, or Sources/Notes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "paper-self-review",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/paper-self-review",
+          "description": "This skill should be used when the user asks to \"review paper quality\", \"check paper completeness\", \"validate paper structure\", \"self-review before submission\", or mentions systematic paper quality checking. Provides comprehensive quality assurance checklist for academic papers.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "post-acceptance",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/post-acceptance",
+          "description": "This skill should be used when the user asks to \"prepare conference presentation\", \"create presentation slides\", \"design poster\", \"make academic poster\", \"write promotion content\", \"create Twitter thread\", or mentions post-acceptance conference preparation. Provides comprehensive workflow for presentation, poster, and promotion content creation.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "publication-chart-skill",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/publication-chart-skill",
+          "description": "This skill should be used when the user asks for a publication-quality scientific figure or table, wants help choosing the right chart for results, needs a paper-ready pubfig or pubtab workflow, wants a figure + companion table for a results section, wants an Excel sheet turned into publication-ready LaTeX, or wants an existing scientific figure/table reviewed and upgraded.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "results-report",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/results-report",
+          "description": "This skill should be used when the user asks to \"write an experiment report\", \"summarize experimental results\", \"do experiment retrospection\", \"write a results report\", \"写实验总结报告\", \"写实验复盘\", or mentions turning completed experiment artifacts into a structured, decision-oriented research report. It assumes strict analysis should come from `results-analysis` first.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "review-response",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/review-response",
+          "description": "Systematic review response workflow from comment analysis to professional rebuttal writing. Use when the user asks to \"write rebuttal\", \"respond to reviewers\", \"draft review response\", or \"analyze review comments\". Improves paper acceptance rates.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "skill-quality-reviewer",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/skill-quality-reviewer",
+          "description": "This skill should be used when the user asks to \"analyze skill quality\", \"evaluate this skill\", \"review skill quality\", \"check my skill\", or \"generate quality report\". Evaluates local skills across description quality, content organization, writing style, and structural integrity.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "writing-anti-ai",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/writing-anti-ai",
+          "description": "This skill should be used when the user asks to \"remove AI writing patterns\", \"humanize this text\", \"make this sound more natural\", \"remove AI-generated traces\", \"fix robotic writing\", or needs to eliminate AI writing patterns from prose. Supports both English and Chinese text. Based on Wikipedia's \"Signs of AI writing\" guide, detects and fixes inflated symbolism, promotional language, superficial -ing analyses, vague attributions, AI vocabulary, negative parallelisms, and excessive conjunctive phrases.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "zotero-obsidian-bridge",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/zotero-obsidian-bridge",
+          "description": "Use this skill when Zotero is the literature source of truth and the project KB should receive source notes under Sources/Papers plus project-linked synthesis in Knowledge and Writing.",
+          "version": "0.3.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Galaxy-Dawn",
+        "repo": "claude-scholar",
+        "repoUrl": "https://github.com/Galaxy-Dawn/claude-scholar.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "galaxy-dawn-claude-scholar-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from Galaxy-Dawn/claude-scholar.",
+      "author": "ASM (Galaxy-Dawn/claude-scholar)",
+      "createdAt": "2026-05-09T08:10:46.497Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "galaxy-dawn",
+        "claude-scholar"
+      ],
+      "skills": [
+        {
+          "name": "agent-identifier",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/agent-identifier",
+          "description": "Use when creating or configuring Claude Code agents and their frontmatter.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "architecture-design",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/architecture-design",
+          "description": "Use only when creating new registrable ML components that require Factory or Registry patterns.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "bug-detective",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/bug-detective",
+          "description": "This skill should be used when the user asks to \"debug this\", \"fix this error\", \"investigate this bug\", \"troubleshoot this issue\", \"find the problem\", \"something is broken\", \"this isn't working\", \"why is this failing\", or reports errors/exceptions/bugs. Provides systematic debugging workflow and common error patterns.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "citation-verification",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/citation-verification",
+          "description": "This skill provides reference guidance for citation verification in academic writing. Use when the user asks about \"citation verification best practices\", \"how to verify references\", \"preventing fake citations\", or needs guidance on citation accuracy. This skill supports ml-paper-writing by providing detailed verification principles and common error patterns.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "code-review-excellence",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/code-review-excellence",
+          "description": "This skill should be used when the user asks to review a diff or pull request, write review comments, audit code quality, establish review standards, or improve how a team performs code review.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "command-development",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/command-development",
+          "description": "This skill should be used when the user asks to \"create a slash command\", \"add a command\", \"write a custom command\", \"define command arguments\", \"use command frontmatter\", \"organize commands\", \"create command with file references\", \"interactive command\", \"use AskUserQuestion in command\", or needs guidance on slash command structure, YAML frontmatter fields, dynamic arguments, bash execution in commands, user interaction patterns, or command development best practices for Claude Code.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "daily-coding",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/daily-coding",
+          "description": "Use for everyday coding tasks that involve writing or modifying source code.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "daily-paper-generator",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/daily-paper-generator",
+          "description": "Use when the user asks to generate daily paper digests on a general topic. This skill supports both arXiv and bioRxiv (or either one), then produces structured Chinese/English summaries for selected papers.",
+          "version": "0.5.1"
+        },
+        {
+          "name": "defuddle",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/defuddle",
+          "description": "Extract clean Markdown from web pages. In the KB workflow, use it as a utility under obsidian-source-ingestion.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "doc-coauthoring",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/doc-coauthoring",
+          "description": "This skill should be used when the user asks to co-author documentation, draft a proposal, write a technical spec, create a decision doc or RFC, or structure a substantial document through iterative collaboration and reader testing.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "frontend-design",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/frontend-design",
+          "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "git-workflow",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/git-workflow",
+          "description": "This skill should be used when the user asks to \"create git commit\", \"manage branches\", \"follow git workflow\", \"use Conventional Commits\", \"handle merge conflicts\", or asks about git branching strategies, version control best practices, pull request workflows. Provides comprehensive Git workflow guidance for team collaboration.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "hook-development",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/hook-development",
+          "description": "This skill should be used when the user asks to \"create a hook\", \"add a PreToolUse/PostToolUse/Stop hook\", \"validate tool use\", \"implement prompt-based hooks\", \"use ${CLAUDE_PLUGIN_ROOT}\", \"set up event-driven automation\", \"block dangerous commands\", or mentions hook events (PreToolUse, PostToolUse, Stop, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification). Provides comprehensive guidance for creating and implementing Claude Code plugin hooks with focus on advanced prompt-based hooks API.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "kaggle-learner",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/kaggle-learner",
+          "description": "This skill should be used when the user asks to \"learn from Kaggle\", \"study Kaggle solutions\", \"analyze Kaggle competitions\", or mentions Kaggle competition URLs. Provides access to extracted knowledge from winning Kaggle solutions across NLP, CV, time series, tabular, and multimodal domains.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "latex-conference-template-organizer",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/latex-conference-template-organizer",
+          "description": "Organize messy conference LaTeX template .zip files into clean Overleaf-ready structure. Use when the user asks to \"organize LaTeX template\", \"clean up .zip template\", or \"prepare Overleaf submission template\".",
+          "version": "0.1.0"
+        },
+        {
+          "name": "mcp-integration",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/mcp-integration",
+          "description": "This skill should be used when the user asks to \"add MCP server\", \"integrate MCP\", \"configure MCP in plugin\", \"use .mcp.json\", \"set up Model Context Protocol\", \"connect external service\", mentions \"${CLAUDE_PLUGIN_ROOT} with MCP\", or discusses MCP server types (SSE, stdio, HTTP, WebSocket). Provides comprehensive guidance for integrating Model Context Protocol servers into Claude Code plugins for external tool and service integration.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "ml-paper-writing",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/ml-paper-writing",
+          "description": "Write publication-ready ML/AI papers for NeurIPS, ICML, ICLR, ACL, AAAI, COLM. Use when drafting papers from research repos, conducting literature reviews, finding related work, verifying citations, or preparing camera-ready submissions. Includes LaTeX templates, citation verification workflows, and paper discovery/evaluation criteria.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "obsidian-kb-artifacts",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-kb-artifacts",
+          "description": "Use this skill for Obsidian-native formatting and derived artifacts such as Markdown formatting, wikilinks, registry tables, canvas files, optional Bases, CLI operations, and link repair. This skill does not decide knowledge routing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "obsidian-literature-workflow",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-literature-workflow",
+          "description": "Use this skill for project-scoped literature review built on Sources/Papers, with synthesis landing in Knowledge, writing handoff in Writing, and the default literature canvas under Maps/literature.canvas.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "obsidian-project-kb-core",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-project-kb-core",
+          "description": "Use this as the main Claude Scholar skill for a vault-first, project-scoped Obsidian research knowledge base rooted at Research/{project-slug}/. It owns bootstrap, routing, daily logging, hub/plan/index maintenance, registry updates, lifecycle actions, and lint orchestration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "obsidian-source-ingestion",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-source-ingestion",
+          "description": "Use this skill to ingest external materials into the current project-scoped Obsidian KB as source notes under Sources/Papers, Sources/Web, Sources/Docs, Sources/Data, Sources/Interviews, or Sources/Notes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "paper-self-review",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/paper-self-review",
+          "description": "This skill should be used when the user asks to \"review paper quality\", \"check paper completeness\", \"validate paper structure\", \"self-review before submission\", or mentions systematic paper quality checking. Provides comprehensive quality assurance checklist for academic papers.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "plugin-structure",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/plugin-structure",
+          "description": "This skill should be used when the user asks to \"create a plugin\", \"scaffold a plugin\", \"understand plugin structure\", \"organize plugin components\", \"set up plugin.json\", \"use ${CLAUDE_PLUGIN_ROOT}\", \"add commands/agents/skills/hooks\", \"configure auto-discovery\", or needs guidance on plugin directory layout, manifest configuration, component organization, file naming conventions, or Claude Code plugin architecture best practices.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "post-acceptance",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/post-acceptance",
+          "description": "This skill should be used when the user asks to \"prepare conference presentation\", \"create presentation slides\", \"design poster\", \"make academic poster\", \"write promotion content\", \"create Twitter thread\", or mentions post-acceptance conference preparation. Provides comprehensive workflow for presentation, poster, and promotion content creation.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "publication-chart-skill",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/publication-chart-skill",
+          "description": "This skill should be used when the user asks for a publication-quality scientific figure or table, wants help choosing the right chart for results, needs a paper-ready pubfig or pubtab workflow, wants a figure + companion table for a results section, wants an Excel sheet turned into publication-ready LaTeX, or wants an existing scientific figure/table reviewed and upgraded.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "research-ideation",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/research-ideation",
+          "description": "This skill should be used when the user asks to \"brainstorm research ideas\", \"use 5W1H framework\", \"identify research gaps\", \"conduct gap analysis\", \"start research project\", \"conduct literature review\", \"define research question\", \"select research method\", \"plan research\", or mentions research project initiation phase. Provides comprehensive guidance for research startup workflow from idea generation to planning.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "results-analysis",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/results-analysis",
+          "description": "This skill should be used when the user asks to \"analyze experimental results\", \"run strict statistical analysis\", \"compare model performance\", \"generate scientific figures\", \"check significance\", \"do ablation analysis\", or mentions interpreting experiment data with rigorous statistics and visualization. It focuses on strict analysis bundles, not Results-section prose.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "results-report",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/results-report",
+          "description": "This skill should be used when the user asks to \"write an experiment report\", \"summarize experimental results\", \"do experiment retrospection\", \"write a results report\", \"写实验总结报告\", \"写实验复盘\", or mentions turning completed experiment artifacts into a structured, decision-oriented research report. It assumes strict analysis should come from `results-analysis` first.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "review-response",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/review-response",
+          "description": "Systematic review response workflow from comment analysis to professional rebuttal writing. Use when the user asks to \"write rebuttal\", \"respond to reviewers\", \"draft review response\", or \"analyze review comments\". Improves paper acceptance rates.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "skill-development",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/skill-development",
+          "description": "This skill should be used when the user asks to create a new skill, repair an existing skill, improve trigger descriptions, reorganize skill structure, or make a Claude skill more reusable and internally consistent.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "skill-improver",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/skill-improver",
+          "description": "This skill should be used when the user asks to \"apply skill improvements\", \"update skill from plan\", \"execute improvement plan\", \"fix skill issues\", \"implement skill recommendations\", or mentions applying improvements from quality review reports. Reads improvement-plan-{name}.md files generated by skill-quality-reviewer and intelligently merges and executes the suggested changes to improve Claude Skills quality.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "skill-quality-reviewer",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/skill-quality-reviewer",
+          "description": "This skill should be used when the user asks to \"analyze skill quality\", \"evaluate this skill\", \"review skill quality\", \"check my skill\", or \"generate quality report\". Evaluates local skills across description quality, content organization, writing style, and structural integrity.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "ui-ux-pro-max",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/ui-ux-pro-max",
+          "description": "This skill should be used when the user asks to design or review a UI, create a landing page or dashboard, choose colors or typography, improve accessibility, or implement polished frontend interfaces with a clear design system.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "uv-package-manager",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/uv-package-manager",
+          "description": "Master the uv package manager for fast Python dependency management, virtual environments, and modern Python project workflows. Use when setting up Python projects, managing dependencies, or optimizing Python development workflows with uv.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "verification-loop",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/verification-loop",
+          "description": "This skill should be used when the user asks to \"verify code\", \"run verification\", \"check quality\", \"validate changes\", or before creating a PR. Provides comprehensive verification including build, type check, lint, tests, security scan, and diff review.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "web-design-reviewer",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/web-design-reviewer",
+          "description": "This skill enables visual inspection of websites running locally or remotely to identify and fix design issues. Triggers on requests like \"review website design\", \"check the UI\", \"fix the layout\", \"find design problems\". Detects issues with responsive design, accessibility, visual consistency, and layout breakage, then performs fixes at the source code level.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "webapp-testing",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/webapp-testing",
+          "description": "Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "writing-anti-ai",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/writing-anti-ai",
+          "description": "This skill should be used when the user asks to \"remove AI writing patterns\", \"humanize this text\", \"make this sound more natural\", \"remove AI-generated traces\", \"fix robotic writing\", or needs to eliminate AI writing patterns from prose. Supports both English and Chinese text. Based on Wikipedia's \"Signs of AI writing\" guide, detects and fixes inflated symbolism, promotional language, superficial -ing analyses, vague attributions, AI vocabulary, negative parallelisms, and excessive conjunctive phrases.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "zotero-obsidian-bridge",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/zotero-obsidian-bridge",
+          "description": "Use this skill when Zotero is the literature source of truth and the project KB should receive source notes under Sources/Papers plus project-linked synthesis in Knowledge and Writing.",
+          "version": "0.3.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Galaxy-Dawn",
+        "repo": "claude-scholar",
+        "repoUrl": "https://github.com/Galaxy-Dawn/claude-scholar.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "galaxy-dawn-claude-scholar-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from Galaxy-Dawn/claude-scholar.",
+      "author": "ASM (Galaxy-Dawn/claude-scholar)",
+      "createdAt": "2026-05-09T08:10:46.497Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "galaxy-dawn",
+        "claude-scholar"
+      ],
+      "skills": [
+        {
+          "name": "agent-identifier",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/agent-identifier",
+          "description": "Use when creating or configuring Claude Code agents and their frontmatter.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "architecture-design",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/architecture-design",
+          "description": "Use only when creating new registrable ML components that require Factory or Registry patterns.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "bug-detective",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/bug-detective",
+          "description": "This skill should be used when the user asks to \"debug this\", \"fix this error\", \"investigate this bug\", \"troubleshoot this issue\", \"find the problem\", \"something is broken\", \"this isn't working\", \"why is this failing\", or reports errors/exceptions/bugs. Provides systematic debugging workflow and common error patterns.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "code-review-excellence",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/code-review-excellence",
+          "description": "This skill should be used when the user asks to review a diff or pull request, write review comments, audit code quality, establish review standards, or improve how a team performs code review.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "command-development",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/command-development",
+          "description": "This skill should be used when the user asks to \"create a slash command\", \"add a command\", \"write a custom command\", \"define command arguments\", \"use command frontmatter\", \"organize commands\", \"create command with file references\", \"interactive command\", \"use AskUserQuestion in command\", or needs guidance on slash command structure, YAML frontmatter fields, dynamic arguments, bash execution in commands, user interaction patterns, or command development best practices for Claude Code.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "daily-coding",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/daily-coding",
+          "description": "Use for everyday coding tasks that involve writing or modifying source code.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "doc-coauthoring",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/doc-coauthoring",
+          "description": "This skill should be used when the user asks to co-author documentation, draft a proposal, write a technical spec, create a decision doc or RFC, or structure a substantial document through iterative collaboration and reader testing.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "frontend-design",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/frontend-design",
+          "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "hook-development",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/hook-development",
+          "description": "This skill should be used when the user asks to \"create a hook\", \"add a PreToolUse/PostToolUse/Stop hook\", \"validate tool use\", \"implement prompt-based hooks\", \"use ${CLAUDE_PLUGIN_ROOT}\", \"set up event-driven automation\", \"block dangerous commands\", or mentions hook events (PreToolUse, PostToolUse, Stop, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification). Provides comprehensive guidance for creating and implementing Claude Code plugin hooks with focus on advanced prompt-based hooks API.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "mcp-integration",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/mcp-integration",
+          "description": "This skill should be used when the user asks to \"add MCP server\", \"integrate MCP\", \"configure MCP in plugin\", \"use .mcp.json\", \"set up Model Context Protocol\", \"connect external service\", mentions \"${CLAUDE_PLUGIN_ROOT} with MCP\", or discusses MCP server types (SSE, stdio, HTTP, WebSocket). Provides comprehensive guidance for integrating Model Context Protocol servers into Claude Code plugins for external tool and service integration.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "ml-paper-writing",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/ml-paper-writing",
+          "description": "Write publication-ready ML/AI papers for NeurIPS, ICML, ICLR, ACL, AAAI, COLM. Use when drafting papers from research repos, conducting literature reviews, finding related work, verifying citations, or preparing camera-ready submissions. Includes LaTeX templates, citation verification workflows, and paper discovery/evaluation criteria.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "obsidian-kb-artifacts",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-kb-artifacts",
+          "description": "Use this skill for Obsidian-native formatting and derived artifacts such as Markdown formatting, wikilinks, registry tables, canvas files, optional Bases, CLI operations, and link repair. This skill does not decide knowledge routing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "obsidian-literature-workflow",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-literature-workflow",
+          "description": "Use this skill for project-scoped literature review built on Sources/Papers, with synthesis landing in Knowledge, writing handoff in Writing, and the default literature canvas under Maps/literature.canvas.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "paper-self-review",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/paper-self-review",
+          "description": "This skill should be used when the user asks to \"review paper quality\", \"check paper completeness\", \"validate paper structure\", \"self-review before submission\", or mentions systematic paper quality checking. Provides comprehensive quality assurance checklist for academic papers.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "plugin-structure",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/plugin-structure",
+          "description": "This skill should be used when the user asks to \"create a plugin\", \"scaffold a plugin\", \"understand plugin structure\", \"organize plugin components\", \"set up plugin.json\", \"use ${CLAUDE_PLUGIN_ROOT}\", \"add commands/agents/skills/hooks\", \"configure auto-discovery\", or needs guidance on plugin directory layout, manifest configuration, component organization, file naming conventions, or Claude Code plugin architecture best practices.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "publication-chart-skill",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/publication-chart-skill",
+          "description": "This skill should be used when the user asks for a publication-quality scientific figure or table, wants help choosing the right chart for results, needs a paper-ready pubfig or pubtab workflow, wants a figure + companion table for a results section, wants an Excel sheet turned into publication-ready LaTeX, or wants an existing scientific figure/table reviewed and upgraded.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "research-ideation",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/research-ideation",
+          "description": "This skill should be used when the user asks to \"brainstorm research ideas\", \"use 5W1H framework\", \"identify research gaps\", \"conduct gap analysis\", \"start research project\", \"conduct literature review\", \"define research question\", \"select research method\", \"plan research\", or mentions research project initiation phase. Provides comprehensive guidance for research startup workflow from idea generation to planning.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "review-response",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/review-response",
+          "description": "Systematic review response workflow from comment analysis to professional rebuttal writing. Use when the user asks to \"write rebuttal\", \"respond to reviewers\", \"draft review response\", or \"analyze review comments\". Improves paper acceptance rates.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "skill-improver",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/skill-improver",
+          "description": "This skill should be used when the user asks to \"apply skill improvements\", \"update skill from plan\", \"execute improvement plan\", \"fix skill issues\", \"implement skill recommendations\", or mentions applying improvements from quality review reports. Reads improvement-plan-{name}.md files generated by skill-quality-reviewer and intelligently merges and executes the suggested changes to improve Claude Skills quality.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "skill-quality-reviewer",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/skill-quality-reviewer",
+          "description": "This skill should be used when the user asks to \"analyze skill quality\", \"evaluate this skill\", \"review skill quality\", \"check my skill\", or \"generate quality report\". Evaluates local skills across description quality, content organization, writing style, and structural integrity.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "ui-ux-pro-max",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/ui-ux-pro-max",
+          "description": "This skill should be used when the user asks to design or review a UI, create a landing page or dashboard, choose colors or typography, improve accessibility, or implement polished frontend interfaces with a clear design system.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "uv-package-manager",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/uv-package-manager",
+          "description": "Master the uv package manager for fast Python dependency management, virtual environments, and modern Python project workflows. Use when setting up Python projects, managing dependencies, or optimizing Python development workflows with uv.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "verification-loop",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/verification-loop",
+          "description": "This skill should be used when the user asks to \"verify code\", \"run verification\", \"check quality\", \"validate changes\", or before creating a PR. Provides comprehensive verification including build, type check, lint, tests, security scan, and diff review.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "web-design-reviewer",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/web-design-reviewer",
+          "description": "This skill enables visual inspection of websites running locally or remotely to identify and fix design issues. Triggers on requests like \"review website design\", \"check the UI\", \"fix the layout\", \"find design problems\". Detects issues with responsive design, accessibility, visual consistency, and layout breakage, then performs fixes at the source code level.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "webapp-testing",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/webapp-testing",
+          "description": "Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.",
+          "version": "0.1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Galaxy-Dawn",
+        "repo": "claude-scholar",
+        "repoUrl": "https://github.com/Galaxy-Dawn/claude-scholar.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "galaxy-dawn-claude-scholar-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from Galaxy-Dawn/claude-scholar.",
+      "author": "ASM (Galaxy-Dawn/claude-scholar)",
+      "createdAt": "2026-05-09T08:10:46.497Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "galaxy-dawn",
+        "claude-scholar"
+      ],
+      "skills": [
+        {
+          "name": "architecture-design",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/architecture-design",
+          "description": "Use only when creating new registrable ML components that require Factory or Registry patterns.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "citation-verification",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/citation-verification",
+          "description": "This skill provides reference guidance for citation verification in academic writing. Use when the user asks about \"citation verification best practices\", \"how to verify references\", \"preventing fake citations\", or needs guidance on citation accuracy. This skill supports ml-paper-writing by providing detailed verification principles and common error patterns.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "command-development",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/command-development",
+          "description": "This skill should be used when the user asks to \"create a slash command\", \"add a command\", \"write a custom command\", \"define command arguments\", \"use command frontmatter\", \"organize commands\", \"create command with file references\", \"interactive command\", \"use AskUserQuestion in command\", or needs guidance on slash command structure, YAML frontmatter fields, dynamic arguments, bash execution in commands, user interaction patterns, or command development best practices for Claude Code.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "frontend-design",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/frontend-design",
+          "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "git-workflow",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/git-workflow",
+          "description": "This skill should be used when the user asks to \"create git commit\", \"manage branches\", \"follow git workflow\", \"use Conventional Commits\", \"handle merge conflicts\", or asks about git branching strategies, version control best practices, pull request workflows. Provides comprehensive Git workflow guidance for team collaboration.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "hook-development",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/hook-development",
+          "description": "This skill should be used when the user asks to \"create a hook\", \"add a PreToolUse/PostToolUse/Stop hook\", \"validate tool use\", \"implement prompt-based hooks\", \"use ${CLAUDE_PLUGIN_ROOT}\", \"set up event-driven automation\", \"block dangerous commands\", or mentions hook events (PreToolUse, PostToolUse, Stop, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification). Provides comprehensive guidance for creating and implementing Claude Code plugin hooks with focus on advanced prompt-based hooks API.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "mcp-integration",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/mcp-integration",
+          "description": "This skill should be used when the user asks to \"add MCP server\", \"integrate MCP\", \"configure MCP in plugin\", \"use .mcp.json\", \"set up Model Context Protocol\", \"connect external service\", mentions \"${CLAUDE_PLUGIN_ROOT} with MCP\", or discusses MCP server types (SSE, stdio, HTTP, WebSocket). Provides comprehensive guidance for integrating Model Context Protocol servers into Claude Code plugins for external tool and service integration.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "obsidian-literature-workflow",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-literature-workflow",
+          "description": "Use this skill for project-scoped literature review built on Sources/Papers, with synthesis landing in Knowledge, writing handoff in Writing, and the default literature canvas under Maps/literature.canvas.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "plugin-structure",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/plugin-structure",
+          "description": "This skill should be used when the user asks to \"create a plugin\", \"scaffold a plugin\", \"understand plugin structure\", \"organize plugin components\", \"set up plugin.json\", \"use ${CLAUDE_PLUGIN_ROOT}\", \"add commands/agents/skills/hooks\", \"configure auto-discovery\", or needs guidance on plugin directory layout, manifest configuration, component organization, file naming conventions, or Claude Code plugin architecture best practices.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "post-acceptance",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/post-acceptance",
+          "description": "This skill should be used when the user asks to \"prepare conference presentation\", \"create presentation slides\", \"design poster\", \"make academic poster\", \"write promotion content\", \"create Twitter thread\", or mentions post-acceptance conference preparation. Provides comprehensive workflow for presentation, poster, and promotion content creation.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "research-ideation",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/research-ideation",
+          "description": "This skill should be used when the user asks to \"brainstorm research ideas\", \"use 5W1H framework\", \"identify research gaps\", \"conduct gap analysis\", \"start research project\", \"conduct literature review\", \"define research question\", \"select research method\", \"plan research\", or mentions research project initiation phase. Provides comprehensive guidance for research startup workflow from idea generation to planning.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "results-analysis",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/results-analysis",
+          "description": "This skill should be used when the user asks to \"analyze experimental results\", \"run strict statistical analysis\", \"compare model performance\", \"generate scientific figures\", \"check significance\", \"do ablation analysis\", or mentions interpreting experiment data with rigorous statistics and visualization. It focuses on strict analysis bundles, not Results-section prose.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "ui-ux-pro-max",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/ui-ux-pro-max",
+          "description": "This skill should be used when the user asks to design or review a UI, create a landing page or dashboard, choose colors or typography, improve accessibility, or implement polished frontend interfaces with a clear design system.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "verification-loop",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/verification-loop",
+          "description": "This skill should be used when the user asks to \"verify code\", \"run verification\", \"check quality\", \"validate changes\", or before creating a PR. Provides comprehensive verification including build, type check, lint, tests, security scan, and diff review.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "web-design-reviewer",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/web-design-reviewer",
+          "description": "This skill enables visual inspection of websites running locally or remotely to identify and fix design issues. Triggers on requests like \"review website design\", \"check the UI\", \"fix the layout\", \"find design problems\". Detects issues with responsive design, accessibility, visual consistency, and layout breakage, then performs fixes at the source code level.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "webapp-testing",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/webapp-testing",
+          "description": "Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "writing-anti-ai",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/writing-anti-ai",
+          "description": "This skill should be used when the user asks to \"remove AI writing patterns\", \"humanize this text\", \"make this sound more natural\", \"remove AI-generated traces\", \"fix robotic writing\", or needs to eliminate AI writing patterns from prose. Supports both English and Chinese text. Based on Wikipedia's \"Signs of AI writing\" guide, detects and fixes inflated symbolism, promotional language, superficial -ing analyses, vague attributions, AI vocabulary, negative parallelisms, and excessive conjunctive phrases.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Galaxy-Dawn",
+        "repo": "claude-scholar",
+        "repoUrl": "https://github.com/Galaxy-Dawn/claude-scholar.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "galaxy-dawn-claude-scholar-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from Galaxy-Dawn/claude-scholar.",
+      "author": "ASM (Galaxy-Dawn/claude-scholar)",
+      "createdAt": "2026-05-09T08:10:46.497Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "galaxy-dawn",
+        "claude-scholar"
+      ],
+      "skills": [
+        {
+          "name": "bug-detective",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/bug-detective",
+          "description": "This skill should be used when the user asks to \"debug this\", \"fix this error\", \"investigate this bug\", \"troubleshoot this issue\", \"find the problem\", \"something is broken\", \"this isn't working\", \"why is this failing\", or reports errors/exceptions/bugs. Provides systematic debugging workflow and common error patterns.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "citation-verification",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/citation-verification",
+          "description": "This skill provides reference guidance for citation verification in academic writing. Use when the user asks about \"citation verification best practices\", \"how to verify references\", \"preventing fake citations\", or needs guidance on citation accuracy. This skill supports ml-paper-writing by providing detailed verification principles and common error patterns.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "defuddle",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/defuddle",
+          "description": "Extract clean Markdown from web pages. In the KB workflow, use it as a utility under obsidian-source-ingestion.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "doc-coauthoring",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/doc-coauthoring",
+          "description": "This skill should be used when the user asks to co-author documentation, draft a proposal, write a technical spec, create a decision doc or RFC, or structure a substantial document through iterative collaboration and reader testing.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "git-workflow",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/git-workflow",
+          "description": "This skill should be used when the user asks to \"create git commit\", \"manage branches\", \"follow git workflow\", \"use Conventional Commits\", \"handle merge conflicts\", or asks about git branching strategies, version control best practices, pull request workflows. Provides comprehensive Git workflow guidance for team collaboration.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "ml-paper-writing",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/ml-paper-writing",
+          "description": "Write publication-ready ML/AI papers for NeurIPS, ICML, ICLR, ACL, AAAI, COLM. Use when drafting papers from research repos, conducting literature reviews, finding related work, verifying citations, or preparing camera-ready submissions. Includes LaTeX templates, citation verification workflows, and paper discovery/evaluation criteria.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "obsidian-kb-artifacts",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-kb-artifacts",
+          "description": "Use this skill for Obsidian-native formatting and derived artifacts such as Markdown formatting, wikilinks, registry tables, canvas files, optional Bases, CLI operations, and link repair. This skill does not decide knowledge routing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "obsidian-literature-workflow",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-literature-workflow",
+          "description": "Use this skill for project-scoped literature review built on Sources/Papers, with synthesis landing in Knowledge, writing handoff in Writing, and the default literature canvas under Maps/literature.canvas.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "post-acceptance",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/post-acceptance",
+          "description": "This skill should be used when the user asks to \"prepare conference presentation\", \"create presentation slides\", \"design poster\", \"make academic poster\", \"write promotion content\", \"create Twitter thread\", or mentions post-acceptance conference preparation. Provides comprehensive workflow for presentation, poster, and promotion content creation.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "publication-chart-skill",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/publication-chart-skill",
+          "description": "This skill should be used when the user asks for a publication-quality scientific figure or table, wants help choosing the right chart for results, needs a paper-ready pubfig or pubtab workflow, wants a figure + companion table for a results section, wants an Excel sheet turned into publication-ready LaTeX, or wants an existing scientific figure/table reviewed and upgraded.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "research-ideation",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/research-ideation",
+          "description": "This skill should be used when the user asks to \"brainstorm research ideas\", \"use 5W1H framework\", \"identify research gaps\", \"conduct gap analysis\", \"start research project\", \"conduct literature review\", \"define research question\", \"select research method\", \"plan research\", or mentions research project initiation phase. Provides comprehensive guidance for research startup workflow from idea generation to planning.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "results-analysis",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/results-analysis",
+          "description": "This skill should be used when the user asks to \"analyze experimental results\", \"run strict statistical analysis\", \"compare model performance\", \"generate scientific figures\", \"check significance\", \"do ablation analysis\", or mentions interpreting experiment data with rigorous statistics and visualization. It focuses on strict analysis bundles, not Results-section prose.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "results-report",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/results-report",
+          "description": "This skill should be used when the user asks to \"write an experiment report\", \"summarize experimental results\", \"do experiment retrospection\", \"write a results report\", \"写实验总结报告\", \"写实验复盘\", or mentions turning completed experiment artifacts into a structured, decision-oriented research report. It assumes strict analysis should come from `results-analysis` first.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "review-response",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/review-response",
+          "description": "Systematic review response workflow from comment analysis to professional rebuttal writing. Use when the user asks to \"write rebuttal\", \"respond to reviewers\", \"draft review response\", or \"analyze review comments\". Improves paper acceptance rates.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "uv-package-manager",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/uv-package-manager",
+          "description": "Master the uv package manager for fast Python dependency management, virtual environments, and modern Python project workflows. Use when setting up Python projects, managing dependencies, or optimizing Python development workflows with uv.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "writing-anti-ai",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/writing-anti-ai",
+          "description": "This skill should be used when the user asks to \"remove AI writing patterns\", \"humanize this text\", \"make this sound more natural\", \"remove AI-generated traces\", \"fix robotic writing\", or needs to eliminate AI writing patterns from prose. Supports both English and Chinese text. Based on Wikipedia's \"Signs of AI writing\" guide, detects and fixes inflated symbolism, promotional language, superficial -ing analyses, vague attributions, AI vocabulary, negative parallelisms, and excessive conjunctive phrases.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Galaxy-Dawn",
+        "repo": "claude-scholar",
+        "repoUrl": "https://github.com/Galaxy-Dawn/claude-scholar.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "galaxy-dawn-claude-scholar-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from Galaxy-Dawn/claude-scholar.",
+      "author": "ASM (Galaxy-Dawn/claude-scholar)",
+      "createdAt": "2026-05-09T08:10:46.497Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "galaxy-dawn",
+        "claude-scholar"
+      ],
+      "skills": [
+        {
+          "name": "agent-identifier",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/agent-identifier",
+          "description": "Use when creating or configuring Claude Code agents and their frontmatter.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "architecture-design",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/architecture-design",
+          "description": "Use only when creating new registrable ML components that require Factory or Registry patterns.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "bug-detective",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/bug-detective",
+          "description": "This skill should be used when the user asks to \"debug this\", \"fix this error\", \"investigate this bug\", \"troubleshoot this issue\", \"find the problem\", \"something is broken\", \"this isn't working\", \"why is this failing\", or reports errors/exceptions/bugs. Provides systematic debugging workflow and common error patterns.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "citation-verification",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/citation-verification",
+          "description": "This skill provides reference guidance for citation verification in academic writing. Use when the user asks about \"citation verification best practices\", \"how to verify references\", \"preventing fake citations\", or needs guidance on citation accuracy. This skill supports ml-paper-writing by providing detailed verification principles and common error patterns.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "code-review-excellence",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/code-review-excellence",
+          "description": "This skill should be used when the user asks to review a diff or pull request, write review comments, audit code quality, establish review standards, or improve how a team performs code review.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "command-development",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/command-development",
+          "description": "This skill should be used when the user asks to \"create a slash command\", \"add a command\", \"write a custom command\", \"define command arguments\", \"use command frontmatter\", \"organize commands\", \"create command with file references\", \"interactive command\", \"use AskUserQuestion in command\", or needs guidance on slash command structure, YAML frontmatter fields, dynamic arguments, bash execution in commands, user interaction patterns, or command development best practices for Claude Code.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "daily-coding",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/daily-coding",
+          "description": "Use for everyday coding tasks that involve writing or modifying source code.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "daily-paper-generator",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/daily-paper-generator",
+          "description": "Use when the user asks to generate daily paper digests on a general topic. This skill supports both arXiv and bioRxiv (or either one), then produces structured Chinese/English summaries for selected papers.",
+          "version": "0.5.1"
+        },
+        {
+          "name": "defuddle",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/defuddle",
+          "description": "Extract clean Markdown from web pages. In the KB workflow, use it as a utility under obsidian-source-ingestion.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "doc-coauthoring",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/doc-coauthoring",
+          "description": "This skill should be used when the user asks to co-author documentation, draft a proposal, write a technical spec, create a decision doc or RFC, or structure a substantial document through iterative collaboration and reader testing.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "frontend-design",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/frontend-design",
+          "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "git-workflow",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/git-workflow",
+          "description": "This skill should be used when the user asks to \"create git commit\", \"manage branches\", \"follow git workflow\", \"use Conventional Commits\", \"handle merge conflicts\", or asks about git branching strategies, version control best practices, pull request workflows. Provides comprehensive Git workflow guidance for team collaboration.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "hook-development",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/hook-development",
+          "description": "This skill should be used when the user asks to \"create a hook\", \"add a PreToolUse/PostToolUse/Stop hook\", \"validate tool use\", \"implement prompt-based hooks\", \"use ${CLAUDE_PLUGIN_ROOT}\", \"set up event-driven automation\", \"block dangerous commands\", or mentions hook events (PreToolUse, PostToolUse, Stop, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification). Provides comprehensive guidance for creating and implementing Claude Code plugin hooks with focus on advanced prompt-based hooks API.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "kaggle-learner",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/kaggle-learner",
+          "description": "This skill should be used when the user asks to \"learn from Kaggle\", \"study Kaggle solutions\", \"analyze Kaggle competitions\", or mentions Kaggle competition URLs. Provides access to extracted knowledge from winning Kaggle solutions across NLP, CV, time series, tabular, and multimodal domains.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "latex-conference-template-organizer",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/latex-conference-template-organizer",
+          "description": "Organize messy conference LaTeX template .zip files into clean Overleaf-ready structure. Use when the user asks to \"organize LaTeX template\", \"clean up .zip template\", or \"prepare Overleaf submission template\".",
+          "version": "0.1.0"
+        },
+        {
+          "name": "mcp-integration",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/mcp-integration",
+          "description": "This skill should be used when the user asks to \"add MCP server\", \"integrate MCP\", \"configure MCP in plugin\", \"use .mcp.json\", \"set up Model Context Protocol\", \"connect external service\", mentions \"${CLAUDE_PLUGIN_ROOT} with MCP\", or discusses MCP server types (SSE, stdio, HTTP, WebSocket). Provides comprehensive guidance for integrating Model Context Protocol servers into Claude Code plugins for external tool and service integration.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "ml-paper-writing",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/ml-paper-writing",
+          "description": "Write publication-ready ML/AI papers for NeurIPS, ICML, ICLR, ACL, AAAI, COLM. Use when drafting papers from research repos, conducting literature reviews, finding related work, verifying citations, or preparing camera-ready submissions. Includes LaTeX templates, citation verification workflows, and paper discovery/evaluation criteria.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "obsidian-kb-artifacts",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-kb-artifacts",
+          "description": "Use this skill for Obsidian-native formatting and derived artifacts such as Markdown formatting, wikilinks, registry tables, canvas files, optional Bases, CLI operations, and link repair. This skill does not decide knowledge routing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "obsidian-literature-workflow",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-literature-workflow",
+          "description": "Use this skill for project-scoped literature review built on Sources/Papers, with synthesis landing in Knowledge, writing handoff in Writing, and the default literature canvas under Maps/literature.canvas.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "obsidian-project-kb-core",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-project-kb-core",
+          "description": "Use this as the main Claude Scholar skill for a vault-first, project-scoped Obsidian research knowledge base rooted at Research/{project-slug}/. It owns bootstrap, routing, daily logging, hub/plan/index maintenance, registry updates, lifecycle actions, and lint orchestration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "obsidian-source-ingestion",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-source-ingestion",
+          "description": "Use this skill to ingest external materials into the current project-scoped Obsidian KB as source notes under Sources/Papers, Sources/Web, Sources/Docs, Sources/Data, Sources/Interviews, or Sources/Notes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "paper-self-review",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/paper-self-review",
+          "description": "This skill should be used when the user asks to \"review paper quality\", \"check paper completeness\", \"validate paper structure\", \"self-review before submission\", or mentions systematic paper quality checking. Provides comprehensive quality assurance checklist for academic papers.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "plugin-structure",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/plugin-structure",
+          "description": "This skill should be used when the user asks to \"create a plugin\", \"scaffold a plugin\", \"understand plugin structure\", \"organize plugin components\", \"set up plugin.json\", \"use ${CLAUDE_PLUGIN_ROOT}\", \"add commands/agents/skills/hooks\", \"configure auto-discovery\", or needs guidance on plugin directory layout, manifest configuration, component organization, file naming conventions, or Claude Code plugin architecture best practices.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "post-acceptance",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/post-acceptance",
+          "description": "This skill should be used when the user asks to \"prepare conference presentation\", \"create presentation slides\", \"design poster\", \"make academic poster\", \"write promotion content\", \"create Twitter thread\", or mentions post-acceptance conference preparation. Provides comprehensive workflow for presentation, poster, and promotion content creation.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "publication-chart-skill",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/publication-chart-skill",
+          "description": "This skill should be used when the user asks for a publication-quality scientific figure or table, wants help choosing the right chart for results, needs a paper-ready pubfig or pubtab workflow, wants a figure + companion table for a results section, wants an Excel sheet turned into publication-ready LaTeX, or wants an existing scientific figure/table reviewed and upgraded.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "research-ideation",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/research-ideation",
+          "description": "This skill should be used when the user asks to \"brainstorm research ideas\", \"use 5W1H framework\", \"identify research gaps\", \"conduct gap analysis\", \"start research project\", \"conduct literature review\", \"define research question\", \"select research method\", \"plan research\", or mentions research project initiation phase. Provides comprehensive guidance for research startup workflow from idea generation to planning.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "results-analysis",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/results-analysis",
+          "description": "This skill should be used when the user asks to \"analyze experimental results\", \"run strict statistical analysis\", \"compare model performance\", \"generate scientific figures\", \"check significance\", \"do ablation analysis\", or mentions interpreting experiment data with rigorous statistics and visualization. It focuses on strict analysis bundles, not Results-section prose.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "results-report",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/results-report",
+          "description": "This skill should be used when the user asks to \"write an experiment report\", \"summarize experimental results\", \"do experiment retrospection\", \"write a results report\", \"写实验总结报告\", \"写实验复盘\", or mentions turning completed experiment artifacts into a structured, decision-oriented research report. It assumes strict analysis should come from `results-analysis` first.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "review-response",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/review-response",
+          "description": "Systematic review response workflow from comment analysis to professional rebuttal writing. Use when the user asks to \"write rebuttal\", \"respond to reviewers\", \"draft review response\", or \"analyze review comments\". Improves paper acceptance rates.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "skill-development",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/skill-development",
+          "description": "This skill should be used when the user asks to create a new skill, repair an existing skill, improve trigger descriptions, reorganize skill structure, or make a Claude skill more reusable and internally consistent.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "skill-improver",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/skill-improver",
+          "description": "This skill should be used when the user asks to \"apply skill improvements\", \"update skill from plan\", \"execute improvement plan\", \"fix skill issues\", \"implement skill recommendations\", or mentions applying improvements from quality review reports. Reads improvement-plan-{name}.md files generated by skill-quality-reviewer and intelligently merges and executes the suggested changes to improve Claude Skills quality.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "skill-quality-reviewer",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/skill-quality-reviewer",
+          "description": "This skill should be used when the user asks to \"analyze skill quality\", \"evaluate this skill\", \"review skill quality\", \"check my skill\", or \"generate quality report\". Evaluates local skills across description quality, content organization, writing style, and structural integrity.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "ui-ux-pro-max",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/ui-ux-pro-max",
+          "description": "This skill should be used when the user asks to design or review a UI, create a landing page or dashboard, choose colors or typography, improve accessibility, or implement polished frontend interfaces with a clear design system.",
+          "version": "0.2.0"
+        },
+        {
+          "name": "uv-package-manager",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/uv-package-manager",
+          "description": "Master the uv package manager for fast Python dependency management, virtual environments, and modern Python project workflows. Use when setting up Python projects, managing dependencies, or optimizing Python development workflows with uv.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "verification-loop",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/verification-loop",
+          "description": "This skill should be used when the user asks to \"verify code\", \"run verification\", \"check quality\", \"validate changes\", or before creating a PR. Provides comprehensive verification including build, type check, lint, tests, security scan, and diff review.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "web-design-reviewer",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/web-design-reviewer",
+          "description": "This skill enables visual inspection of websites running locally or remotely to identify and fix design issues. Triggers on requests like \"review website design\", \"check the UI\", \"fix the layout\", \"find design problems\". Detects issues with responsive design, accessibility, visual consistency, and layout breakage, then performs fixes at the source code level.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "webapp-testing",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/webapp-testing",
+          "description": "Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "writing-anti-ai",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/writing-anti-ai",
+          "description": "This skill should be used when the user asks to \"remove AI writing patterns\", \"humanize this text\", \"make this sound more natural\", \"remove AI-generated traces\", \"fix robotic writing\", or needs to eliminate AI writing patterns from prose. Supports both English and Chinese text. Based on Wikipedia's \"Signs of AI writing\" guide, detects and fixes inflated symbolism, promotional language, superficial -ing analyses, vague attributions, AI vocabulary, negative parallelisms, and excessive conjunctive phrases.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "zotero-obsidian-bridge",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/zotero-obsidian-bridge",
+          "description": "Use this skill when Zotero is the literature source of truth and the project KB should receive source notes under Sources/Papers plus project-linked synthesis in Knowledge and Writing.",
+          "version": "0.3.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Galaxy-Dawn",
+        "repo": "claude-scholar",
+        "repoUrl": "https://github.com/Galaxy-Dawn/claude-scholar.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "galaxy-dawn-claude-scholar-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from Galaxy-Dawn/claude-scholar.",
+      "author": "ASM (Galaxy-Dawn/claude-scholar)",
+      "createdAt": "2026-05-09T08:10:46.497Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "galaxy-dawn",
+        "claude-scholar"
+      ],
+      "skills": [
+        {
+          "name": "frontend-design",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/frontend-design",
+          "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.",
+          "version": "0.1.0"
+        },
+        {
+          "name": "research-ideation",
+          "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/research-ideation",
+          "description": "This skill should be used when the user asks to \"brainstorm research ideas\", \"use 5W1H framework\", \"identify research gaps\", \"conduct gap analysis\", \"start research project\", \"conduct literature review\", \"define research question\", \"select research method\", \"plan research\", or mentions research project initiation phase. Provides comprehensive guidance for research startup workflow from idea generation to planning.",
+          "version": "0.1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Galaxy-Dawn",
+        "repo": "claude-scholar",
+        "repoUrl": "https://github.com/Galaxy-Dawn/claude-scholar.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/Imbad0202_academic-research-skills.json
+++ b/data/skill-index/Imbad0202_academic-research-skills.json
@@ -553,5 +553,277 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "imbad0202-academic-research-skills-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from Imbad0202/academic-research-skills.",
+      "author": "ASM (Imbad0202/academic-research-skills)",
+      "createdAt": "2026-05-09T08:11:00.610Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "imbad0202",
+        "academic-research-skills"
+      ],
+      "skills": [
+        {
+          "name": "academic-paper",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-paper",
+          "description": "12-agent academic paper writing pipeline. 10 modes (full/plan/outline/revision/revision-coach/abstract/lit-review/format-convert/citation-check/disclosure). 6 paper types, 5 citation formats, bilingual abstracts, LaTeX/DOCX-via-Pandoc/PDF output. Style Calibration + Writing Quality Check + Anti-Patterns with IRON RULE markers. Triggers: write paper, academic paper, guide my paper, parse reviews, AI disclosure, 寫論文, 學術論文, 引導我寫論文, 審查意見.",
+          "version": "3.1.1"
+        },
+        {
+          "name": "academic-paper-reviewer",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-paper-reviewer",
+          "description": "Multi-perspective academic paper review with dynamic reviewer personas. Simulates 5 independent reviewers (EIC + 3 peer reviewers + Devil's Advocate) with field-specific expertise. Supports full review, re-review (verification), quick assessment, methodology focus, Socratic guided, and calibration modes. Triggers on: review paper, peer review, manuscript review, referee report, review my paper, critique paper, simulate review, editorial review, calibrate reviewer, reviewer calibration, measure reviewer accuracy.",
+          "version": "1.9.0"
+        },
+        {
+          "name": "academic-pipeline",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-pipeline",
+          "description": "Orchestrator for the full academic research pipeline: research -> write -> integrity check -> review -> revise -> re-review -> re-revise -> final integrity check -> finalize. Coordinates deep-research, academic-paper, and academic-paper-reviewer into a seamless 10-stage workflow with mandatory integrity verification, two-stage peer review, and reproducible quality gates. Triggers on: academic pipeline, research to paper, full paper workflow, paper pipeline, end-to-end paper, research-to-publication, complete paper workflow.",
+          "version": "3.7.0"
+        },
+        {
+          "name": "deep-research",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/deep-research",
+          "description": "Universal deep research agent team. 13-agent pipeline for rigorous academic research on any topic. 7 modes: full research, quick brief, paper review, lit-review, fact-check, Socratic guided research dialogue, and systematic review with optional meta-analysis. Covers research question formulation, Socratic mentoring, methodology design, systematic literature search, source verification, cross-source synthesis, risk of bias assessment, meta-analysis, APA 7.0 report compilation, editorial review, devil's advocate challenges, ethics review, and post-research literature monitoring. Triggers on: research, deep research, literature review, systematic review, meta-analysis, PRISMA, evidence synthesis, fact-check, guide my research, help me think through, 研究, 深度研究, 文獻回顧, 文獻探討, 系統性回顧, 後設分析, 事實查核, 引導我的研究, 幫我釐清, 幫我想想, 我不確定要研究什麼, 研究方向, 研究主題.",
+          "version": "2.9.3"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Imbad0202",
+        "repo": "academic-research-skills",
+        "repoUrl": "https://github.com/Imbad0202/academic-research-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "imbad0202-academic-research-skills-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from Imbad0202/academic-research-skills.",
+      "author": "ASM (Imbad0202/academic-research-skills)",
+      "createdAt": "2026-05-09T08:11:00.610Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "imbad0202",
+        "academic-research-skills"
+      ],
+      "skills": [
+        {
+          "name": "academic-paper",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-paper",
+          "description": "12-agent academic paper writing pipeline. 10 modes (full/plan/outline/revision/revision-coach/abstract/lit-review/format-convert/citation-check/disclosure). 6 paper types, 5 citation formats, bilingual abstracts, LaTeX/DOCX-via-Pandoc/PDF output. Style Calibration + Writing Quality Check + Anti-Patterns with IRON RULE markers. Triggers: write paper, academic paper, guide my paper, parse reviews, AI disclosure, 寫論文, 學術論文, 引導我寫論文, 審查意見.",
+          "version": "3.1.1"
+        },
+        {
+          "name": "academic-paper-reviewer",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-paper-reviewer",
+          "description": "Multi-perspective academic paper review with dynamic reviewer personas. Simulates 5 independent reviewers (EIC + 3 peer reviewers + Devil's Advocate) with field-specific expertise. Supports full review, re-review (verification), quick assessment, methodology focus, Socratic guided, and calibration modes. Triggers on: review paper, peer review, manuscript review, referee report, review my paper, critique paper, simulate review, editorial review, calibrate reviewer, reviewer calibration, measure reviewer accuracy.",
+          "version": "1.9.0"
+        },
+        {
+          "name": "academic-pipeline",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-pipeline",
+          "description": "Orchestrator for the full academic research pipeline: research -> write -> integrity check -> review -> revise -> re-review -> re-revise -> final integrity check -> finalize. Coordinates deep-research, academic-paper, and academic-paper-reviewer into a seamless 10-stage workflow with mandatory integrity verification, two-stage peer review, and reproducible quality gates. Triggers on: academic pipeline, research to paper, full paper workflow, paper pipeline, end-to-end paper, research-to-publication, complete paper workflow.",
+          "version": "3.7.0"
+        },
+        {
+          "name": "deep-research",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/deep-research",
+          "description": "Universal deep research agent team. 13-agent pipeline for rigorous academic research on any topic. 7 modes: full research, quick brief, paper review, lit-review, fact-check, Socratic guided research dialogue, and systematic review with optional meta-analysis. Covers research question formulation, Socratic mentoring, methodology design, systematic literature search, source verification, cross-source synthesis, risk of bias assessment, meta-analysis, APA 7.0 report compilation, editorial review, devil's advocate challenges, ethics review, and post-research literature monitoring. Triggers on: research, deep research, literature review, systematic review, meta-analysis, PRISMA, evidence synthesis, fact-check, guide my research, help me think through, 研究, 深度研究, 文獻回顧, 文獻探討, 系統性回顧, 後設分析, 事實查核, 引導我的研究, 幫我釐清, 幫我想想, 我不確定要研究什麼, 研究方向, 研究主題.",
+          "version": "2.9.3"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Imbad0202",
+        "repo": "academic-research-skills",
+        "repoUrl": "https://github.com/Imbad0202/academic-research-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "imbad0202-academic-research-skills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from Imbad0202/academic-research-skills.",
+      "author": "ASM (Imbad0202/academic-research-skills)",
+      "createdAt": "2026-05-09T08:11:00.610Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "imbad0202",
+        "academic-research-skills"
+      ],
+      "skills": [
+        {
+          "name": "academic-paper",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-paper",
+          "description": "12-agent academic paper writing pipeline. 10 modes (full/plan/outline/revision/revision-coach/abstract/lit-review/format-convert/citation-check/disclosure). 6 paper types, 5 citation formats, bilingual abstracts, LaTeX/DOCX-via-Pandoc/PDF output. Style Calibration + Writing Quality Check + Anti-Patterns with IRON RULE markers. Triggers: write paper, academic paper, guide my paper, parse reviews, AI disclosure, 寫論文, 學術論文, 引導我寫論文, 審查意見.",
+          "version": "3.1.1"
+        },
+        {
+          "name": "academic-paper-reviewer",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-paper-reviewer",
+          "description": "Multi-perspective academic paper review with dynamic reviewer personas. Simulates 5 independent reviewers (EIC + 3 peer reviewers + Devil's Advocate) with field-specific expertise. Supports full review, re-review (verification), quick assessment, methodology focus, Socratic guided, and calibration modes. Triggers on: review paper, peer review, manuscript review, referee report, review my paper, critique paper, simulate review, editorial review, calibrate reviewer, reviewer calibration, measure reviewer accuracy.",
+          "version": "1.9.0"
+        },
+        {
+          "name": "academic-pipeline",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-pipeline",
+          "description": "Orchestrator for the full academic research pipeline: research -> write -> integrity check -> review -> revise -> re-review -> re-revise -> final integrity check -> finalize. Coordinates deep-research, academic-paper, and academic-paper-reviewer into a seamless 10-stage workflow with mandatory integrity verification, two-stage peer review, and reproducible quality gates. Triggers on: academic pipeline, research to paper, full paper workflow, paper pipeline, end-to-end paper, research-to-publication, complete paper workflow.",
+          "version": "3.7.0"
+        },
+        {
+          "name": "deep-research",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/deep-research",
+          "description": "Universal deep research agent team. 13-agent pipeline for rigorous academic research on any topic. 7 modes: full research, quick brief, paper review, lit-review, fact-check, Socratic guided research dialogue, and systematic review with optional meta-analysis. Covers research question formulation, Socratic mentoring, methodology design, systematic literature search, source verification, cross-source synthesis, risk of bias assessment, meta-analysis, APA 7.0 report compilation, editorial review, devil's advocate challenges, ethics review, and post-research literature monitoring. Triggers on: research, deep research, literature review, systematic review, meta-analysis, PRISMA, evidence synthesis, fact-check, guide my research, help me think through, 研究, 深度研究, 文獻回顧, 文獻探討, 系統性回顧, 後設分析, 事實查核, 引導我的研究, 幫我釐清, 幫我想想, 我不確定要研究什麼, 研究方向, 研究主題.",
+          "version": "2.9.3"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Imbad0202",
+        "repo": "academic-research-skills",
+        "repoUrl": "https://github.com/Imbad0202/academic-research-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "imbad0202-academic-research-skills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from Imbad0202/academic-research-skills.",
+      "author": "ASM (Imbad0202/academic-research-skills)",
+      "createdAt": "2026-05-09T08:11:00.610Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "imbad0202",
+        "academic-research-skills"
+      ],
+      "skills": [
+        {
+          "name": "academic-paper",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-paper",
+          "description": "12-agent academic paper writing pipeline. 10 modes (full/plan/outline/revision/revision-coach/abstract/lit-review/format-convert/citation-check/disclosure). 6 paper types, 5 citation formats, bilingual abstracts, LaTeX/DOCX-via-Pandoc/PDF output. Style Calibration + Writing Quality Check + Anti-Patterns with IRON RULE markers. Triggers: write paper, academic paper, guide my paper, parse reviews, AI disclosure, 寫論文, 學術論文, 引導我寫論文, 審查意見.",
+          "version": "3.1.1"
+        },
+        {
+          "name": "academic-paper-reviewer",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-paper-reviewer",
+          "description": "Multi-perspective academic paper review with dynamic reviewer personas. Simulates 5 independent reviewers (EIC + 3 peer reviewers + Devil's Advocate) with field-specific expertise. Supports full review, re-review (verification), quick assessment, methodology focus, Socratic guided, and calibration modes. Triggers on: review paper, peer review, manuscript review, referee report, review my paper, critique paper, simulate review, editorial review, calibrate reviewer, reviewer calibration, measure reviewer accuracy.",
+          "version": "1.9.0"
+        },
+        {
+          "name": "deep-research",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/deep-research",
+          "description": "Universal deep research agent team. 13-agent pipeline for rigorous academic research on any topic. 7 modes: full research, quick brief, paper review, lit-review, fact-check, Socratic guided research dialogue, and systematic review with optional meta-analysis. Covers research question formulation, Socratic mentoring, methodology design, systematic literature search, source verification, cross-source synthesis, risk of bias assessment, meta-analysis, APA 7.0 report compilation, editorial review, devil's advocate challenges, ethics review, and post-research literature monitoring. Triggers on: research, deep research, literature review, systematic review, meta-analysis, PRISMA, evidence synthesis, fact-check, guide my research, help me think through, 研究, 深度研究, 文獻回顧, 文獻探討, 系統性回顧, 後設分析, 事實查核, 引導我的研究, 幫我釐清, 幫我想想, 我不確定要研究什麼, 研究方向, 研究主題.",
+          "version": "2.9.3"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Imbad0202",
+        "repo": "academic-research-skills",
+        "repoUrl": "https://github.com/Imbad0202/academic-research-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "imbad0202-academic-research-skills-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from Imbad0202/academic-research-skills.",
+      "author": "ASM (Imbad0202/academic-research-skills)",
+      "createdAt": "2026-05-09T08:11:00.610Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "imbad0202",
+        "academic-research-skills"
+      ],
+      "skills": [
+        {
+          "name": "academic-paper",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-paper",
+          "description": "12-agent academic paper writing pipeline. 10 modes (full/plan/outline/revision/revision-coach/abstract/lit-review/format-convert/citation-check/disclosure). 6 paper types, 5 citation formats, bilingual abstracts, LaTeX/DOCX-via-Pandoc/PDF output. Style Calibration + Writing Quality Check + Anti-Patterns with IRON RULE markers. Triggers: write paper, academic paper, guide my paper, parse reviews, AI disclosure, 寫論文, 學術論文, 引導我寫論文, 審查意見.",
+          "version": "3.1.1"
+        },
+        {
+          "name": "academic-paper-reviewer",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-paper-reviewer",
+          "description": "Multi-perspective academic paper review with dynamic reviewer personas. Simulates 5 independent reviewers (EIC + 3 peer reviewers + Devil's Advocate) with field-specific expertise. Supports full review, re-review (verification), quick assessment, methodology focus, Socratic guided, and calibration modes. Triggers on: review paper, peer review, manuscript review, referee report, review my paper, critique paper, simulate review, editorial review, calibrate reviewer, reviewer calibration, measure reviewer accuracy.",
+          "version": "1.9.0"
+        },
+        {
+          "name": "academic-pipeline",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-pipeline",
+          "description": "Orchestrator for the full academic research pipeline: research -> write -> integrity check -> review -> revise -> re-review -> re-revise -> final integrity check -> finalize. Coordinates deep-research, academic-paper, and academic-paper-reviewer into a seamless 10-stage workflow with mandatory integrity verification, two-stage peer review, and reproducible quality gates. Triggers on: academic pipeline, research to paper, full paper workflow, paper pipeline, end-to-end paper, research-to-publication, complete paper workflow.",
+          "version": "3.7.0"
+        },
+        {
+          "name": "deep-research",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/deep-research",
+          "description": "Universal deep research agent team. 13-agent pipeline for rigorous academic research on any topic. 7 modes: full research, quick brief, paper review, lit-review, fact-check, Socratic guided research dialogue, and systematic review with optional meta-analysis. Covers research question formulation, Socratic mentoring, methodology design, systematic literature search, source verification, cross-source synthesis, risk of bias assessment, meta-analysis, APA 7.0 report compilation, editorial review, devil's advocate challenges, ethics review, and post-research literature monitoring. Triggers on: research, deep research, literature review, systematic review, meta-analysis, PRISMA, evidence synthesis, fact-check, guide my research, help me think through, 研究, 深度研究, 文獻回顧, 文獻探討, 系統性回顧, 後設分析, 事實查核, 引導我的研究, 幫我釐清, 幫我想想, 我不確定要研究什麼, 研究方向, 研究主題.",
+          "version": "2.9.3"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Imbad0202",
+        "repo": "academic-research-skills",
+        "repoUrl": "https://github.com/Imbad0202/academic-research-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "imbad0202-academic-research-skills-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from Imbad0202/academic-research-skills.",
+      "author": "ASM (Imbad0202/academic-research-skills)",
+      "createdAt": "2026-05-09T08:11:00.610Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "imbad0202",
+        "academic-research-skills"
+      ],
+      "skills": [
+        {
+          "name": "academic-paper",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-paper",
+          "description": "12-agent academic paper writing pipeline. 10 modes (full/plan/outline/revision/revision-coach/abstract/lit-review/format-convert/citation-check/disclosure). 6 paper types, 5 citation formats, bilingual abstracts, LaTeX/DOCX-via-Pandoc/PDF output. Style Calibration + Writing Quality Check + Anti-Patterns with IRON RULE markers. Triggers: write paper, academic paper, guide my paper, parse reviews, AI disclosure, 寫論文, 學術論文, 引導我寫論文, 審查意見.",
+          "version": "3.1.1"
+        },
+        {
+          "name": "deep-research",
+          "installUrl": "github:Imbad0202/academic-research-skills:skills/deep-research",
+          "description": "Universal deep research agent team. 13-agent pipeline for rigorous academic research on any topic. 7 modes: full research, quick brief, paper review, lit-review, fact-check, Socratic guided research dialogue, and systematic review with optional meta-analysis. Covers research question formulation, Socratic mentoring, methodology design, systematic literature search, source verification, cross-source synthesis, risk of bias assessment, meta-analysis, APA 7.0 report compilation, editorial review, devil's advocate challenges, ethics review, and post-research literature monitoring. Triggers on: research, deep research, literature review, systematic review, meta-analysis, PRISMA, evidence synthesis, fact-check, guide my research, help me think through, 研究, 深度研究, 文獻回顧, 文獻探討, 系統性回顧, 後設分析, 事實查核, 引導我的研究, 幫我釐清, 幫我想想, 我不確定要研究什麼, 研究方向, 研究主題.",
+          "version": "2.9.3"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Imbad0202",
+        "repo": "academic-research-skills",
+        "repoUrl": "https://github.com/Imbad0202/academic-research-skills.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/K-Dense-AI_claude-scientific-skills.json
+++ b/data/skill-index/K-Dense-AI_claude-scientific-skills.json
@@ -697,7 +697,12 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/autoskill",
       "relPath": "scientific-skills/autoskill",
       "verified": true,
@@ -971,7 +976,9 @@
       "license": "MIT",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Bash"],
+      "allowedTools": [
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/bgpt-paper-search",
       "relPath": "scientific-skills/bgpt-paper-search",
       "verified": true,
@@ -1656,7 +1663,12 @@
       "license": "MIT License",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/citation-management",
       "relPath": "scientific-skills/citation-management",
       "verified": true,
@@ -1793,7 +1805,12 @@
       "license": "MIT License",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/clinical-decision-support",
       "relPath": "scientific-skills/clinical-decision-support",
       "verified": true,
@@ -1930,7 +1947,12 @@
       "license": "MIT License",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/clinical-reports",
       "relPath": "scientific-skills/clinical-reports",
       "verified": true,
@@ -2204,7 +2226,10 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write"],
+      "allowedTools": [
+        "Read",
+        "Write"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/consciousness-council",
       "relPath": "scientific-skills/consciousness-council",
       "verified": true,
@@ -3163,7 +3188,10 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write"],
+      "allowedTools": [
+        "Read",
+        "Write"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/dhdna-profiler",
       "relPath": "scientific-skills/dhdna-profiler",
       "verified": true,
@@ -6177,7 +6205,12 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hypothesis-generation",
       "relPath": "scientific-skills/hypothesis-generation",
       "verified": true,
@@ -6451,7 +6484,12 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/infographics",
       "relPath": "scientific-skills/infographics",
       "verified": true,
@@ -7136,7 +7174,12 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/latex-posters",
       "relPath": "scientific-skills/latex-posters",
       "verified": true,
@@ -7273,7 +7316,12 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/literature-review",
       "relPath": "scientific-skills/literature-review",
       "verified": true,
@@ -7410,7 +7458,12 @@
       "license": "Apache-2.0",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/markdown-mermaid-writing",
       "relPath": "scientific-skills/markdown-mermaid-writing",
       "verified": true,
@@ -7547,7 +7600,12 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/market-research-reports",
       "relPath": "scientific-skills/market-research-reports",
       "verified": true,
@@ -7684,7 +7742,12 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/markitdown",
       "relPath": "scientific-skills/markitdown",
       "verified": true,
@@ -10424,7 +10487,12 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/peer-review",
       "relPath": "scientific-skills/peer-review",
       "verified": true,
@@ -11246,7 +11314,12 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pptx-posters",
       "relPath": "scientific-skills/pptx-posters",
       "verified": true,
@@ -13301,7 +13374,12 @@
       "license": "MIT License",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pyzotero",
       "relPath": "scientific-skills/pyzotero",
       "verified": true,
@@ -13849,7 +13927,12 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/research-grants",
       "relPath": "scientific-skills/research-grants",
       "verified": true,
@@ -13986,7 +14069,12 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "parallel-cli required (primary); PARALLEL_API_KEY and OPENROUTER_API_KEY optional for deep/academic backends",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/research-lookup",
       "relPath": "scientific-skills/research-lookup",
       "verified": true,
@@ -14671,7 +14759,12 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-critical-thinking",
       "relPath": "scientific-skills/scientific-critical-thinking",
       "verified": true,
@@ -14808,7 +14901,12 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-schematics",
       "relPath": "scientific-skills/scientific-schematics",
       "verified": true,
@@ -14945,7 +15043,12 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-slides",
       "relPath": "scientific-skills/scientific-slides",
       "verified": true,
@@ -15219,7 +15322,12 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-writing",
       "relPath": "scientific-skills/scientific-writing",
       "verified": true,
@@ -17137,7 +17245,12 @@
       "license": "Apache-2.0 license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/timesfm-forecasting",
       "relPath": "scientific-skills/timesfm-forecasting",
       "verified": true,
@@ -17685,7 +17798,12 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/treatment-plans",
       "relPath": "scientific-skills/treatment-plans",
       "verified": true,
@@ -18233,7 +18351,12 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/venue-templates",
       "relPath": "scientific-skills/venue-templates",
       "verified": true,
@@ -18370,7 +18493,10 @@
       "license": "MIT license",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write"],
+      "allowedTools": [
+        "Read",
+        "Write"
+      ],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/what-if-oracle",
       "relPath": "scientific-skills/what-if-oracle",
       "verified": true,
@@ -18773,6 +18899,2912 @@
           "evaluatedVersion": "0.0.0"
         }
       }
+    }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "k-dense-ai-claude-scientific-skills-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from K-Dense-AI/claude-scientific-skills.",
+      "author": "ASM (K-Dense-AI/claude-scientific-skills)",
+      "createdAt": "2026-05-09T08:10:53.521Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "k-dense-ai",
+        "claude-scientific-skills"
+      ],
+      "skills": [
+        {
+          "name": "astropy",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/astropy",
+          "description": "Comprehensive Python library for astronomy and astrophysics. This skill should be used when working with astronomical data including celestial coordinates, physical units, FITS files, cosmological calculations, time systems, tables, world coordinate systems (WCS), and astronomical data analysis. Use when tasks involve coordinate transformations, unit conversions, FITS file manipulation, cosmological distance calculations, time scale conversions, or astronomical data processing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bioservices",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/bioservices",
+          "description": "Unified Python interface to 40+ bioinformatics services. Use when querying multiple databases (UniProt, KEGG, ChEMBL, Reactome) in a single workflow with consistent API. Best for cross-database analysis, ID mapping across services. For quick single-database lookups use gget; for sequence/file manipulation use biopython.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cellxgene-census",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/cellxgene-census",
+          "description": "Query the CELLxGENE Census (61M+ cells) programmatically. Use when you need expression data across tissues, diseases, or cell types from the largest curated single-cell atlas. Best for population-scale queries, reference atlas comparisons. For analyzing your own data use scanpy or scvi-tools.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dask",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/dask",
+          "description": "Distributed computing for larger-than-RAM pandas/NumPy workflows. Use when you need to scale existing pandas/NumPy code beyond memory or across clusters. Best for parallel file processing, distributed ML, integration with existing pandas code. For out-of-core analytics on single machine use vaex; for in-memory speed use polars.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deeptools",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/deeptools",
+          "description": "NGS analysis toolkit. BAM to bigWig conversion, QC (correlation, PCA, fingerprints), heatmaps/profiles (TSS, peaks), for ChIP-seq, RNA-seq, ATAC-seq visualization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dhdna-profiler",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/dhdna-profiler",
+          "description": "Extract cognitive patterns and thinking fingerprints from any text. Use this skill when the user wants to analyze how someone thinks, understand cognitive style, profile writing or speech patterns, compare thinking styles between people, asks \"what's my thinking style\", \"analyze how this person reasons\", \"cognitive profile\", \"thinking pattern\", \"DHDNA\", \"digital DNA\", or wants to understand the mind behind any text. Also trigger when the user provides text and wants deeper insight into the author's reasoning patterns, decision-making style, or cognitive signature.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "esm",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/esm",
+          "description": "Comprehensive toolkit for protein language models including ESM3 (generative multimodal protein design across sequence, structure, and function) and ESM C (efficient protein embeddings and representations). Use this skill when working with protein sequences, structures, or function prediction; designing novel proteins; generating protein embeddings; performing inverse folding; or conducting protein engineering tasks. Supports both local model usage and cloud-based Forge API for scalable inference.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "exploratory-data-analysis",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/exploratory-data-analysis",
+          "description": "Perform comprehensive exploratory data analysis on scientific data files across 200+ file formats. This skill should be used when analyzing any scientific data file to understand its structure, content, quality, and characteristics. Automatically detects file type and generates detailed markdown reports with format-specific analysis, quality metrics, and downstream analysis recommendations. Covers chemistry, bioinformatics, microscopy, spectroscopy, proteomics, metabolomics, and general scientific data formats.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hugging-science",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hugging-science",
+          "description": "Use when the user is doing AI/ML work in a scientific domain — biology, chemistry, physics, astronomy, climate, genomics, materials science, medicine, ecology, energy, conservation, engineering, mathematics, scientific reasoning, drug discovery, protein design, weather modeling, theorem proving, single-cell, PDE solving, or anything similar. Hugging Science (huggingscience.co) is a curated catalog of scientific datasets, models, blog posts, and interactive Spaces; the `hugging-science` org on Hugging Face hosts community datasets, models, and demo Spaces. This skill helps you discover the right resource AND actually use it — loading datasets via `datasets`, running models via `transformers` or the HF Inference API, calling Spaces like BoltzGen via `gradio_client`, and citing blog posts for methodology. Trigger this skill whenever a user mentions a scientific ML task, asks for \"a dataset/model for X\" where X is a scientific topic, wants to fine-tune on scientific data, asks about protein / molecule / genome / climate / materials / astronomy / pathology / weather ML, or needs AI tools for research — even if they never say \"Hugging Science\" explicitly. The catalog is purpose-built for LLM agents (it ships an `llms-full.txt`); prefer it over generic web search for these tasks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "literature-review",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/literature-review",
+          "description": "Conduct comprehensive, systematic literature reviews using multiple academic databases (PubMed, arXiv, bioRxiv, Semantic Scholar, etc.). This skill should be used when conducting systematic literature reviews, meta-analyses, research synthesis, or comprehensive literature searches across biomedical, scientific, and technical domains. Creates professionally formatted markdown documents and PDFs with verified citations in multiple citation styles (APA, Nature, Vancouver, etc.).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "networkx",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/networkx",
+          "description": "Comprehensive toolkit for creating, analyzing, and visualizing complex networks and graphs in Python. Use when working with network/graph data structures, analyzing relationships between entities, computing graph algorithms (shortest paths, centrality, clustering), detecting communities, generating synthetic networks, or visualizing network topologies. Applicable to social networks, biological networks, transportation systems, citation networks, and any domain involving pairwise relationships.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "omero-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/omero-integration",
+          "description": "Microscopy data management platform. Access images via Python, retrieve datasets, analyze pixels, manage ROIs/annotations, batch processing, for high-content screening and microscopy workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "open-notebook",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/open-notebook",
+          "description": "Self-hosted, open-source alternative to Google NotebookLM for AI-powered research and document analysis. Use when organizing research materials into notebooks, ingesting diverse content sources (PDFs, videos, audio, web pages, Office documents), generating AI-powered notes and summaries, creating multi-speaker podcasts from research, chatting with documents using context-aware AI, searching across materials with full-text and vector search, or running custom content transformations. Supports 16+ AI providers including OpenAI, Anthropic, Google, Ollama, Groq, and Mistral with complete data privacy through self-hosting.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "paper-lookup",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/paper-lookup",
+          "description": "Search 10 academic paper databases via REST APIs for research papers, preprints, and scholarly articles. Covers PubMed, PMC (full text), bioRxiv, medRxiv, arXiv, OpenAlex, Crossref, Semantic Scholar, CORE, Unpaywall. Use when searching for papers, citations, DOI/PMID lookups, abstracts, full text, open access, preprints, citation graphs, author search, or any scholarly literature query. Triggers on mentions of any supported database or requests like \"find papers on X\" or \"look up this DOI\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pennylane",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pennylane",
+          "description": "Hardware-agnostic quantum ML framework with automatic differentiation. Use when training quantum circuits via gradients, building hybrid quantum-classical models, or needing device portability across IBM/Google/Rigetti/IonQ. Best for variational algorithms (VQE, QAOA), quantum neural networks, and integration with PyTorch/JAX/TensorFlow. For hardware-specific optimizations use qiskit (IBM) or cirq (Google); for open quantum systems use qutip.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "phylogenetics",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/phylogenetics",
+          "description": "Build and analyze phylogenetic trees using MAFFT (multiple alignment), IQ-TREE 2 (maximum likelihood), and FastTree (fast NJ/ML). Visualize with ETE3 or FigTree. For evolutionary analysis, microbial genomics, viral phylodynamics, protein family analysis, and molecular clock studies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pydicom",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pydicom",
+          "description": "Python library for working with DICOM (Digital Imaging and Communications in Medicine) files. Use this skill when reading, writing, or modifying medical imaging data in DICOM format, extracting pixel data from medical images (CT, MRI, X-ray, ultrasound), anonymizing DICOM files, working with DICOM metadata and tags, converting DICOM images to other formats, handling compressed DICOM data, or processing medical imaging datasets. Applies to tasks involving medical image analysis, PACS systems, radiology workflows, and healthcare imaging applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pyhealth",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pyhealth",
+          "description": "Build clinical/healthcare deep-learning pipelines with PyHealth — loading EHR/signal/imaging datasets (MIMIC-III/IV, eICU, OMOP, SleepEDF, ChestXray14, EHRShot), defining tasks (mortality, readmission, length-of-stay, drug recommendation, sleep staging, ICD coding, EEG events), instantiating models (Transformer, RETAIN, GAMENet, SafeDrug, MICRON, StageNet, AdaCare, CNN/RNN/MLP), training with the PyHealth Trainer, computing clinical metrics, and using medical code utilities (ICD/ATC/NDC/RxNorm lookup and cross-mapping). Use this skill whenever the user mentions PyHealth, MIMIC, eICU, OMOP, EHR modeling, clinical prediction, drug recommendation, sleep staging, medical code mapping, ICD/ATC codes, or any healthcare ML pipeline that fits the dataset → task → model → trainer → metrics pattern, even if \"PyHealth\" isn't named explicitly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pylabrobot",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pylabrobot",
+          "description": "Vendor-agnostic lab automation framework. Use when controlling multiple equipment types (Hamilton, Tecan, Opentrons, plate readers, pumps) or needing unified programming across different vendors. Best for complex workflows, multi-vendor setups, simulation. For Opentrons-only protocols with official API, opentrons-integration may be simpler.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pymatgen",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pymatgen",
+          "description": "Materials science toolkit. Crystal structures (CIF, POSCAR), phase diagrams, band structure, DOS, Materials Project integration, format conversion, for computational materials science.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "rowan",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/rowan",
+          "description": "Rowan is a cloud-native molecular modeling and medicinal-chemistry workflow platform with a Python API. Use for pKa and macropKa prediction, conformer and tautomer ensembles, docking and analogue docking, protein-ligand cofolding, MSA generation, molecular dynamics, permeability, descriptor workflows, and related small-molecule or protein modeling tasks. Ideal for programmatic batch screening, multi-step chemistry pipelines, and workflows that would otherwise require maintaining local HPC/GPU infrastructure.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scholar-evaluation",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scholar-evaluation",
+          "description": "Systematically evaluate scholarly work using the ScholarEval framework, providing structured assessment across research quality dimensions including problem formulation, methodology, analysis, and writing with quantitative scoring and actionable feedback.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scikit-bio",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scikit-bio",
+          "description": "Biological data toolkit. Sequence analysis, alignments, phylogenetic trees, diversity metrics (alpha/beta, UniFrac), ordination (PCoA), PERMANOVA, FASTA/Newick I/O, for microbiome analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "timesfm-forecasting",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/timesfm-forecasting",
+          "description": "Zero-shot time series forecasting with Google's TimesFM foundation model. Use for any univariate time series (sales, sensors, energy, vitals, weather) without training a custom model. Supports CSV/DataFrame/array inputs with point forecasts and prediction intervals. Includes a preflight system checker script to verify RAM/GPU before first use.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "torchdrug",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/torchdrug",
+          "description": "PyTorch-native graph neural networks for molecules and proteins. Use when building custom GNN architectures for drug discovery, protein modeling, or knowledge graph reasoning. Best for custom model development, protein property prediction, retrosynthesis. For pre-trained models and diverse featurizers use deepchem; for benchmark datasets use pytdc.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "K-Dense-AI",
+        "repo": "claude-scientific-skills",
+        "repoUrl": "https://github.com/K-Dense-AI/claude-scientific-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "k-dense-ai-claude-scientific-skills-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from K-Dense-AI/claude-scientific-skills.",
+      "author": "ASM (K-Dense-AI/claude-scientific-skills)",
+      "createdAt": "2026-05-09T08:10:53.521Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "k-dense-ai",
+        "claude-scientific-skills"
+      ],
+      "skills": [
+        {
+          "name": "autoskill",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/autoskill",
+          "description": "Observe the user's screen via screenpipe, detect repeated research workflows, match them against existing scientific-agent-skills, and draft new skills (or composition recipes that chain existing ones) for the patterns not yet covered. Use when the user asks to analyze their recent work and propose skills based on what they actually do. Requires the screenpipe daemon (https://github.com/screenpipe/screenpipe) running locally on port 3030 — the skill has no other data source and will refuse to run if screenpipe is unreachable. All detection runs locally; only redacted cluster summaries reach the LLM.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bgpt-paper-search",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/bgpt-paper-search",
+          "description": "Search scientific papers and retrieve structured experimental data extracted from full-text studies via the BGPT MCP server. Returns 25+ fields per paper including methods, results, sample sizes, quality scores, and conclusions. Use for literature reviews, evidence synthesis, and finding experimental details not available in abstracts alone.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "citation-management",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/citation-management",
+          "description": "Comprehensive citation management for academic research. Search Google Scholar and PubMed for papers, extract accurate metadata, validate citations, and generate properly formatted BibTeX entries. This skill should be used when you need to find papers, verify citation information, convert DOIs to BibTeX, or ensure reference accuracy in scientific writing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "clinical-decision-support",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/clinical-decision-support",
+          "description": "Generate professional clinical decision support (CDS) documents for pharmaceutical and clinical research settings, including patient cohort analyses (biomarker-stratified with outcomes) and treatment recommendation reports (evidence-based guidelines with decision algorithms). Supports GRADE evidence grading, statistical analysis (hazard ratios, survival curves, waterfall plots), biomarker integration, and regulatory compliance. Outputs publication-ready LaTeX/PDF format optimized for drug development, clinical research, and evidence synthesis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "clinical-reports",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/clinical-reports",
+          "description": "Write comprehensive clinical reports including case reports (CARE guidelines), diagnostic reports (radiology/pathology/lab), clinical trial reports (ICH-E3, SAE, CSR), and patient documentation (SOAP, H&P, discharge summaries). Full support with templates, regulatory compliance (HIPAA, FDA, ICH-GCP), and validation tools.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dhdna-profiler",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/dhdna-profiler",
+          "description": "Extract cognitive patterns and thinking fingerprints from any text. Use this skill when the user wants to analyze how someone thinks, understand cognitive style, profile writing or speech patterns, compare thinking styles between people, asks \"what's my thinking style\", \"analyze how this person reasons\", \"cognitive profile\", \"thinking pattern\", \"DHDNA\", \"digital DNA\", or wants to understand the mind behind any text. Also trigger when the user provides text and wants deeper insight into the author's reasoning patterns, decision-making style, or cognitive signature.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docx",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/docx",
+          "description": "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of 'Word doc', 'word document', '.docx', or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting or reorganizing content from .docx files, inserting or replacing images in documents, performing find-and-replace in Word files, working with tracked changes or comments, or converting content into a polished Word document. If the user asks for a 'report', 'memo', 'letter', 'template', or similar deliverable as a Word or .docx file, use this skill. Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks unrelated to document generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "exa-search",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/exa-search",
+          "description": "Web toolkit powered by Exa, tuned for scientific and technical content. Use this skill when the user needs to search the web or fetch/extract URL content. Covers: web search (semantic lookups, research, current info — with optional research-paper category and academic domain filtering) and URL extraction (fetching pages, articles, academic PDFs in batch). Use this skill for web-related tasks when the user wants high-quality search or scholarly filtering via category=research paper. Triggers on requests to search, look up, fetch a page, or extract an article.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "exploratory-data-analysis",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/exploratory-data-analysis",
+          "description": "Perform comprehensive exploratory data analysis on scientific data files across 200+ file formats. This skill should be used when analyzing any scientific data file to understand its structure, content, quality, and characteristics. Automatically detects file type and generates detailed markdown reports with format-specific analysis, quality metrics, and downstream analysis recommendations. Covers chemistry, bioinformatics, microscopy, spectroscopy, proteomics, metabolomics, and general scientific data formats.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "geopandas",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geopandas",
+          "description": "Python library for working with geospatial vector data including shapefiles, GeoJSON, and GeoPackage files. Use when working with geographic data for spatial analysis, geometric operations, coordinate transformations, spatial joins, overlay operations, choropleth mapping, or any task involving reading/writing/analyzing vector geographic data. Supports PostGIS databases, interactive maps, and integration with matplotlib/folium/cartopy. Use for tasks like buffer analysis, spatial joins between datasets, dissolving boundaries, clipping data, calculating areas/distances, reprojecting coordinate systems, creating maps, or converting between spatial file formats.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hugging-science",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hugging-science",
+          "description": "Use when the user is doing AI/ML work in a scientific domain — biology, chemistry, physics, astronomy, climate, genomics, materials science, medicine, ecology, energy, conservation, engineering, mathematics, scientific reasoning, drug discovery, protein design, weather modeling, theorem proving, single-cell, PDE solving, or anything similar. Hugging Science (huggingscience.co) is a curated catalog of scientific datasets, models, blog posts, and interactive Spaces; the `hugging-science` org on Hugging Face hosts community datasets, models, and demo Spaces. This skill helps you discover the right resource AND actually use it — loading datasets via `datasets`, running models via `transformers` or the HF Inference API, calling Spaces like BoltzGen via `gradio_client`, and citing blog posts for methodology. Trigger this skill whenever a user mentions a scientific ML task, asks for \"a dataset/model for X\" where X is a scientific topic, wants to fine-tune on scientific data, asks about protein / molecule / genome / climate / materials / astronomy / pathology / weather ML, or needs AI tools for research — even if they never say \"Hugging Science\" explicitly. The catalog is purpose-built for LLM agents (it ships an `llms-full.txt`); prefer it over generic web search for these tasks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hypogenic",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hypogenic",
+          "description": "Automated LLM-driven hypothesis generation and testing on tabular datasets. Use when you want to systematically explore hypotheses about patterns in empirical data (e.g., deception detection, content analysis). Combines literature insights with data-driven hypothesis testing. For manual hypothesis formulation use hypothesis-generation; for creative ideation use scientific-brainstorming.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hypothesis-generation",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hypothesis-generation",
+          "description": "Structured hypothesis formulation from observations. Use when you have experimental observations or data and need to formulate testable hypotheses with predictions, propose mechanisms, and design experiments to test them. Follows scientific method framework. For open-ended ideation use scientific-brainstorming; for automated LLM-driven hypothesis testing on datasets use hypogenic.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "iso-13485-certification",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/iso-13485-certification",
+          "description": "Comprehensive toolkit for preparing ISO 13485 certification documentation for medical device Quality Management Systems. Use when users need help with ISO 13485 QMS documentation, including (1) conducting gap analysis of existing documentation, (2) creating Quality Manuals, (3) developing required procedures and work instructions, (4) preparing Medical Device Files, (5) understanding ISO 13485 requirements, or (6) identifying missing documentation for medical device certification. Also use when users mention medical device regulations, QMS certification, FDA QMSR, EU MDR, or need help with quality system documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "literature-review",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/literature-review",
+          "description": "Conduct comprehensive, systematic literature reviews using multiple academic databases (PubMed, arXiv, bioRxiv, Semantic Scholar, etc.). This skill should be used when conducting systematic literature reviews, meta-analyses, research synthesis, or comprehensive literature searches across biomedical, scientific, and technical domains. Creates professionally formatted markdown documents and PDFs with verified citations in multiple citation styles (APA, Nature, Vancouver, etc.).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "markdown-mermaid-writing",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/markdown-mermaid-writing",
+          "description": "Comprehensive markdown and Mermaid diagram writing skill. Use when creating any scientific document, report, analysis, or visualization. Establishes text-based diagrams as the default documentation standard with full style guides (markdown + mermaid), 24 diagram type references, and 9 document templates.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "matlab",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/matlab",
+          "description": "MATLAB and GNU Octave numerical computing for matrix operations, data analysis, visualization, and scientific computing. Use when writing MATLAB/Octave scripts for linear algebra, signal processing, image processing, differential equations, optimization, statistics, or creating scientific visualizations. Also use when the user needs help with MATLAB syntax, functions, or wants to convert between MATLAB and Python code. Scripts can be executed with MATLAB or the open-source GNU Octave interpreter.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "omero-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/omero-integration",
+          "description": "Microscopy data management platform. Access images via Python, retrieve datasets, analyze pixels, manage ROIs/annotations, batch processing, for high-content screening and microscopy workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "open-notebook",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/open-notebook",
+          "description": "Self-hosted, open-source alternative to Google NotebookLM for AI-powered research and document analysis. Use when organizing research materials into notebooks, ingesting diverse content sources (PDFs, videos, audio, web pages, Office documents), generating AI-powered notes and summaries, creating multi-speaker podcasts from research, chatting with documents using context-aware AI, searching across materials with full-text and vector search, or running custom content transformations. Supports 16+ AI providers including OpenAI, Anthropic, Google, Ollama, Groq, and Mistral with complete data privacy through self-hosting.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "opentrons-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/opentrons-integration",
+          "description": "Official Opentrons Protocol API for OT-2 and Flex robots. Use when writing protocols specifically for Opentrons hardware with full access to Protocol API v2 features. Best for production Opentrons protocols, official API compatibility. For multi-vendor automation or broader equipment control use pylabrobot.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "optimize-for-gpu",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/optimize-for-gpu",
+          "description": "GPU-accelerate Python code using CuPy, Numba CUDA, Warp, cuDF, cuML, cuGraph, KvikIO, cuCIM, cuxfilter, cuVS, cuSpatial, and RAFT. Use whenever the user mentions GPU/CUDA/NVIDIA acceleration, or wants to speed up NumPy, pandas, scikit-learn, scikit-image, NetworkX, GeoPandas, or Faiss workloads. Covers physics simulation, differentiable rendering, mesh ray casting, particle systems (DEM/SPH/fluids), vector/similarity search, GPUDirect Storage file IO, interactive dashboards, geospatial analysis, medical imaging, and sparse eigensolvers. Also use when you see CPU-bound Python code (loops, large arrays, ML pipelines, graph analytics, image processing) that would benefit from GPU acceleration, even if not explicitly requested.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "paper-lookup",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/paper-lookup",
+          "description": "Search 10 academic paper databases via REST APIs for research papers, preprints, and scholarly articles. Covers PubMed, PMC (full text), bioRxiv, medRxiv, arXiv, OpenAlex, Crossref, Semantic Scholar, CORE, Unpaywall. Use when searching for papers, citations, DOI/PMID lookups, abstracts, full text, open access, preprints, citation graphs, author search, or any scholarly literature query. Triggers on mentions of any supported database or requests like \"find papers on X\" or \"look up this DOI\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "paperzilla",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/paperzilla",
+          "description": "Chat with your agent about projects, recommendations, and canonical papers in Paperzilla. Use when users ask for recent project recommendations, canonical paper details, markdown-based summaries, recommendation feedback, feed export, or Atom feed URLs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "parallel-web",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/parallel-web",
+          "description": "All-in-one web toolkit powered by parallel-cli, with a strong emphasis on academic and scientific sources. Use this skill whenever the user needs to search the web, fetch/extract URL content, enrich data with web-sourced fields, or run deep research reports. Covers: web search (fast lookups, research, current info — prioritizing peer-reviewed papers, preprints, and scholarly databases), URL extraction (fetching pages, articles, academic PDFs), bulk data enrichment (adding fields to CSV/lists from the web), and deep research (exhaustive multi-source reports grounded in academic literature). Also handles setup, status checks, and result retrieval. Use this skill for ANY web-related task — even if the user doesn't mention 'parallel' or 'web' explicitly. If they want to look something up, fetch a page, enrich a dataset, investigate a topic, find academic papers, check citations, or review scientific literature, this is the skill to use.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "peer-review",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/peer-review",
+          "description": "Structured manuscript/grant review with checklist-based evaluation. Use when writing formal peer reviews with specific criteria methodology assessment, statistical validity, reporting standards compliance (CONSORT/STROBE), and constructive feedback. Best for actual review writing, manuscript revision. For evaluating claims/evidence quality use scientific-critical-thinking; for quantitative scoring frameworks use scholar-evaluation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pptx",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pptx",
+          "description": "Use this skill any time a .pptx file is involved in any way — as input, output, or both. This includes: creating slide decks, pitch decks, or presentations; reading, parsing, or extracting text from any .pptx file (even if the extracted content will be used elsewhere, like in an email or summary); editing, modifying, or updating existing presentations; combining or splitting slide files; working with templates, layouts, speaker notes, or comments. Trigger whenever the user mentions \\\"deck,\\\" \\\"slides,\\\" \\\"presentation,\\\" or references a .pptx filename, regardless of what they plan to do with the content afterward. If a .pptx file needs to be opened, created, or touched, use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "protocolsio-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/protocolsio-integration",
+          "description": "Integration with protocols.io API for managing scientific protocols. This skill should be used when working with protocols.io to search, create, update, or publish protocols; manage protocol steps and materials; handle discussions and comments; organize workspaces; upload and manage files; or integrate protocols.io functionality into workflows. Applicable for protocol discovery, collaborative protocol development, experiment tracking, lab protocol management, and scientific documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pufferlib",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pufferlib",
+          "description": "High-performance reinforcement learning framework optimized for speed and scale. Use when you need fast parallel training, vectorized environments, multi-agent systems, or integration with game environments (Atari, Procgen, NetHack). Achieves 2-10x speedups over standard implementations. For quick prototyping or standard algorithm implementations with extensive documentation, use stable-baselines3 instead.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pydicom",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pydicom",
+          "description": "Python library for working with DICOM (Digital Imaging and Communications in Medicine) files. Use this skill when reading, writing, or modifying medical imaging data in DICOM format, extracting pixel data from medical images (CT, MRI, X-ray, ultrasound), anonymizing DICOM files, working with DICOM metadata and tags, converting DICOM images to other formats, handling compressed DICOM data, or processing medical imaging datasets. Applies to tasks involving medical image analysis, PACS systems, radiology workflows, and healthcare imaging applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pysam",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pysam",
+          "description": "Genomic file toolkit. Read/write SAM/BAM/CRAM alignments, VCF/BCF variants, FASTA/FASTQ sequences, extract regions, calculate coverage, for NGS data processing pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pyzotero",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pyzotero",
+          "description": "Interact with Zotero reference management libraries using the pyzotero Python client. Retrieve, create, update, and delete items, collections, tags, and attachments via the Zotero Web API v3. Use this skill when working with Zotero libraries programmatically, managing bibliographic references, exporting citations, searching library contents, uploading PDF attachments, or building research automation workflows that integrate with Zotero.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "research-grants",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/research-grants",
+          "description": "Write competitive research proposals for NSF, NIH, DOE, DARPA, and Taiwan NSTC. Agency-specific formatting, review criteria, budget preparation, broader impacts, significance statements, innovation narratives, and compliance with submission requirements.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "research-lookup",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/research-lookup",
+          "description": "Look up current research information using parallel-cli search (primary, fast web search), the Parallel Chat API (deep research), or Perplexity sonar-pro-search (academic paper searches). Automatically routes queries to the best backend. Use for finding papers, gathering research data, and verifying scientific information. Note: query text is transmitted to api.parallel.ai (PARALLEL_API_KEY) and, for academic searches, to openrouter.ai (OPENROUTER_API_KEY).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scholar-evaluation",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scholar-evaluation",
+          "description": "Systematically evaluate scholarly work using the ScholarEval framework, providing structured assessment across research quality dimensions including problem formulation, methodology, analysis, and writing with quantitative scoring and actionable feedback.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-brainstorming",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-brainstorming",
+          "description": "Creative research ideation and exploration. Use for open-ended brainstorming sessions, exploring interdisciplinary connections, challenging assumptions, or identifying research gaps. Best for early-stage research planning when you do not have specific observations yet. For formulating testable hypotheses from data use hypothesis-generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-critical-thinking",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-critical-thinking",
+          "description": "Evaluate scientific claims and evidence quality. Use for assessing experimental design validity, identifying biases and confounders, applying evidence grading frameworks (GRADE, Cochrane Risk of Bias), or teaching critical analysis. Best for understanding evidence quality, identifying flaws. For formal peer review writing use peer-review.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-slides",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-slides",
+          "description": "Build slide decks and presentations for research talks. Use this for making PowerPoint slides, conference presentations, seminar talks, research presentations, thesis defense slides, or any scientific talk. Provides slide structure, design templates, timing guidance, and visual validation. Works with PowerPoint and LaTeX Beamer.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-writing",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-writing",
+          "description": "Core skill for the deep research and writing tool. Write scientific manuscripts in full paragraphs (never bullet points). Use two-stage process with (1) section outlines with key points using research-lookup then (2) convert to flowing prose. IMRAD structure, citations (APA/AMA/Vancouver), figures/tables, reporting guidelines (CONSORT/STROBE/PRISMA), for research papers and journal submissions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scikit-learn",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scikit-learn",
+          "description": "Machine learning in Python with scikit-learn. Use when working with supervised learning (classification, regression), unsupervised learning (clustering, dimensionality reduction), model evaluation, hyperparameter tuning, preprocessing, or building ML pipelines. Provides comprehensive reference documentation for algorithms, preprocessing techniques, pipelines, and best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "torchdrug",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/torchdrug",
+          "description": "PyTorch-native graph neural networks for molecules and proteins. Use when building custom GNN architectures for drug discovery, protein modeling, or knowledge graph reasoning. Best for custom model development, protein property prediction, retrosynthesis. For pre-trained models and diverse featurizers use deepchem; for benchmark datasets use pytdc.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "venue-templates",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/venue-templates",
+          "description": "Access comprehensive LaTeX templates, formatting requirements, and submission guidelines for major scientific publication venues (Nature, Science, PLOS, IEEE, ACM), academic conferences (NeurIPS, ICML, CVPR, CHI), research posters, and grant proposals (NSF, NIH, DOE, DARPA). This skill should be used when preparing manuscripts for journal submission, conference papers, research posters, or grant proposals and need venue-specific formatting requirements and templates.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "K-Dense-AI",
+        "repo": "claude-scientific-skills",
+        "repoUrl": "https://github.com/K-Dense-AI/claude-scientific-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "k-dense-ai-claude-scientific-skills-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from K-Dense-AI/claude-scientific-skills.",
+      "author": "ASM (K-Dense-AI/claude-scientific-skills)",
+      "createdAt": "2026-05-09T08:10:53.521Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "k-dense-ai",
+        "claude-scientific-skills"
+      ],
+      "skills": [
+        {
+          "name": "aeon",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/aeon",
+          "description": "This skill should be used for time series machine learning tasks including classification, regression, clustering, forecasting, anomaly detection, segmentation, and similarity search. Use when working with temporal data, sequential patterns, or time-indexed observations requiring specialized algorithms beyond standard ML approaches. Particularly suited for univariate and multivariate time series analysis with scikit-learn compatible APIs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "anndata",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/anndata",
+          "description": "Data structure for annotated matrices in single-cell analysis. Use when working with .h5ad files or integrating with the scverse ecosystem. This is the data format skill—for analysis workflows use scanpy; for probabilistic models use scvi-tools; for population-scale queries use cellxgene-census.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "astropy",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/astropy",
+          "description": "Comprehensive Python library for astronomy and astrophysics. This skill should be used when working with astronomical data including celestial coordinates, physical units, FITS files, cosmological calculations, time systems, tables, world coordinate systems (WCS), and astronomical data analysis. Use when tasks involve coordinate transformations, unit conversions, FITS file manipulation, cosmological distance calculations, time scale conversions, or astronomical data processing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autoskill",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/autoskill",
+          "description": "Observe the user's screen via screenpipe, detect repeated research workflows, match them against existing scientific-agent-skills, and draft new skills (or composition recipes that chain existing ones) for the patterns not yet covered. Use when the user asks to analyze their recent work and propose skills based on what they actually do. Requires the screenpipe daemon (https://github.com/screenpipe/screenpipe) running locally on port 3030 — the skill has no other data source and will refuse to run if screenpipe is unreachable. All detection runs locally; only redacted cluster summaries reach the LLM.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bgpt-paper-search",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/bgpt-paper-search",
+          "description": "Search scientific papers and retrieve structured experimental data extracted from full-text studies via the BGPT MCP server. Returns 25+ fields per paper including methods, results, sample sizes, quality scores, and conclusions. Use for literature reviews, evidence synthesis, and finding experimental details not available in abstracts alone.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bioservices",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/bioservices",
+          "description": "Unified Python interface to 40+ bioinformatics services. Use when querying multiple databases (UniProt, KEGG, ChEMBL, Reactome) in a single workflow with consistent API. Best for cross-database analysis, ID mapping across services. For quick single-database lookups use gget; for sequence/file manipulation use biopython.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "citation-management",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/citation-management",
+          "description": "Comprehensive citation management for academic research. Search Google Scholar and PubMed for papers, extract accurate metadata, validate citations, and generate properly formatted BibTeX entries. This skill should be used when you need to find papers, verify citation information, convert DOIs to BibTeX, or ensure reference accuracy in scientific writing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "clinical-decision-support",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/clinical-decision-support",
+          "description": "Generate professional clinical decision support (CDS) documents for pharmaceutical and clinical research settings, including patient cohort analyses (biomarker-stratified with outcomes) and treatment recommendation reports (evidence-based guidelines with decision algorithms). Supports GRADE evidence grading, statistical analysis (hazard ratios, survival curves, waterfall plots), biomarker integration, and regulatory compliance. Outputs publication-ready LaTeX/PDF format optimized for drug development, clinical research, and evidence synthesis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "clinical-reports",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/clinical-reports",
+          "description": "Write comprehensive clinical reports including case reports (CARE guidelines), diagnostic reports (radiology/pathology/lab), clinical trial reports (ICH-E3, SAE, CSR), and patient documentation (SOAP, H&P, discharge summaries). Full support with templates, regulatory compliance (HIPAA, FDA, ICH-GCP), and validation tools.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cobrapy",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/cobrapy",
+          "description": "Constraint-based metabolic modeling (COBRA). FBA, FVA, gene knockouts, flux sampling, SBML models, for systems biology and metabolic engineering analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "consciousness-council",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/consciousness-council",
+          "description": "Run a multi-perspective Mind Council deliberation on any question, decision, or creative challenge. Use this skill whenever the user wants diverse viewpoints, needs help making a tough decision, asks for a council/panel/board discussion, wants to explore a problem from multiple angles, requests devil's advocate analysis, or says things like \"what would different experts think about this\", \"help me think through this from all sides\", \"council mode\", \"mind council\", or \"deliberate on this\". Also trigger when the user faces a dilemma, trade-off, or complex choice with no obvious answer.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deeptools",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/deeptools",
+          "description": "NGS analysis toolkit. BAM to bigWig conversion, QC (correlation, PCA, fingerprints), heatmaps/profiles (TSS, peaks), for ChIP-seq, RNA-seq, ATAC-seq visualization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "exa-search",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/exa-search",
+          "description": "Web toolkit powered by Exa, tuned for scientific and technical content. Use this skill when the user needs to search the web or fetch/extract URL content. Covers: web search (semantic lookups, research, current info — with optional research-paper category and academic domain filtering) and URL extraction (fetching pages, articles, academic PDFs in batch). Use this skill for web-related tasks when the user wants high-quality search or scholarly filtering via category=research paper. Triggers on requests to search, look up, fetch a page, or extract an article.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "exploratory-data-analysis",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/exploratory-data-analysis",
+          "description": "Perform comprehensive exploratory data analysis on scientific data files across 200+ file formats. This skill should be used when analyzing any scientific data file to understand its structure, content, quality, and characteristics. Automatically detects file type and generates detailed markdown reports with format-specific analysis, quality metrics, and downstream analysis recommendations. Covers chemistry, bioinformatics, microscopy, spectroscopy, proteomics, metabolomics, and general scientific data formats.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fluidsim",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/fluidsim",
+          "description": "Framework for computational fluid dynamics simulations using Python. Use when running fluid dynamics simulations including Navier-Stokes equations (2D/3D), shallow water equations, stratified flows, or when analyzing turbulence, vortex dynamics, or geophysical flows. Provides pseudospectral methods with FFT, HPC support, and comprehensive output analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "geniml",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geniml",
+          "description": "This skill should be used when working with genomic interval data (BED files) for machine learning tasks. Use for training region embeddings (Region2Vec, BEDspace), single-cell ATAC-seq analysis (scEmbed), building consensus peaks (universes), or any ML-based analysis of genomic regions. Applies to BED file collections, scATAC-seq data, chromatin accessibility datasets, and region-based genomic feature learning.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "geomaster",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geomaster",
+          "description": "Comprehensive geospatial science skill covering remote sensing, GIS, spatial analysis, machine learning for earth observation, and 30+ scientific domains. Supports satellite imagery processing (Sentinel, Landsat, MODIS, SAR, hyperspectral), vector and raster data operations, spatial statistics, point cloud processing, network analysis, cloud-native workflows (STAC, COG, Planetary Computer), and 8 programming languages (Python, R, Julia, JavaScript, C++, Java, Go, Rust) with 500+ code examples. Use for remote sensing workflows, GIS analysis, spatial ML, Earth observation data processing, terrain analysis, hydrological modeling, marine spatial analysis, atmospheric science, and any geospatial computation task.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "geopandas",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geopandas",
+          "description": "Python library for working with geospatial vector data including shapefiles, GeoJSON, and GeoPackage files. Use when working with geographic data for spatial analysis, geometric operations, coordinate transformations, spatial joins, overlay operations, choropleth mapping, or any task involving reading/writing/analyzing vector geographic data. Supports PostGIS databases, interactive maps, and integration with matplotlib/folium/cartopy. Use for tasks like buffer analysis, spatial joins between datasets, dissolving boundaries, clipping data, calculating areas/distances, reprojecting coordinate systems, creating maps, or converting between spatial file formats.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gget",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/gget",
+          "description": "Fast CLI/Python queries to 20+ bioinformatics databases. Use for quick lookups: gene info, BLAST searches, AlphaFold structures, enrichment analysis. Best for interactive exploration, simple queries. For batch processing or advanced BLAST use biopython; for multi-database Python workflows use bioservices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtars",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/gtars",
+          "description": "High-performance toolkit for genomic interval analysis in Rust with Python bindings. Use when working with genomic regions, BED files, coverage tracks, overlap detection, tokenization for ML models, or fragment analysis in computational genomics and machine learning applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "histolab",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/histolab",
+          "description": "Lightweight WSI tile extraction and preprocessing. Use for basic slide processing tissue detection, tile extraction, stain normalization for H&E images. Best for simple pipelines, dataset preparation, quick tile-based analysis. For advanced spatial proteomics, multiplexed imaging, or deep learning pipelines use pathml.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hugging-science",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hugging-science",
+          "description": "Use when the user is doing AI/ML work in a scientific domain — biology, chemistry, physics, astronomy, climate, genomics, materials science, medicine, ecology, energy, conservation, engineering, mathematics, scientific reasoning, drug discovery, protein design, weather modeling, theorem proving, single-cell, PDE solving, or anything similar. Hugging Science (huggingscience.co) is a curated catalog of scientific datasets, models, blog posts, and interactive Spaces; the `hugging-science` org on Hugging Face hosts community datasets, models, and demo Spaces. This skill helps you discover the right resource AND actually use it — loading datasets via `datasets`, running models via `transformers` or the HF Inference API, calling Spaces like BoltzGen via `gradio_client`, and citing blog posts for methodology. Trigger this skill whenever a user mentions a scientific ML task, asks for \"a dataset/model for X\" where X is a scientific topic, wants to fine-tune on scientific data, asks about protein / molecule / genome / climate / materials / astronomy / pathology / weather ML, or needs AI tools for research — even if they never say \"Hugging Science\" explicitly. The catalog is purpose-built for LLM agents (it ships an `llms-full.txt`); prefer it over generic web search for these tasks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hypogenic",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hypogenic",
+          "description": "Automated LLM-driven hypothesis generation and testing on tabular datasets. Use when you want to systematically explore hypotheses about patterns in empirical data (e.g., deception detection, content analysis). Combines literature insights with data-driven hypothesis testing. For manual hypothesis formulation use hypothesis-generation; for creative ideation use scientific-brainstorming.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "imaging-data-commons",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/imaging-data-commons",
+          "description": "Query and download public cancer imaging data from NCI Imaging Data Commons using idc-index. Use for accessing large-scale radiology (CT, MR, PET) and pathology datasets for AI training or research. No authentication required. Query by metadata, visualize in browser, check licenses.",
+          "version": "1.4.0"
+        },
+        {
+          "name": "infographics",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/infographics",
+          "description": "Create professional infographics using Nano Banana Pro AI with smart iterative refinement. Uses Gemini 3 Pro for quality review. Integrates research-lookup and web search for accurate data. Supports 10 infographic types, 8 industry styles, and colorblind-safe palettes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "iso-13485-certification",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/iso-13485-certification",
+          "description": "Comprehensive toolkit for preparing ISO 13485 certification documentation for medical device Quality Management Systems. Use when users need help with ISO 13485 QMS documentation, including (1) conducting gap analysis of existing documentation, (2) creating Quality Manuals, (3) developing required procedures and work instructions, (4) preparing Medical Device Files, (5) understanding ISO 13485 requirements, or (6) identifying missing documentation for medical device certification. Also use when users mention medical device regulations, QMS certification, FDA QMSR, EU MDR, or need help with quality system documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "lamindb",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/lamindb",
+          "description": "This skill should be used when working with LaminDB, an open-source data framework for biology that makes data queryable, traceable, reproducible, and FAIR. Use when managing biological datasets (scRNA-seq, spatial, flow cytometry, etc.), tracking computational workflows, curating and validating data with biological ontologies, building data lakehouses, or ensuring data lineage and reproducibility in biological research. Covers data management, annotation, ontologies (genes, cell types, diseases, tissues), schema validation, integrations with workflow managers (Nextflow, Snakemake) and MLOps platforms (W&B, MLflow), and deployment strategies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "latex-posters",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/latex-posters",
+          "description": "Create professional research posters in LaTeX using beamerposter, tikzposter, or baposter. Support for conference presentations, academic posters, and scientific communication. Includes layout design, color schemes, multi-column formats, figure integration, and poster-specific best practices for visual communication.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "literature-review",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/literature-review",
+          "description": "Conduct comprehensive, systematic literature reviews using multiple academic databases (PubMed, arXiv, bioRxiv, Semantic Scholar, etc.). This skill should be used when conducting systematic literature reviews, meta-analyses, research synthesis, or comprehensive literature searches across biomedical, scientific, and technical domains. Creates professionally formatted markdown documents and PDFs with verified citations in multiple citation styles (APA, Nature, Vancouver, etc.).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "markdown-mermaid-writing",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/markdown-mermaid-writing",
+          "description": "Comprehensive markdown and Mermaid diagram writing skill. Use when creating any scientific document, report, analysis, or visualization. Establishes text-based diagrams as the default documentation standard with full style guides (markdown + mermaid), 24 diagram type references, and 9 document templates.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "market-research-reports",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/market-research-reports",
+          "description": "Generate comprehensive market research reports (50+ pages) in the style of top consulting firms (McKinsey, BCG, Gartner). Features professional LaTeX formatting, extensive visual generation with scientific-schematics and generate-image, deep integration with research-lookup for data gathering, and multi-framework strategic analysis including Porter Five Forces, PESTLE, SWOT, TAM/SAM/SOM, and BCG Matrix.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "matlab",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/matlab",
+          "description": "MATLAB and GNU Octave numerical computing for matrix operations, data analysis, visualization, and scientific computing. Use when writing MATLAB/Octave scripts for linear algebra, signal processing, image processing, differential equations, optimization, statistics, or creating scientific visualizations. Also use when the user needs help with MATLAB syntax, functions, or wants to convert between MATLAB and Python code. Scripts can be executed with MATLAB or the open-source GNU Octave interpreter.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "molecular-dynamics",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/molecular-dynamics",
+          "description": "Run and analyze molecular dynamics simulations with OpenMM and MDAnalysis. Set up protein/small molecule systems, define force fields, run energy minimization and production MD, analyze trajectories (RMSD, RMSF, contact maps, free energy surfaces). For structural biology, drug binding, and biophysics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "networkx",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/networkx",
+          "description": "Comprehensive toolkit for creating, analyzing, and visualizing complex networks and graphs in Python. Use when working with network/graph data structures, analyzing relationships between entities, computing graph algorithms (shortest paths, centrality, clustering), detecting communities, generating synthetic networks, or visualizing network topologies. Applicable to social networks, biological networks, transportation systems, citation networks, and any domain involving pairwise relationships.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "neurokit2",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/neurokit2",
+          "description": "Comprehensive biosignal processing toolkit for analyzing physiological data including ECG, EEG, EDA, RSP, PPG, EMG, and EOG signals. Use this skill when processing cardiovascular signals, brain activity, electrodermal responses, respiratory patterns, muscle activity, or eye movements. Applicable for heart rate variability analysis, event-related potentials, complexity measures, autonomic nervous system assessment, psychophysiology research, and multi-modal physiological signal integration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "neuropixels-analysis",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/neuropixels-analysis",
+          "description": "Neuropixels neural recording analysis. Load SpikeGLX/OpenEphys data, preprocess, motion correction, Kilosort4 spike sorting, quality metrics, Allen/IBL curation, AI-assisted visual analysis, for Neuropixels 1.0/2.0 extracellular electrophysiology. Use when working with neural recordings, spike sorting, extracellular electrophysiology, or when the user mentions Neuropixels, SpikeGLX, Open Ephys, Kilosort, quality metrics, or unit curation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "open-notebook",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/open-notebook",
+          "description": "Self-hosted, open-source alternative to Google NotebookLM for AI-powered research and document analysis. Use when organizing research materials into notebooks, ingesting diverse content sources (PDFs, videos, audio, web pages, Office documents), generating AI-powered notes and summaries, creating multi-speaker podcasts from research, chatting with documents using context-aware AI, searching across materials with full-text and vector search, or running custom content transformations. Supports 16+ AI providers including OpenAI, Anthropic, Google, Ollama, Groq, and Mistral with complete data privacy through self-hosting.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "optimize-for-gpu",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/optimize-for-gpu",
+          "description": "GPU-accelerate Python code using CuPy, Numba CUDA, Warp, cuDF, cuML, cuGraph, KvikIO, cuCIM, cuxfilter, cuVS, cuSpatial, and RAFT. Use whenever the user mentions GPU/CUDA/NVIDIA acceleration, or wants to speed up NumPy, pandas, scikit-learn, scikit-image, NetworkX, GeoPandas, or Faiss workloads. Covers physics simulation, differentiable rendering, mesh ray casting, particle systems (DEM/SPH/fluids), vector/similarity search, GPUDirect Storage file IO, interactive dashboards, geospatial analysis, medical imaging, and sparse eigensolvers. Also use when you see CPU-bound Python code (loops, large arrays, ML pipelines, graph analytics, image processing) that would benefit from GPU acceleration, even if not explicitly requested.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "paper-lookup",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/paper-lookup",
+          "description": "Search 10 academic paper databases via REST APIs for research papers, preprints, and scholarly articles. Covers PubMed, PMC (full text), bioRxiv, medRxiv, arXiv, OpenAlex, Crossref, Semantic Scholar, CORE, Unpaywall. Use when searching for papers, citations, DOI/PMID lookups, abstracts, full text, open access, preprints, citation graphs, author search, or any scholarly literature query. Triggers on mentions of any supported database or requests like \"find papers on X\" or \"look up this DOI\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "paperzilla",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/paperzilla",
+          "description": "Chat with your agent about projects, recommendations, and canonical papers in Paperzilla. Use when users ask for recent project recommendations, canonical paper details, markdown-based summaries, recommendation feedback, feed export, or Atom feed URLs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "parallel-web",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/parallel-web",
+          "description": "All-in-one web toolkit powered by parallel-cli, with a strong emphasis on academic and scientific sources. Use this skill whenever the user needs to search the web, fetch/extract URL content, enrich data with web-sourced fields, or run deep research reports. Covers: web search (fast lookups, research, current info — prioritizing peer-reviewed papers, preprints, and scholarly databases), URL extraction (fetching pages, articles, academic PDFs), bulk data enrichment (adding fields to CSV/lists from the web), and deep research (exhaustive multi-source reports grounded in academic literature). Also handles setup, status checks, and result retrieval. Use this skill for ANY web-related task — even if the user doesn't mention 'parallel' or 'web' explicitly. If they want to look something up, fetch a page, enrich a dataset, investigate a topic, find academic papers, check citations, or review scientific literature, this is the skill to use.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pathml",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pathml",
+          "description": "Full-featured computational pathology toolkit. Use for advanced WSI analysis including multiplexed immunofluorescence (CODEX, Vectra), nucleus segmentation, tissue graph construction, and ML model training on pathology data. Supports 160+ slide formats. For simple tile extraction from H&E slides, histolab may be simpler.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "peer-review",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/peer-review",
+          "description": "Structured manuscript/grant review with checklist-based evaluation. Use when writing formal peer reviews with specific criteria methodology assessment, statistical validity, reporting standards compliance (CONSORT/STROBE), and constructive feedback. Best for actual review writing, manuscript revision. For evaluating claims/evidence quality use scientific-critical-thinking; for quantitative scoring frameworks use scholar-evaluation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "phylogenetics",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/phylogenetics",
+          "description": "Build and analyze phylogenetic trees using MAFFT (multiple alignment), IQ-TREE 2 (maximum likelihood), and FastTree (fast NJ/ML). Visualize with ETE3 or FigTree. For evolutionary analysis, microbial genomics, viral phylodynamics, protein family analysis, and molecular clock studies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pptx",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pptx",
+          "description": "Use this skill any time a .pptx file is involved in any way — as input, output, or both. This includes: creating slide decks, pitch decks, or presentations; reading, parsing, or extracting text from any .pptx file (even if the extracted content will be used elsewhere, like in an email or summary); editing, modifying, or updating existing presentations; combining or splitting slide files; working with templates, layouts, speaker notes, or comments. Trigger whenever the user mentions \\\"deck,\\\" \\\"slides,\\\" \\\"presentation,\\\" or references a .pptx filename, regardless of what they plan to do with the content afterward. If a .pptx file needs to be opened, created, or touched, use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pptx-posters",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pptx-posters",
+          "description": "Create research posters using HTML/CSS that can be exported to PDF or PPTX. Use this skill ONLY when the user explicitly requests PowerPoint/PPTX poster format. For standard research posters, use latex-posters instead. This skill provides modern web-based poster design with responsive layouts and easy visual integration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pydeseq2",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pydeseq2",
+          "description": "Differential gene expression analysis (Python DESeq2). Identify DE genes from bulk RNA-seq counts, Wald tests, FDR correction, volcano/MA plots, for RNA-seq analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pydicom",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pydicom",
+          "description": "Python library for working with DICOM (Digital Imaging and Communications in Medicine) files. Use this skill when reading, writing, or modifying medical imaging data in DICOM format, extracting pixel data from medical images (CT, MRI, X-ray, ultrasound), anonymizing DICOM files, working with DICOM metadata and tags, converting DICOM images to other formats, handling compressed DICOM data, or processing medical imaging datasets. Applies to tasks involving medical image analysis, PACS systems, radiology workflows, and healthcare imaging applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pyopenms",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pyopenms",
+          "description": "Complete mass spectrometry analysis platform. Use for proteomics workflows feature detection, peptide identification, protein quantification, and complex LC-MS/MS pipelines. Supports extensive file formats and algorithms. Best for proteomics, comprehensive MS data processing. For simple spectral comparison and metabolite ID use matchms.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pyzotero",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pyzotero",
+          "description": "Interact with Zotero reference management libraries using the pyzotero Python client. Retrieve, create, update, and delete items, collections, tags, and attachments via the Zotero Web API v3. Use this skill when working with Zotero libraries programmatically, managing bibliographic references, exporting citations, searching library contents, uploading PDF attachments, or building research automation workflows that integrate with Zotero.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "qutip",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/qutip",
+          "description": "Quantum physics simulation library for open quantum systems. Use when studying master equations, Lindblad dynamics, decoherence, quantum optics, or cavity QED. Best for physics research, open system dynamics, and educational simulations. NOT for circuit-based quantum computing—use qiskit, cirq, or pennylane for quantum algorithms and hardware execution.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "research-grants",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/research-grants",
+          "description": "Write competitive research proposals for NSF, NIH, DOE, DARPA, and Taiwan NSTC. Agency-specific formatting, review criteria, budget preparation, broader impacts, significance statements, innovation narratives, and compliance with submission requirements.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "research-lookup",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/research-lookup",
+          "description": "Look up current research information using parallel-cli search (primary, fast web search), the Parallel Chat API (deep research), or Perplexity sonar-pro-search (academic paper searches). Automatically routes queries to the best backend. Use for finding papers, gathering research data, and verifying scientific information. Note: query text is transmitted to api.parallel.ai (PARALLEL_API_KEY) and, for academic searches, to openrouter.ai (OPENROUTER_API_KEY).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scanpy",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scanpy",
+          "description": "Standard single-cell RNA-seq analysis pipeline. Use for QC, normalization, dimensionality reduction (PCA/UMAP/t-SNE), clustering, differential expression, and visualization. Best for exploratory scRNA-seq analysis with established workflows. For deep learning models use scvi-tools; for data format questions use anndata.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scholar-evaluation",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scholar-evaluation",
+          "description": "Systematically evaluate scholarly work using the ScholarEval framework, providing structured assessment across research quality dimensions including problem formulation, methodology, analysis, and writing with quantitative scoring and actionable feedback.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-brainstorming",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-brainstorming",
+          "description": "Creative research ideation and exploration. Use for open-ended brainstorming sessions, exploring interdisciplinary connections, challenging assumptions, or identifying research gaps. Best for early-stage research planning when you do not have specific observations yet. For formulating testable hypotheses from data use hypothesis-generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-critical-thinking",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-critical-thinking",
+          "description": "Evaluate scientific claims and evidence quality. Use for assessing experimental design validity, identifying biases and confounders, applying evidence grading frameworks (GRADE, Cochrane Risk of Bias), or teaching critical analysis. Best for understanding evidence quality, identifying flaws. For formal peer review writing use peer-review.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-schematics",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-schematics",
+          "description": "Create publication-quality scientific diagrams using Nano Banana 2 AI with smart iterative refinement. Uses Gemini 3.1 Pro Preview for quality review. Only regenerates if quality is below threshold for your document type. Specialized in neural network architectures, system diagrams, flowcharts, biological pathways, and complex scientific visualizations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-slides",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-slides",
+          "description": "Build slide decks and presentations for research talks. Use this for making PowerPoint slides, conference presentations, seminar talks, research presentations, thesis defense slides, or any scientific talk. Provides slide structure, design templates, timing guidance, and visual validation. Works with PowerPoint and LaTeX Beamer.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-writing",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-writing",
+          "description": "Core skill for the deep research and writing tool. Write scientific manuscripts in full paragraphs (never bullet points). Use two-stage process with (1) section outlines with key points using research-lookup then (2) convert to flowing prose. IMRAD structure, citations (APA/AMA/Vancouver), figures/tables, reporting guidelines (CONSORT/STROBE/PRISMA), for research papers and journal submissions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scikit-bio",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scikit-bio",
+          "description": "Biological data toolkit. Sequence analysis, alignments, phylogenetic trees, diversity metrics (alpha/beta, UniFrac), ordination (PCoA), PERMANOVA, FASTA/Newick I/O, for microbiome analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scikit-survival",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scikit-survival",
+          "description": "Comprehensive toolkit for survival analysis and time-to-event modeling in Python using scikit-survival. Use this skill when working with censored survival data, performing time-to-event analysis, fitting Cox models, Random Survival Forests, Gradient Boosting models, or Survival SVMs, evaluating survival predictions with concordance index or Brier score, handling competing risks, or implementing any survival analysis workflow with the scikit-survival library.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scvelo",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scvelo",
+          "description": "RNA velocity analysis with scVelo. Estimate cell state transitions from unspliced/spliced mRNA dynamics, infer trajectory directions, compute latent time, and identify driver genes in single-cell RNA-seq data. Complements Scanpy/scVI-tools for trajectory inference.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scvi-tools",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scvi-tools",
+          "description": "Deep generative models for single-cell omics. Use when you need probabilistic batch correction (scVI), transfer learning, differential expression with uncertainty, or multi-modal integration (TOTALVI, MultiVI). Best for advanced modeling, batch effects, multimodal data. For standard analysis pipelines use scanpy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "statistical-analysis",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/statistical-analysis",
+          "description": "Guided statistical analysis with test selection and reporting. Use when you need help choosing appropriate tests for your data, assumption checking, power analysis, and APA-formatted results. Best for academic research reporting, test selection guidance. For implementing specific models programmatically use statsmodels.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "statsmodels",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/statsmodels",
+          "description": "Statistical models library for Python. Use when you need specific model classes (OLS, GLM, mixed models, ARIMA) with detailed diagnostics, residuals, and inference. Best for econometrics, time series, rigorous inference with coefficient tables. For guided statistical test selection with APA reporting use statistical-analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "timesfm-forecasting",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/timesfm-forecasting",
+          "description": "Zero-shot time series forecasting with Google's TimesFM foundation model. Use for any univariate time series (sales, sensors, energy, vitals, weather) without training a custom model. Supports CSV/DataFrame/array inputs with point forecasts and prediction intervals. Includes a preflight system checker script to verify RAM/GPU before first use.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "transformers",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/transformers",
+          "description": "This skill should be used when working with pre-trained transformer models for natural language processing, computer vision, audio, or multimodal tasks. Use for text generation, classification, question answering, translation, summarization, image classification, object detection, speech recognition, and fine-tuning models on custom datasets.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "treatment-plans",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/treatment-plans",
+          "description": "Generate concise (3-4 page), focused medical treatment plans in LaTeX/PDF format for all clinical specialties. Supports general medical treatment, rehabilitation therapy, mental health care, chronic disease management, perioperative care, and pain management. Includes SMART goal frameworks, evidence-based interventions with minimal text citations, regulatory compliance (HIPAA), and professional formatting. Prioritizes brevity and clinical actionability.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "venue-templates",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/venue-templates",
+          "description": "Access comprehensive LaTeX templates, formatting requirements, and submission guidelines for major scientific publication venues (Nature, Science, PLOS, IEEE, ACM), academic conferences (NeurIPS, ICML, CVPR, CHI), research posters, and grant proposals (NSF, NIH, DOE, DARPA). This skill should be used when preparing manuscripts for journal submission, conference papers, research posters, or grant proposals and need venue-specific formatting requirements and templates.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "what-if-oracle",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/what-if-oracle",
+          "description": "Run structured What-If scenario analysis with multi-branch possibility exploration. Use this skill when the user asks speculative questions like \"what if...\", \"what would happen if...\", \"what are the possibilities\", \"explore scenarios\", \"scenario analysis\", \"possibility space\", \"what could go wrong\", \"best case / worst case\", \"risk analysis\", \"contingency planning\", \"strategic options\", or any question about uncertain futures. Also trigger when the user faces a fork-in-the-road decision, wants to stress-test an idea, or needs to think through consequences before committing.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "K-Dense-AI",
+        "repo": "claude-scientific-skills",
+        "repoUrl": "https://github.com/K-Dense-AI/claude-scientific-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "k-dense-ai-claude-scientific-skills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from K-Dense-AI/claude-scientific-skills.",
+      "author": "ASM (K-Dense-AI/claude-scientific-skills)",
+      "createdAt": "2026-05-09T08:10:53.521Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "k-dense-ai",
+        "claude-scientific-skills"
+      ],
+      "skills": [
+        {
+          "name": "adaptyv",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/adaptyv",
+          "description": "How to use the Adaptyv Bio Foundry API and Python SDK for protein experiment design, submission, and results retrieval. Use this skill whenever the user mentions Adaptyv, Foundry API, protein binding assays, protein screening experiments, BLI/SPR assays, thermostability assays, or wants to submit protein sequences for experimental characterization. Also trigger when code imports `adaptyv`, `adaptyv_sdk`, or `FoundryClient`, or references `foundry-api-public.adaptyvbio.com`.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aeon",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/aeon",
+          "description": "This skill should be used for time series machine learning tasks including classification, regression, clustering, forecasting, anomaly detection, segmentation, and similarity search. Use when working with temporal data, sequential patterns, or time-indexed observations requiring specialized algorithms beyond standard ML approaches. Particularly suited for univariate and multivariate time series analysis with scikit-learn compatible APIs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "astropy",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/astropy",
+          "description": "Comprehensive Python library for astronomy and astrophysics. This skill should be used when working with astronomical data including celestial coordinates, physical units, FITS files, cosmological calculations, time systems, tables, world coordinate systems (WCS), and astronomical data analysis. Use when tasks involve coordinate transformations, unit conversions, FITS file manipulation, cosmological distance calculations, time scale conversions, or astronomical data processing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "benchling-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/benchling-integration",
+          "description": "Benchling R&D platform integration. Access registry (DNA, proteins), inventory, ELN entries, workflows via API, build Benchling Apps, query Data Warehouse, for lab data management automation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bgpt-paper-search",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/bgpt-paper-search",
+          "description": "Search scientific papers and retrieve structured experimental data extracted from full-text studies via the BGPT MCP server. Returns 25+ fields per paper including methods, results, sample sizes, quality scores, and conclusions. Use for literature reviews, evidence synthesis, and finding experimental details not available in abstracts alone.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "biopython",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/biopython",
+          "description": "Comprehensive molecular biology toolkit. Use for sequence manipulation, file parsing (FASTA/GenBank/PDB), phylogenetics, and programmatic NCBI/PubMed access (Bio.Entrez). Best for batch processing, custom bioinformatics pipelines, BLAST automation. For quick lookups use gget; for multi-service integration use bioservices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bioservices",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/bioservices",
+          "description": "Unified Python interface to 40+ bioinformatics services. Use when querying multiple databases (UniProt, KEGG, ChEMBL, Reactome) in a single workflow with consistent API. Best for cross-database analysis, ID mapping across services. For quick single-database lookups use gget; for sequence/file manipulation use biopython.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "clinical-decision-support",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/clinical-decision-support",
+          "description": "Generate professional clinical decision support (CDS) documents for pharmaceutical and clinical research settings, including patient cohort analyses (biomarker-stratified with outcomes) and treatment recommendation reports (evidence-based guidelines with decision algorithms). Supports GRADE evidence grading, statistical analysis (hazard ratios, survival curves, waterfall plots), biomarker integration, and regulatory compliance. Outputs publication-ready LaTeX/PDF format optimized for drug development, clinical research, and evidence synthesis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "clinical-reports",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/clinical-reports",
+          "description": "Write comprehensive clinical reports including case reports (CARE guidelines), diagnostic reports (radiology/pathology/lab), clinical trial reports (ICH-E3, SAE, CSR), and patient documentation (SOAP, H&P, discharge summaries). Full support with templates, regulatory compliance (HIPAA, FDA, ICH-GCP), and validation tools.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dask",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/dask",
+          "description": "Distributed computing for larger-than-RAM pandas/NumPy workflows. Use when you need to scale existing pandas/NumPy code beyond memory or across clusters. Best for parallel file processing, distributed ML, integration with existing pandas code. For out-of-core analytics on single machine use vaex; for in-memory speed use polars.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "database-lookup",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/database-lookup",
+          "description": "Search 78 public scientific, biomedical, materials science, and economic databases via REST APIs. Covers physics/astronomy (NASA, NIST, SDSS, SIMBAD), earth/environment (USGS, NOAA, EPA), chemistry/drugs (PubChem, ChEMBL, DrugBank, FDA, KEGG, ZINC, BindingDB), materials (Materials Project, COD), biology/genomics (Reactome, UniProt, STRING, Ensembl, NCBI Gene, GEO, GTEx, PDB, AlphaFold, InterPro, BioGRID, Gene Ontology, dbSNP, gnomAD, ENCODE, Human Protein Atlas, Human Cell Atlas), disease/clinical (COSMIC, Open Targets, ClinicalTrials.gov, OMIM, ClinVar, GDC/TCGA, cBioPortal, DisGeNET, GWAS Catalog), regulatory (FDA, USPTO, SEC EDGAR), economics/finance (FRED, World Bank, US Treasury), demographics (US Census, Eurostat, WHO). Use when looking up compounds, genes, proteins, pathways, variants, clinical trials, patents, economic indicators, or any public database API query.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "datamol",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/datamol",
+          "description": "Pythonic wrapper around RDKit with simplified interface and sensible defaults. Preferred for standard drug discovery including SMILES parsing, standardization, descriptors, fingerprints, clustering, 3D conformers, parallel processing. Returns native rdkit.Chem.Mol objects. For advanced control or custom parameters, use rdkit directly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dnanexus-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/dnanexus-integration",
+          "description": "DNAnexus cloud genomics platform. Build apps/applets, manage data (upload/download), dxpy Python SDK, run workflows, FASTQ/BAM/VCF, for genomics pipeline development and execution.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docx",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/docx",
+          "description": "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of 'Word doc', 'word document', '.docx', or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting or reorganizing content from .docx files, inserting or replacing images in documents, performing find-and-replace in Word files, working with tracked changes or comments, or converting content into a polished Word document. If the user asks for a 'report', 'memo', 'letter', 'template', or similar deliverable as a Word or .docx file, use this skill. Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks unrelated to document generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "esm",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/esm",
+          "description": "Comprehensive toolkit for protein language models including ESM3 (generative multimodal protein design across sequence, structure, and function) and ESM C (efficient protein embeddings and representations). Use this skill when working with protein sequences, structures, or function prediction; designing novel proteins; generating protein embeddings; performing inverse folding; or conducting protein engineering tasks. Supports both local model usage and cloud-based Forge API for scalable inference.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fluidsim",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/fluidsim",
+          "description": "Framework for computational fluid dynamics simulations using Python. Use when running fluid dynamics simulations including Navier-Stokes equations (2D/3D), shallow water equations, stratified flows, or when analyzing turbulence, vortex dynamics, or geophysical flows. Provides pseudospectral methods with FFT, HPC support, and comprehensive output analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "geniml",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geniml",
+          "description": "This skill should be used when working with genomic interval data (BED files) for machine learning tasks. Use for training region embeddings (Region2Vec, BEDspace), single-cell ATAC-seq analysis (scEmbed), building consensus peaks (universes), or any ML-based analysis of genomic regions. Applies to BED file collections, scATAC-seq data, chromatin accessibility datasets, and region-based genomic feature learning.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "geomaster",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geomaster",
+          "description": "Comprehensive geospatial science skill covering remote sensing, GIS, spatial analysis, machine learning for earth observation, and 30+ scientific domains. Supports satellite imagery processing (Sentinel, Landsat, MODIS, SAR, hyperspectral), vector and raster data operations, spatial statistics, point cloud processing, network analysis, cloud-native workflows (STAC, COG, Planetary Computer), and 8 programming languages (Python, R, Julia, JavaScript, C++, Java, Go, Rust) with 500+ code examples. Use for remote sensing workflows, GIS analysis, spatial ML, Earth observation data processing, terrain analysis, hydrological modeling, marine spatial analysis, atmospheric science, and any geospatial computation task.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "geopandas",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geopandas",
+          "description": "Python library for working with geospatial vector data including shapefiles, GeoJSON, and GeoPackage files. Use when working with geographic data for spatial analysis, geometric operations, coordinate transformations, spatial joins, overlay operations, choropleth mapping, or any task involving reading/writing/analyzing vector geographic data. Supports PostGIS databases, interactive maps, and integration with matplotlib/folium/cartopy. Use for tasks like buffer analysis, spatial joins between datasets, dissolving boundaries, clipping data, calculating areas/distances, reprojecting coordinate systems, creating maps, or converting between spatial file formats.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gget",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/gget",
+          "description": "Fast CLI/Python queries to 20+ bioinformatics databases. Use for quick lookups: gene info, BLAST searches, AlphaFold structures, enrichment analysis. Best for interactive exploration, simple queries. For batch processing or advanced BLAST use biopython; for multi-database Python workflows use bioservices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtars",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/gtars",
+          "description": "High-performance toolkit for genomic interval analysis in Rust with Python bindings. Use when working with genomic regions, BED files, coverage tracks, overlap detection, tokenization for ML models, or fragment analysis in computational genomics and machine learning applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hugging-science",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hugging-science",
+          "description": "Use when the user is doing AI/ML work in a scientific domain — biology, chemistry, physics, astronomy, climate, genomics, materials science, medicine, ecology, energy, conservation, engineering, mathematics, scientific reasoning, drug discovery, protein design, weather modeling, theorem proving, single-cell, PDE solving, or anything similar. Hugging Science (huggingscience.co) is a curated catalog of scientific datasets, models, blog posts, and interactive Spaces; the `hugging-science` org on Hugging Face hosts community datasets, models, and demo Spaces. This skill helps you discover the right resource AND actually use it — loading datasets via `datasets`, running models via `transformers` or the HF Inference API, calling Spaces like BoltzGen via `gradio_client`, and citing blog posts for methodology. Trigger this skill whenever a user mentions a scientific ML task, asks for \"a dataset/model for X\" where X is a scientific topic, wants to fine-tune on scientific data, asks about protein / molecule / genome / climate / materials / astronomy / pathology / weather ML, or needs AI tools for research — even if they never say \"Hugging Science\" explicitly. The catalog is purpose-built for LLM agents (it ships an `llms-full.txt`); prefer it over generic web search for these tasks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hypogenic",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hypogenic",
+          "description": "Automated LLM-driven hypothesis generation and testing on tabular datasets. Use when you want to systematically explore hypotheses about patterns in empirical data (e.g., deception detection, content analysis). Combines literature insights with data-driven hypothesis testing. For manual hypothesis formulation use hypothesis-generation; for creative ideation use scientific-brainstorming.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hypothesis-generation",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hypothesis-generation",
+          "description": "Structured hypothesis formulation from observations. Use when you have experimental observations or data and need to formulate testable hypotheses with predictions, propose mechanisms, and design experiments to test them. Follows scientific method framework. For open-ended ideation use scientific-brainstorming; for automated LLM-driven hypothesis testing on datasets use hypogenic.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "infographics",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/infographics",
+          "description": "Create professional infographics using Nano Banana Pro AI with smart iterative refinement. Uses Gemini 3 Pro for quality review. Integrates research-lookup and web search for accurate data. Supports 10 infographic types, 8 industry styles, and colorblind-safe palettes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "labarchive-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/labarchive-integration",
+          "description": "Electronic lab notebook API integration. Access notebooks, manage entries/attachments, backup notebooks, integrate with Protocols.io/Jupyter/REDCap, for programmatic ELN workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "lamindb",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/lamindb",
+          "description": "This skill should be used when working with LaminDB, an open-source data framework for biology that makes data queryable, traceable, reproducible, and FAIR. Use when managing biological datasets (scRNA-seq, spatial, flow cytometry, etc.), tracking computational workflows, curating and validating data with biological ontologies, building data lakehouses, or ensuring data lineage and reproducibility in biological research. Covers data management, annotation, ontologies (genes, cell types, diseases, tissues), schema validation, integrations with workflow managers (Nextflow, Snakemake) and MLOps platforms (W&B, MLflow), and deployment strategies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "latchbio-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/latchbio-integration",
+          "description": "Latch platform for bioinformatics workflows. Build pipelines with Latch SDK, @workflow/@task decorators, deploy serverless workflows, LatchFile/LatchDir, Nextflow/Snakemake integration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "literature-review",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/literature-review",
+          "description": "Conduct comprehensive, systematic literature reviews using multiple academic databases (PubMed, arXiv, bioRxiv, Semantic Scholar, etc.). This skill should be used when conducting systematic literature reviews, meta-analyses, research synthesis, or comprehensive literature searches across biomedical, scientific, and technical domains. Creates professionally formatted markdown documents and PDFs with verified citations in multiple citation styles (APA, Nature, Vancouver, etc.).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "matlab",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/matlab",
+          "description": "MATLAB and GNU Octave numerical computing for matrix operations, data analysis, visualization, and scientific computing. Use when writing MATLAB/Octave scripts for linear algebra, signal processing, image processing, differential equations, optimization, statistics, or creating scientific visualizations. Also use when the user needs help with MATLAB syntax, functions, or wants to convert between MATLAB and Python code. Scripts can be executed with MATLAB or the open-source GNU Octave interpreter.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "modal",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/modal",
+          "description": "Cloud computing platform for running Python on GPUs and serverless infrastructure. Use when deploying AI/ML models, running GPU-accelerated workloads, serving web endpoints, scheduling batch jobs, or scaling Python code to the cloud. Use this skill whenever the user mentions Modal, serverless GPU compute, deploying ML models to the cloud, serving inference endpoints, running batch processing in the cloud, or needs to scale Python workloads beyond their local machine. Also use when the user wants to run code on H100s, A100s, or other cloud GPUs, or needs to create a web API for a model.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "networkx",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/networkx",
+          "description": "Comprehensive toolkit for creating, analyzing, and visualizing complex networks and graphs in Python. Use when working with network/graph data structures, analyzing relationships between entities, computing graph algorithms (shortest paths, centrality, clustering), detecting communities, generating synthetic networks, or visualizing network topologies. Applicable to social networks, biological networks, transportation systems, citation networks, and any domain involving pairwise relationships.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "omero-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/omero-integration",
+          "description": "Microscopy data management platform. Access images via Python, retrieve datasets, analyze pixels, manage ROIs/annotations, batch processing, for high-content screening and microscopy workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "opentrons-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/opentrons-integration",
+          "description": "Official Opentrons Protocol API for OT-2 and Flex robots. Use when writing protocols specifically for Opentrons hardware with full access to Protocol API v2 features. Best for production Opentrons protocols, official API compatibility. For multi-vendor automation or broader equipment control use pylabrobot.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "optimize-for-gpu",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/optimize-for-gpu",
+          "description": "GPU-accelerate Python code using CuPy, Numba CUDA, Warp, cuDF, cuML, cuGraph, KvikIO, cuCIM, cuxfilter, cuVS, cuSpatial, and RAFT. Use whenever the user mentions GPU/CUDA/NVIDIA acceleration, or wants to speed up NumPy, pandas, scikit-learn, scikit-image, NetworkX, GeoPandas, or Faiss workloads. Covers physics simulation, differentiable rendering, mesh ray casting, particle systems (DEM/SPH/fluids), vector/similarity search, GPUDirect Storage file IO, interactive dashboards, geospatial analysis, medical imaging, and sparse eigensolvers. Also use when you see CPU-bound Python code (loops, large arrays, ML pipelines, graph analytics, image processing) that would benefit from GPU acceleration, even if not explicitly requested.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "paper-lookup",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/paper-lookup",
+          "description": "Search 10 academic paper databases via REST APIs for research papers, preprints, and scholarly articles. Covers PubMed, PMC (full text), bioRxiv, medRxiv, arXiv, OpenAlex, Crossref, Semantic Scholar, CORE, Unpaywall. Use when searching for papers, citations, DOI/PMID lookups, abstracts, full text, open access, preprints, citation graphs, author search, or any scholarly literature query. Triggers on mentions of any supported database or requests like \"find papers on X\" or \"look up this DOI\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "parallel-web",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/parallel-web",
+          "description": "All-in-one web toolkit powered by parallel-cli, with a strong emphasis on academic and scientific sources. Use this skill whenever the user needs to search the web, fetch/extract URL content, enrich data with web-sourced fields, or run deep research reports. Covers: web search (fast lookups, research, current info — prioritizing peer-reviewed papers, preprints, and scholarly databases), URL extraction (fetching pages, articles, academic PDFs), bulk data enrichment (adding fields to CSV/lists from the web), and deep research (exhaustive multi-source reports grounded in academic literature). Also handles setup, status checks, and result retrieval. Use this skill for ANY web-related task — even if the user doesn't mention 'parallel' or 'web' explicitly. If they want to look something up, fetch a page, enrich a dataset, investigate a topic, find academic papers, check citations, or review scientific literature, this is the skill to use.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pathml",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pathml",
+          "description": "Full-featured computational pathology toolkit. Use for advanced WSI analysis including multiplexed immunofluorescence (CODEX, Vectra), nucleus segmentation, tissue graph construction, and ML model training on pathology data. Supports 160+ slide formats. For simple tile extraction from H&E slides, histolab may be simpler.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "peer-review",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/peer-review",
+          "description": "Structured manuscript/grant review with checklist-based evaluation. Use when writing formal peer reviews with specific criteria methodology assessment, statistical validity, reporting standards compliance (CONSORT/STROBE), and constructive feedback. Best for actual review writing, manuscript revision. For evaluating claims/evidence quality use scientific-critical-thinking; for quantitative scoring frameworks use scholar-evaluation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pennylane",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pennylane",
+          "description": "Hardware-agnostic quantum ML framework with automatic differentiation. Use when training quantum circuits via gradients, building hybrid quantum-classical models, or needing device portability across IBM/Google/Rigetti/IonQ. Best for variational algorithms (VQE, QAOA), quantum neural networks, and integration with PyTorch/JAX/TensorFlow. For hardware-specific optimizations use qiskit (IBM) or cirq (Google); for open quantum systems use qutip.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "phylogenetics",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/phylogenetics",
+          "description": "Build and analyze phylogenetic trees using MAFFT (multiple alignment), IQ-TREE 2 (maximum likelihood), and FastTree (fast NJ/ML). Visualize with ETE3 or FigTree. For evolutionary analysis, microbial genomics, viral phylodynamics, protein family analysis, and molecular clock studies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "polars-bio",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/polars-bio",
+          "description": "High-performance genomic interval operations and bioinformatics file I/O on Polars DataFrames. Overlap, nearest, merge, coverage, complement, subtract for BED/VCF/BAM/GFF intervals. Streaming, cloud-native, faster bioframe alternative.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "protocolsio-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/protocolsio-integration",
+          "description": "Integration with protocols.io API for managing scientific protocols. This skill should be used when working with protocols.io to search, create, update, or publish protocols; manage protocol steps and materials; handle discussions and comments; organize workspaces; upload and manage files; or integrate protocols.io functionality into workflows. Applicable for protocol discovery, collaborative protocol development, experiment tracking, lab protocol management, and scientific documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pydeseq2",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pydeseq2",
+          "description": "Differential gene expression analysis (Python DESeq2). Identify DE genes from bulk RNA-seq counts, Wald tests, FDR correction, volcano/MA plots, for RNA-seq analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pydicom",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pydicom",
+          "description": "Python library for working with DICOM (Digital Imaging and Communications in Medicine) files. Use this skill when reading, writing, or modifying medical imaging data in DICOM format, extracting pixel data from medical images (CT, MRI, X-ray, ultrasound), anonymizing DICOM files, working with DICOM metadata and tags, converting DICOM images to other formats, handling compressed DICOM data, or processing medical imaging datasets. Applies to tasks involving medical image analysis, PACS systems, radiology workflows, and healthcare imaging applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pyhealth",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pyhealth",
+          "description": "Build clinical/healthcare deep-learning pipelines with PyHealth — loading EHR/signal/imaging datasets (MIMIC-III/IV, eICU, OMOP, SleepEDF, ChestXray14, EHRShot), defining tasks (mortality, readmission, length-of-stay, drug recommendation, sleep staging, ICD coding, EEG events), instantiating models (Transformer, RETAIN, GAMENet, SafeDrug, MICRON, StageNet, AdaCare, CNN/RNN/MLP), training with the PyHealth Trainer, computing clinical metrics, and using medical code utilities (ICD/ATC/NDC/RxNorm lookup and cross-mapping). Use this skill whenever the user mentions PyHealth, MIMIC, eICU, OMOP, EHR modeling, clinical prediction, drug recommendation, sleep staging, medical code mapping, ICD/ATC codes, or any healthcare ML pipeline that fits the dataset → task → model → trainer → metrics pattern, even if \"PyHealth\" isn't named explicitly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pylabrobot",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pylabrobot",
+          "description": "Vendor-agnostic lab automation framework. Use when controlling multiple equipment types (Hamilton, Tecan, Opentrons, plate readers, pumps) or needing unified programming across different vendors. Best for complex workflows, multi-vendor setups, simulation. For Opentrons-only protocols with official API, opentrons-integration may be simpler.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pymc",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pymc",
+          "description": "Bayesian modeling with PyMC. Build hierarchical models, MCMC (NUTS), variational inference, LOO/WAIC comparison, posterior checks, for probabilistic programming and inference.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pysam",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pysam",
+          "description": "Genomic file toolkit. Read/write SAM/BAM/CRAM alignments, VCF/BCF variants, FASTA/FASTQ sequences, extract regions, calculate coverage, for NGS data processing pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pytorch-lightning",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pytorch-lightning",
+          "description": "Deep learning framework (PyTorch Lightning). Organize PyTorch code into LightningModules, configure Trainers for multi-GPU/TPU, implement data pipelines, callbacks, logging (W&B, TensorBoard), distributed training (DDP, FSDP, DeepSpeed), for scalable neural network training.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pyzotero",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pyzotero",
+          "description": "Interact with Zotero reference management libraries using the pyzotero Python client. Retrieve, create, update, and delete items, collections, tags, and attachments via the Zotero Web API v3. Use this skill when working with Zotero libraries programmatically, managing bibliographic references, exporting citations, searching library contents, uploading PDF attachments, or building research automation workflows that integrate with Zotero.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "research-grants",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/research-grants",
+          "description": "Write competitive research proposals for NSF, NIH, DOE, DARPA, and Taiwan NSTC. Agency-specific formatting, review criteria, budget preparation, broader impacts, significance statements, innovation narratives, and compliance with submission requirements.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "research-lookup",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/research-lookup",
+          "description": "Look up current research information using parallel-cli search (primary, fast web search), the Parallel Chat API (deep research), or Perplexity sonar-pro-search (academic paper searches). Automatically routes queries to the best backend. Use for finding papers, gathering research data, and verifying scientific information. Note: query text is transmitted to api.parallel.ai (PARALLEL_API_KEY) and, for academic searches, to openrouter.ai (OPENROUTER_API_KEY).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "rowan",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/rowan",
+          "description": "Rowan is a cloud-native molecular modeling and medicinal-chemistry workflow platform with a Python API. Use for pKa and macropKa prediction, conformer and tautomer ensembles, docking and analogue docking, protein-ligand cofolding, MSA generation, molecular dynamics, permeability, descriptor workflows, and related small-molecule or protein modeling tasks. Ideal for programmatic batch screening, multi-step chemistry pipelines, and workflows that would otherwise require maintaining local HPC/GPU infrastructure.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-brainstorming",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-brainstorming",
+          "description": "Creative research ideation and exploration. Use for open-ended brainstorming sessions, exploring interdisciplinary connections, challenging assumptions, or identifying research gaps. Best for early-stage research planning when you do not have specific observations yet. For formulating testable hypotheses from data use hypothesis-generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-critical-thinking",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-critical-thinking",
+          "description": "Evaluate scientific claims and evidence quality. Use for assessing experimental design validity, identifying biases and confounders, applying evidence grading frameworks (GRADE, Cochrane Risk of Bias), or teaching critical analysis. Best for understanding evidence quality, identifying flaws. For formal peer review writing use peer-review.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-schematics",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-schematics",
+          "description": "Create publication-quality scientific diagrams using Nano Banana 2 AI with smart iterative refinement. Uses Gemini 3.1 Pro Preview for quality review. Only regenerates if quality is below threshold for your document type. Specialized in neural network architectures, system diagrams, flowcharts, biological pathways, and complex scientific visualizations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-slides",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-slides",
+          "description": "Build slide decks and presentations for research talks. Use this for making PowerPoint slides, conference presentations, seminar talks, research presentations, thesis defense slides, or any scientific talk. Provides slide structure, design templates, timing guidance, and visual validation. Works with PowerPoint and LaTeX Beamer.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scikit-learn",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scikit-learn",
+          "description": "Machine learning in Python with scikit-learn. Use when working with supervised learning (classification, regression), unsupervised learning (clustering, dimensionality reduction), model evaluation, hyperparameter tuning, preprocessing, or building ML pipelines. Provides comprehensive reference documentation for algorithms, preprocessing techniques, pipelines, and best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scikit-survival",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scikit-survival",
+          "description": "Comprehensive toolkit for survival analysis and time-to-event modeling in Python using scikit-survival. Use this skill when working with censored survival data, performing time-to-event analysis, fitting Cox models, Random Survival Forests, Gradient Boosting models, or Survival SVMs, evaluating survival predictions with concordance index or Brier score, handling competing risks, or implementing any survival analysis workflow with the scikit-survival library.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "shap",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/shap",
+          "description": "Model interpretability and explainability using SHAP (SHapley Additive exPlanations). Use this skill when explaining machine learning model predictions, computing feature importance, generating SHAP plots (waterfall, beeswarm, bar, scatter, force, heatmap), debugging models, analyzing model bias or fairness, comparing models, or implementing explainable AI. Works with tree-based models (XGBoost, LightGBM, Random Forest), deep learning (TensorFlow, PyTorch), linear models, and any black-box model.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "simpy",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/simpy",
+          "description": "Process-based discrete-event simulation framework in Python. Use this skill when building simulations of systems with processes, queues, resources, and time-based events such as manufacturing systems, service operations, network traffic, logistics, or any system where entities interact with shared resources over time.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "stable-baselines3",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/stable-baselines3",
+          "description": "Production-ready reinforcement learning algorithms (PPO, SAC, DQN, TD3, DDPG, A2C) with scikit-learn-like API. Use for standard RL experiments, quick prototyping, and well-documented algorithm implementations. Best for single-agent RL with Gymnasium environments. For high-performance parallel training, multi-agent systems, or custom vectorized environments, use pufferlib instead.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "statistical-analysis",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/statistical-analysis",
+          "description": "Guided statistical analysis with test selection and reporting. Use when you need help choosing appropriate tests for your data, assumption checking, power analysis, and APA-formatted results. Best for academic research reporting, test selection guidance. For implementing specific models programmatically use statsmodels.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "statsmodels",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/statsmodels",
+          "description": "Statistical models library for Python. Use when you need specific model classes (OLS, GLM, mixed models, ARIMA) with detailed diagnostics, residuals, and inference. Best for econometrics, time series, rigorous inference with coefficient tables. For guided statistical test selection with APA reporting use statistical-analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "sympy",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/sympy",
+          "description": "Use this skill when working with symbolic mathematics in Python. This skill should be used for symbolic computation tasks including solving equations algebraically, performing calculus operations (derivatives, integrals, limits), manipulating algebraic expressions, working with matrices symbolically, physics calculations, number theory problems, geometry computations, and generating executable code from mathematical expressions. Apply this skill when the user needs exact symbolic results rather than numerical approximations, or when working with mathematical formulas that contain variables and parameters.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "torch-geometric",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/torch-geometric",
+          "description": "Guide for building Graph Neural Networks with PyTorch Geometric (PyG). Use this skill whenever the user asks about graph neural networks, GNNs, node classification, link prediction, graph classification, message passing networks, heterogeneous graphs, neighbor sampling, or any task involving torch_geometric / PyG. Also trigger when you see imports from torch_geometric, or the user mentions graph convolutions (GCN, GAT, GraphSAGE, GIN), graph data structures, or working with relational/network data. Even if the user just says 'graph learning' or 'geometric deep learning', use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "torchdrug",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/torchdrug",
+          "description": "PyTorch-native graph neural networks for molecules and proteins. Use when building custom GNN architectures for drug discovery, protein modeling, or knowledge graph reasoning. Best for custom model development, protein property prediction, retrosynthesis. For pre-trained models and diverse featurizers use deepchem; for benchmark datasets use pytdc.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "treatment-plans",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/treatment-plans",
+          "description": "Generate concise (3-4 page), focused medical treatment plans in LaTeX/PDF format for all clinical specialties. Supports general medical treatment, rehabilitation therapy, mental health care, chronic disease management, perioperative care, and pain management. Includes SMART goal frameworks, evidence-based interventions with minimal text citations, regulatory compliance (HIPAA), and professional formatting. Prioritizes brevity and clinical actionability.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "usfiscaldata",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/usfiscaldata",
+          "description": "Query the U.S. Treasury Fiscal Data API for federal financial data including national debt, government spending, revenue, interest rates, exchange rates, and savings bonds. Access 54 datasets and 182 data tables with no API key required. Use when working with U.S. federal fiscal data, national debt tracking (Debt to the Penny), Daily Treasury Statements, Monthly Treasury Statements, Treasury securities auctions, interest rates on Treasury securities, foreign exchange rates, savings bonds, or any U.S. government financial statistics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "vaex",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/vaex",
+          "description": "Use this skill for processing and analyzing large tabular datasets (billions of rows) that exceed available RAM. Vaex excels at out-of-core DataFrame operations, lazy evaluation, fast aggregations, efficient visualization of big data, and machine learning on large datasets. Apply when users need to work with large CSV/HDF5/Arrow/Parquet files, perform fast statistics on massive datasets, create visualizations of big data, or build ML pipelines that do not fit in memory.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "what-if-oracle",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/what-if-oracle",
+          "description": "Run structured What-If scenario analysis with multi-branch possibility exploration. Use this skill when the user asks speculative questions like \"what if...\", \"what would happen if...\", \"what are the possibilities\", \"explore scenarios\", \"scenario analysis\", \"possibility space\", \"what could go wrong\", \"best case / worst case\", \"risk analysis\", \"contingency planning\", \"strategic options\", or any question about uncertain futures. Also trigger when the user faces a fork-in-the-road decision, wants to stress-test an idea, or needs to think through consequences before committing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "xlsx",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/xlsx",
+          "description": "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .csv, or .tsv file (e.g., adding columns, computing formulas, formatting, charting, cleaning messy data); create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger especially when the user references a spreadsheet file by name or path — even casually (like \\\"the xlsx in my downloads\\\") — and wants something done to it or produced from it. Also trigger for cleaning or restructuring messy tabular data files (malformed rows, misplaced headers, junk data) into proper spreadsheets. The deliverable must be a spreadsheet file. Do NOT trigger when the primary deliverable is a Word document, HTML report, standalone Python script, database pipeline, or Google Sheets API integration, even if tabular data is involved.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "zarr-python",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/zarr-python",
+          "description": "Chunked N-D arrays for cloud storage. Compressed arrays, parallel I/O, S3/GCS integration, NumPy/Dask/Xarray compatible, for large-scale scientific computing pipelines.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "K-Dense-AI",
+        "repo": "claude-scientific-skills",
+        "repoUrl": "https://github.com/K-Dense-AI/claude-scientific-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "k-dense-ai-claude-scientific-skills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from K-Dense-AI/claude-scientific-skills.",
+      "author": "ASM (K-Dense-AI/claude-scientific-skills)",
+      "createdAt": "2026-05-09T08:10:53.521Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "k-dense-ai",
+        "claude-scientific-skills"
+      ],
+      "skills": [
+        {
+          "name": "adaptyv",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/adaptyv",
+          "description": "How to use the Adaptyv Bio Foundry API and Python SDK for protein experiment design, submission, and results retrieval. Use this skill whenever the user mentions Adaptyv, Foundry API, protein binding assays, protein screening experiments, BLI/SPR assays, thermostability assays, or wants to submit protein sequences for experimental characterization. Also trigger when code imports `adaptyv`, `adaptyv_sdk`, or `FoundryClient`, or references `foundry-api-public.adaptyvbio.com`.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aeon",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/aeon",
+          "description": "This skill should be used for time series machine learning tasks including classification, regression, clustering, forecasting, anomaly detection, segmentation, and similarity search. Use when working with temporal data, sequential patterns, or time-indexed observations requiring specialized algorithms beyond standard ML approaches. Particularly suited for univariate and multivariate time series analysis with scikit-learn compatible APIs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autoskill",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/autoskill",
+          "description": "Observe the user's screen via screenpipe, detect repeated research workflows, match them against existing scientific-agent-skills, and draft new skills (or composition recipes that chain existing ones) for the patterns not yet covered. Use when the user asks to analyze their recent work and propose skills based on what they actually do. Requires the screenpipe daemon (https://github.com/screenpipe/screenpipe) running locally on port 3030 — the skill has no other data source and will refuse to run if screenpipe is unreachable. All detection runs locally; only redacted cluster summaries reach the LLM.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "benchling-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/benchling-integration",
+          "description": "Benchling R&D platform integration. Access registry (DNA, proteins), inventory, ELN entries, workflows via API, build Benchling Apps, query Data Warehouse, for lab data management automation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "biopython",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/biopython",
+          "description": "Comprehensive molecular biology toolkit. Use for sequence manipulation, file parsing (FASTA/GenBank/PDB), phylogenetics, and programmatic NCBI/PubMed access (Bio.Entrez). Best for batch processing, custom bioinformatics pipelines, BLAST automation. For quick lookups use gget; for multi-service integration use bioservices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bioservices",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/bioservices",
+          "description": "Unified Python interface to 40+ bioinformatics services. Use when querying multiple databases (UniProt, KEGG, ChEMBL, Reactome) in a single workflow with consistent API. Best for cross-database analysis, ID mapping across services. For quick single-database lookups use gget; for sequence/file manipulation use biopython.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cirq",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/cirq",
+          "description": "Google quantum computing framework. Use when targeting Google Quantum AI hardware, designing noise-aware circuits, or running quantum characterization experiments. Best for Google hardware, noise modeling, and low-level circuit design. For IBM hardware use qiskit; for quantum ML with autodiff use pennylane; for physics simulations use qutip.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "clinical-decision-support",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/clinical-decision-support",
+          "description": "Generate professional clinical decision support (CDS) documents for pharmaceutical and clinical research settings, including patient cohort analyses (biomarker-stratified with outcomes) and treatment recommendation reports (evidence-based guidelines with decision algorithms). Supports GRADE evidence grading, statistical analysis (hazard ratios, survival curves, waterfall plots), biomarker integration, and regulatory compliance. Outputs publication-ready LaTeX/PDF format optimized for drug development, clinical research, and evidence synthesis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "clinical-reports",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/clinical-reports",
+          "description": "Write comprehensive clinical reports including case reports (CARE guidelines), diagnostic reports (radiology/pathology/lab), clinical trial reports (ICH-E3, SAE, CSR), and patient documentation (SOAP, H&P, discharge summaries). Full support with templates, regulatory compliance (HIPAA, FDA, ICH-GCP), and validation tools.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cobrapy",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/cobrapy",
+          "description": "Constraint-based metabolic modeling (COBRA). FBA, FVA, gene knockouts, flux sampling, SBML models, for systems biology and metabolic engineering analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "database-lookup",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/database-lookup",
+          "description": "Search 78 public scientific, biomedical, materials science, and economic databases via REST APIs. Covers physics/astronomy (NASA, NIST, SDSS, SIMBAD), earth/environment (USGS, NOAA, EPA), chemistry/drugs (PubChem, ChEMBL, DrugBank, FDA, KEGG, ZINC, BindingDB), materials (Materials Project, COD), biology/genomics (Reactome, UniProt, STRING, Ensembl, NCBI Gene, GEO, GTEx, PDB, AlphaFold, InterPro, BioGRID, Gene Ontology, dbSNP, gnomAD, ENCODE, Human Protein Atlas, Human Cell Atlas), disease/clinical (COSMIC, Open Targets, ClinicalTrials.gov, OMIM, ClinVar, GDC/TCGA, cBioPortal, DisGeNET, GWAS Catalog), regulatory (FDA, USPTO, SEC EDGAR), economics/finance (FRED, World Bank, US Treasury), demographics (US Census, Eurostat, WHO). Use when looking up compounds, genes, proteins, pathways, variants, clinical trials, patents, economic indicators, or any public database API query.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deepchem",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/deepchem",
+          "description": "Molecular ML with diverse featurizers and pre-built datasets. Use for property prediction (ADMET, toxicity) with traditional ML or GNNs when you want extensive featurization options and MoleculeNet benchmarks. Best for quick experiments with pre-trained models, diverse molecular representations. For graph-first PyTorch workflows use torchdrug; for benchmark datasets use pytdc.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deeptools",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/deeptools",
+          "description": "NGS analysis toolkit. BAM to bigWig conversion, QC (correlation, PCA, fingerprints), heatmaps/profiles (TSS, peaks), for ChIP-seq, RNA-seq, ATAC-seq visualization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "diffdock",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/diffdock",
+          "description": "Diffusion-based molecular docking. Predict protein-ligand binding poses from PDB/SMILES, confidence scores, virtual screening, for structure-based drug design. Not for affinity prediction.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dnanexus-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/dnanexus-integration",
+          "description": "DNAnexus cloud genomics platform. Build apps/applets, manage data (upload/download), dxpy Python SDK, run workflows, FASTQ/BAM/VCF, for genomics pipeline development and execution.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "esm",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/esm",
+          "description": "Comprehensive toolkit for protein language models including ESM3 (generative multimodal protein design across sequence, structure, and function) and ESM C (efficient protein embeddings and representations). Use this skill when working with protein sequences, structures, or function prediction; designing novel proteins; generating protein embeddings; performing inverse folding; or conducting protein engineering tasks. Supports both local model usage and cloud-based Forge API for scalable inference.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "etetoolkit",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/etetoolkit",
+          "description": "Phylogenetic tree toolkit (ETE). Tree manipulation (Newick/NHX), evolutionary event detection, orthology/paralogy, NCBI taxonomy, visualization (PDF/SVG), for phylogenomics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fluidsim",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/fluidsim",
+          "description": "Framework for computational fluid dynamics simulations using Python. Use when running fluid dynamics simulations including Navier-Stokes equations (2D/3D), shallow water equations, stratified flows, or when analyzing turbulence, vortex dynamics, or geophysical flows. Provides pseudospectral methods with FFT, HPC support, and comprehensive output analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "generate-image",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/generate-image",
+          "description": "Generate or edit images using AI models (FLUX, Nano Banana 2). Use for general-purpose image generation including photos, illustrations, artwork, visual assets, concept art, and any image that is not a technical diagram or schematic. For flowcharts, circuits, pathways, and technical diagrams, use the scientific-schematics skill instead.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "geniml",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geniml",
+          "description": "This skill should be used when working with genomic interval data (BED files) for machine learning tasks. Use for training region embeddings (Region2Vec, BEDspace), single-cell ATAC-seq analysis (scEmbed), building consensus peaks (universes), or any ML-based analysis of genomic regions. Applies to BED file collections, scATAC-seq data, chromatin accessibility datasets, and region-based genomic feature learning.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gget",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/gget",
+          "description": "Fast CLI/Python queries to 20+ bioinformatics databases. Use for quick lookups: gene info, BLAST searches, AlphaFold structures, enrichment analysis. Best for interactive exploration, simple queries. For batch processing or advanced BLAST use biopython; for multi-database Python workflows use bioservices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "glycoengineering",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/glycoengineering",
+          "description": "Analyze and engineer protein glycosylation. Scan sequences for N-glycosylation sequons (N-X-S/T), predict O-glycosylation hotspots, and access curated glycoengineering tools (NetOGlyc, GlycoShield, GlycoWorkbench). For glycoprotein engineering, therapeutic antibody optimization, and vaccine design.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "histolab",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/histolab",
+          "description": "Lightweight WSI tile extraction and preprocessing. Use for basic slide processing tissue detection, tile extraction, stain normalization for H&E images. Best for simple pipelines, dataset preparation, quick tile-based analysis. For advanced spatial proteomics, multiplexed imaging, or deep learning pipelines use pathml.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hugging-science",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hugging-science",
+          "description": "Use when the user is doing AI/ML work in a scientific domain — biology, chemistry, physics, astronomy, climate, genomics, materials science, medicine, ecology, energy, conservation, engineering, mathematics, scientific reasoning, drug discovery, protein design, weather modeling, theorem proving, single-cell, PDE solving, or anything similar. Hugging Science (huggingscience.co) is a curated catalog of scientific datasets, models, blog posts, and interactive Spaces; the `hugging-science` org on Hugging Face hosts community datasets, models, and demo Spaces. This skill helps you discover the right resource AND actually use it — loading datasets via `datasets`, running models via `transformers` or the HF Inference API, calling Spaces like BoltzGen via `gradio_client`, and citing blog posts for methodology. Trigger this skill whenever a user mentions a scientific ML task, asks for \"a dataset/model for X\" where X is a scientific topic, wants to fine-tune on scientific data, asks about protein / molecule / genome / climate / materials / astronomy / pathology / weather ML, or needs AI tools for research — even if they never say \"Hugging Science\" explicitly. The catalog is purpose-built for LLM agents (it ships an `llms-full.txt`); prefer it over generic web search for these tasks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hypothesis-generation",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hypothesis-generation",
+          "description": "Structured hypothesis formulation from observations. Use when you have experimental observations or data and need to formulate testable hypotheses with predictions, propose mechanisms, and design experiments to test them. Follows scientific method framework. For open-ended ideation use scientific-brainstorming; for automated LLM-driven hypothesis testing on datasets use hypogenic.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "imaging-data-commons",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/imaging-data-commons",
+          "description": "Query and download public cancer imaging data from NCI Imaging Data Commons using idc-index. Use for accessing large-scale radiology (CT, MR, PET) and pathology datasets for AI training or research. No authentication required. Query by metadata, visualize in browser, check licenses.",
+          "version": "1.4.0"
+        },
+        {
+          "name": "iso-13485-certification",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/iso-13485-certification",
+          "description": "Comprehensive toolkit for preparing ISO 13485 certification documentation for medical device Quality Management Systems. Use when users need help with ISO 13485 QMS documentation, including (1) conducting gap analysis of existing documentation, (2) creating Quality Manuals, (3) developing required procedures and work instructions, (4) preparing Medical Device Files, (5) understanding ISO 13485 requirements, or (6) identifying missing documentation for medical device certification. Also use when users mention medical device regulations, QMS certification, FDA QMSR, EU MDR, or need help with quality system documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "lamindb",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/lamindb",
+          "description": "This skill should be used when working with LaminDB, an open-source data framework for biology that makes data queryable, traceable, reproducible, and FAIR. Use when managing biological datasets (scRNA-seq, spatial, flow cytometry, etc.), tracking computational workflows, curating and validating data with biological ontologies, building data lakehouses, or ensuring data lineage and reproducibility in biological research. Covers data management, annotation, ontologies (genes, cell types, diseases, tissues), schema validation, integrations with workflow managers (Nextflow, Snakemake) and MLOps platforms (W&B, MLflow), and deployment strategies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "latchbio-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/latchbio-integration",
+          "description": "Latch platform for bioinformatics workflows. Build pipelines with Latch SDK, @workflow/@task decorators, deploy serverless workflows, LatchFile/LatchDir, Nextflow/Snakemake integration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "latex-posters",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/latex-posters",
+          "description": "Create professional research posters in LaTeX using beamerposter, tikzposter, or baposter. Support for conference presentations, academic posters, and scientific communication. Includes layout design, color schemes, multi-column formats, figure integration, and poster-specific best practices for visual communication.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "markdown-mermaid-writing",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/markdown-mermaid-writing",
+          "description": "Comprehensive markdown and Mermaid diagram writing skill. Use when creating any scientific document, report, analysis, or visualization. Establishes text-based diagrams as the default documentation standard with full style guides (markdown + mermaid), 24 diagram type references, and 9 document templates.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "market-research-reports",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/market-research-reports",
+          "description": "Generate comprehensive market research reports (50+ pages) in the style of top consulting firms (McKinsey, BCG, Gartner). Features professional LaTeX formatting, extensive visual generation with scientific-schematics and generate-image, deep integration with research-lookup for data gathering, and multi-framework strategic analysis including Porter Five Forces, PESTLE, SWOT, TAM/SAM/SOM, and BCG Matrix.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "markitdown",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/markitdown",
+          "description": "Convert files and office documents to Markdown. Supports PDF, DOCX, PPTX, XLSX, images (with OCR), audio (with transcription), HTML, CSV, JSON, XML, ZIP, YouTube URLs, EPubs and more.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "matlab",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/matlab",
+          "description": "MATLAB and GNU Octave numerical computing for matrix operations, data analysis, visualization, and scientific computing. Use when writing MATLAB/Octave scripts for linear algebra, signal processing, image processing, differential equations, optimization, statistics, or creating scientific visualizations. Also use when the user needs help with MATLAB syntax, functions, or wants to convert between MATLAB and Python code. Scripts can be executed with MATLAB or the open-source GNU Octave interpreter.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "matplotlib",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/matplotlib",
+          "description": "Low-level plotting library for full customization. Use when you need fine-grained control over every plot element, creating novel plot types, or integrating with specific scientific workflows. Export to PNG/PDF/SVG for publication. For quick statistical plots use seaborn; for interactive plots use plotly; for publication-ready multi-panel figures with journal styling, use scientific-visualization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "networkx",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/networkx",
+          "description": "Comprehensive toolkit for creating, analyzing, and visualizing complex networks and graphs in Python. Use when working with network/graph data structures, analyzing relationships between entities, computing graph algorithms (shortest paths, centrality, clustering), detecting communities, generating synthetic networks, or visualizing network topologies. Applicable to social networks, biological networks, transportation systems, citation networks, and any domain involving pairwise relationships.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "neuropixels-analysis",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/neuropixels-analysis",
+          "description": "Neuropixels neural recording analysis. Load SpikeGLX/OpenEphys data, preprocess, motion correction, Kilosort4 spike sorting, quality metrics, Allen/IBL curation, AI-assisted visual analysis, for Neuropixels 1.0/2.0 extracellular electrophysiology. Use when working with neural recordings, spike sorting, extracellular electrophysiology, or when the user mentions Neuropixels, SpikeGLX, Open Ephys, Kilosort, quality metrics, or unit curation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "opentrons-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/opentrons-integration",
+          "description": "Official Opentrons Protocol API for OT-2 and Flex robots. Use when writing protocols specifically for Opentrons hardware with full access to Protocol API v2 features. Best for production Opentrons protocols, official API compatibility. For multi-vendor automation or broader equipment control use pylabrobot.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "optimize-for-gpu",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/optimize-for-gpu",
+          "description": "GPU-accelerate Python code using CuPy, Numba CUDA, Warp, cuDF, cuML, cuGraph, KvikIO, cuCIM, cuxfilter, cuVS, cuSpatial, and RAFT. Use whenever the user mentions GPU/CUDA/NVIDIA acceleration, or wants to speed up NumPy, pandas, scikit-learn, scikit-image, NetworkX, GeoPandas, or Faiss workloads. Covers physics simulation, differentiable rendering, mesh ray casting, particle systems (DEM/SPH/fluids), vector/similarity search, GPUDirect Storage file IO, interactive dashboards, geospatial analysis, medical imaging, and sparse eigensolvers. Also use when you see CPU-bound Python code (loops, large arrays, ML pipelines, graph analytics, image processing) that would benefit from GPU acceleration, even if not explicitly requested.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pennylane",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pennylane",
+          "description": "Hardware-agnostic quantum ML framework with automatic differentiation. Use when training quantum circuits via gradients, building hybrid quantum-classical models, or needing device portability across IBM/Google/Rigetti/IonQ. Best for variational algorithms (VQE, QAOA), quantum neural networks, and integration with PyTorch/JAX/TensorFlow. For hardware-specific optimizations use qiskit (IBM) or cirq (Google); for open quantum systems use qutip.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "phylogenetics",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/phylogenetics",
+          "description": "Build and analyze phylogenetic trees using MAFFT (multiple alignment), IQ-TREE 2 (maximum likelihood), and FastTree (fast NJ/ML). Visualize with ETE3 or FigTree. For evolutionary analysis, microbial genomics, viral phylodynamics, protein family analysis, and molecular clock studies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pptx",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pptx",
+          "description": "Use this skill any time a .pptx file is involved in any way — as input, output, or both. This includes: creating slide decks, pitch decks, or presentations; reading, parsing, or extracting text from any .pptx file (even if the extracted content will be used elsewhere, like in an email or summary); editing, modifying, or updating existing presentations; combining or splitting slide files; working with templates, layouts, speaker notes, or comments. Trigger whenever the user mentions \\\"deck,\\\" \\\"slides,\\\" \\\"presentation,\\\" or references a .pptx filename, regardless of what they plan to do with the content afterward. If a .pptx file needs to be opened, created, or touched, use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pptx-posters",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pptx-posters",
+          "description": "Create research posters using HTML/CSS that can be exported to PDF or PPTX. Use this skill ONLY when the user explicitly requests PowerPoint/PPTX poster format. For standard research posters, use latex-posters instead. This skill provides modern web-based poster design with responsive layouts and easy visual integration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pufferlib",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pufferlib",
+          "description": "High-performance reinforcement learning framework optimized for speed and scale. Use when you need fast parallel training, vectorized environments, multi-agent systems, or integration with game environments (Atari, Procgen, NetHack). Achieves 2-10x speedups over standard implementations. For quick prototyping or standard algorithm implementations with extensive documentation, use stable-baselines3 instead.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pyhealth",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pyhealth",
+          "description": "Build clinical/healthcare deep-learning pipelines with PyHealth — loading EHR/signal/imaging datasets (MIMIC-III/IV, eICU, OMOP, SleepEDF, ChestXray14, EHRShot), defining tasks (mortality, readmission, length-of-stay, drug recommendation, sleep staging, ICD coding, EEG events), instantiating models (Transformer, RETAIN, GAMENet, SafeDrug, MICRON, StageNet, AdaCare, CNN/RNN/MLP), training with the PyHealth Trainer, computing clinical metrics, and using medical code utilities (ICD/ATC/NDC/RxNorm lookup and cross-mapping). Use this skill whenever the user mentions PyHealth, MIMIC, eICU, OMOP, EHR modeling, clinical prediction, drug recommendation, sleep staging, medical code mapping, ICD/ATC codes, or any healthcare ML pipeline that fits the dataset → task → model → trainer → metrics pattern, even if \"PyHealth\" isn't named explicitly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pylabrobot",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pylabrobot",
+          "description": "Vendor-agnostic lab automation framework. Use when controlling multiple equipment types (Hamilton, Tecan, Opentrons, plate readers, pumps) or needing unified programming across different vendors. Best for complex workflows, multi-vendor setups, simulation. For Opentrons-only protocols with official API, opentrons-integration may be simpler.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pymc",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pymc",
+          "description": "Bayesian modeling with PyMC. Build hierarchical models, MCMC (NUTS), variational inference, LOO/WAIC comparison, posterior checks, for probabilistic programming and inference.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pymoo",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pymoo",
+          "description": "Multi-objective optimization framework. NSGA-II, NSGA-III, MOEA/D, Pareto fronts, constraint handling, benchmarks (ZDT, DTLZ), for engineering design and optimization problems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pyzotero",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pyzotero",
+          "description": "Interact with Zotero reference management libraries using the pyzotero Python client. Retrieve, create, update, and delete items, collections, tags, and attachments via the Zotero Web API v3. Use this skill when working with Zotero libraries programmatically, managing bibliographic references, exporting citations, searching library contents, uploading PDF attachments, or building research automation workflows that integrate with Zotero.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "qutip",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/qutip",
+          "description": "Quantum physics simulation library for open quantum systems. Use when studying master equations, Lindblad dynamics, decoherence, quantum optics, or cavity QED. Best for physics research, open system dynamics, and educational simulations. NOT for circuit-based quantum computing—use qiskit, cirq, or pennylane for quantum algorithms and hardware execution.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "rdkit",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/rdkit",
+          "description": "Cheminformatics toolkit for fine-grained molecular control. SMILES/SDF parsing, descriptors (MW, LogP, TPSA), fingerprints, substructure search, 2D/3D generation, similarity, reactions. For standard workflows with simpler interface, use datamol (wrapper around RDKit). Use rdkit for advanced control, custom sanitization, specialized algorithms.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "research-grants",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/research-grants",
+          "description": "Write competitive research proposals for NSF, NIH, DOE, DARPA, and Taiwan NSTC. Agency-specific formatting, review criteria, budget preparation, broader impacts, significance statements, innovation narratives, and compliance with submission requirements.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "rowan",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/rowan",
+          "description": "Rowan is a cloud-native molecular modeling and medicinal-chemistry workflow platform with a Python API. Use for pKa and macropKa prediction, conformer and tautomer ensembles, docking and analogue docking, protein-ligand cofolding, MSA generation, molecular dynamics, permeability, descriptor workflows, and related small-molecule or protein modeling tasks. Ideal for programmatic batch screening, multi-step chemistry pipelines, and workflows that would otherwise require maintaining local HPC/GPU infrastructure.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scanpy",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scanpy",
+          "description": "Standard single-cell RNA-seq analysis pipeline. Use for QC, normalization, dimensionality reduction (PCA/UMAP/t-SNE), clustering, differential expression, and visualization. Best for exploratory scRNA-seq analysis with established workflows. For deep learning models use scvi-tools; for data format questions use anndata.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-critical-thinking",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-critical-thinking",
+          "description": "Evaluate scientific claims and evidence quality. Use for assessing experimental design validity, identifying biases and confounders, applying evidence grading frameworks (GRADE, Cochrane Risk of Bias), or teaching critical analysis. Best for understanding evidence quality, identifying flaws. For formal peer review writing use peer-review.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-schematics",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-schematics",
+          "description": "Create publication-quality scientific diagrams using Nano Banana 2 AI with smart iterative refinement. Uses Gemini 3.1 Pro Preview for quality review. Only regenerates if quality is below threshold for your document type. Specialized in neural network architectures, system diagrams, flowcharts, biological pathways, and complex scientific visualizations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-slides",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-slides",
+          "description": "Build slide decks and presentations for research talks. Use this for making PowerPoint slides, conference presentations, seminar talks, research presentations, thesis defense slides, or any scientific talk. Provides slide structure, design templates, timing guidance, and visual validation. Works with PowerPoint and LaTeX Beamer.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-visualization",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-visualization",
+          "description": "Meta-skill for publication-ready figures. Use when creating journal submission figures requiring multi-panel layouts, significance annotations, error bars, colorblind-safe palettes, and specific journal formatting (Nature, Science, Cell). Orchestrates matplotlib/seaborn/plotly with publication styles. For quick exploration use seaborn or plotly directly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-writing",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-writing",
+          "description": "Core skill for the deep research and writing tool. Write scientific manuscripts in full paragraphs (never bullet points). Use two-stage process with (1) section outlines with key points using research-lookup then (2) convert to flowing prose. IMRAD structure, citations (APA/AMA/Vancouver), figures/tables, reporting guidelines (CONSORT/STROBE/PRISMA), for research papers and journal submissions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scikit-learn",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scikit-learn",
+          "description": "Machine learning in Python with scikit-learn. Use when working with supervised learning (classification, regression), unsupervised learning (clustering, dimensionality reduction), model evaluation, hyperparameter tuning, preprocessing, or building ML pipelines. Provides comprehensive reference documentation for algorithms, preprocessing techniques, pipelines, and best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "seaborn",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/seaborn",
+          "description": "Statistical visualization with pandas integration. Use for quick exploration of distributions, relationships, and categorical comparisons with attractive defaults. Best for box plots, violin plots, pair plots, heatmaps. Built on matplotlib. For interactive plots use plotly; for publication styling use scientific-visualization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "simpy",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/simpy",
+          "description": "Process-based discrete-event simulation framework in Python. Use this skill when building simulations of systems with processes, queues, resources, and time-based events such as manufacturing systems, service operations, network traffic, logistics, or any system where entities interact with shared resources over time.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "stable-baselines3",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/stable-baselines3",
+          "description": "Production-ready reinforcement learning algorithms (PPO, SAC, DQN, TD3, DDPG, A2C) with scikit-learn-like API. Use for standard RL experiments, quick prototyping, and well-documented algorithm implementations. Best for single-agent RL with Gymnasium environments. For high-performance parallel training, multi-agent systems, or custom vectorized environments, use pufferlib instead.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "statistical-analysis",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/statistical-analysis",
+          "description": "Guided statistical analysis with test selection and reporting. Use when you need help choosing appropriate tests for your data, assumption checking, power analysis, and APA-formatted results. Best for academic research reporting, test selection guidance. For implementing specific models programmatically use statsmodels.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "statsmodels",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/statsmodels",
+          "description": "Statistical models library for Python. Use when you need specific model classes (OLS, GLM, mixed models, ARIMA) with detailed diagnostics, residuals, and inference. Best for econometrics, time series, rigorous inference with coefficient tables. For guided statistical test selection with APA reporting use statistical-analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "torch-geometric",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/torch-geometric",
+          "description": "Guide for building Graph Neural Networks with PyTorch Geometric (PyG). Use this skill whenever the user asks about graph neural networks, GNNs, node classification, link prediction, graph classification, message passing networks, heterogeneous graphs, neighbor sampling, or any task involving torch_geometric / PyG. Also trigger when you see imports from torch_geometric, or the user mentions graph convolutions (GCN, GAT, GraphSAGE, GIN), graph data structures, or working with relational/network data. Even if the user just says 'graph learning' or 'geometric deep learning', use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "torchdrug",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/torchdrug",
+          "description": "PyTorch-native graph neural networks for molecules and proteins. Use when building custom GNN architectures for drug discovery, protein modeling, or knowledge graph reasoning. Best for custom model development, protein property prediction, retrosynthesis. For pre-trained models and diverse featurizers use deepchem; for benchmark datasets use pytdc.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "umap-learn",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/umap-learn",
+          "description": "UMAP dimensionality reduction. Fast nonlinear manifold learning for 2D/3D visualization, clustering preprocessing (HDBSCAN), supervised/parametric UMAP, for high-dimensional data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "usfiscaldata",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/usfiscaldata",
+          "description": "Query the U.S. Treasury Fiscal Data API for federal financial data including national debt, government spending, revenue, interest rates, exchange rates, and savings bonds. Access 54 datasets and 182 data tables with no API key required. Use when working with U.S. federal fiscal data, national debt tracking (Debt to the Penny), Daily Treasury Statements, Monthly Treasury Statements, Treasury securities auctions, interest rates on Treasury securities, foreign exchange rates, savings bonds, or any U.S. government financial statistics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "vaex",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/vaex",
+          "description": "Use this skill for processing and analyzing large tabular datasets (billions of rows) that exceed available RAM. Vaex excels at out-of-core DataFrame operations, lazy evaluation, fast aggregations, efficient visualization of big data, and machine learning on large datasets. Apply when users need to work with large CSV/HDF5/Arrow/Parquet files, perform fast statistics on massive datasets, create visualizations of big data, or build ML pipelines that do not fit in memory.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "venue-templates",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/venue-templates",
+          "description": "Access comprehensive LaTeX templates, formatting requirements, and submission guidelines for major scientific publication venues (Nature, Science, PLOS, IEEE, ACM), academic conferences (NeurIPS, ICML, CVPR, CHI), research posters, and grant proposals (NSF, NIH, DOE, DARPA). This skill should be used when preparing manuscripts for journal submission, conference papers, research posters, or grant proposals and need venue-specific formatting requirements and templates.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "xlsx",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/xlsx",
+          "description": "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .csv, or .tsv file (e.g., adding columns, computing formulas, formatting, charting, cleaning messy data); create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger especially when the user references a spreadsheet file by name or path — even casually (like \\\"the xlsx in my downloads\\\") — and wants something done to it or produced from it. Also trigger for cleaning or restructuring messy tabular data files (malformed rows, misplaced headers, junk data) into proper spreadsheets. The deliverable must be a spreadsheet file. Do NOT trigger when the primary deliverable is a Word document, HTML report, standalone Python script, database pipeline, or Google Sheets API integration, even if tabular data is involved.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "K-Dense-AI",
+        "repo": "claude-scientific-skills",
+        "repoUrl": "https://github.com/K-Dense-AI/claude-scientific-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "k-dense-ai-claude-scientific-skills-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from K-Dense-AI/claude-scientific-skills.",
+      "author": "ASM (K-Dense-AI/claude-scientific-skills)",
+      "createdAt": "2026-05-09T08:10:53.521Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "k-dense-ai",
+        "claude-scientific-skills"
+      ],
+      "skills": [
+        {
+          "name": "adaptyv",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/adaptyv",
+          "description": "How to use the Adaptyv Bio Foundry API and Python SDK for protein experiment design, submission, and results retrieval. Use this skill whenever the user mentions Adaptyv, Foundry API, protein binding assays, protein screening experiments, BLI/SPR assays, thermostability assays, or wants to submit protein sequences for experimental characterization. Also trigger when code imports `adaptyv`, `adaptyv_sdk`, or `FoundryClient`, or references `foundry-api-public.adaptyvbio.com`.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aeon",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/aeon",
+          "description": "This skill should be used for time series machine learning tasks including classification, regression, clustering, forecasting, anomaly detection, segmentation, and similarity search. Use when working with temporal data, sequential patterns, or time-indexed observations requiring specialized algorithms beyond standard ML approaches. Particularly suited for univariate and multivariate time series analysis with scikit-learn compatible APIs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "anndata",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/anndata",
+          "description": "Data structure for annotated matrices in single-cell analysis. Use when working with .h5ad files or integrating with the scverse ecosystem. This is the data format skill—for analysis workflows use scanpy; for probabilistic models use scvi-tools; for population-scale queries use cellxgene-census.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arboreto",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/arboreto",
+          "description": "Infer gene regulatory networks (GRNs) from gene expression data using scalable algorithms (GRNBoost2, GENIE3). Use when analyzing transcriptomics data (bulk RNA-seq, single-cell RNA-seq) to identify transcription factor-target gene relationships and regulatory interactions. Supports distributed computation for large-scale datasets.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "astropy",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/astropy",
+          "description": "Comprehensive Python library for astronomy and astrophysics. This skill should be used when working with astronomical data including celestial coordinates, physical units, FITS files, cosmological calculations, time systems, tables, world coordinate systems (WCS), and astronomical data analysis. Use when tasks involve coordinate transformations, unit conversions, FITS file manipulation, cosmological distance calculations, time scale conversions, or astronomical data processing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autoskill",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/autoskill",
+          "description": "Observe the user's screen via screenpipe, detect repeated research workflows, match them against existing scientific-agent-skills, and draft new skills (or composition recipes that chain existing ones) for the patterns not yet covered. Use when the user asks to analyze their recent work and propose skills based on what they actually do. Requires the screenpipe daemon (https://github.com/screenpipe/screenpipe) running locally on port 3030 — the skill has no other data source and will refuse to run if screenpipe is unreachable. All detection runs locally; only redacted cluster summaries reach the LLM.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "benchling-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/benchling-integration",
+          "description": "Benchling R&D platform integration. Access registry (DNA, proteins), inventory, ELN entries, workflows via API, build Benchling Apps, query Data Warehouse, for lab data management automation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bgpt-paper-search",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/bgpt-paper-search",
+          "description": "Search scientific papers and retrieve structured experimental data extracted from full-text studies via the BGPT MCP server. Returns 25+ fields per paper including methods, results, sample sizes, quality scores, and conclusions. Use for literature reviews, evidence synthesis, and finding experimental details not available in abstracts alone.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "biopython",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/biopython",
+          "description": "Comprehensive molecular biology toolkit. Use for sequence manipulation, file parsing (FASTA/GenBank/PDB), phylogenetics, and programmatic NCBI/PubMed access (Bio.Entrez). Best for batch processing, custom bioinformatics pipelines, BLAST automation. For quick lookups use gget; for multi-service integration use bioservices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bioservices",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/bioservices",
+          "description": "Unified Python interface to 40+ bioinformatics services. Use when querying multiple databases (UniProt, KEGG, ChEMBL, Reactome) in a single workflow with consistent API. Best for cross-database analysis, ID mapping across services. For quick single-database lookups use gget; for sequence/file manipulation use biopython.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cellxgene-census",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/cellxgene-census",
+          "description": "Query the CELLxGENE Census (61M+ cells) programmatically. Use when you need expression data across tissues, diseases, or cell types from the largest curated single-cell atlas. Best for population-scale queries, reference atlas comparisons. For analyzing your own data use scanpy or scvi-tools.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cirq",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/cirq",
+          "description": "Google quantum computing framework. Use when targeting Google Quantum AI hardware, designing noise-aware circuits, or running quantum characterization experiments. Best for Google hardware, noise modeling, and low-level circuit design. For IBM hardware use qiskit; for quantum ML with autodiff use pennylane; for physics simulations use qutip.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "citation-management",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/citation-management",
+          "description": "Comprehensive citation management for academic research. Search Google Scholar and PubMed for papers, extract accurate metadata, validate citations, and generate properly formatted BibTeX entries. This skill should be used when you need to find papers, verify citation information, convert DOIs to BibTeX, or ensure reference accuracy in scientific writing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "clinical-decision-support",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/clinical-decision-support",
+          "description": "Generate professional clinical decision support (CDS) documents for pharmaceutical and clinical research settings, including patient cohort analyses (biomarker-stratified with outcomes) and treatment recommendation reports (evidence-based guidelines with decision algorithms). Supports GRADE evidence grading, statistical analysis (hazard ratios, survival curves, waterfall plots), biomarker integration, and regulatory compliance. Outputs publication-ready LaTeX/PDF format optimized for drug development, clinical research, and evidence synthesis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "clinical-reports",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/clinical-reports",
+          "description": "Write comprehensive clinical reports including case reports (CARE guidelines), diagnostic reports (radiology/pathology/lab), clinical trial reports (ICH-E3, SAE, CSR), and patient documentation (SOAP, H&P, discharge summaries). Full support with templates, regulatory compliance (HIPAA, FDA, ICH-GCP), and validation tools.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cobrapy",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/cobrapy",
+          "description": "Constraint-based metabolic modeling (COBRA). FBA, FVA, gene knockouts, flux sampling, SBML models, for systems biology and metabolic engineering analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "consciousness-council",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/consciousness-council",
+          "description": "Run a multi-perspective Mind Council deliberation on any question, decision, or creative challenge. Use this skill whenever the user wants diverse viewpoints, needs help making a tough decision, asks for a council/panel/board discussion, wants to explore a problem from multiple angles, requests devil's advocate analysis, or says things like \"what would different experts think about this\", \"help me think through this from all sides\", \"council mode\", \"mind council\", or \"deliberate on this\". Also trigger when the user faces a dilemma, trade-off, or complex choice with no obvious answer.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dask",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/dask",
+          "description": "Distributed computing for larger-than-RAM pandas/NumPy workflows. Use when you need to scale existing pandas/NumPy code beyond memory or across clusters. Best for parallel file processing, distributed ML, integration with existing pandas code. For out-of-core analytics on single machine use vaex; for in-memory speed use polars.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "database-lookup",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/database-lookup",
+          "description": "Search 78 public scientific, biomedical, materials science, and economic databases via REST APIs. Covers physics/astronomy (NASA, NIST, SDSS, SIMBAD), earth/environment (USGS, NOAA, EPA), chemistry/drugs (PubChem, ChEMBL, DrugBank, FDA, KEGG, ZINC, BindingDB), materials (Materials Project, COD), biology/genomics (Reactome, UniProt, STRING, Ensembl, NCBI Gene, GEO, GTEx, PDB, AlphaFold, InterPro, BioGRID, Gene Ontology, dbSNP, gnomAD, ENCODE, Human Protein Atlas, Human Cell Atlas), disease/clinical (COSMIC, Open Targets, ClinicalTrials.gov, OMIM, ClinVar, GDC/TCGA, cBioPortal, DisGeNET, GWAS Catalog), regulatory (FDA, USPTO, SEC EDGAR), economics/finance (FRED, World Bank, US Treasury), demographics (US Census, Eurostat, WHO). Use when looking up compounds, genes, proteins, pathways, variants, clinical trials, patents, economic indicators, or any public database API query.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "datamol",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/datamol",
+          "description": "Pythonic wrapper around RDKit with simplified interface and sensible defaults. Preferred for standard drug discovery including SMILES parsing, standardization, descriptors, fingerprints, clustering, 3D conformers, parallel processing. Returns native rdkit.Chem.Mol objects. For advanced control or custom parameters, use rdkit directly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deepchem",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/deepchem",
+          "description": "Molecular ML with diverse featurizers and pre-built datasets. Use for property prediction (ADMET, toxicity) with traditional ML or GNNs when you want extensive featurization options and MoleculeNet benchmarks. Best for quick experiments with pre-trained models, diverse molecular representations. For graph-first PyTorch workflows use torchdrug; for benchmark datasets use pytdc.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deeptools",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/deeptools",
+          "description": "NGS analysis toolkit. BAM to bigWig conversion, QC (correlation, PCA, fingerprints), heatmaps/profiles (TSS, peaks), for ChIP-seq, RNA-seq, ATAC-seq visualization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "depmap",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/depmap",
+          "description": "Query the Cancer Dependency Map (DepMap) for cancer cell line gene dependency scores (CRISPR Chronos), drug sensitivity data, and gene effect profiles. Use for identifying cancer-specific vulnerabilities, synthetic lethal interactions, and validating oncology drug targets.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dhdna-profiler",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/dhdna-profiler",
+          "description": "Extract cognitive patterns and thinking fingerprints from any text. Use this skill when the user wants to analyze how someone thinks, understand cognitive style, profile writing or speech patterns, compare thinking styles between people, asks \"what's my thinking style\", \"analyze how this person reasons\", \"cognitive profile\", \"thinking pattern\", \"DHDNA\", \"digital DNA\", or wants to understand the mind behind any text. Also trigger when the user provides text and wants deeper insight into the author's reasoning patterns, decision-making style, or cognitive signature.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "diffdock",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/diffdock",
+          "description": "Diffusion-based molecular docking. Predict protein-ligand binding poses from PDB/SMILES, confidence scores, virtual screening, for structure-based drug design. Not for affinity prediction.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dnanexus-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/dnanexus-integration",
+          "description": "DNAnexus cloud genomics platform. Build apps/applets, manage data (upload/download), dxpy Python SDK, run workflows, FASTQ/BAM/VCF, for genomics pipeline development and execution.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docx",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/docx",
+          "description": "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of 'Word doc', 'word document', '.docx', or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting or reorganizing content from .docx files, inserting or replacing images in documents, performing find-and-replace in Word files, working with tracked changes or comments, or converting content into a polished Word document. If the user asks for a 'report', 'memo', 'letter', 'template', or similar deliverable as a Word or .docx file, use this skill. Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks unrelated to document generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "esm",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/esm",
+          "description": "Comprehensive toolkit for protein language models including ESM3 (generative multimodal protein design across sequence, structure, and function) and ESM C (efficient protein embeddings and representations). Use this skill when working with protein sequences, structures, or function prediction; designing novel proteins; generating protein embeddings; performing inverse folding; or conducting protein engineering tasks. Supports both local model usage and cloud-based Forge API for scalable inference.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "etetoolkit",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/etetoolkit",
+          "description": "Phylogenetic tree toolkit (ETE). Tree manipulation (Newick/NHX), evolutionary event detection, orthology/paralogy, NCBI taxonomy, visualization (PDF/SVG), for phylogenomics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "exa-search",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/exa-search",
+          "description": "Web toolkit powered by Exa, tuned for scientific and technical content. Use this skill when the user needs to search the web or fetch/extract URL content. Covers: web search (semantic lookups, research, current info — with optional research-paper category and academic domain filtering) and URL extraction (fetching pages, articles, academic PDFs in batch). Use this skill for web-related tasks when the user wants high-quality search or scholarly filtering via category=research paper. Triggers on requests to search, look up, fetch a page, or extract an article.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "exploratory-data-analysis",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/exploratory-data-analysis",
+          "description": "Perform comprehensive exploratory data analysis on scientific data files across 200+ file formats. This skill should be used when analyzing any scientific data file to understand its structure, content, quality, and characteristics. Automatically detects file type and generates detailed markdown reports with format-specific analysis, quality metrics, and downstream analysis recommendations. Covers chemistry, bioinformatics, microscopy, spectroscopy, proteomics, metabolomics, and general scientific data formats.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowio",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/flowio",
+          "description": "Parse FCS (Flow Cytometry Standard) files v2.0-3.1. Extract events as NumPy arrays, read metadata/channels, convert to CSV/DataFrame, for flow cytometry data preprocessing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fluidsim",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/fluidsim",
+          "description": "Framework for computational fluid dynamics simulations using Python. Use when running fluid dynamics simulations including Navier-Stokes equations (2D/3D), shallow water equations, stratified flows, or when analyzing turbulence, vortex dynamics, or geophysical flows. Provides pseudospectral methods with FFT, HPC support, and comprehensive output analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "generate-image",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/generate-image",
+          "description": "Generate or edit images using AI models (FLUX, Nano Banana 2). Use for general-purpose image generation including photos, illustrations, artwork, visual assets, concept art, and any image that is not a technical diagram or schematic. For flowcharts, circuits, pathways, and technical diagrams, use the scientific-schematics skill instead.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "geniml",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geniml",
+          "description": "This skill should be used when working with genomic interval data (BED files) for machine learning tasks. Use for training region embeddings (Region2Vec, BEDspace), single-cell ATAC-seq analysis (scEmbed), building consensus peaks (universes), or any ML-based analysis of genomic regions. Applies to BED file collections, scATAC-seq data, chromatin accessibility datasets, and region-based genomic feature learning.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "geomaster",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geomaster",
+          "description": "Comprehensive geospatial science skill covering remote sensing, GIS, spatial analysis, machine learning for earth observation, and 30+ scientific domains. Supports satellite imagery processing (Sentinel, Landsat, MODIS, SAR, hyperspectral), vector and raster data operations, spatial statistics, point cloud processing, network analysis, cloud-native workflows (STAC, COG, Planetary Computer), and 8 programming languages (Python, R, Julia, JavaScript, C++, Java, Go, Rust) with 500+ code examples. Use for remote sensing workflows, GIS analysis, spatial ML, Earth observation data processing, terrain analysis, hydrological modeling, marine spatial analysis, atmospheric science, and any geospatial computation task.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "geopandas",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geopandas",
+          "description": "Python library for working with geospatial vector data including shapefiles, GeoJSON, and GeoPackage files. Use when working with geographic data for spatial analysis, geometric operations, coordinate transformations, spatial joins, overlay operations, choropleth mapping, or any task involving reading/writing/analyzing vector geographic data. Supports PostGIS databases, interactive maps, and integration with matplotlib/folium/cartopy. Use for tasks like buffer analysis, spatial joins between datasets, dissolving boundaries, clipping data, calculating areas/distances, reprojecting coordinate systems, creating maps, or converting between spatial file formats.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "get-available-resources",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/get-available-resources",
+          "description": "This skill should be used at the start of any computationally intensive scientific task to detect and report available system resources (CPU cores, GPUs, memory, disk space). It creates a JSON file with resource information and strategic recommendations that inform computational approach decisions such as whether to use parallel processing (joblib, multiprocessing), out-of-core computing (Dask, Zarr), GPU acceleration (PyTorch, JAX), or memory-efficient strategies. Use this skill before running analyses, training models, processing large datasets, or any task where resource constraints matter.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gget",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/gget",
+          "description": "Fast CLI/Python queries to 20+ bioinformatics databases. Use for quick lookups: gene info, BLAST searches, AlphaFold structures, enrichment analysis. Best for interactive exploration, simple queries. For batch processing or advanced BLAST use biopython; for multi-database Python workflows use bioservices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ginkgo-cloud-lab",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/ginkgo-cloud-lab",
+          "description": "Submit and manage protocols on Ginkgo Bioworks Cloud Lab (cloud.ginkgo.bio), a web-based interface for autonomous lab execution on Reconfigurable Automation Carts (RACs). Use when the user wants to run cell-free protein expression (validation or optimization), generate fluorescent pixel art, or interact with Ginkgo Cloud Lab services. Covers protocol selection, input preparation, pricing, and ordering workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "glycoengineering",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/glycoengineering",
+          "description": "Analyze and engineer protein glycosylation. Scan sequences for N-glycosylation sequons (N-X-S/T), predict O-glycosylation hotspots, and access curated glycoengineering tools (NetOGlyc, GlycoShield, GlycoWorkbench). For glycoprotein engineering, therapeutic antibody optimization, and vaccine design.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtars",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/gtars",
+          "description": "High-performance toolkit for genomic interval analysis in Rust with Python bindings. Use when working with genomic regions, BED files, coverage tracks, overlap detection, tokenization for ML models, or fragment analysis in computational genomics and machine learning applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "histolab",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/histolab",
+          "description": "Lightweight WSI tile extraction and preprocessing. Use for basic slide processing tissue detection, tile extraction, stain normalization for H&E images. Best for simple pipelines, dataset preparation, quick tile-based analysis. For advanced spatial proteomics, multiplexed imaging, or deep learning pipelines use pathml.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hugging-science",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hugging-science",
+          "description": "Use when the user is doing AI/ML work in a scientific domain — biology, chemistry, physics, astronomy, climate, genomics, materials science, medicine, ecology, energy, conservation, engineering, mathematics, scientific reasoning, drug discovery, protein design, weather modeling, theorem proving, single-cell, PDE solving, or anything similar. Hugging Science (huggingscience.co) is a curated catalog of scientific datasets, models, blog posts, and interactive Spaces; the `hugging-science` org on Hugging Face hosts community datasets, models, and demo Spaces. This skill helps you discover the right resource AND actually use it — loading datasets via `datasets`, running models via `transformers` or the HF Inference API, calling Spaces like BoltzGen via `gradio_client`, and citing blog posts for methodology. Trigger this skill whenever a user mentions a scientific ML task, asks for \"a dataset/model for X\" where X is a scientific topic, wants to fine-tune on scientific data, asks about protein / molecule / genome / climate / materials / astronomy / pathology / weather ML, or needs AI tools for research — even if they never say \"Hugging Science\" explicitly. The catalog is purpose-built for LLM agents (it ships an `llms-full.txt`); prefer it over generic web search for these tasks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hypogenic",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hypogenic",
+          "description": "Automated LLM-driven hypothesis generation and testing on tabular datasets. Use when you want to systematically explore hypotheses about patterns in empirical data (e.g., deception detection, content analysis). Combines literature insights with data-driven hypothesis testing. For manual hypothesis formulation use hypothesis-generation; for creative ideation use scientific-brainstorming.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hypothesis-generation",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hypothesis-generation",
+          "description": "Structured hypothesis formulation from observations. Use when you have experimental observations or data and need to formulate testable hypotheses with predictions, propose mechanisms, and design experiments to test them. Follows scientific method framework. For open-ended ideation use scientific-brainstorming; for automated LLM-driven hypothesis testing on datasets use hypogenic.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "imaging-data-commons",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/imaging-data-commons",
+          "description": "Query and download public cancer imaging data from NCI Imaging Data Commons using idc-index. Use for accessing large-scale radiology (CT, MR, PET) and pathology datasets for AI training or research. No authentication required. Query by metadata, visualize in browser, check licenses.",
+          "version": "1.4.0"
+        },
+        {
+          "name": "infographics",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/infographics",
+          "description": "Create professional infographics using Nano Banana Pro AI with smart iterative refinement. Uses Gemini 3 Pro for quality review. Integrates research-lookup and web search for accurate data. Supports 10 infographic types, 8 industry styles, and colorblind-safe palettes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "iso-13485-certification",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/iso-13485-certification",
+          "description": "Comprehensive toolkit for preparing ISO 13485 certification documentation for medical device Quality Management Systems. Use when users need help with ISO 13485 QMS documentation, including (1) conducting gap analysis of existing documentation, (2) creating Quality Manuals, (3) developing required procedures and work instructions, (4) preparing Medical Device Files, (5) understanding ISO 13485 requirements, or (6) identifying missing documentation for medical device certification. Also use when users mention medical device regulations, QMS certification, FDA QMSR, EU MDR, or need help with quality system documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "labarchive-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/labarchive-integration",
+          "description": "Electronic lab notebook API integration. Access notebooks, manage entries/attachments, backup notebooks, integrate with Protocols.io/Jupyter/REDCap, for programmatic ELN workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "lamindb",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/lamindb",
+          "description": "This skill should be used when working with LaminDB, an open-source data framework for biology that makes data queryable, traceable, reproducible, and FAIR. Use when managing biological datasets (scRNA-seq, spatial, flow cytometry, etc.), tracking computational workflows, curating and validating data with biological ontologies, building data lakehouses, or ensuring data lineage and reproducibility in biological research. Covers data management, annotation, ontologies (genes, cell types, diseases, tissues), schema validation, integrations with workflow managers (Nextflow, Snakemake) and MLOps platforms (W&B, MLflow), and deployment strategies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "latchbio-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/latchbio-integration",
+          "description": "Latch platform for bioinformatics workflows. Build pipelines with Latch SDK, @workflow/@task decorators, deploy serverless workflows, LatchFile/LatchDir, Nextflow/Snakemake integration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "latex-posters",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/latex-posters",
+          "description": "Create professional research posters in LaTeX using beamerposter, tikzposter, or baposter. Support for conference presentations, academic posters, and scientific communication. Includes layout design, color schemes, multi-column formats, figure integration, and poster-specific best practices for visual communication.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "literature-review",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/literature-review",
+          "description": "Conduct comprehensive, systematic literature reviews using multiple academic databases (PubMed, arXiv, bioRxiv, Semantic Scholar, etc.). This skill should be used when conducting systematic literature reviews, meta-analyses, research synthesis, or comprehensive literature searches across biomedical, scientific, and technical domains. Creates professionally formatted markdown documents and PDFs with verified citations in multiple citation styles (APA, Nature, Vancouver, etc.).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "markdown-mermaid-writing",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/markdown-mermaid-writing",
+          "description": "Comprehensive markdown and Mermaid diagram writing skill. Use when creating any scientific document, report, analysis, or visualization. Establishes text-based diagrams as the default documentation standard with full style guides (markdown + mermaid), 24 diagram type references, and 9 document templates.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "market-research-reports",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/market-research-reports",
+          "description": "Generate comprehensive market research reports (50+ pages) in the style of top consulting firms (McKinsey, BCG, Gartner). Features professional LaTeX formatting, extensive visual generation with scientific-schematics and generate-image, deep integration with research-lookup for data gathering, and multi-framework strategic analysis including Porter Five Forces, PESTLE, SWOT, TAM/SAM/SOM, and BCG Matrix.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "markitdown",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/markitdown",
+          "description": "Convert files and office documents to Markdown. Supports PDF, DOCX, PPTX, XLSX, images (with OCR), audio (with transcription), HTML, CSV, JSON, XML, ZIP, YouTube URLs, EPubs and more.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "matchms",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/matchms",
+          "description": "Spectral similarity and compound identification for metabolomics. Use for comparing mass spectra, computing similarity scores (cosine, modified cosine), and identifying unknown compounds from spectral libraries. Best for metabolite identification, spectral matching, library searching. For full LC-MS/MS proteomics pipelines use pyopenms.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "matlab",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/matlab",
+          "description": "MATLAB and GNU Octave numerical computing for matrix operations, data analysis, visualization, and scientific computing. Use when writing MATLAB/Octave scripts for linear algebra, signal processing, image processing, differential equations, optimization, statistics, or creating scientific visualizations. Also use when the user needs help with MATLAB syntax, functions, or wants to convert between MATLAB and Python code. Scripts can be executed with MATLAB or the open-source GNU Octave interpreter.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "matplotlib",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/matplotlib",
+          "description": "Low-level plotting library for full customization. Use when you need fine-grained control over every plot element, creating novel plot types, or integrating with specific scientific workflows. Export to PNG/PDF/SVG for publication. For quick statistical plots use seaborn; for interactive plots use plotly; for publication-ready multi-panel figures with journal styling, use scientific-visualization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "medchem",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/medchem",
+          "description": "Medicinal chemistry filters. Apply drug-likeness rules (Lipinski, Veber), PAINS filters, structural alerts, complexity metrics, for compound prioritization and library filtering.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "modal",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/modal",
+          "description": "Cloud computing platform for running Python on GPUs and serverless infrastructure. Use when deploying AI/ML models, running GPU-accelerated workloads, serving web endpoints, scheduling batch jobs, or scaling Python code to the cloud. Use this skill whenever the user mentions Modal, serverless GPU compute, deploying ML models to the cloud, serving inference endpoints, running batch processing in the cloud, or needs to scale Python workloads beyond their local machine. Also use when the user wants to run code on H100s, A100s, or other cloud GPUs, or needs to create a web API for a model.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "molecular-dynamics",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/molecular-dynamics",
+          "description": "Run and analyze molecular dynamics simulations with OpenMM and MDAnalysis. Set up protein/small molecule systems, define force fields, run energy minimization and production MD, analyze trajectories (RMSD, RMSF, contact maps, free energy surfaces). For structural biology, drug binding, and biophysics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "molfeat",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/molfeat",
+          "description": "Molecular featurization for ML (100+ featurizers). ECFP, MACCS, descriptors, pretrained models (ChemBERTa), convert SMILES to features, for QSAR and molecular ML.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "networkx",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/networkx",
+          "description": "Comprehensive toolkit for creating, analyzing, and visualizing complex networks and graphs in Python. Use when working with network/graph data structures, analyzing relationships between entities, computing graph algorithms (shortest paths, centrality, clustering), detecting communities, generating synthetic networks, or visualizing network topologies. Applicable to social networks, biological networks, transportation systems, citation networks, and any domain involving pairwise relationships.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "neurokit2",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/neurokit2",
+          "description": "Comprehensive biosignal processing toolkit for analyzing physiological data including ECG, EEG, EDA, RSP, PPG, EMG, and EOG signals. Use this skill when processing cardiovascular signals, brain activity, electrodermal responses, respiratory patterns, muscle activity, or eye movements. Applicable for heart rate variability analysis, event-related potentials, complexity measures, autonomic nervous system assessment, psychophysiology research, and multi-modal physiological signal integration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "neuropixels-analysis",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/neuropixels-analysis",
+          "description": "Neuropixels neural recording analysis. Load SpikeGLX/OpenEphys data, preprocess, motion correction, Kilosort4 spike sorting, quality metrics, Allen/IBL curation, AI-assisted visual analysis, for Neuropixels 1.0/2.0 extracellular electrophysiology. Use when working with neural recordings, spike sorting, extracellular electrophysiology, or when the user mentions Neuropixels, SpikeGLX, Open Ephys, Kilosort, quality metrics, or unit curation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "omero-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/omero-integration",
+          "description": "Microscopy data management platform. Access images via Python, retrieve datasets, analyze pixels, manage ROIs/annotations, batch processing, for high-content screening and microscopy workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "open-notebook",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/open-notebook",
+          "description": "Self-hosted, open-source alternative to Google NotebookLM for AI-powered research and document analysis. Use when organizing research materials into notebooks, ingesting diverse content sources (PDFs, videos, audio, web pages, Office documents), generating AI-powered notes and summaries, creating multi-speaker podcasts from research, chatting with documents using context-aware AI, searching across materials with full-text and vector search, or running custom content transformations. Supports 16+ AI providers including OpenAI, Anthropic, Google, Ollama, Groq, and Mistral with complete data privacy through self-hosting.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "opentrons-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/opentrons-integration",
+          "description": "Official Opentrons Protocol API for OT-2 and Flex robots. Use when writing protocols specifically for Opentrons hardware with full access to Protocol API v2 features. Best for production Opentrons protocols, official API compatibility. For multi-vendor automation or broader equipment control use pylabrobot.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "optimize-for-gpu",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/optimize-for-gpu",
+          "description": "GPU-accelerate Python code using CuPy, Numba CUDA, Warp, cuDF, cuML, cuGraph, KvikIO, cuCIM, cuxfilter, cuVS, cuSpatial, and RAFT. Use whenever the user mentions GPU/CUDA/NVIDIA acceleration, or wants to speed up NumPy, pandas, scikit-learn, scikit-image, NetworkX, GeoPandas, or Faiss workloads. Covers physics simulation, differentiable rendering, mesh ray casting, particle systems (DEM/SPH/fluids), vector/similarity search, GPUDirect Storage file IO, interactive dashboards, geospatial analysis, medical imaging, and sparse eigensolvers. Also use when you see CPU-bound Python code (loops, large arrays, ML pipelines, graph analytics, image processing) that would benefit from GPU acceleration, even if not explicitly requested.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "paper-lookup",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/paper-lookup",
+          "description": "Search 10 academic paper databases via REST APIs for research papers, preprints, and scholarly articles. Covers PubMed, PMC (full text), bioRxiv, medRxiv, arXiv, OpenAlex, Crossref, Semantic Scholar, CORE, Unpaywall. Use when searching for papers, citations, DOI/PMID lookups, abstracts, full text, open access, preprints, citation graphs, author search, or any scholarly literature query. Triggers on mentions of any supported database or requests like \"find papers on X\" or \"look up this DOI\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "paperzilla",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/paperzilla",
+          "description": "Chat with your agent about projects, recommendations, and canonical papers in Paperzilla. Use when users ask for recent project recommendations, canonical paper details, markdown-based summaries, recommendation feedback, feed export, or Atom feed URLs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "parallel-web",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/parallel-web",
+          "description": "All-in-one web toolkit powered by parallel-cli, with a strong emphasis on academic and scientific sources. Use this skill whenever the user needs to search the web, fetch/extract URL content, enrich data with web-sourced fields, or run deep research reports. Covers: web search (fast lookups, research, current info — prioritizing peer-reviewed papers, preprints, and scholarly databases), URL extraction (fetching pages, articles, academic PDFs), bulk data enrichment (adding fields to CSV/lists from the web), and deep research (exhaustive multi-source reports grounded in academic literature). Also handles setup, status checks, and result retrieval. Use this skill for ANY web-related task — even if the user doesn't mention 'parallel' or 'web' explicitly. If they want to look something up, fetch a page, enrich a dataset, investigate a topic, find academic papers, check citations, or review scientific literature, this is the skill to use.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pathml",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pathml",
+          "description": "Full-featured computational pathology toolkit. Use for advanced WSI analysis including multiplexed immunofluorescence (CODEX, Vectra), nucleus segmentation, tissue graph construction, and ML model training on pathology data. Supports 160+ slide formats. For simple tile extraction from H&E slides, histolab may be simpler.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pdf",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pdf",
+          "description": "Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "peer-review",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/peer-review",
+          "description": "Structured manuscript/grant review with checklist-based evaluation. Use when writing formal peer reviews with specific criteria methodology assessment, statistical validity, reporting standards compliance (CONSORT/STROBE), and constructive feedback. Best for actual review writing, manuscript revision. For evaluating claims/evidence quality use scientific-critical-thinking; for quantitative scoring frameworks use scholar-evaluation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pennylane",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pennylane",
+          "description": "Hardware-agnostic quantum ML framework with automatic differentiation. Use when training quantum circuits via gradients, building hybrid quantum-classical models, or needing device portability across IBM/Google/Rigetti/IonQ. Best for variational algorithms (VQE, QAOA), quantum neural networks, and integration with PyTorch/JAX/TensorFlow. For hardware-specific optimizations use qiskit (IBM) or cirq (Google); for open quantum systems use qutip.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "phylogenetics",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/phylogenetics",
+          "description": "Build and analyze phylogenetic trees using MAFFT (multiple alignment), IQ-TREE 2 (maximum likelihood), and FastTree (fast NJ/ML). Visualize with ETE3 or FigTree. For evolutionary analysis, microbial genomics, viral phylodynamics, protein family analysis, and molecular clock studies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "polars",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/polars",
+          "description": "Fast in-memory DataFrame library for datasets that fit in RAM. Use when pandas is too slow but data still fits in memory. Lazy evaluation, parallel execution, Apache Arrow backend. Best for 1-100GB datasets, ETL pipelines, faster pandas replacement. For larger-than-RAM data use dask or vaex.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "K-Dense-AI",
+        "repo": "claude-scientific-skills",
+        "repoUrl": "https://github.com/K-Dense-AI/claude-scientific-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "k-dense-ai-claude-scientific-skills-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from K-Dense-AI/claude-scientific-skills.",
+      "author": "ASM (K-Dense-AI/claude-scientific-skills)",
+      "createdAt": "2026-05-09T08:10:53.521Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "k-dense-ai",
+        "claude-scientific-skills"
+      ],
+      "skills": [
+        {
+          "name": "adaptyv",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/adaptyv",
+          "description": "How to use the Adaptyv Bio Foundry API and Python SDK for protein experiment design, submission, and results retrieval. Use this skill whenever the user mentions Adaptyv, Foundry API, protein binding assays, protein screening experiments, BLI/SPR assays, thermostability assays, or wants to submit protein sequences for experimental characterization. Also trigger when code imports `adaptyv`, `adaptyv_sdk`, or `FoundryClient`, or references `foundry-api-public.adaptyvbio.com`.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aeon",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/aeon",
+          "description": "This skill should be used for time series machine learning tasks including classification, regression, clustering, forecasting, anomaly detection, segmentation, and similarity search. Use when working with temporal data, sequential patterns, or time-indexed observations requiring specialized algorithms beyond standard ML approaches. Particularly suited for univariate and multivariate time series analysis with scikit-learn compatible APIs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "anndata",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/anndata",
+          "description": "Data structure for annotated matrices in single-cell analysis. Use when working with .h5ad files or integrating with the scverse ecosystem. This is the data format skill—for analysis workflows use scanpy; for probabilistic models use scvi-tools; for population-scale queries use cellxgene-census.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arboreto",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/arboreto",
+          "description": "Infer gene regulatory networks (GRNs) from gene expression data using scalable algorithms (GRNBoost2, GENIE3). Use when analyzing transcriptomics data (bulk RNA-seq, single-cell RNA-seq) to identify transcription factor-target gene relationships and regulatory interactions. Supports distributed computation for large-scale datasets.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "astropy",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/astropy",
+          "description": "Comprehensive Python library for astronomy and astrophysics. This skill should be used when working with astronomical data including celestial coordinates, physical units, FITS files, cosmological calculations, time systems, tables, world coordinate systems (WCS), and astronomical data analysis. Use when tasks involve coordinate transformations, unit conversions, FITS file manipulation, cosmological distance calculations, time scale conversions, or astronomical data processing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autoskill",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/autoskill",
+          "description": "Observe the user's screen via screenpipe, detect repeated research workflows, match them against existing scientific-agent-skills, and draft new skills (or composition recipes that chain existing ones) for the patterns not yet covered. Use when the user asks to analyze their recent work and propose skills based on what they actually do. Requires the screenpipe daemon (https://github.com/screenpipe/screenpipe) running locally on port 3030 — the skill has no other data source and will refuse to run if screenpipe is unreachable. All detection runs locally; only redacted cluster summaries reach the LLM.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "benchling-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/benchling-integration",
+          "description": "Benchling R&D platform integration. Access registry (DNA, proteins), inventory, ELN entries, workflows via API, build Benchling Apps, query Data Warehouse, for lab data management automation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bgpt-paper-search",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/bgpt-paper-search",
+          "description": "Search scientific papers and retrieve structured experimental data extracted from full-text studies via the BGPT MCP server. Returns 25+ fields per paper including methods, results, sample sizes, quality scores, and conclusions. Use for literature reviews, evidence synthesis, and finding experimental details not available in abstracts alone.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "biopython",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/biopython",
+          "description": "Comprehensive molecular biology toolkit. Use for sequence manipulation, file parsing (FASTA/GenBank/PDB), phylogenetics, and programmatic NCBI/PubMed access (Bio.Entrez). Best for batch processing, custom bioinformatics pipelines, BLAST automation. For quick lookups use gget; for multi-service integration use bioservices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bioservices",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/bioservices",
+          "description": "Unified Python interface to 40+ bioinformatics services. Use when querying multiple databases (UniProt, KEGG, ChEMBL, Reactome) in a single workflow with consistent API. Best for cross-database analysis, ID mapping across services. For quick single-database lookups use gget; for sequence/file manipulation use biopython.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cellxgene-census",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/cellxgene-census",
+          "description": "Query the CELLxGENE Census (61M+ cells) programmatically. Use when you need expression data across tissues, diseases, or cell types from the largest curated single-cell atlas. Best for population-scale queries, reference atlas comparisons. For analyzing your own data use scanpy or scvi-tools.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cirq",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/cirq",
+          "description": "Google quantum computing framework. Use when targeting Google Quantum AI hardware, designing noise-aware circuits, or running quantum characterization experiments. Best for Google hardware, noise modeling, and low-level circuit design. For IBM hardware use qiskit; for quantum ML with autodiff use pennylane; for physics simulations use qutip.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "citation-management",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/citation-management",
+          "description": "Comprehensive citation management for academic research. Search Google Scholar and PubMed for papers, extract accurate metadata, validate citations, and generate properly formatted BibTeX entries. This skill should be used when you need to find papers, verify citation information, convert DOIs to BibTeX, or ensure reference accuracy in scientific writing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "clinical-decision-support",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/clinical-decision-support",
+          "description": "Generate professional clinical decision support (CDS) documents for pharmaceutical and clinical research settings, including patient cohort analyses (biomarker-stratified with outcomes) and treatment recommendation reports (evidence-based guidelines with decision algorithms). Supports GRADE evidence grading, statistical analysis (hazard ratios, survival curves, waterfall plots), biomarker integration, and regulatory compliance. Outputs publication-ready LaTeX/PDF format optimized for drug development, clinical research, and evidence synthesis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "clinical-reports",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/clinical-reports",
+          "description": "Write comprehensive clinical reports including case reports (CARE guidelines), diagnostic reports (radiology/pathology/lab), clinical trial reports (ICH-E3, SAE, CSR), and patient documentation (SOAP, H&P, discharge summaries). Full support with templates, regulatory compliance (HIPAA, FDA, ICH-GCP), and validation tools.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cobrapy",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/cobrapy",
+          "description": "Constraint-based metabolic modeling (COBRA). FBA, FVA, gene knockouts, flux sampling, SBML models, for systems biology and metabolic engineering analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "consciousness-council",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/consciousness-council",
+          "description": "Run a multi-perspective Mind Council deliberation on any question, decision, or creative challenge. Use this skill whenever the user wants diverse viewpoints, needs help making a tough decision, asks for a council/panel/board discussion, wants to explore a problem from multiple angles, requests devil's advocate analysis, or says things like \"what would different experts think about this\", \"help me think through this from all sides\", \"council mode\", \"mind council\", or \"deliberate on this\". Also trigger when the user faces a dilemma, trade-off, or complex choice with no obvious answer.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dask",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/dask",
+          "description": "Distributed computing for larger-than-RAM pandas/NumPy workflows. Use when you need to scale existing pandas/NumPy code beyond memory or across clusters. Best for parallel file processing, distributed ML, integration with existing pandas code. For out-of-core analytics on single machine use vaex; for in-memory speed use polars.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "database-lookup",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/database-lookup",
+          "description": "Search 78 public scientific, biomedical, materials science, and economic databases via REST APIs. Covers physics/astronomy (NASA, NIST, SDSS, SIMBAD), earth/environment (USGS, NOAA, EPA), chemistry/drugs (PubChem, ChEMBL, DrugBank, FDA, KEGG, ZINC, BindingDB), materials (Materials Project, COD), biology/genomics (Reactome, UniProt, STRING, Ensembl, NCBI Gene, GEO, GTEx, PDB, AlphaFold, InterPro, BioGRID, Gene Ontology, dbSNP, gnomAD, ENCODE, Human Protein Atlas, Human Cell Atlas), disease/clinical (COSMIC, Open Targets, ClinicalTrials.gov, OMIM, ClinVar, GDC/TCGA, cBioPortal, DisGeNET, GWAS Catalog), regulatory (FDA, USPTO, SEC EDGAR), economics/finance (FRED, World Bank, US Treasury), demographics (US Census, Eurostat, WHO). Use when looking up compounds, genes, proteins, pathways, variants, clinical trials, patents, economic indicators, or any public database API query.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "datamol",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/datamol",
+          "description": "Pythonic wrapper around RDKit with simplified interface and sensible defaults. Preferred for standard drug discovery including SMILES parsing, standardization, descriptors, fingerprints, clustering, 3D conformers, parallel processing. Returns native rdkit.Chem.Mol objects. For advanced control or custom parameters, use rdkit directly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deepchem",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/deepchem",
+          "description": "Molecular ML with diverse featurizers and pre-built datasets. Use for property prediction (ADMET, toxicity) with traditional ML or GNNs when you want extensive featurization options and MoleculeNet benchmarks. Best for quick experiments with pre-trained models, diverse molecular representations. For graph-first PyTorch workflows use torchdrug; for benchmark datasets use pytdc.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deeptools",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/deeptools",
+          "description": "NGS analysis toolkit. BAM to bigWig conversion, QC (correlation, PCA, fingerprints), heatmaps/profiles (TSS, peaks), for ChIP-seq, RNA-seq, ATAC-seq visualization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "depmap",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/depmap",
+          "description": "Query the Cancer Dependency Map (DepMap) for cancer cell line gene dependency scores (CRISPR Chronos), drug sensitivity data, and gene effect profiles. Use for identifying cancer-specific vulnerabilities, synthetic lethal interactions, and validating oncology drug targets.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dhdna-profiler",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/dhdna-profiler",
+          "description": "Extract cognitive patterns and thinking fingerprints from any text. Use this skill when the user wants to analyze how someone thinks, understand cognitive style, profile writing or speech patterns, compare thinking styles between people, asks \"what's my thinking style\", \"analyze how this person reasons\", \"cognitive profile\", \"thinking pattern\", \"DHDNA\", \"digital DNA\", or wants to understand the mind behind any text. Also trigger when the user provides text and wants deeper insight into the author's reasoning patterns, decision-making style, or cognitive signature.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "diffdock",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/diffdock",
+          "description": "Diffusion-based molecular docking. Predict protein-ligand binding poses from PDB/SMILES, confidence scores, virtual screening, for structure-based drug design. Not for affinity prediction.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dnanexus-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/dnanexus-integration",
+          "description": "DNAnexus cloud genomics platform. Build apps/applets, manage data (upload/download), dxpy Python SDK, run workflows, FASTQ/BAM/VCF, for genomics pipeline development and execution.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docx",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/docx",
+          "description": "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of 'Word doc', 'word document', '.docx', or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting or reorganizing content from .docx files, inserting or replacing images in documents, performing find-and-replace in Word files, working with tracked changes or comments, or converting content into a polished Word document. If the user asks for a 'report', 'memo', 'letter', 'template', or similar deliverable as a Word or .docx file, use this skill. Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks unrelated to document generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "esm",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/esm",
+          "description": "Comprehensive toolkit for protein language models including ESM3 (generative multimodal protein design across sequence, structure, and function) and ESM C (efficient protein embeddings and representations). Use this skill when working with protein sequences, structures, or function prediction; designing novel proteins; generating protein embeddings; performing inverse folding; or conducting protein engineering tasks. Supports both local model usage and cloud-based Forge API for scalable inference.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "etetoolkit",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/etetoolkit",
+          "description": "Phylogenetic tree toolkit (ETE). Tree manipulation (Newick/NHX), evolutionary event detection, orthology/paralogy, NCBI taxonomy, visualization (PDF/SVG), for phylogenomics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "exa-search",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/exa-search",
+          "description": "Web toolkit powered by Exa, tuned for scientific and technical content. Use this skill when the user needs to search the web or fetch/extract URL content. Covers: web search (semantic lookups, research, current info — with optional research-paper category and academic domain filtering) and URL extraction (fetching pages, articles, academic PDFs in batch). Use this skill for web-related tasks when the user wants high-quality search or scholarly filtering via category=research paper. Triggers on requests to search, look up, fetch a page, or extract an article.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "exploratory-data-analysis",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/exploratory-data-analysis",
+          "description": "Perform comprehensive exploratory data analysis on scientific data files across 200+ file formats. This skill should be used when analyzing any scientific data file to understand its structure, content, quality, and characteristics. Automatically detects file type and generates detailed markdown reports with format-specific analysis, quality metrics, and downstream analysis recommendations. Covers chemistry, bioinformatics, microscopy, spectroscopy, proteomics, metabolomics, and general scientific data formats.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowio",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/flowio",
+          "description": "Parse FCS (Flow Cytometry Standard) files v2.0-3.1. Extract events as NumPy arrays, read metadata/channels, convert to CSV/DataFrame, for flow cytometry data preprocessing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fluidsim",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/fluidsim",
+          "description": "Framework for computational fluid dynamics simulations using Python. Use when running fluid dynamics simulations including Navier-Stokes equations (2D/3D), shallow water equations, stratified flows, or when analyzing turbulence, vortex dynamics, or geophysical flows. Provides pseudospectral methods with FFT, HPC support, and comprehensive output analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "generate-image",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/generate-image",
+          "description": "Generate or edit images using AI models (FLUX, Nano Banana 2). Use for general-purpose image generation including photos, illustrations, artwork, visual assets, concept art, and any image that is not a technical diagram or schematic. For flowcharts, circuits, pathways, and technical diagrams, use the scientific-schematics skill instead.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "geniml",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geniml",
+          "description": "This skill should be used when working with genomic interval data (BED files) for machine learning tasks. Use for training region embeddings (Region2Vec, BEDspace), single-cell ATAC-seq analysis (scEmbed), building consensus peaks (universes), or any ML-based analysis of genomic regions. Applies to BED file collections, scATAC-seq data, chromatin accessibility datasets, and region-based genomic feature learning.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "geomaster",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geomaster",
+          "description": "Comprehensive geospatial science skill covering remote sensing, GIS, spatial analysis, machine learning for earth observation, and 30+ scientific domains. Supports satellite imagery processing (Sentinel, Landsat, MODIS, SAR, hyperspectral), vector and raster data operations, spatial statistics, point cloud processing, network analysis, cloud-native workflows (STAC, COG, Planetary Computer), and 8 programming languages (Python, R, Julia, JavaScript, C++, Java, Go, Rust) with 500+ code examples. Use for remote sensing workflows, GIS analysis, spatial ML, Earth observation data processing, terrain analysis, hydrological modeling, marine spatial analysis, atmospheric science, and any geospatial computation task.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "geopandas",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geopandas",
+          "description": "Python library for working with geospatial vector data including shapefiles, GeoJSON, and GeoPackage files. Use when working with geographic data for spatial analysis, geometric operations, coordinate transformations, spatial joins, overlay operations, choropleth mapping, or any task involving reading/writing/analyzing vector geographic data. Supports PostGIS databases, interactive maps, and integration with matplotlib/folium/cartopy. Use for tasks like buffer analysis, spatial joins between datasets, dissolving boundaries, clipping data, calculating areas/distances, reprojecting coordinate systems, creating maps, or converting between spatial file formats.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "get-available-resources",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/get-available-resources",
+          "description": "This skill should be used at the start of any computationally intensive scientific task to detect and report available system resources (CPU cores, GPUs, memory, disk space). It creates a JSON file with resource information and strategic recommendations that inform computational approach decisions such as whether to use parallel processing (joblib, multiprocessing), out-of-core computing (Dask, Zarr), GPU acceleration (PyTorch, JAX), or memory-efficient strategies. Use this skill before running analyses, training models, processing large datasets, or any task where resource constraints matter.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gget",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/gget",
+          "description": "Fast CLI/Python queries to 20+ bioinformatics databases. Use for quick lookups: gene info, BLAST searches, AlphaFold structures, enrichment analysis. Best for interactive exploration, simple queries. For batch processing or advanced BLAST use biopython; for multi-database Python workflows use bioservices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ginkgo-cloud-lab",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/ginkgo-cloud-lab",
+          "description": "Submit and manage protocols on Ginkgo Bioworks Cloud Lab (cloud.ginkgo.bio), a web-based interface for autonomous lab execution on Reconfigurable Automation Carts (RACs). Use when the user wants to run cell-free protein expression (validation or optimization), generate fluorescent pixel art, or interact with Ginkgo Cloud Lab services. Covers protocol selection, input preparation, pricing, and ordering workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "glycoengineering",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/glycoengineering",
+          "description": "Analyze and engineer protein glycosylation. Scan sequences for N-glycosylation sequons (N-X-S/T), predict O-glycosylation hotspots, and access curated glycoengineering tools (NetOGlyc, GlycoShield, GlycoWorkbench). For glycoprotein engineering, therapeutic antibody optimization, and vaccine design.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtars",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/gtars",
+          "description": "High-performance toolkit for genomic interval analysis in Rust with Python bindings. Use when working with genomic regions, BED files, coverage tracks, overlap detection, tokenization for ML models, or fragment analysis in computational genomics and machine learning applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "histolab",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/histolab",
+          "description": "Lightweight WSI tile extraction and preprocessing. Use for basic slide processing tissue detection, tile extraction, stain normalization for H&E images. Best for simple pipelines, dataset preparation, quick tile-based analysis. For advanced spatial proteomics, multiplexed imaging, or deep learning pipelines use pathml.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hugging-science",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hugging-science",
+          "description": "Use when the user is doing AI/ML work in a scientific domain — biology, chemistry, physics, astronomy, climate, genomics, materials science, medicine, ecology, energy, conservation, engineering, mathematics, scientific reasoning, drug discovery, protein design, weather modeling, theorem proving, single-cell, PDE solving, or anything similar. Hugging Science (huggingscience.co) is a curated catalog of scientific datasets, models, blog posts, and interactive Spaces; the `hugging-science` org on Hugging Face hosts community datasets, models, and demo Spaces. This skill helps you discover the right resource AND actually use it — loading datasets via `datasets`, running models via `transformers` or the HF Inference API, calling Spaces like BoltzGen via `gradio_client`, and citing blog posts for methodology. Trigger this skill whenever a user mentions a scientific ML task, asks for \"a dataset/model for X\" where X is a scientific topic, wants to fine-tune on scientific data, asks about protein / molecule / genome / climate / materials / astronomy / pathology / weather ML, or needs AI tools for research — even if they never say \"Hugging Science\" explicitly. The catalog is purpose-built for LLM agents (it ships an `llms-full.txt`); prefer it over generic web search for these tasks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hypogenic",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hypogenic",
+          "description": "Automated LLM-driven hypothesis generation and testing on tabular datasets. Use when you want to systematically explore hypotheses about patterns in empirical data (e.g., deception detection, content analysis). Combines literature insights with data-driven hypothesis testing. For manual hypothesis formulation use hypothesis-generation; for creative ideation use scientific-brainstorming.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hypothesis-generation",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hypothesis-generation",
+          "description": "Structured hypothesis formulation from observations. Use when you have experimental observations or data and need to formulate testable hypotheses with predictions, propose mechanisms, and design experiments to test them. Follows scientific method framework. For open-ended ideation use scientific-brainstorming; for automated LLM-driven hypothesis testing on datasets use hypogenic.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "imaging-data-commons",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/imaging-data-commons",
+          "description": "Query and download public cancer imaging data from NCI Imaging Data Commons using idc-index. Use for accessing large-scale radiology (CT, MR, PET) and pathology datasets for AI training or research. No authentication required. Query by metadata, visualize in browser, check licenses.",
+          "version": "1.4.0"
+        },
+        {
+          "name": "infographics",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/infographics",
+          "description": "Create professional infographics using Nano Banana Pro AI with smart iterative refinement. Uses Gemini 3 Pro for quality review. Integrates research-lookup and web search for accurate data. Supports 10 infographic types, 8 industry styles, and colorblind-safe palettes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "iso-13485-certification",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/iso-13485-certification",
+          "description": "Comprehensive toolkit for preparing ISO 13485 certification documentation for medical device Quality Management Systems. Use when users need help with ISO 13485 QMS documentation, including (1) conducting gap analysis of existing documentation, (2) creating Quality Manuals, (3) developing required procedures and work instructions, (4) preparing Medical Device Files, (5) understanding ISO 13485 requirements, or (6) identifying missing documentation for medical device certification. Also use when users mention medical device regulations, QMS certification, FDA QMSR, EU MDR, or need help with quality system documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "labarchive-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/labarchive-integration",
+          "description": "Electronic lab notebook API integration. Access notebooks, manage entries/attachments, backup notebooks, integrate with Protocols.io/Jupyter/REDCap, for programmatic ELN workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "lamindb",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/lamindb",
+          "description": "This skill should be used when working with LaminDB, an open-source data framework for biology that makes data queryable, traceable, reproducible, and FAIR. Use when managing biological datasets (scRNA-seq, spatial, flow cytometry, etc.), tracking computational workflows, curating and validating data with biological ontologies, building data lakehouses, or ensuring data lineage and reproducibility in biological research. Covers data management, annotation, ontologies (genes, cell types, diseases, tissues), schema validation, integrations with workflow managers (Nextflow, Snakemake) and MLOps platforms (W&B, MLflow), and deployment strategies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "latchbio-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/latchbio-integration",
+          "description": "Latch platform for bioinformatics workflows. Build pipelines with Latch SDK, @workflow/@task decorators, deploy serverless workflows, LatchFile/LatchDir, Nextflow/Snakemake integration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "latex-posters",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/latex-posters",
+          "description": "Create professional research posters in LaTeX using beamerposter, tikzposter, or baposter. Support for conference presentations, academic posters, and scientific communication. Includes layout design, color schemes, multi-column formats, figure integration, and poster-specific best practices for visual communication.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "literature-review",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/literature-review",
+          "description": "Conduct comprehensive, systematic literature reviews using multiple academic databases (PubMed, arXiv, bioRxiv, Semantic Scholar, etc.). This skill should be used when conducting systematic literature reviews, meta-analyses, research synthesis, or comprehensive literature searches across biomedical, scientific, and technical domains. Creates professionally formatted markdown documents and PDFs with verified citations in multiple citation styles (APA, Nature, Vancouver, etc.).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "markdown-mermaid-writing",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/markdown-mermaid-writing",
+          "description": "Comprehensive markdown and Mermaid diagram writing skill. Use when creating any scientific document, report, analysis, or visualization. Establishes text-based diagrams as the default documentation standard with full style guides (markdown + mermaid), 24 diagram type references, and 9 document templates.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "market-research-reports",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/market-research-reports",
+          "description": "Generate comprehensive market research reports (50+ pages) in the style of top consulting firms (McKinsey, BCG, Gartner). Features professional LaTeX formatting, extensive visual generation with scientific-schematics and generate-image, deep integration with research-lookup for data gathering, and multi-framework strategic analysis including Porter Five Forces, PESTLE, SWOT, TAM/SAM/SOM, and BCG Matrix.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "markitdown",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/markitdown",
+          "description": "Convert files and office documents to Markdown. Supports PDF, DOCX, PPTX, XLSX, images (with OCR), audio (with transcription), HTML, CSV, JSON, XML, ZIP, YouTube URLs, EPubs and more.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "matchms",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/matchms",
+          "description": "Spectral similarity and compound identification for metabolomics. Use for comparing mass spectra, computing similarity scores (cosine, modified cosine), and identifying unknown compounds from spectral libraries. Best for metabolite identification, spectral matching, library searching. For full LC-MS/MS proteomics pipelines use pyopenms.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "matlab",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/matlab",
+          "description": "MATLAB and GNU Octave numerical computing for matrix operations, data analysis, visualization, and scientific computing. Use when writing MATLAB/Octave scripts for linear algebra, signal processing, image processing, differential equations, optimization, statistics, or creating scientific visualizations. Also use when the user needs help with MATLAB syntax, functions, or wants to convert between MATLAB and Python code. Scripts can be executed with MATLAB or the open-source GNU Octave interpreter.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "matplotlib",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/matplotlib",
+          "description": "Low-level plotting library for full customization. Use when you need fine-grained control over every plot element, creating novel plot types, or integrating with specific scientific workflows. Export to PNG/PDF/SVG for publication. For quick statistical plots use seaborn; for interactive plots use plotly; for publication-ready multi-panel figures with journal styling, use scientific-visualization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "medchem",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/medchem",
+          "description": "Medicinal chemistry filters. Apply drug-likeness rules (Lipinski, Veber), PAINS filters, structural alerts, complexity metrics, for compound prioritization and library filtering.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "modal",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/modal",
+          "description": "Cloud computing platform for running Python on GPUs and serverless infrastructure. Use when deploying AI/ML models, running GPU-accelerated workloads, serving web endpoints, scheduling batch jobs, or scaling Python code to the cloud. Use this skill whenever the user mentions Modal, serverless GPU compute, deploying ML models to the cloud, serving inference endpoints, running batch processing in the cloud, or needs to scale Python workloads beyond their local machine. Also use when the user wants to run code on H100s, A100s, or other cloud GPUs, or needs to create a web API for a model.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "molecular-dynamics",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/molecular-dynamics",
+          "description": "Run and analyze molecular dynamics simulations with OpenMM and MDAnalysis. Set up protein/small molecule systems, define force fields, run energy minimization and production MD, analyze trajectories (RMSD, RMSF, contact maps, free energy surfaces). For structural biology, drug binding, and biophysics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "molfeat",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/molfeat",
+          "description": "Molecular featurization for ML (100+ featurizers). ECFP, MACCS, descriptors, pretrained models (ChemBERTa), convert SMILES to features, for QSAR and molecular ML.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "networkx",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/networkx",
+          "description": "Comprehensive toolkit for creating, analyzing, and visualizing complex networks and graphs in Python. Use when working with network/graph data structures, analyzing relationships between entities, computing graph algorithms (shortest paths, centrality, clustering), detecting communities, generating synthetic networks, or visualizing network topologies. Applicable to social networks, biological networks, transportation systems, citation networks, and any domain involving pairwise relationships.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "neurokit2",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/neurokit2",
+          "description": "Comprehensive biosignal processing toolkit for analyzing physiological data including ECG, EEG, EDA, RSP, PPG, EMG, and EOG signals. Use this skill when processing cardiovascular signals, brain activity, electrodermal responses, respiratory patterns, muscle activity, or eye movements. Applicable for heart rate variability analysis, event-related potentials, complexity measures, autonomic nervous system assessment, psychophysiology research, and multi-modal physiological signal integration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "neuropixels-analysis",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/neuropixels-analysis",
+          "description": "Neuropixels neural recording analysis. Load SpikeGLX/OpenEphys data, preprocess, motion correction, Kilosort4 spike sorting, quality metrics, Allen/IBL curation, AI-assisted visual analysis, for Neuropixels 1.0/2.0 extracellular electrophysiology. Use when working with neural recordings, spike sorting, extracellular electrophysiology, or when the user mentions Neuropixels, SpikeGLX, Open Ephys, Kilosort, quality metrics, or unit curation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "omero-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/omero-integration",
+          "description": "Microscopy data management platform. Access images via Python, retrieve datasets, analyze pixels, manage ROIs/annotations, batch processing, for high-content screening and microscopy workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "open-notebook",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/open-notebook",
+          "description": "Self-hosted, open-source alternative to Google NotebookLM for AI-powered research and document analysis. Use when organizing research materials into notebooks, ingesting diverse content sources (PDFs, videos, audio, web pages, Office documents), generating AI-powered notes and summaries, creating multi-speaker podcasts from research, chatting with documents using context-aware AI, searching across materials with full-text and vector search, or running custom content transformations. Supports 16+ AI providers including OpenAI, Anthropic, Google, Ollama, Groq, and Mistral with complete data privacy through self-hosting.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "opentrons-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/opentrons-integration",
+          "description": "Official Opentrons Protocol API for OT-2 and Flex robots. Use when writing protocols specifically for Opentrons hardware with full access to Protocol API v2 features. Best for production Opentrons protocols, official API compatibility. For multi-vendor automation or broader equipment control use pylabrobot.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "optimize-for-gpu",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/optimize-for-gpu",
+          "description": "GPU-accelerate Python code using CuPy, Numba CUDA, Warp, cuDF, cuML, cuGraph, KvikIO, cuCIM, cuxfilter, cuVS, cuSpatial, and RAFT. Use whenever the user mentions GPU/CUDA/NVIDIA acceleration, or wants to speed up NumPy, pandas, scikit-learn, scikit-image, NetworkX, GeoPandas, or Faiss workloads. Covers physics simulation, differentiable rendering, mesh ray casting, particle systems (DEM/SPH/fluids), vector/similarity search, GPUDirect Storage file IO, interactive dashboards, geospatial analysis, medical imaging, and sparse eigensolvers. Also use when you see CPU-bound Python code (loops, large arrays, ML pipelines, graph analytics, image processing) that would benefit from GPU acceleration, even if not explicitly requested.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "paper-lookup",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/paper-lookup",
+          "description": "Search 10 academic paper databases via REST APIs for research papers, preprints, and scholarly articles. Covers PubMed, PMC (full text), bioRxiv, medRxiv, arXiv, OpenAlex, Crossref, Semantic Scholar, CORE, Unpaywall. Use when searching for papers, citations, DOI/PMID lookups, abstracts, full text, open access, preprints, citation graphs, author search, or any scholarly literature query. Triggers on mentions of any supported database or requests like \"find papers on X\" or \"look up this DOI\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "paperzilla",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/paperzilla",
+          "description": "Chat with your agent about projects, recommendations, and canonical papers in Paperzilla. Use when users ask for recent project recommendations, canonical paper details, markdown-based summaries, recommendation feedback, feed export, or Atom feed URLs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "parallel-web",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/parallel-web",
+          "description": "All-in-one web toolkit powered by parallel-cli, with a strong emphasis on academic and scientific sources. Use this skill whenever the user needs to search the web, fetch/extract URL content, enrich data with web-sourced fields, or run deep research reports. Covers: web search (fast lookups, research, current info — prioritizing peer-reviewed papers, preprints, and scholarly databases), URL extraction (fetching pages, articles, academic PDFs), bulk data enrichment (adding fields to CSV/lists from the web), and deep research (exhaustive multi-source reports grounded in academic literature). Also handles setup, status checks, and result retrieval. Use this skill for ANY web-related task — even if the user doesn't mention 'parallel' or 'web' explicitly. If they want to look something up, fetch a page, enrich a dataset, investigate a topic, find academic papers, check citations, or review scientific literature, this is the skill to use.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pathml",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pathml",
+          "description": "Full-featured computational pathology toolkit. Use for advanced WSI analysis including multiplexed immunofluorescence (CODEX, Vectra), nucleus segmentation, tissue graph construction, and ML model training on pathology data. Supports 160+ slide formats. For simple tile extraction from H&E slides, histolab may be simpler.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pdf",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pdf",
+          "description": "Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "peer-review",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/peer-review",
+          "description": "Structured manuscript/grant review with checklist-based evaluation. Use when writing formal peer reviews with specific criteria methodology assessment, statistical validity, reporting standards compliance (CONSORT/STROBE), and constructive feedback. Best for actual review writing, manuscript revision. For evaluating claims/evidence quality use scientific-critical-thinking; for quantitative scoring frameworks use scholar-evaluation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pennylane",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pennylane",
+          "description": "Hardware-agnostic quantum ML framework with automatic differentiation. Use when training quantum circuits via gradients, building hybrid quantum-classical models, or needing device portability across IBM/Google/Rigetti/IonQ. Best for variational algorithms (VQE, QAOA), quantum neural networks, and integration with PyTorch/JAX/TensorFlow. For hardware-specific optimizations use qiskit (IBM) or cirq (Google); for open quantum systems use qutip.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "phylogenetics",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/phylogenetics",
+          "description": "Build and analyze phylogenetic trees using MAFFT (multiple alignment), IQ-TREE 2 (maximum likelihood), and FastTree (fast NJ/ML). Visualize with ETE3 or FigTree. For evolutionary analysis, microbial genomics, viral phylodynamics, protein family analysis, and molecular clock studies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "polars",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/polars",
+          "description": "Fast in-memory DataFrame library for datasets that fit in RAM. Use when pandas is too slow but data still fits in memory. Lazy evaluation, parallel execution, Apache Arrow backend. Best for 1-100GB datasets, ETL pipelines, faster pandas replacement. For larger-than-RAM data use dask or vaex.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "K-Dense-AI",
+        "repo": "claude-scientific-skills",
+        "repoUrl": "https://github.com/K-Dense-AI/claude-scientific-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "k-dense-ai-claude-scientific-skills-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from K-Dense-AI/claude-scientific-skills.",
+      "author": "ASM (K-Dense-AI/claude-scientific-skills)",
+      "createdAt": "2026-05-09T08:10:53.521Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "k-dense-ai",
+        "claude-scientific-skills"
+      ],
+      "skills": [
+        {
+          "name": "database-lookup",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/database-lookup",
+          "description": "Search 78 public scientific, biomedical, materials science, and economic databases via REST APIs. Covers physics/astronomy (NASA, NIST, SDSS, SIMBAD), earth/environment (USGS, NOAA, EPA), chemistry/drugs (PubChem, ChEMBL, DrugBank, FDA, KEGG, ZINC, BindingDB), materials (Materials Project, COD), biology/genomics (Reactome, UniProt, STRING, Ensembl, NCBI Gene, GEO, GTEx, PDB, AlphaFold, InterPro, BioGRID, Gene Ontology, dbSNP, gnomAD, ENCODE, Human Protein Atlas, Human Cell Atlas), disease/clinical (COSMIC, Open Targets, ClinicalTrials.gov, OMIM, ClinVar, GDC/TCGA, cBioPortal, DisGeNET, GWAS Catalog), regulatory (FDA, USPTO, SEC EDGAR), economics/finance (FRED, World Bank, US Treasury), demographics (US Census, Eurostat, WHO). Use when looking up compounds, genes, proteins, pathways, variants, clinical trials, patents, economic indicators, or any public database API query.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "market-research-reports",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/market-research-reports",
+          "description": "Generate comprehensive market research reports (50+ pages) in the style of top consulting firms (McKinsey, BCG, Gartner). Features professional LaTeX formatting, extensive visual generation with scientific-schematics and generate-image, deep integration with research-lookup for data gathering, and multi-framework strategic analysis including Porter Five Forces, PESTLE, SWOT, TAM/SAM/SOM, and BCG Matrix.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "molecular-dynamics",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/molecular-dynamics",
+          "description": "Run and analyze molecular dynamics simulations with OpenMM and MDAnalysis. Set up protein/small molecule systems, define force fields, run energy minimization and production MD, analyze trajectories (RMSD, RMSF, contact maps, free energy surfaces). For structural biology, drug binding, and biophysics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "opentrons-integration",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/opentrons-integration",
+          "description": "Official Opentrons Protocol API for OT-2 and Flex robots. Use when writing protocols specifically for Opentrons hardware with full access to Protocol API v2 features. Best for production Opentrons protocols, official API compatibility. For multi-vendor automation or broader equipment control use pylabrobot.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "qiskit",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/qiskit",
+          "description": "IBM quantum computing framework. Use when targeting IBM Quantum hardware, working with Qiskit Runtime for production workloads, or needing IBM optimization tools. Best for IBM hardware execution, quantum error mitigation, and enterprise quantum computing. For Google hardware use cirq; for gradient-based quantum ML use pennylane; for open quantum system simulations use qutip.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scientific-brainstorming",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-brainstorming",
+          "description": "Creative research ideation and exploration. Use for open-ended brainstorming sessions, exploring interdisciplinary connections, challenging assumptions, or identifying research gaps. Best for early-stage research planning when you do not have specific observations yet. For formulating testable hypotheses from data use hypothesis-generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "stable-baselines3",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/stable-baselines3",
+          "description": "Production-ready reinforcement learning algorithms (PPO, SAC, DQN, TD3, DDPG, A2C) with scikit-learn-like API. Use for standard RL experiments, quick prototyping, and well-documented algorithm implementations. Best for single-agent RL with Gymnasium environments. For high-performance parallel training, multi-agent systems, or custom vectorized environments, use pufferlib instead.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "timesfm-forecasting",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/timesfm-forecasting",
+          "description": "Zero-shot time series forecasting with Google's TimesFM foundation model. Use for any univariate time series (sales, sensors, energy, vitals, weather) without training a custom model. Supports CSV/DataFrame/array inputs with point forecasts and prediction intervals. Includes a preflight system checker script to verify RAM/GPU before first use.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "what-if-oracle",
+          "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/what-if-oracle",
+          "description": "Run structured What-If scenario analysis with multi-branch possibility exploration. Use this skill when the user asks speculative questions like \"what if...\", \"what would happen if...\", \"what are the possibilities\", \"explore scenarios\", \"scenario analysis\", \"possibility space\", \"what could go wrong\", \"best case / worst case\", \"risk analysis\", \"contingency planning\", \"strategic options\", or any question about uncertain futures. Also trigger when the user faces a fork-in-the-road decision, wants to stress-test an idea, or needs to think through consequences before committing.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "K-Dense-AI",
+        "repo": "claude-scientific-skills",
+        "repoUrl": "https://github.com/K-Dense-AI/claude-scientific-skills.git"
+      },
+      "inferred": true
     }
   ]
 }

--- a/data/skill-index/Leonxlnx_taste-skill.json
+++ b/data/skill-index/Leonxlnx_taste-skill.json
@@ -1649,5 +1649,397 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "leonxlnx-taste-skill-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from Leonxlnx/taste-skill.",
+      "author": "ASM (Leonxlnx/taste-skill)",
+      "createdAt": "2026-05-09T08:10:39.871Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "leonxlnx",
+        "taste-skill"
+      ],
+      "skills": [
+        {
+          "name": "brandkit",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/brandkit",
+          "description": "Premium brand-kit image generation skill for creating high-end brand-guidelines boards, logo systems, identity decks, and visual-world presentations. Trained for minimalist, cinematic, editorial, dark-tech, luxury, cultural, security, gaming, developer-tool, and consumer-app brand systems. Optimized for intentional logo concepting, refined composition, sparse typography, strong symbolic meaning, premium mockups, art-directed imagery, and flexible grid layouts.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gpt-taste",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/gpt-tasteskill",
+          "description": "Elite UX/UI & Advanced GSAP Motion Engineer. Enforces Python-driven true randomization for layout variance, strict AIDA page structure, wide editorial typography (bans 6-line wraps), gapless bento grids, strict GSAP ScrollTriggers (pinning, stacking, scrubbing), inline micro-images, and massive section spacing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "image-to-code",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/image-to-code-skill",
+          "description": "Elite website image-to-code skill for Codex. For visually important web tasks, it must first generate the design image(s) itself, deeply analyze them, then implement the website to match them as closely as possible. In Codex, it must prefer large, readable, section-specific images instead of tiny compressed boards, generate fresh standalone images for sections or detail views instead of cropping old ones, avoid lazy under-generation, avoid cards-inside-cards-inside-cards UI, and keep the hero clean, spacious, readable, and visible on a small laptop.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "imagegen-frontend-mobile",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/imagegen-frontend-mobile",
+          "description": "Elite mobile app image-generation skill for creating premium, app-native screen concepts and flows. Designed for iOS, Android, and cross-platform mobile products. Prioritizes clean hierarchy, comfortably readable text, strong multi-screen consistency, controlled color palettes, non-generic creative direction, textured surfaces, image-led composition, tasteful custom iconography, and clean phone mockup framing. By default, screens should be shown inside a subtle premium iPhone or similar phone mockup with a visible frame, while the main focus stays on the app content itself. This skill generates images only. It does not write code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "imagegen-frontend-web",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/imagegen-frontend-web",
+          "description": "Elite frontend image-direction skill for generating premium, conversion-aware website design references. CRITICAL OUTPUT RULE — generate ONE separate horizontal image FOR EVERY section. A landing page with 8 sections produces 8 images. Never compress multiple sections into one image. Enforces composition variety (not always left-text / right-image), background-image freedom, varied CTAs, varied hero scales (giant / mid / mini minimalist), narrative concept spine, second-read moments, and a single consistent palette across all images. Optimized for landing pages, marketing sites, and product comps that developers or coding models can accurately recreate.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "stitch-design-taste",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/stitch-skill",
+          "description": "Semantic Design System Skill for Google Stitch. Generates agent-friendly DESIGN.md files that enforce premium, anti-generic UI standards — strict typography, calibrated color, asymmetric layouts, perpetual micro-motion, and hardware-accelerated performance.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Leonxlnx",
+        "repo": "taste-skill",
+        "repoUrl": "https://github.com/Leonxlnx/taste-skill.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "leonxlnx-taste-skill-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from Leonxlnx/taste-skill.",
+      "author": "ASM (Leonxlnx/taste-skill)",
+      "createdAt": "2026-05-09T08:10:39.871Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "leonxlnx",
+        "taste-skill"
+      ],
+      "skills": [
+        {
+          "name": "design-taste-frontend",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/taste-skill",
+          "description": "Senior UI/UX Engineer. Architect digital interfaces overriding default LLM biases. Enforces metric-based rules, strict component architecture, CSS hardware acceleration, and balanced design engineering.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "full-output-enforcement",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/output-skill",
+          "description": "Overrides default LLM truncation behavior. Enforces complete code generation, bans placeholder patterns, and handles token-limit splits cleanly. Apply to any task requiring exhaustive, unabridged output.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gpt-taste",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/gpt-tasteskill",
+          "description": "Elite UX/UI & Advanced GSAP Motion Engineer. Enforces Python-driven true randomization for layout variance, strict AIDA page structure, wide editorial typography (bans 6-line wraps), gapless bento grids, strict GSAP ScrollTriggers (pinning, stacking, scrubbing), inline micro-images, and massive section spacing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "image-to-code",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/image-to-code-skill",
+          "description": "Elite website image-to-code skill for Codex. For visually important web tasks, it must first generate the design image(s) itself, deeply analyze them, then implement the website to match them as closely as possible. In Codex, it must prefer large, readable, section-specific images instead of tiny compressed boards, generate fresh standalone images for sections or detail views instead of cropping old ones, avoid lazy under-generation, avoid cards-inside-cards-inside-cards UI, and keep the hero clean, spacious, readable, and visible on a small laptop.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "imagegen-frontend-mobile",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/imagegen-frontend-mobile",
+          "description": "Elite mobile app image-generation skill for creating premium, app-native screen concepts and flows. Designed for iOS, Android, and cross-platform mobile products. Prioritizes clean hierarchy, comfortably readable text, strong multi-screen consistency, controlled color palettes, non-generic creative direction, textured surfaces, image-led composition, tasteful custom iconography, and clean phone mockup framing. By default, screens should be shown inside a subtle premium iPhone or similar phone mockup with a visible frame, while the main focus stays on the app content itself. This skill generates images only. It does not write code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "imagegen-frontend-web",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/imagegen-frontend-web",
+          "description": "Elite frontend image-direction skill for generating premium, conversion-aware website design references. CRITICAL OUTPUT RULE — generate ONE separate horizontal image FOR EVERY section. A landing page with 8 sections produces 8 images. Never compress multiple sections into one image. Enforces composition variety (not always left-text / right-image), background-image freedom, varied CTAs, varied hero scales (giant / mid / mini minimalist), narrative concept spine, second-read moments, and a single consistent palette across all images. Optimized for landing pages, marketing sites, and product comps that developers or coding models can accurately recreate.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Leonxlnx",
+        "repo": "taste-skill",
+        "repoUrl": "https://github.com/Leonxlnx/taste-skill.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "leonxlnx-taste-skill-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from Leonxlnx/taste-skill.",
+      "author": "ASM (Leonxlnx/taste-skill)",
+      "createdAt": "2026-05-09T08:10:39.871Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "leonxlnx",
+        "taste-skill"
+      ],
+      "skills": [
+        {
+          "name": "brandkit",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/brandkit",
+          "description": "Premium brand-kit image generation skill for creating high-end brand-guidelines boards, logo systems, identity decks, and visual-world presentations. Trained for minimalist, cinematic, editorial, dark-tech, luxury, cultural, security, gaming, developer-tool, and consumer-app brand systems. Optimized for intentional logo concepting, refined composition, sparse typography, strong symbolic meaning, premium mockups, art-directed imagery, and flexible grid layouts.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "design-taste-frontend",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/taste-skill",
+          "description": "Senior UI/UX Engineer. Architect digital interfaces overriding default LLM biases. Enforces metric-based rules, strict component architecture, CSS hardware acceleration, and balanced design engineering.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "full-output-enforcement",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/output-skill",
+          "description": "Overrides default LLM truncation behavior. Enforces complete code generation, bans placeholder patterns, and handles token-limit splits cleanly. Apply to any task requiring exhaustive, unabridged output.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gpt-taste",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/gpt-tasteskill",
+          "description": "Elite UX/UI & Advanced GSAP Motion Engineer. Enforces Python-driven true randomization for layout variance, strict AIDA page structure, wide editorial typography (bans 6-line wraps), gapless bento grids, strict GSAP ScrollTriggers (pinning, stacking, scrubbing), inline micro-images, and massive section spacing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "high-end-visual-design",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/soft-skill",
+          "description": "Teaches the AI to design like a high-end agency. Defines the exact fonts, spacing, shadows, card structures, and animations that make a website feel expensive. Blocks all the common defaults that make AI designs look cheap or generic.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "image-to-code",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/image-to-code-skill",
+          "description": "Elite website image-to-code skill for Codex. For visually important web tasks, it must first generate the design image(s) itself, deeply analyze them, then implement the website to match them as closely as possible. In Codex, it must prefer large, readable, section-specific images instead of tiny compressed boards, generate fresh standalone images for sections or detail views instead of cropping old ones, avoid lazy under-generation, avoid cards-inside-cards-inside-cards UI, and keep the hero clean, spacious, readable, and visible on a small laptop.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "imagegen-frontend-mobile",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/imagegen-frontend-mobile",
+          "description": "Elite mobile app image-generation skill for creating premium, app-native screen concepts and flows. Designed for iOS, Android, and cross-platform mobile products. Prioritizes clean hierarchy, comfortably readable text, strong multi-screen consistency, controlled color palettes, non-generic creative direction, textured surfaces, image-led composition, tasteful custom iconography, and clean phone mockup framing. By default, screens should be shown inside a subtle premium iPhone or similar phone mockup with a visible frame, while the main focus stays on the app content itself. This skill generates images only. It does not write code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "imagegen-frontend-web",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/imagegen-frontend-web",
+          "description": "Elite frontend image-direction skill for generating premium, conversion-aware website design references. CRITICAL OUTPUT RULE — generate ONE separate horizontal image FOR EVERY section. A landing page with 8 sections produces 8 images. Never compress multiple sections into one image. Enforces composition variety (not always left-text / right-image), background-image freedom, varied CTAs, varied hero scales (giant / mid / mini minimalist), narrative concept spine, second-read moments, and a single consistent palette across all images. Optimized for landing pages, marketing sites, and product comps that developers or coding models can accurately recreate.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "industrial-brutalist-ui",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/brutalist-skill",
+          "description": "Raw mechanical interfaces fusing Swiss typographic print with military terminal aesthetics. Rigid grids, extreme type scale contrast, utilitarian color, analog degradation effects. For data-heavy dashboards, portfolios, or editorial sites that need to feel like declassified blueprints.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "minimalist-ui",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/minimalist-skill",
+          "description": "Clean editorial-style interfaces. Warm monochrome palette, typographic contrast, flat bento grids, muted pastels. No gradients, no heavy shadows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "redesign-existing-projects",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/redesign-skill",
+          "description": "Upgrades existing websites and apps to premium quality. Audits current design, identifies generic AI patterns, and applies high-end design standards without breaking functionality. Works with any CSS framework or vanilla CSS.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "stitch-design-taste",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/stitch-skill",
+          "description": "Semantic Design System Skill for Google Stitch. Generates agent-friendly DESIGN.md files that enforce premium, anti-generic UI standards — strict typography, calibrated color, asymmetric layouts, perpetual micro-motion, and hardware-accelerated performance.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Leonxlnx",
+        "repo": "taste-skill",
+        "repoUrl": "https://github.com/Leonxlnx/taste-skill.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "leonxlnx-taste-skill-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from Leonxlnx/taste-skill.",
+      "author": "ASM (Leonxlnx/taste-skill)",
+      "createdAt": "2026-05-09T08:10:39.871Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "leonxlnx",
+        "taste-skill"
+      ],
+      "skills": [
+        {
+          "name": "brandkit",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/brandkit",
+          "description": "Premium brand-kit image generation skill for creating high-end brand-guidelines boards, logo systems, identity decks, and visual-world presentations. Trained for minimalist, cinematic, editorial, dark-tech, luxury, cultural, security, gaming, developer-tool, and consumer-app brand systems. Optimized for intentional logo concepting, refined composition, sparse typography, strong symbolic meaning, premium mockups, art-directed imagery, and flexible grid layouts.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gpt-taste",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/gpt-tasteskill",
+          "description": "Elite UX/UI & Advanced GSAP Motion Engineer. Enforces Python-driven true randomization for layout variance, strict AIDA page structure, wide editorial typography (bans 6-line wraps), gapless bento grids, strict GSAP ScrollTriggers (pinning, stacking, scrubbing), inline micro-images, and massive section spacing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "high-end-visual-design",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/soft-skill",
+          "description": "Teaches the AI to design like a high-end agency. Defines the exact fonts, spacing, shadows, card structures, and animations that make a website feel expensive. Blocks all the common defaults that make AI designs look cheap or generic.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "image-to-code",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/image-to-code-skill",
+          "description": "Elite website image-to-code skill for Codex. For visually important web tasks, it must first generate the design image(s) itself, deeply analyze them, then implement the website to match them as closely as possible. In Codex, it must prefer large, readable, section-specific images instead of tiny compressed boards, generate fresh standalone images for sections or detail views instead of cropping old ones, avoid lazy under-generation, avoid cards-inside-cards-inside-cards UI, and keep the hero clean, spacious, readable, and visible on a small laptop.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Leonxlnx",
+        "repo": "taste-skill",
+        "repoUrl": "https://github.com/Leonxlnx/taste-skill.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "leonxlnx-taste-skill-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from Leonxlnx/taste-skill.",
+      "author": "ASM (Leonxlnx/taste-skill)",
+      "createdAt": "2026-05-09T08:10:39.871Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "leonxlnx",
+        "taste-skill"
+      ],
+      "skills": [
+        {
+          "name": "brandkit",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/brandkit",
+          "description": "Premium brand-kit image generation skill for creating high-end brand-guidelines boards, logo systems, identity decks, and visual-world presentations. Trained for minimalist, cinematic, editorial, dark-tech, luxury, cultural, security, gaming, developer-tool, and consumer-app brand systems. Optimized for intentional logo concepting, refined composition, sparse typography, strong symbolic meaning, premium mockups, art-directed imagery, and flexible grid layouts.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "design-taste-frontend",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/taste-skill",
+          "description": "Senior UI/UX Engineer. Architect digital interfaces overriding default LLM biases. Enforces metric-based rules, strict component architecture, CSS hardware acceleration, and balanced design engineering.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "full-output-enforcement",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/output-skill",
+          "description": "Overrides default LLM truncation behavior. Enforces complete code generation, bans placeholder patterns, and handles token-limit splits cleanly. Apply to any task requiring exhaustive, unabridged output.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gpt-taste",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/gpt-tasteskill",
+          "description": "Elite UX/UI & Advanced GSAP Motion Engineer. Enforces Python-driven true randomization for layout variance, strict AIDA page structure, wide editorial typography (bans 6-line wraps), gapless bento grids, strict GSAP ScrollTriggers (pinning, stacking, scrubbing), inline micro-images, and massive section spacing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "high-end-visual-design",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/soft-skill",
+          "description": "Teaches the AI to design like a high-end agency. Defines the exact fonts, spacing, shadows, card structures, and animations that make a website feel expensive. Blocks all the common defaults that make AI designs look cheap or generic.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "image-to-code",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/image-to-code-skill",
+          "description": "Elite website image-to-code skill for Codex. For visually important web tasks, it must first generate the design image(s) itself, deeply analyze them, then implement the website to match them as closely as possible. In Codex, it must prefer large, readable, section-specific images instead of tiny compressed boards, generate fresh standalone images for sections or detail views instead of cropping old ones, avoid lazy under-generation, avoid cards-inside-cards-inside-cards UI, and keep the hero clean, spacious, readable, and visible on a small laptop.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "imagegen-frontend-mobile",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/imagegen-frontend-mobile",
+          "description": "Elite mobile app image-generation skill for creating premium, app-native screen concepts and flows. Designed for iOS, Android, and cross-platform mobile products. Prioritizes clean hierarchy, comfortably readable text, strong multi-screen consistency, controlled color palettes, non-generic creative direction, textured surfaces, image-led composition, tasteful custom iconography, and clean phone mockup framing. By default, screens should be shown inside a subtle premium iPhone or similar phone mockup with a visible frame, while the main focus stays on the app content itself. This skill generates images only. It does not write code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "imagegen-frontend-web",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/imagegen-frontend-web",
+          "description": "Elite frontend image-direction skill for generating premium, conversion-aware website design references. CRITICAL OUTPUT RULE — generate ONE separate horizontal image FOR EVERY section. A landing page with 8 sections produces 8 images. Never compress multiple sections into one image. Enforces composition variety (not always left-text / right-image), background-image freedom, varied CTAs, varied hero scales (giant / mid / mini minimalist), narrative concept spine, second-read moments, and a single consistent palette across all images. Optimized for landing pages, marketing sites, and product comps that developers or coding models can accurately recreate.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "industrial-brutalist-ui",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/brutalist-skill",
+          "description": "Raw mechanical interfaces fusing Swiss typographic print with military terminal aesthetics. Rigid grids, extreme type scale contrast, utilitarian color, analog degradation effects. For data-heavy dashboards, portfolios, or editorial sites that need to feel like declassified blueprints.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "redesign-existing-projects",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/redesign-skill",
+          "description": "Upgrades existing websites and apps to premium quality. Audits current design, identifies generic AI patterns, and applies high-end design standards without breaking functionality. Works with any CSS framework or vanilla CSS.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "stitch-design-taste",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/stitch-skill",
+          "description": "Semantic Design System Skill for Google Stitch. Generates agent-friendly DESIGN.md files that enforce premium, anti-generic UI standards — strict typography, calibrated color, asymmetric layouts, perpetual micro-motion, and hardware-accelerated performance.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Leonxlnx",
+        "repo": "taste-skill",
+        "repoUrl": "https://github.com/Leonxlnx/taste-skill.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "leonxlnx-taste-skill-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from Leonxlnx/taste-skill.",
+      "author": "ASM (Leonxlnx/taste-skill)",
+      "createdAt": "2026-05-09T08:10:39.871Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "leonxlnx",
+        "taste-skill"
+      ],
+      "skills": [
+        {
+          "name": "imagegen-frontend-mobile",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/imagegen-frontend-mobile",
+          "description": "Elite mobile app image-generation skill for creating premium, app-native screen concepts and flows. Designed for iOS, Android, and cross-platform mobile products. Prioritizes clean hierarchy, comfortably readable text, strong multi-screen consistency, controlled color palettes, non-generic creative direction, textured surfaces, image-led composition, tasteful custom iconography, and clean phone mockup framing. By default, screens should be shown inside a subtle premium iPhone or similar phone mockup with a visible frame, while the main focus stays on the app content itself. This skill generates images only. It does not write code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "imagegen-frontend-web",
+          "installUrl": "github:Leonxlnx/taste-skill:skills/imagegen-frontend-web",
+          "description": "Elite frontend image-direction skill for generating premium, conversion-aware website design references. CRITICAL OUTPUT RULE — generate ONE separate horizontal image FOR EVERY section. A landing page with 8 sections produces 8 images. Never compress multiple sections into one image. Enforces composition variety (not always left-text / right-image), background-image freedom, varied CTAs, varied hero scales (giant / mid / mini minimalist), narrative concept spine, second-read moments, and a single consistent palette across all images. Optimized for landing pages, marketing sites, and product comps that developers or coding models can accurately recreate.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Leonxlnx",
+        "repo": "taste-skill",
+        "repoUrl": "https://github.com/Leonxlnx/taste-skill.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/MiniMax-AI_skills.json
+++ b/data/skill-index/MiniMax-AI_skills.json
@@ -3156,5 +3156,739 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "minimax-ai-skills-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from MiniMax-AI/skills.",
+      "author": "ASM (MiniMax-AI/skills)",
+      "createdAt": "2026-05-09T08:10:42.466Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "minimax-ai",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "color-font-skill",
+          "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/color-font-skill",
+          "description": "Choose presentation-ready color palettes and font pairings for PPT/design tasks. Use when users ask for visual theme choices, brand-safe palettes, or font recommendations. Triggers include: 配色, 色板, 字体, color palette, font, PPT配色, 字体搭配.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flutter-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/flutter-dev",
+          "description": "Flutter cross-platform development guide covering widget patterns, Riverpod/Bloc state management, GoRouter navigation, performance optimization, and platform-specific implementations. Includes const optimization, responsive layouts, testing strategies, and DevTools profiling. Use when: building Flutter apps, implementing state management (Riverpod/Bloc), setting up GoRouter navigation, creating custom widgets, optimizing performance, writing widget tests, cross-platform development.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "frontend-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/frontend-dev",
+          "description": "Full-stack frontend development combining premium UI design, cinematic animations, AI-generated media assets, persuasive copywriting, and visual art. Builds complete, visually striking web pages with real media, advanced motion, and compelling copy. Use when: building landing pages, marketing sites, product pages, dashboards, generating media assets (image/video/audio/music), writing conversion copy, creating generative art, or implementing cinematic scroll animations.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "MiniMax-AI",
+        "repo": "skills",
+        "repoUrl": "https://github.com/MiniMax-AI/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "minimax-ai-skills-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from MiniMax-AI/skills.",
+      "author": "ASM (MiniMax-AI/skills)",
+      "createdAt": "2026-05-09T08:10:42.466Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "minimax-ai",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "flutter-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/flutter-dev",
+          "description": "Flutter cross-platform development guide covering widget patterns, Riverpod/Bloc state management, GoRouter navigation, performance optimization, and platform-specific implementations. Includes const optimization, responsive layouts, testing strategies, and DevTools profiling. Use when: building Flutter apps, implementing state management (Riverpod/Bloc), setting up GoRouter navigation, creating custom widgets, optimizing performance, writing widget tests, cross-platform development.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "frontend-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/frontend-dev",
+          "description": "Full-stack frontend development combining premium UI design, cinematic animations, AI-generated media assets, persuasive copywriting, and visual art. Builds complete, visually striking web pages with real media, advanced motion, and compelling copy. Use when: building landing pages, marketing sites, product pages, dashboards, generating media assets (image/video/audio/music), writing conversion copy, creating generative art, or implementing cinematic scroll animations.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "minimax-docx",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-docx",
+          "description": "Professional DOCX document creation, editing, and formatting using OpenXML SDK (.NET). Three pipelines: (A) create new documents from scratch, (B) fill/edit content in existing documents, (C) apply template formatting with XSD validation gate-check. MUST use this skill whenever the user wants to produce, modify, or format a Word document — including when they say \"write a report\", \"draft a proposal\", \"make a contract\", \"fill in this form\", \"reformat to match this template\", or any task whose final output is a .docx file. Even if the user doesn't mention \"docx\" explicitly, if the task implies a printable/formal document, use this skill.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "minimax-music-gen",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-music-gen",
+          "description": "Use when user wants to generate music, songs, or audio tracks. Triggers on any request involving music creation, song writing, lyrics generation, audio production, or covers. Also triggers when user provides lyrics and wants them turned into a song, or describes a mood/scene and wants background music. Supports multilingual triggers — match equivalent phrases in any language. Do NOT use for music playback of existing files, music theory questions, or music recommendation without generation.",
+          "version": "1.1"
+        },
+        {
+          "name": "minimax-pdf",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-pdf",
+          "description": "Use this skill when visual quality and design identity matter for a PDF. CREATE (generate from scratch): \"make a PDF\", \"generate a report\", \"write a proposal\", \"create a resume\", \"beautiful PDF\", \"professional document\", \"cover page\", \"polished PDF\", \"client-ready document\". FILL (complete form fields): \"fill in the form\", \"fill out this PDF\", \"complete the form fields\", \"write values into PDF\", \"what fields does this PDF have\". REFORMAT (apply design to an existing doc): \"reformat this document\", \"apply our style\", \"convert this Markdown/text to PDF\", \"make this doc look good\", \"re-style this PDF\". This skill uses a token-based design system: color, typography, and spacing are derived from the document type and flow through every page. The output is print-ready. Prefer this skill when appearance matters, not just when any PDF output is needed.",
+          "version": "1.0"
+        },
+        {
+          "name": "mmx-cli",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-multimodal-toolkit",
+          "description": "Use mmx to generate text, images, video, speech, and music via the MiniMax AI platform. Use when the user wants to create media content, chat with MiniMax models, perform web search, or manage MiniMax API resources from the terminal.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ppt-editing-skill",
+          "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/ppt-editing-skill",
+          "description": "Edit existing PowerPoint files or templates with XML-safe workflows. Use for template-based deck updates: analyze layouts, map content to slides, duplicate/reorder/delete slides safely, edit slide XML in parallel, clean orphaned assets, and repack validated PPTX output.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ppt-orchestra-skill",
+          "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/ppt-orchestra-skill",
+          "description": "Plan and orchestrate multi-slide PowerPoint creation from scratch. Use before generating a full deck with subagents: classify each slide type, enforce visual variety, set typography/spacing rules, and run text-based QA to catch content issues.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pptx-generator",
+          "installUrl": "github:MiniMax-AI/skills:skills/pptx-generator",
+          "description": "Generate, edit, and read PowerPoint presentations. Create from scratch with PptxGenJS (cover, TOC, content, section divider, summary slides), edit existing PPTX via XML workflows, or extract text with markitdown. Triggers: PPT, PPTX, PowerPoint, presentation, slide, deck, slides.",
+          "version": "1.0"
+        },
+        {
+          "name": "pr-review",
+          "installUrl": "github:MiniMax-AI/skills:.claude/skills/pr-review",
+          "description": "Review pull requests for the MiniMax Skills repository. Use when reviewing PRs, validating new skill submissions, or checking existing skills for compliance. Run the validation script first for hard checks, then apply quality guidelines for content review. Triggers: PR review, pull request, validate skill, check skill.",
+          "version": "1.0"
+        },
+        {
+          "name": "react-native-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/react-native-dev",
+          "description": "React Native and Expo development guide covering components, styling, animations, navigation, state management, forms, networking, performance optimization, testing, native capabilities, and engineering (project structure, deployment, SDK upgrades, CI/CD). Use when: building React Native or Expo apps, implementing animations or native UI, managing state, fetching data, writing tests, optimizing performance, deploying to App Store/Play Store, setting up CI/CD, upgrading Expo SDK, or configuring Tailwind/NativeWind.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "shader-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/shader-dev",
+          "description": "Comprehensive GLSL shader techniques for creating stunning visual effects — ray marching, SDF modeling, fluid simulation, particle systems, procedural generation, lighting, post-processing, and more.",
+          "version": "1.0"
+        },
+        {
+          "name": "slide-making-skill",
+          "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/slide-making-skill",
+          "description": "Implement single-slide PowerPoint pages with PptxGenJS. Use when writing or fixing slide JS files: dimensions, positioning, text/image/chart APIs, styling rules, and export expectations for native .pptx output.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "MiniMax-AI",
+        "repo": "skills",
+        "repoUrl": "https://github.com/MiniMax-AI/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "minimax-ai-skills-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from MiniMax-AI/skills.",
+      "author": "ASM (MiniMax-AI/skills)",
+      "createdAt": "2026-05-09T08:10:42.466Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "minimax-ai",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "ios-application-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/ios-application-dev",
+          "description": "iOS application development guide covering UIKit, SnapKit, and SwiftUI. Includes touch targets, safe areas, navigation patterns, Dynamic Type, Dark Mode, accessibility, collection views, common UI components, and SwiftUI design guidelines. For detailed references on specific topics, see the reference files. Use when: developing iOS apps, implementing UI, reviewing iOS code, working with UIKit/SnapKit/SwiftUI layouts, building iPhone interfaces, Swift mobile development, Apple HIG compliance, iOS accessibility implementation.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "pptx-generator",
+          "installUrl": "github:MiniMax-AI/skills:skills/pptx-generator",
+          "description": "Generate, edit, and read PowerPoint presentations. Create from scratch with PptxGenJS (cover, TOC, content, section divider, summary slides), edit existing PPTX via XML workflows, or extract text with markitdown. Triggers: PPT, PPTX, PowerPoint, presentation, slide, deck, slides.",
+          "version": "1.0"
+        },
+        {
+          "name": "pr-review",
+          "installUrl": "github:MiniMax-AI/skills:.claude/skills/pr-review",
+          "description": "Review pull requests for the MiniMax Skills repository. Use when reviewing PRs, validating new skill submissions, or checking existing skills for compliance. Run the validation script first for hard checks, then apply quality guidelines for content review. Triggers: PR review, pull request, validate skill, check skill.",
+          "version": "1.0"
+        },
+        {
+          "name": "vision-analysis",
+          "installUrl": "github:MiniMax-AI/skills:skills/vision-analysis",
+          "description": "Analyze, describe, and extract information from images using the MiniMax vision MCP tool. Use when: user shares an image file path or URL (any message containing .jpg, .jpeg, .png, .gif, .webp, .bmp, or .svg file extension) or uses any of these words/phrases near an image: \"analyze\", \"analyse\", \"describe\", \"explain\", \"understand\", \"look at\", \"review\", \"extract text\", \"OCR\", \"what is in\", \"what's in\", \"read this image\", \"see this image\", \"tell me about\", \"explain this\", \"interpret this\", in connection with an image, screenshot, diagram, chart, mockup, wireframe, or photo. Also triggers for: UI mockup review, wireframe analysis, design critique, data extraction from charts, object detection, person/animal/activity identification. Triggers: any message with an image file extension (jpg, jpeg, png, gif, webp, bmp, svg), or any request to analyze/describ/understand/review/extract text from an image, screenshot, diagram, chart, photo, mockup, or wireframe.",
+          "version": "1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "MiniMax-AI",
+        "repo": "skills",
+        "repoUrl": "https://github.com/MiniMax-AI/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "minimax-ai-skills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from MiniMax-AI/skills.",
+      "author": "ASM (MiniMax-AI/skills)",
+      "createdAt": "2026-05-09T08:10:42.466Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "minimax-ai",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "android-native-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/android-native-dev",
+          "description": "Android native application development and UI design guide. Covers Material Design 3, Kotlin/Compose development, project configuration, accessibility, and build troubleshooting. Read this before Android native application development.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "buddy-sings",
+          "installUrl": "github:MiniMax-AI/skills:skills/buddy-sings",
+          "description": "Use when user wants their Claude Code pet (/buddy) to sing a song. Triggers on any request that combines the concept of their Claude Code buddy, pet, or companion with singing or music. Supports multilingual triggers — match equivalent phrases in any language.",
+          "version": "1.1"
+        },
+        {
+          "name": "flutter-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/flutter-dev",
+          "description": "Flutter cross-platform development guide covering widget patterns, Riverpod/Bloc state management, GoRouter navigation, performance optimization, and platform-specific implementations. Includes const optimization, responsive layouts, testing strategies, and DevTools profiling. Use when: building Flutter apps, implementing state management (Riverpod/Bloc), setting up GoRouter navigation, creating custom widgets, optimizing performance, writing widget tests, cross-platform development.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "frontend-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/frontend-dev",
+          "description": "Full-stack frontend development combining premium UI design, cinematic animations, AI-generated media assets, persuasive copywriting, and visual art. Builds complete, visually striking web pages with real media, advanced motion, and compelling copy. Use when: building landing pages, marketing sites, product pages, dashboards, generating media assets (image/video/audio/music), writing conversion copy, creating generative art, or implementing cinematic scroll animations.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "fullstack-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/fullstack-dev",
+          "description": "Full-stack backend architecture and frontend-backend integration guide. TRIGGER when: building a full-stack app, creating REST API with frontend, scaffolding backend service, building todo app, building CRUD app, building real-time app, building chat app, Express + React, Next.js API, Node.js backend, Python backend, Go backend, designing service layers, implementing error handling, managing config/auth, setting up API clients, implementing auth flows, handling file uploads, adding real-time features (SSE/WebSocket), hardening for production. DO NOT TRIGGER when: pure frontend UI work, pure CSS/styling, database schema only.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ios-application-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/ios-application-dev",
+          "description": "iOS application development guide covering UIKit, SnapKit, and SwiftUI. Includes touch targets, safe areas, navigation patterns, Dynamic Type, Dark Mode, accessibility, collection views, common UI components, and SwiftUI design guidelines. For detailed references on specific topics, see the reference files. Use when: developing iOS apps, implementing UI, reviewing iOS code, working with UIKit/SnapKit/SwiftUI layouts, building iPhone interfaces, Swift mobile development, Apple HIG compliance, iOS accessibility implementation.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "minimax-pdf",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-pdf",
+          "description": "Use this skill when visual quality and design identity matter for a PDF. CREATE (generate from scratch): \"make a PDF\", \"generate a report\", \"write a proposal\", \"create a resume\", \"beautiful PDF\", \"professional document\", \"cover page\", \"polished PDF\", \"client-ready document\". FILL (complete form fields): \"fill in the form\", \"fill out this PDF\", \"complete the form fields\", \"write values into PDF\", \"what fields does this PDF have\". REFORMAT (apply design to an existing doc): \"reformat this document\", \"apply our style\", \"convert this Markdown/text to PDF\", \"make this doc look good\", \"re-style this PDF\". This skill uses a token-based design system: color, typography, and spacing are derived from the document type and flow through every page. The output is print-ready. Prefer this skill when appearance matters, not just when any PDF output is needed.",
+          "version": "1.0"
+        },
+        {
+          "name": "minimax-xlsx",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-xlsx",
+          "description": "Open, create, read, analyze, edit, or validate Excel/spreadsheet files (.xlsx, .xlsm, .csv, .tsv). Use when the user asks to create, build, modify, analyze, read, validate, or format any Excel spreadsheet, financial model, pivot table, or tabular data file. Covers: creating new xlsx from scratch, reading and analyzing existing files, editing existing xlsx with zero format loss, formula recalculation and validation, and applying professional financial formatting standards. Triggers on 'spreadsheet', 'Excel', '.xlsx', '.csv', 'pivot table', 'financial model', 'formula', or any request to produce tabular data in Excel format.",
+          "version": "1.0"
+        },
+        {
+          "name": "mmx-cli",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-multimodal-toolkit",
+          "description": "Use mmx to generate text, images, video, speech, and music via the MiniMax AI platform. Use when the user wants to create media content, chat with MiniMax models, perform web search, or manage MiniMax API resources from the terminal.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pr-review",
+          "installUrl": "github:MiniMax-AI/skills:.claude/skills/pr-review",
+          "description": "Review pull requests for the MiniMax Skills repository. Use when reviewing PRs, validating new skill submissions, or checking existing skills for compliance. Run the validation script first for hard checks, then apply quality guidelines for content review. Triggers: PR review, pull request, validate skill, check skill.",
+          "version": "1.0"
+        },
+        {
+          "name": "react-native-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/react-native-dev",
+          "description": "React Native and Expo development guide covering components, styling, animations, navigation, state management, forms, networking, performance optimization, testing, native capabilities, and engineering (project structure, deployment, SDK upgrades, CI/CD). Use when: building React Native or Expo apps, implementing animations or native UI, managing state, fetching data, writing tests, optimizing performance, deploying to App Store/Play Store, setting up CI/CD, upgrading Expo SDK, or configuring Tailwind/NativeWind.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "slide-making-skill",
+          "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/slide-making-skill",
+          "description": "Implement single-slide PowerPoint pages with PptxGenJS. Use when writing or fixing slide JS files: dimensions, positioning, text/image/chart APIs, styling rules, and export expectations for native .pptx output.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "vision-analysis",
+          "installUrl": "github:MiniMax-AI/skills:skills/vision-analysis",
+          "description": "Analyze, describe, and extract information from images using the MiniMax vision MCP tool. Use when: user shares an image file path or URL (any message containing .jpg, .jpeg, .png, .gif, .webp, .bmp, or .svg file extension) or uses any of these words/phrases near an image: \"analyze\", \"analyse\", \"describe\", \"explain\", \"understand\", \"look at\", \"review\", \"extract text\", \"OCR\", \"what is in\", \"what's in\", \"read this image\", \"see this image\", \"tell me about\", \"explain this\", \"interpret this\", in connection with an image, screenshot, diagram, chart, mockup, wireframe, or photo. Also triggers for: UI mockup review, wireframe analysis, design critique, data extraction from charts, object detection, person/animal/activity identification. Triggers: any message with an image file extension (jpg, jpeg, png, gif, webp, bmp, svg), or any request to analyze/describ/understand/review/extract text from an image, screenshot, diagram, chart, photo, mockup, or wireframe.",
+          "version": "1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "MiniMax-AI",
+        "repo": "skills",
+        "repoUrl": "https://github.com/MiniMax-AI/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "minimax-ai-skills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from MiniMax-AI/skills.",
+      "author": "ASM (MiniMax-AI/skills)",
+      "createdAt": "2026-05-09T08:10:42.466Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "minimax-ai",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "android-native-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/android-native-dev",
+          "description": "Android native application development and UI design guide. Covers Material Design 3, Kotlin/Compose development, project configuration, accessibility, and build troubleshooting. Read this before Android native application development.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "buddy-sings",
+          "installUrl": "github:MiniMax-AI/skills:skills/buddy-sings",
+          "description": "Use when user wants their Claude Code pet (/buddy) to sing a song. Triggers on any request that combines the concept of their Claude Code buddy, pet, or companion with singing or music. Supports multilingual triggers — match equivalent phrases in any language.",
+          "version": "1.1"
+        },
+        {
+          "name": "color-font-skill",
+          "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/color-font-skill",
+          "description": "Choose presentation-ready color palettes and font pairings for PPT/design tasks. Use when users ask for visual theme choices, brand-safe palettes, or font recommendations. Triggers include: 配色, 色板, 字体, color palette, font, PPT配色, 字体搭配.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "design-style-skill",
+          "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/design-style-skill",
+          "description": "Select a consistent visual design system for PPT slides using radius/spacing style recipes. Use when users ask for overall style direction or component styling consistency. Includes Sharp/Soft/Rounded/Pill recipes, component mappings, typography/spacing rules, and mixing guidance. Triggers: 风格, style, radius, spacing, 圆角, 间距, PPT风格, 视觉风格, design style, component style.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flutter-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/flutter-dev",
+          "description": "Flutter cross-platform development guide covering widget patterns, Riverpod/Bloc state management, GoRouter navigation, performance optimization, and platform-specific implementations. Includes const optimization, responsive layouts, testing strategies, and DevTools profiling. Use when: building Flutter apps, implementing state management (Riverpod/Bloc), setting up GoRouter navigation, creating custom widgets, optimizing performance, writing widget tests, cross-platform development.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "frontend-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/frontend-dev",
+          "description": "Full-stack frontend development combining premium UI design, cinematic animations, AI-generated media assets, persuasive copywriting, and visual art. Builds complete, visually striking web pages with real media, advanced motion, and compelling copy. Use when: building landing pages, marketing sites, product pages, dashboards, generating media assets (image/video/audio/music), writing conversion copy, creating generative art, or implementing cinematic scroll animations.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "fullstack-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/fullstack-dev",
+          "description": "Full-stack backend architecture and frontend-backend integration guide. TRIGGER when: building a full-stack app, creating REST API with frontend, scaffolding backend service, building todo app, building CRUD app, building real-time app, building chat app, Express + React, Next.js API, Node.js backend, Python backend, Go backend, designing service layers, implementing error handling, managing config/auth, setting up API clients, implementing auth flows, handling file uploads, adding real-time features (SSE/WebSocket), hardening for production. DO NOT TRIGGER when: pure frontend UI work, pure CSS/styling, database schema only.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "gif-sticker-maker",
+          "installUrl": "github:MiniMax-AI/skills:skills/gif-sticker-maker",
+          "description": "Convert photos (people, pets, objects, logos) into 4 animated GIF stickers with captions. Use when: user wants to create cartoon stickers, GIF expressions, emoji packs, animated avatars, or convert photos to Funko Pop / Pop Mart blind box style animations. Triggers: sticker, GIF, cartoon, emoji, expression pack, avatar animation.",
+          "version": "1.2"
+        },
+        {
+          "name": "ios-application-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/ios-application-dev",
+          "description": "iOS application development guide covering UIKit, SnapKit, and SwiftUI. Includes touch targets, safe areas, navigation patterns, Dynamic Type, Dark Mode, accessibility, collection views, common UI components, and SwiftUI design guidelines. For detailed references on specific topics, see the reference files. Use when: developing iOS apps, implementing UI, reviewing iOS code, working with UIKit/SnapKit/SwiftUI layouts, building iPhone interfaces, Swift mobile development, Apple HIG compliance, iOS accessibility implementation.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "minimax-music-gen",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-music-gen",
+          "description": "Use when user wants to generate music, songs, or audio tracks. Triggers on any request involving music creation, song writing, lyrics generation, audio production, or covers. Also triggers when user provides lyrics and wants them turned into a song, or describes a mood/scene and wants background music. Supports multilingual triggers — match equivalent phrases in any language. Do NOT use for music playback of existing files, music theory questions, or music recommendation without generation.",
+          "version": "1.1"
+        },
+        {
+          "name": "minimax-music-playlist",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-music-playlist",
+          "description": "Generate personalized music playlists by analyzing the user's music taste and generation feedback history. Triggers on any request involving playlist generation, music taste profiling, or personalized music recommendations. Supports multilingual triggers — match equivalent phrases in any language.",
+          "version": "2.0"
+        },
+        {
+          "name": "minimax-pdf",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-pdf",
+          "description": "Use this skill when visual quality and design identity matter for a PDF. CREATE (generate from scratch): \"make a PDF\", \"generate a report\", \"write a proposal\", \"create a resume\", \"beautiful PDF\", \"professional document\", \"cover page\", \"polished PDF\", \"client-ready document\". FILL (complete form fields): \"fill in the form\", \"fill out this PDF\", \"complete the form fields\", \"write values into PDF\", \"what fields does this PDF have\". REFORMAT (apply design to an existing doc): \"reformat this document\", \"apply our style\", \"convert this Markdown/text to PDF\", \"make this doc look good\", \"re-style this PDF\". This skill uses a token-based design system: color, typography, and spacing are derived from the document type and flow through every page. The output is print-ready. Prefer this skill when appearance matters, not just when any PDF output is needed.",
+          "version": "1.0"
+        },
+        {
+          "name": "minimax-xlsx",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-xlsx",
+          "description": "Open, create, read, analyze, edit, or validate Excel/spreadsheet files (.xlsx, .xlsm, .csv, .tsv). Use when the user asks to create, build, modify, analyze, read, validate, or format any Excel spreadsheet, financial model, pivot table, or tabular data file. Covers: creating new xlsx from scratch, reading and analyzing existing files, editing existing xlsx with zero format loss, formula recalculation and validation, and applying professional financial formatting standards. Triggers on 'spreadsheet', 'Excel', '.xlsx', '.csv', 'pivot table', 'financial model', 'formula', or any request to produce tabular data in Excel format.",
+          "version": "1.0"
+        },
+        {
+          "name": "ppt-editing-skill",
+          "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/ppt-editing-skill",
+          "description": "Edit existing PowerPoint files or templates with XML-safe workflows. Use for template-based deck updates: analyze layouts, map content to slides, duplicate/reorder/delete slides safely, edit slide XML in parallel, clean orphaned assets, and repack validated PPTX output.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ppt-orchestra-skill",
+          "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/ppt-orchestra-skill",
+          "description": "Plan and orchestrate multi-slide PowerPoint creation from scratch. Use before generating a full deck with subagents: classify each slide type, enforce visual variety, set typography/spacing rules, and run text-based QA to catch content issues.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pr-review",
+          "installUrl": "github:MiniMax-AI/skills:.claude/skills/pr-review",
+          "description": "Review pull requests for the MiniMax Skills repository. Use when reviewing PRs, validating new skill submissions, or checking existing skills for compliance. Run the validation script first for hard checks, then apply quality guidelines for content review. Triggers: PR review, pull request, validate skill, check skill.",
+          "version": "1.0"
+        },
+        {
+          "name": "react-native-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/react-native-dev",
+          "description": "React Native and Expo development guide covering components, styling, animations, navigation, state management, forms, networking, performance optimization, testing, native capabilities, and engineering (project structure, deployment, SDK upgrades, CI/CD). Use when: building React Native or Expo apps, implementing animations or native UI, managing state, fetching data, writing tests, optimizing performance, deploying to App Store/Play Store, setting up CI/CD, upgrading Expo SDK, or configuring Tailwind/NativeWind.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "shader-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/shader-dev",
+          "description": "Comprehensive GLSL shader techniques for creating stunning visual effects — ray marching, SDF modeling, fluid simulation, particle systems, procedural generation, lighting, post-processing, and more.",
+          "version": "1.0"
+        },
+        {
+          "name": "vision-analysis",
+          "installUrl": "github:MiniMax-AI/skills:skills/vision-analysis",
+          "description": "Analyze, describe, and extract information from images using the MiniMax vision MCP tool. Use when: user shares an image file path or URL (any message containing .jpg, .jpeg, .png, .gif, .webp, .bmp, or .svg file extension) or uses any of these words/phrases near an image: \"analyze\", \"analyse\", \"describe\", \"explain\", \"understand\", \"look at\", \"review\", \"extract text\", \"OCR\", \"what is in\", \"what's in\", \"read this image\", \"see this image\", \"tell me about\", \"explain this\", \"interpret this\", in connection with an image, screenshot, diagram, chart, mockup, wireframe, or photo. Also triggers for: UI mockup review, wireframe analysis, design critique, data extraction from charts, object detection, person/animal/activity identification. Triggers: any message with an image file extension (jpg, jpeg, png, gif, webp, bmp, svg), or any request to analyze/describ/understand/review/extract text from an image, screenshot, diagram, chart, photo, mockup, or wireframe.",
+          "version": "1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "MiniMax-AI",
+        "repo": "skills",
+        "repoUrl": "https://github.com/MiniMax-AI/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "minimax-ai-skills-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from MiniMax-AI/skills.",
+      "author": "ASM (MiniMax-AI/skills)",
+      "createdAt": "2026-05-09T08:10:42.466Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "minimax-ai",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "design-style-skill",
+          "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/design-style-skill",
+          "description": "Select a consistent visual design system for PPT slides using radius/spacing style recipes. Use when users ask for overall style direction or component styling consistency. Includes Sharp/Soft/Rounded/Pill recipes, component mappings, typography/spacing rules, and mixing guidance. Triggers: 风格, style, radius, spacing, 圆角, 间距, PPT风格, 视觉风格, design style, component style.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flutter-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/flutter-dev",
+          "description": "Flutter cross-platform development guide covering widget patterns, Riverpod/Bloc state management, GoRouter navigation, performance optimization, and platform-specific implementations. Includes const optimization, responsive layouts, testing strategies, and DevTools profiling. Use when: building Flutter apps, implementing state management (Riverpod/Bloc), setting up GoRouter navigation, creating custom widgets, optimizing performance, writing widget tests, cross-platform development.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "frontend-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/frontend-dev",
+          "description": "Full-stack frontend development combining premium UI design, cinematic animations, AI-generated media assets, persuasive copywriting, and visual art. Builds complete, visually striking web pages with real media, advanced motion, and compelling copy. Use when: building landing pages, marketing sites, product pages, dashboards, generating media assets (image/video/audio/music), writing conversion copy, creating generative art, or implementing cinematic scroll animations.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ios-application-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/ios-application-dev",
+          "description": "iOS application development guide covering UIKit, SnapKit, and SwiftUI. Includes touch targets, safe areas, navigation patterns, Dynamic Type, Dark Mode, accessibility, collection views, common UI components, and SwiftUI design guidelines. For detailed references on specific topics, see the reference files. Use when: developing iOS apps, implementing UI, reviewing iOS code, working with UIKit/SnapKit/SwiftUI layouts, building iPhone interfaces, Swift mobile development, Apple HIG compliance, iOS accessibility implementation.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "minimax-docx",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-docx",
+          "description": "Professional DOCX document creation, editing, and formatting using OpenXML SDK (.NET). Three pipelines: (A) create new documents from scratch, (B) fill/edit content in existing documents, (C) apply template formatting with XSD validation gate-check. MUST use this skill whenever the user wants to produce, modify, or format a Word document — including when they say \"write a report\", \"draft a proposal\", \"make a contract\", \"fill in this form\", \"reformat to match this template\", or any task whose final output is a .docx file. Even if the user doesn't mention \"docx\" explicitly, if the task implies a printable/formal document, use this skill.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "minimax-pdf",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-pdf",
+          "description": "Use this skill when visual quality and design identity matter for a PDF. CREATE (generate from scratch): \"make a PDF\", \"generate a report\", \"write a proposal\", \"create a resume\", \"beautiful PDF\", \"professional document\", \"cover page\", \"polished PDF\", \"client-ready document\". FILL (complete form fields): \"fill in the form\", \"fill out this PDF\", \"complete the form fields\", \"write values into PDF\", \"what fields does this PDF have\". REFORMAT (apply design to an existing doc): \"reformat this document\", \"apply our style\", \"convert this Markdown/text to PDF\", \"make this doc look good\", \"re-style this PDF\". This skill uses a token-based design system: color, typography, and spacing are derived from the document type and flow through every page. The output is print-ready. Prefer this skill when appearance matters, not just when any PDF output is needed.",
+          "version": "1.0"
+        },
+        {
+          "name": "minimax-xlsx",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-xlsx",
+          "description": "Open, create, read, analyze, edit, or validate Excel/spreadsheet files (.xlsx, .xlsm, .csv, .tsv). Use when the user asks to create, build, modify, analyze, read, validate, or format any Excel spreadsheet, financial model, pivot table, or tabular data file. Covers: creating new xlsx from scratch, reading and analyzing existing files, editing existing xlsx with zero format loss, formula recalculation and validation, and applying professional financial formatting standards. Triggers on 'spreadsheet', 'Excel', '.xlsx', '.csv', 'pivot table', 'financial model', 'formula', or any request to produce tabular data in Excel format.",
+          "version": "1.0"
+        },
+        {
+          "name": "ppt-editing-skill",
+          "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/ppt-editing-skill",
+          "description": "Edit existing PowerPoint files or templates with XML-safe workflows. Use for template-based deck updates: analyze layouts, map content to slides, duplicate/reorder/delete slides safely, edit slide XML in parallel, clean orphaned assets, and repack validated PPTX output.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ppt-orchestra-skill",
+          "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/ppt-orchestra-skill",
+          "description": "Plan and orchestrate multi-slide PowerPoint creation from scratch. Use before generating a full deck with subagents: classify each slide type, enforce visual variety, set typography/spacing rules, and run text-based QA to catch content issues.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pptx-generator",
+          "installUrl": "github:MiniMax-AI/skills:skills/pptx-generator",
+          "description": "Generate, edit, and read PowerPoint presentations. Create from scratch with PptxGenJS (cover, TOC, content, section divider, summary slides), edit existing PPTX via XML workflows, or extract text with markitdown. Triggers: PPT, PPTX, PowerPoint, presentation, slide, deck, slides.",
+          "version": "1.0"
+        },
+        {
+          "name": "react-native-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/react-native-dev",
+          "description": "React Native and Expo development guide covering components, styling, animations, navigation, state management, forms, networking, performance optimization, testing, native capabilities, and engineering (project structure, deployment, SDK upgrades, CI/CD). Use when: building React Native or Expo apps, implementing animations or native UI, managing state, fetching data, writing tests, optimizing performance, deploying to App Store/Play Store, setting up CI/CD, upgrading Expo SDK, or configuring Tailwind/NativeWind.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "MiniMax-AI",
+        "repo": "skills",
+        "repoUrl": "https://github.com/MiniMax-AI/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "minimax-ai-skills-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from MiniMax-AI/skills.",
+      "author": "ASM (MiniMax-AI/skills)",
+      "createdAt": "2026-05-09T08:10:42.466Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "minimax-ai",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "android-native-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/android-native-dev",
+          "description": "Android native application development and UI design guide. Covers Material Design 3, Kotlin/Compose development, project configuration, accessibility, and build troubleshooting. Read this before Android native application development.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "buddy-sings",
+          "installUrl": "github:MiniMax-AI/skills:skills/buddy-sings",
+          "description": "Use when user wants their Claude Code pet (/buddy) to sing a song. Triggers on any request that combines the concept of their Claude Code buddy, pet, or companion with singing or music. Supports multilingual triggers — match equivalent phrases in any language.",
+          "version": "1.1"
+        },
+        {
+          "name": "color-font-skill",
+          "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/color-font-skill",
+          "description": "Choose presentation-ready color palettes and font pairings for PPT/design tasks. Use when users ask for visual theme choices, brand-safe palettes, or font recommendations. Triggers include: 配色, 色板, 字体, color palette, font, PPT配色, 字体搭配.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "design-style-skill",
+          "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/design-style-skill",
+          "description": "Select a consistent visual design system for PPT slides using radius/spacing style recipes. Use when users ask for overall style direction or component styling consistency. Includes Sharp/Soft/Rounded/Pill recipes, component mappings, typography/spacing rules, and mixing guidance. Triggers: 风格, style, radius, spacing, 圆角, 间距, PPT风格, 视觉风格, design style, component style.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flutter-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/flutter-dev",
+          "description": "Flutter cross-platform development guide covering widget patterns, Riverpod/Bloc state management, GoRouter navigation, performance optimization, and platform-specific implementations. Includes const optimization, responsive layouts, testing strategies, and DevTools profiling. Use when: building Flutter apps, implementing state management (Riverpod/Bloc), setting up GoRouter navigation, creating custom widgets, optimizing performance, writing widget tests, cross-platform development.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "frontend-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/frontend-dev",
+          "description": "Full-stack frontend development combining premium UI design, cinematic animations, AI-generated media assets, persuasive copywriting, and visual art. Builds complete, visually striking web pages with real media, advanced motion, and compelling copy. Use when: building landing pages, marketing sites, product pages, dashboards, generating media assets (image/video/audio/music), writing conversion copy, creating generative art, or implementing cinematic scroll animations.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "fullstack-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/fullstack-dev",
+          "description": "Full-stack backend architecture and frontend-backend integration guide. TRIGGER when: building a full-stack app, creating REST API with frontend, scaffolding backend service, building todo app, building CRUD app, building real-time app, building chat app, Express + React, Next.js API, Node.js backend, Python backend, Go backend, designing service layers, implementing error handling, managing config/auth, setting up API clients, implementing auth flows, handling file uploads, adding real-time features (SSE/WebSocket), hardening for production. DO NOT TRIGGER when: pure frontend UI work, pure CSS/styling, database schema only.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "gif-sticker-maker",
+          "installUrl": "github:MiniMax-AI/skills:skills/gif-sticker-maker",
+          "description": "Convert photos (people, pets, objects, logos) into 4 animated GIF stickers with captions. Use when: user wants to create cartoon stickers, GIF expressions, emoji packs, animated avatars, or convert photos to Funko Pop / Pop Mart blind box style animations. Triggers: sticker, GIF, cartoon, emoji, expression pack, avatar animation.",
+          "version": "1.2"
+        },
+        {
+          "name": "ios-application-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/ios-application-dev",
+          "description": "iOS application development guide covering UIKit, SnapKit, and SwiftUI. Includes touch targets, safe areas, navigation patterns, Dynamic Type, Dark Mode, accessibility, collection views, common UI components, and SwiftUI design guidelines. For detailed references on specific topics, see the reference files. Use when: developing iOS apps, implementing UI, reviewing iOS code, working with UIKit/SnapKit/SwiftUI layouts, building iPhone interfaces, Swift mobile development, Apple HIG compliance, iOS accessibility implementation.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "minimax-docx",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-docx",
+          "description": "Professional DOCX document creation, editing, and formatting using OpenXML SDK (.NET). Three pipelines: (A) create new documents from scratch, (B) fill/edit content in existing documents, (C) apply template formatting with XSD validation gate-check. MUST use this skill whenever the user wants to produce, modify, or format a Word document — including when they say \"write a report\", \"draft a proposal\", \"make a contract\", \"fill in this form\", \"reformat to match this template\", or any task whose final output is a .docx file. Even if the user doesn't mention \"docx\" explicitly, if the task implies a printable/formal document, use this skill.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "minimax-music-gen",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-music-gen",
+          "description": "Use when user wants to generate music, songs, or audio tracks. Triggers on any request involving music creation, song writing, lyrics generation, audio production, or covers. Also triggers when user provides lyrics and wants them turned into a song, or describes a mood/scene and wants background music. Supports multilingual triggers — match equivalent phrases in any language. Do NOT use for music playback of existing files, music theory questions, or music recommendation without generation.",
+          "version": "1.1"
+        },
+        {
+          "name": "minimax-music-playlist",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-music-playlist",
+          "description": "Generate personalized music playlists by analyzing the user's music taste and generation feedback history. Triggers on any request involving playlist generation, music taste profiling, or personalized music recommendations. Supports multilingual triggers — match equivalent phrases in any language.",
+          "version": "2.0"
+        },
+        {
+          "name": "minimax-pdf",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-pdf",
+          "description": "Use this skill when visual quality and design identity matter for a PDF. CREATE (generate from scratch): \"make a PDF\", \"generate a report\", \"write a proposal\", \"create a resume\", \"beautiful PDF\", \"professional document\", \"cover page\", \"polished PDF\", \"client-ready document\". FILL (complete form fields): \"fill in the form\", \"fill out this PDF\", \"complete the form fields\", \"write values into PDF\", \"what fields does this PDF have\". REFORMAT (apply design to an existing doc): \"reformat this document\", \"apply our style\", \"convert this Markdown/text to PDF\", \"make this doc look good\", \"re-style this PDF\". This skill uses a token-based design system: color, typography, and spacing are derived from the document type and flow through every page. The output is print-ready. Prefer this skill when appearance matters, not just when any PDF output is needed.",
+          "version": "1.0"
+        },
+        {
+          "name": "minimax-xlsx",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-xlsx",
+          "description": "Open, create, read, analyze, edit, or validate Excel/spreadsheet files (.xlsx, .xlsm, .csv, .tsv). Use when the user asks to create, build, modify, analyze, read, validate, or format any Excel spreadsheet, financial model, pivot table, or tabular data file. Covers: creating new xlsx from scratch, reading and analyzing existing files, editing existing xlsx with zero format loss, formula recalculation and validation, and applying professional financial formatting standards. Triggers on 'spreadsheet', 'Excel', '.xlsx', '.csv', 'pivot table', 'financial model', 'formula', or any request to produce tabular data in Excel format.",
+          "version": "1.0"
+        },
+        {
+          "name": "mmx-cli",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-multimodal-toolkit",
+          "description": "Use mmx to generate text, images, video, speech, and music via the MiniMax AI platform. Use when the user wants to create media content, chat with MiniMax models, perform web search, or manage MiniMax API resources from the terminal.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ppt-editing-skill",
+          "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/ppt-editing-skill",
+          "description": "Edit existing PowerPoint files or templates with XML-safe workflows. Use for template-based deck updates: analyze layouts, map content to slides, duplicate/reorder/delete slides safely, edit slide XML in parallel, clean orphaned assets, and repack validated PPTX output.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ppt-orchestra-skill",
+          "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/ppt-orchestra-skill",
+          "description": "Plan and orchestrate multi-slide PowerPoint creation from scratch. Use before generating a full deck with subagents: classify each slide type, enforce visual variety, set typography/spacing rules, and run text-based QA to catch content issues.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pptx-generator",
+          "installUrl": "github:MiniMax-AI/skills:skills/pptx-generator",
+          "description": "Generate, edit, and read PowerPoint presentations. Create from scratch with PptxGenJS (cover, TOC, content, section divider, summary slides), edit existing PPTX via XML workflows, or extract text with markitdown. Triggers: PPT, PPTX, PowerPoint, presentation, slide, deck, slides.",
+          "version": "1.0"
+        },
+        {
+          "name": "pr-review",
+          "installUrl": "github:MiniMax-AI/skills:.claude/skills/pr-review",
+          "description": "Review pull requests for the MiniMax Skills repository. Use when reviewing PRs, validating new skill submissions, or checking existing skills for compliance. Run the validation script first for hard checks, then apply quality guidelines for content review. Triggers: PR review, pull request, validate skill, check skill.",
+          "version": "1.0"
+        },
+        {
+          "name": "react-native-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/react-native-dev",
+          "description": "React Native and Expo development guide covering components, styling, animations, navigation, state management, forms, networking, performance optimization, testing, native capabilities, and engineering (project structure, deployment, SDK upgrades, CI/CD). Use when: building React Native or Expo apps, implementing animations or native UI, managing state, fetching data, writing tests, optimizing performance, deploying to App Store/Play Store, setting up CI/CD, upgrading Expo SDK, or configuring Tailwind/NativeWind.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "shader-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/shader-dev",
+          "description": "Comprehensive GLSL shader techniques for creating stunning visual effects — ray marching, SDF modeling, fluid simulation, particle systems, procedural generation, lighting, post-processing, and more.",
+          "version": "1.0"
+        },
+        {
+          "name": "slide-making-skill",
+          "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/slide-making-skill",
+          "description": "Implement single-slide PowerPoint pages with PptxGenJS. Use when writing or fixing slide JS files: dimensions, positioning, text/image/chart APIs, styling rules, and export expectations for native .pptx output.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "vision-analysis",
+          "installUrl": "github:MiniMax-AI/skills:skills/vision-analysis",
+          "description": "Analyze, describe, and extract information from images using the MiniMax vision MCP tool. Use when: user shares an image file path or URL (any message containing .jpg, .jpeg, .png, .gif, .webp, .bmp, or .svg file extension) or uses any of these words/phrases near an image: \"analyze\", \"analyse\", \"describe\", \"explain\", \"understand\", \"look at\", \"review\", \"extract text\", \"OCR\", \"what is in\", \"what's in\", \"read this image\", \"see this image\", \"tell me about\", \"explain this\", \"interpret this\", in connection with an image, screenshot, diagram, chart, mockup, wireframe, or photo. Also triggers for: UI mockup review, wireframe analysis, design critique, data extraction from charts, object detection, person/animal/activity identification. Triggers: any message with an image file extension (jpg, jpeg, png, gif, webp, bmp, svg), or any request to analyze/describ/understand/review/extract text from an image, screenshot, diagram, chart, photo, mockup, or wireframe.",
+          "version": "1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "MiniMax-AI",
+        "repo": "skills",
+        "repoUrl": "https://github.com/MiniMax-AI/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "minimax-ai-skills-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from MiniMax-AI/skills.",
+      "author": "ASM (MiniMax-AI/skills)",
+      "createdAt": "2026-05-09T08:10:42.466Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "minimax-ai",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "frontend-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/frontend-dev",
+          "description": "Full-stack frontend development combining premium UI design, cinematic animations, AI-generated media assets, persuasive copywriting, and visual art. Builds complete, visually striking web pages with real media, advanced motion, and compelling copy. Use when: building landing pages, marketing sites, product pages, dashboards, generating media assets (image/video/audio/music), writing conversion copy, creating generative art, or implementing cinematic scroll animations.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "fullstack-dev",
+          "installUrl": "github:MiniMax-AI/skills:skills/fullstack-dev",
+          "description": "Full-stack backend architecture and frontend-backend integration guide. TRIGGER when: building a full-stack app, creating REST API with frontend, scaffolding backend service, building todo app, building CRUD app, building real-time app, building chat app, Express + React, Next.js API, Node.js backend, Python backend, Go backend, designing service layers, implementing error handling, managing config/auth, setting up API clients, implementing auth flows, handling file uploads, adding real-time features (SSE/WebSocket), hardening for production. DO NOT TRIGGER when: pure frontend UI work, pure CSS/styling, database schema only.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "minimax-music-gen",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-music-gen",
+          "description": "Use when user wants to generate music, songs, or audio tracks. Triggers on any request involving music creation, song writing, lyrics generation, audio production, or covers. Also triggers when user provides lyrics and wants them turned into a song, or describes a mood/scene and wants background music. Supports multilingual triggers — match equivalent phrases in any language. Do NOT use for music playback of existing files, music theory questions, or music recommendation without generation.",
+          "version": "1.1"
+        },
+        {
+          "name": "minimax-pdf",
+          "installUrl": "github:MiniMax-AI/skills:skills/minimax-pdf",
+          "description": "Use this skill when visual quality and design identity matter for a PDF. CREATE (generate from scratch): \"make a PDF\", \"generate a report\", \"write a proposal\", \"create a resume\", \"beautiful PDF\", \"professional document\", \"cover page\", \"polished PDF\", \"client-ready document\". FILL (complete form fields): \"fill in the form\", \"fill out this PDF\", \"complete the form fields\", \"write values into PDF\", \"what fields does this PDF have\". REFORMAT (apply design to an existing doc): \"reformat this document\", \"apply our style\", \"convert this Markdown/text to PDF\", \"make this doc look good\", \"re-style this PDF\". This skill uses a token-based design system: color, typography, and spacing are derived from the document type and flow through every page. The output is print-ready. Prefer this skill when appearance matters, not just when any PDF output is needed.",
+          "version": "1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "MiniMax-AI",
+        "repo": "skills",
+        "repoUrl": "https://github.com/MiniMax-AI/skills.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/Paramchoudhary_ResumeSkills.json
+++ b/data/skill-index/Paramchoudhary_ResumeSkills.json
@@ -2745,5 +2745,409 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "paramchoudhary-resumeskills-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from Paramchoudhary/ResumeSkills.",
+      "author": "ASM (Paramchoudhary/ResumeSkills)",
+      "createdAt": "2026-05-09T08:11:12.290Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "paramchoudhary",
+        "resumeskills"
+      ],
+      "skills": [
+        {
+          "name": "Executive Resume Writer",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/executive-resume-writer",
+          "description": "Create C-suite and VP level resumes emphasizing strategic leadership",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Portfolio Case Study Writer",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/portfolio-case-study-writer",
+          "description": "Transform resume bullets into detailed portfolio case studies",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Resume Bullet Writer",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/resume-bullet-writer",
+          "description": "Transform weak resume bullets into achievement-focused statements with metrics and impact",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Paramchoudhary",
+        "repo": "ResumeSkills",
+        "repoUrl": "https://github.com/Paramchoudhary/ResumeSkills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "paramchoudhary-resumeskills-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from Paramchoudhary/ResumeSkills.",
+      "author": "ASM (Paramchoudhary/ResumeSkills)",
+      "createdAt": "2026-05-09T08:11:12.290Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "paramchoudhary",
+        "resumeskills"
+      ],
+      "skills": [
+        {
+          "name": "Academic CV Builder",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/academic-cv-builder",
+          "description": "Format CVs for academic positions with publications, grants, and teaching",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Offer Comparison Analyzer",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/offer-comparison-analyzer",
+          "description": "Compare multiple job offers side-by-side with total compensation analysis",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Salary Negotiation Prep",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/salary-negotiation-prep",
+          "description": "Research market rates, build negotiation strategy, and create counter-offer scripts",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Paramchoudhary",
+        "repo": "ResumeSkills",
+        "repoUrl": "https://github.com/Paramchoudhary/ResumeSkills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "paramchoudhary-resumeskills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from Paramchoudhary/ResumeSkills.",
+      "author": "ASM (Paramchoudhary/ResumeSkills)",
+      "createdAt": "2026-05-09T08:11:12.290Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "paramchoudhary",
+        "resumeskills"
+      ],
+      "skills": [
+        {
+          "name": "Academic CV Builder",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/academic-cv-builder",
+          "description": "Format CVs for academic positions with publications, grants, and teaching",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Reference List Builder",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/reference-list-builder",
+          "description": "Format professional references properly and prepare reference materials",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Resume Section Builder",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/resume-section-builder",
+          "description": "Create targeted resume sections optimized for different experience levels and roles",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Salary Negotiation Prep",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/salary-negotiation-prep",
+          "description": "Research market rates, build negotiation strategy, and create counter-offer scripts",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Paramchoudhary",
+        "repo": "ResumeSkills",
+        "repoUrl": "https://github.com/Paramchoudhary/ResumeSkills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "paramchoudhary-resumeskills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from Paramchoudhary/ResumeSkills.",
+      "author": "ASM (Paramchoudhary/ResumeSkills)",
+      "createdAt": "2026-05-09T08:11:12.290Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "paramchoudhary",
+        "resumeskills"
+      ],
+      "skills": [
+        {
+          "name": "Academic CV Builder",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/academic-cv-builder",
+          "description": "Format CVs for academic positions with publications, grants, and teaching",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Creative Portfolio Resume",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/creative-portfolio-resume",
+          "description": "Balance visual design with ATS compatibility for creative roles",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Executive Resume Writer",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/executive-resume-writer",
+          "description": "Create C-suite and VP level resumes emphasizing strategic leadership",
+          "version": "0.0.0"
+        },
+        {
+          "name": "LinkedIn Profile Optimizer",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/linkedin-profile-optimizer",
+          "description": "Optimize LinkedIn profile for searchability, recruiter visibility, and engagement",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Reference List Builder",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/reference-list-builder",
+          "description": "Format professional references properly and prepare reference materials",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Resume Formatter",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/resume-formatter",
+          "description": "Ensure ATS-friendly formatting and create clean scannable layouts",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Resume Section Builder",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/resume-section-builder",
+          "description": "Create targeted resume sections optimized for different experience levels and roles",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Salary Negotiation Prep",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/salary-negotiation-prep",
+          "description": "Research market rates, build negotiation strategy, and create counter-offer scripts",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Paramchoudhary",
+        "repo": "ResumeSkills",
+        "repoUrl": "https://github.com/Paramchoudhary/ResumeSkills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "paramchoudhary-resumeskills-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from Paramchoudhary/ResumeSkills.",
+      "author": "ASM (Paramchoudhary/ResumeSkills)",
+      "createdAt": "2026-05-09T08:11:12.290Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "paramchoudhary",
+        "resumeskills"
+      ],
+      "skills": [
+        {
+          "name": "Offer Comparison Analyzer",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/offer-comparison-analyzer",
+          "description": "Compare multiple job offers side-by-side with total compensation analysis",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Portfolio Case Study Writer",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/portfolio-case-study-writer",
+          "description": "Transform resume bullets into detailed portfolio case studies",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Resume Quantifier",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/resume-quantifier",
+          "description": "Find opportunities to add metrics and estimate numbers when exact data unavailable",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Resume Tailor",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/resume-tailor",
+          "description": "Customize resume for specific job postings while maintaining truthfulness",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Resume Version Manager",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/resume-version-manager",
+          "description": "Track different resume versions, maintain master resume, manage tailored versions",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Paramchoudhary",
+        "repo": "ResumeSkills",
+        "repoUrl": "https://github.com/Paramchoudhary/ResumeSkills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "paramchoudhary-resumeskills-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from Paramchoudhary/ResumeSkills.",
+      "author": "ASM (Paramchoudhary/ResumeSkills)",
+      "createdAt": "2026-05-09T08:11:12.290Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "paramchoudhary",
+        "resumeskills"
+      ],
+      "skills": [
+        {
+          "name": "Academic CV Builder",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/academic-cv-builder",
+          "description": "Format CVs for academic positions with publications, grants, and teaching",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Career Changer Translator",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/career-changer-translator",
+          "description": "Translate skills from one industry to another, identify transferable skills",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Cover Letter Generator",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/cover-letter-generator",
+          "description": "Create personalized, compelling cover letters from resume and job description",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Creative Portfolio Resume",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/creative-portfolio-resume",
+          "description": "Balance visual design with ATS compatibility for creative roles",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Executive Resume Writer",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/executive-resume-writer",
+          "description": "Create C-suite and VP level resumes emphasizing strategic leadership",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Interview Prep Generator",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/interview-prep-generator",
+          "description": "Generate STAR stories, practice questions, and talking points from resume",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Job Description Analyzer",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/job-description-analyzer",
+          "description": "Analyze job postings, calculate match scores, identify gaps, and create application strategy",
+          "version": "0.0.0"
+        },
+        {
+          "name": "LinkedIn Profile Optimizer",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/linkedin-profile-optimizer",
+          "description": "Optimize LinkedIn profile for searchability, recruiter visibility, and engagement",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Offer Comparison Analyzer",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/offer-comparison-analyzer",
+          "description": "Compare multiple job offers side-by-side with total compensation analysis",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Portfolio Case Study Writer",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/portfolio-case-study-writer",
+          "description": "Transform resume bullets into detailed portfolio case studies",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Reference List Builder",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/reference-list-builder",
+          "description": "Format professional references properly and prepare reference materials",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Resume ATS Optimizer",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/resume-ats-optimizer",
+          "description": "Optimize resumes for Applicant Tracking Systems, check ATS compatibility, and analyze keyword match",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Resume Bullet Writer",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/resume-bullet-writer",
+          "description": "Transform weak resume bullets into achievement-focused statements with metrics and impact",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Resume Formatter",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/resume-formatter",
+          "description": "Ensure ATS-friendly formatting and create clean scannable layouts",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Resume Quantifier",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/resume-quantifier",
+          "description": "Find opportunities to add metrics and estimate numbers when exact data unavailable",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Resume Section Builder",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/resume-section-builder",
+          "description": "Create targeted resume sections optimized for different experience levels and roles",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Resume Tailor",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/resume-tailor",
+          "description": "Customize resume for specific job postings while maintaining truthfulness",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Resume Version Manager",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/resume-version-manager",
+          "description": "Track different resume versions, maintain master resume, manage tailored versions",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Salary Negotiation Prep",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/salary-negotiation-prep",
+          "description": "Research market rates, build negotiation strategy, and create counter-offer scripts",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Tech Resume Optimizer",
+          "installUrl": "github:Paramchoudhary/ResumeSkills:skills/tech-resume-optimizer",
+          "description": "Optimize resumes for software engineering, PM, and technical roles",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "Paramchoudhary",
+        "repo": "ResumeSkills",
+        "repoUrl": "https://github.com/Paramchoudhary/ResumeSkills.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/affaan-m_everything-claude-code.json
+++ b/data/skill-index/affaan-m_everything-claude-code.json
@@ -24809,7 +24809,12 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Grep", "Glob", "Bash(python:*)"],
+      "allowedTools": [
+        "Read",
+        "Grep",
+        "Glob",
+        "Bash(python:*)"
+      ],
       "installUrl": "github:affaan-m/everything-claude-code:skills/videodb",
       "relPath": "skills/videodb",
       "verified": true,
@@ -25349,6 +25354,2670 @@
           "evaluatedVersion": "0.0.0"
         }
       }
+    }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "affaan-m-everything-claude-code-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from affaan-m/everything-claude-code.",
+      "author": "ASM (affaan-m/everything-claude-code)",
+      "createdAt": "2026-05-09T08:10:28.548Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "affaan-m",
+        "everything-claude-code"
+      ],
+      "skills": [
+        {
+          "name": "article-writing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/article-writing",
+          "description": "Write articles, guides, blog posts, tutorials, newsletter issues, and other long-form content in a distinctive voice derived from supplied examples or brand guidance. Use when the user wants polished written content longer than a paragraph, especially when voice consistency, structure, and credibility matter.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autonomous-agent-harness",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/autonomous-agent-harness",
+          "description": "Transform Claude Code into a fully autonomous agent system with persistent memory, scheduled operations, computer use, and task queuing. Replaces standalone agent frameworks (Hermes, AutoGPT) by leveraging Claude Code's native crons, dispatch, MCP tools, and memory. Use when the user wants continuous autonomous operation, scheduled tasks, or a self-directing agent loop.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brand-voice",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/brand-voice",
+          "description": "Build a source-derived writing style profile from real posts, essays, launch notes, docs, or site copy, then reuse that profile across content, outreach, and social workflows. Use when the user wants voice consistency without generic AI writing tropes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ck",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/ck",
+          "description": "Persistent per-project memory for Claude Code. Auto-loads project context on session start, tracks sessions with git activity, and writes to native memory. Commands run deterministic Node.js scripts — behavior is consistent across model versions.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "coding-standards",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/coding-standards",
+          "description": "Baseline cross-project coding conventions for naming, readability, immutability, and code-quality review. Use detailed frontend or backend skills for framework-specific patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "connections-optimizer",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/connections-optimizer",
+          "description": "Reorganize the user's X and LinkedIn network with review-first pruning, add/follow recommendations, and channel-specific warm outreach drafted in the user's real voice. Use when the user wants to clean up following lists, grow toward current priorities, or rebalance a social graph around higher-signal relationships.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-engine",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/content-engine",
+          "description": "Create platform-native content systems for X, LinkedIn, TikTok, YouTube, newsletters, and repurposed multi-platform campaigns. Use when the user wants social posts, threads, scripts, content calendars, or one source asset adapted cleanly across platforms.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "context-budget",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/context-budget",
+          "description": "Audits Claude Code context window consumption across agents, skills, MCP servers, and rules. Identifies bloat, redundant components, and produces prioritized token-savings recommendations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "continuous-learning-v2",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/continuous-learning-v2",
+          "description": "Instinct-based learning system that observes sessions via hooks, creates atomic instincts with confidence scoring, and evolves them into skills/commands/agents. v2.1 adds project-scoped instincts to prevent cross-project contamination.",
+          "version": "2.1.0"
+        },
+        {
+          "name": "crosspost",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/crosspost",
+          "description": "Multi-platform content distribution across X, LinkedIn, Threads, and Bluesky. Adapts content per platform using content-engine patterns. Never posts identical content cross-platform. Use when the user wants to distribute content across social platforms.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "customs-trade-compliance",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/customs-trade-compliance",
+          "description": "Codified expertise for customs documentation, tariff classification, duty optimization, restricted party screening, and regulatory compliance across multiple jurisdictions. Informed by trade compliance specialists with 15+ years experience. Includes HS classification logic, Incoterms application, FTA utilization, and penalty mitigation. Use when handling customs clearance, tariff classification, trade compliance, import/export documentation, or duty optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "database-migrations",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/database-migrations",
+          "description": "Database migration best practices for schema changes, data migrations, rollbacks, and zero-downtime deployments across PostgreSQL, MySQL, and common ORMs (Prisma, Drizzle, Kysely, Django, TypeORM, golang-migrate).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dmux-workflows",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/dmux-workflows",
+          "description": "Multi-agent orchestration using dmux (tmux pane manager for AI agents). Patterns for parallel agent workflows across Claude Code, Codex, OpenCode, and other harnesses. Use when running multiple agent sessions in parallel or coordinating multi-agent development workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "evm-token-decimals",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/evm-token-decimals",
+          "description": "Prevent silent decimal mismatch bugs across EVM chains. Covers runtime decimal lookup, chain-aware caching, bridged-token precision drift, and safe normalization for bots, dashboards, and DeFi tools.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "finance-billing-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/finance-billing-ops",
+          "description": "Evidence-first revenue, pricing, refunds, team-billing, and billing-model truth workflow for ECC. Use when the user wants a sales snapshot, pricing comparison, duplicate-charge diagnosis, or code-backed billing reality instead of generic payments advice.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-workspace-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/google-workspace-ops",
+          "description": "Operate across Google Drive, Docs, Sheets, and Slides as one workflow surface for plans, trackers, decks, and shared documents. Use when the user needs to find, summarize, edit, migrate, or clean up Google Workspace assets without dropping to raw tool calls.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hexagonal-architecture",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/hexagonal-architecture",
+          "description": "Design, implement, and refactor Ports & Adapters systems with clear domain boundaries, dependency inversion, and testable use-case orchestration across TypeScript, Java, Kotlin, and Go services.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "inventory-demand-planning",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/inventory-demand-planning",
+          "description": "Codified expertise for demand forecasting, safety stock optimization, replenishment planning, and promotional lift estimation at multi-location retailers. Informed by demand planners with 15+ years experience managing hundreds of SKUs. Includes forecasting method selection, ABC/XYZ analysis, seasonal transition management, and vendor negotiation frameworks. Use when forecasting demand, setting safety stock, planning replenishment, managing promotions, or optimizing inventory levels.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "investor-materials",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/investor-materials",
+          "description": "Create and update pitch decks, one-pagers, investor memos, accelerator applications, financial models, and fundraising materials. Use when the user needs investor-facing documents, projections, use-of-funds tables, milestone plans, or materials that must stay internally consistent across multiple fundraising assets.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "knowledge-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/knowledge-ops",
+          "description": "Knowledge base management, ingestion, sync, and retrieval across multiple storage layers (local files, MCP memory, vector stores, Git repos). Use when the user wants to save, organize, sync, deduplicate, or search across their knowledge systems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "lead-intelligence",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/lead-intelligence",
+          "description": "AI-native lead intelligence and outreach pipeline. Replaces Apollo, Clay, and ZoomInfo with agent-powered signal scoring, mutual ranking, warm path discovery, source-derived voice modeling, and channel-specific outreach across email, LinkedIn, and X. Use when the user wants to find, qualify, and reach high-value contacts.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "project-flow-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/project-flow-ops",
+          "description": "Operate execution flow across GitHub and Linear by triaging issues and pull requests, linking active work, and keeping GitHub public-facing while Linear remains the internal execution layer. Use when the user wants backlog control, PR triage, or GitHub-to-Linear coordination.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "quality-nonconformance",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/quality-nonconformance",
+          "description": "Codified expertise for quality control, non-conformance investigation, root cause analysis, corrective action, and supplier quality management in regulated manufacturing. Informed by quality engineers with 15+ years experience across FDA, IATF 16949, and AS9100 environments. Includes NCR lifecycle management, CAPA systems, SPC interpretation, and audit methodology. Use when investigating non-conformances, performing root cause analysis, managing CAPAs, interpreting SPC data, or handling supplier quality issues.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "repo-scan",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/repo-scan",
+          "description": "Cross-stack source code asset audit — classifies every file, detects embedded third-party libraries, and delivers actionable four-level verdicts per module with interactive HTML reports.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "rules-distill",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/rules-distill",
+          "description": "Scan skills to extract cross-cutting principles and distill them into rules — append, revise, or create new rule files",
+          "version": "0.0.0"
+        },
+        {
+          "name": "seo",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/seo",
+          "description": "Audit, plan, and implement SEO improvements across technical SEO, on-page optimization, structured data, Core Web Vitals, and content strategy. Use when the user wants better search visibility, SEO remediation, schema markup, sitemap/robots work, or keyword mapping.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "social-graph-ranker",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/social-graph-ranker",
+          "description": "Weighted social-graph ranking for warm intro discovery, bridge scoring, and network gap analysis across X and LinkedIn. Use when the user wants the reusable graph-ranking engine itself, not the broader outreach or network-maintenance workflow layered on top of it.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "unified-notifications-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/unified-notifications-ops",
+          "description": "Operate notifications as one ECC-native workflow across GitHub, Linear, desktop alerts, hooks, and connected communication surfaces. Use when the real problem is alert routing, deduplication, escalation, or inbox collapse.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "videodb",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/videodb",
+          "description": "See, Understand, Act on video and audio. See- ingest from local files, URLs, RTSP/live feeds, or live record desktop; return realtime context and playable stream links. Understand- extract frames, build visual/semantic/temporal indexes, and search moments with timestamps and auto-clips. Act- transcode and normalize (codec, fps, resolution, aspect ratio), perform timeline edits (subtitles, text/image overlays, branding, audio overlays, dubbing, translation), generate media assets (image, audio, video), and create real time alerts for events from live streams or desktop capture.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "affaan-m",
+        "repo": "everything-claude-code",
+        "repoUrl": "https://github.com/affaan-m/everything-claude-code.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "affaan-m-everything-claude-code-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from affaan-m/everything-claude-code.",
+      "author": "ASM (affaan-m/everything-claude-code)",
+      "createdAt": "2026-05-09T08:10:28.548Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "affaan-m",
+        "everything-claude-code"
+      ],
+      "skills": [
+        {
+          "name": "ai-regression-testing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/ai-regression-testing",
+          "description": "Regression testing strategies for AI-assisted development. Sandbox-mode API testing without database dependencies, automated bug-check workflows, and patterns to catch AI blind spots where the same model writes and reviews code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "article-writing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/article-writing",
+          "description": "Write articles, guides, blog posts, tutorials, newsletter issues, and other long-form content in a distinctive voice derived from supplied examples or brand guidance. Use when the user wants polished written content longer than a paragraph, especially when voice consistency, structure, and credibility matter.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brand-voice",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/brand-voice",
+          "description": "Build a source-derived writing style profile from real posts, essays, launch notes, docs, or site copy, then reuse that profile across content, outreach, and social workflows. Use when the user wants voice consistency without generic AI writing tropes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ck",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/ck",
+          "description": "Persistent per-project memory for Claude Code. Auto-loads project context on session start, tracks sessions with git activity, and writes to native memory. Commands run deterministic Node.js scripts — behavior is consistent across model versions.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "connections-optimizer",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/connections-optimizer",
+          "description": "Reorganize the user's X and LinkedIn network with review-first pruning, add/follow recommendations, and channel-specific warm outreach drafted in the user's real voice. Use when the user wants to clean up following lists, grow toward current priorities, or rebalance a social graph around higher-signal relationships.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-engine",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/content-engine",
+          "description": "Create platform-native content systems for X, LinkedIn, TikTok, YouTube, newsletters, and repurposed multi-platform campaigns. Use when the user wants social posts, threads, scripts, content calendars, or one source asset adapted cleanly across platforms.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-hash-cache-pattern",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/content-hash-cache-pattern",
+          "description": "Cache expensive file processing results using SHA-256 content hashes — path-independent, auto-invalidating, with service layer separation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cpp-coding-standards",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/cpp-coding-standards",
+          "description": "C++ coding standards based on the C++ Core Guidelines (isocpp.github.io). Use when writing, reviewing, or refactoring C++ code to enforce modern, safe, and idiomatic practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cpp-testing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/cpp-testing",
+          "description": "Use only when writing/updating/fixing C++ tests, configuring GoogleTest/CTest, diagnosing failing or flaky tests, or adding coverage/sanitizers.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "crosspost",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/crosspost",
+          "description": "Multi-platform content distribution across X, LinkedIn, Threads, and Bluesky. Adapts content per platform using content-engine patterns. Never posts identical content cross-platform. Use when the user wants to distribute content across social platforms.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "customs-trade-compliance",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/customs-trade-compliance",
+          "description": "Codified expertise for customs documentation, tariff classification, duty optimization, restricted party screening, and regulatory compliance across multiple jurisdictions. Informed by trade compliance specialists with 15+ years experience. Includes HS classification logic, Incoterms application, FTA utilization, and penalty mitigation. Use when handling customs clearance, tariff classification, trade compliance, import/export documentation, or duty optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "documentation-lookup",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/documentation-lookup",
+          "description": "Use up-to-date library and framework docs via Context7 MCP instead of training data. Activates for setup questions, API references, code examples, or when the user names a framework (e.g. React, Next.js, Prisma).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "email-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/email-ops",
+          "description": "Evidence-first mailbox triage, drafting, send verification, and sent-mail-safe follow-up workflow for ECC. Use when the user wants to organize email, draft or send through the real mail surface, or prove what landed in Sent.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gan-style-harness",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/gan-style-harness",
+          "description": "GAN-inspired Generator-Evaluator agent harness for building high-quality applications autonomously. Based on Anthropic's March 2026 harness design paper.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gateguard",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/gateguard",
+          "description": "Fact-forcing gate that blocks Edit/Write/Bash (including MultiEdit) and demands concrete investigation (importers, data schemas, user instruction) before allowing the action. Measurably improves output quality by +2.25 points vs ungated agents.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-workspace-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/google-workspace-ops",
+          "description": "Operate across Google Drive, Docs, Sheets, and Slides as one workflow surface for plans, trackers, decks, and shared documents. Use when the user needs to find, summarize, edit, migrate, or clean up Google Workspace assets without dropping to raw tool calls.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hookify-rules",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/hookify-rules",
+          "description": "This skill should be used when the user asks to create a hookify rule, write a hook rule, configure hookify, add a hookify rule, or needs guidance on hookify rule syntax and patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "investor-outreach",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/investor-outreach",
+          "description": "Draft cold emails, warm intro blurbs, follow-ups, update emails, and investor communications for fundraising. Use when the user wants outreach to angels, VCs, strategic investors, or accelerators and needs concise, personalized, investor-facing messaging.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "mcp-server-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/mcp-server-patterns",
+          "description": "Build MCP servers with Node/TypeScript SDK — tools, resources, prompts, Zod validation, stdio vs Streamable HTTP. Use Context7 or official MCP docs for latest API.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "plankton-code-quality",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/plankton-code-quality",
+          "description": "Write-time code quality enforcement using Plankton — auto-formatting, linting, and Claude-powered fixes on every file edit via hooks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "project-guidelines-example",
+          "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/project-guidelines-example",
+          "version": "0.0.0"
+        },
+        {
+          "name": "prompt-optimizer",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/prompt-optimizer",
+          "description": "Analyze raw prompts, identify intent and gaps, match ECC components (skills/commands/agents/hooks), and output a ready-to-paste optimized prompt. Advisory role only — never executes the task itself. TRIGGER when: user says \"optimize prompt\", \"improve my prompt\", \"how to write a prompt for\", \"help me prompt\", \"rewrite this prompt\", or explicitly asks to enhance prompt quality. Also triggers on Chinese equivalents: \"优化prompt\", \"改进prompt\", \"怎么写prompt\", \"帮我优化这个指令\". DO NOT TRIGGER when: user wants the task executed directly, or says \"just do it\" / \"直接做\". DO NOT TRIGGER when user says \"优化代码\", \"优化性能\", \"optimize performance\", \"optimize this code\" — those are refactoring/performance tasks, not prompt optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "search-first",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/search-first",
+          "description": "Research-before-coding workflow. Search for existing tools, libraries, and patterns before writing custom code. Invokes the researcher agent.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "seo",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/seo",
+          "description": "Audit, plan, and implement SEO improvements across technical SEO, on-page optimization, structured data, Core Web Vitals, and content strategy. Use when the user wants better search visibility, SEO remediation, schema markup, sitemap/robots work, or keyword mapping.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "tdd-workflow",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/tdd-workflow",
+          "description": "Use this skill when writing new features, fixing bugs, or refactoring code. Enforces test-driven development with 80%+ coverage including unit, integration, and E2E tests.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "video-editing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/video-editing",
+          "description": "AI-assisted video editing workflows for cutting, structuring, and augmenting real footage. Covers the full pipeline from raw capture through FFmpeg, Remotion, ElevenLabs, fal.ai, and final polish in Descript or CapCut. Use when the user wants to edit video, cut footage, create vlogs, or build video content.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "x-api",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/x-api",
+          "description": "X/Twitter API integration for posting tweets, threads, reading timelines, search, and analytics. Covers OAuth auth patterns, rate limits, and platform-native content posting. Use when the user wants to interact with X programmatically.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "affaan-m",
+        "repo": "everything-claude-code",
+        "repoUrl": "https://github.com/affaan-m/everything-claude-code.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "affaan-m-everything-claude-code-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from affaan-m/everything-claude-code.",
+      "author": "ASM (affaan-m/everything-claude-code)",
+      "createdAt": "2026-05-09T08:10:28.548Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "affaan-m",
+        "everything-claude-code"
+      ],
+      "skills": [
+        {
+          "name": "agent-sort",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/agent-sort",
+          "description": "Build an evidence-backed ECC install plan for a specific repo by sorting skills, commands, rules, hooks, and extras into DAILY vs LIBRARY buckets using parallel repo-aware review passes. Use when ECC should be trimmed to what a project actually needs instead of loading the full bundle.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-regression-testing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/ai-regression-testing",
+          "description": "Regression testing strategies for AI-assisted development. Sandbox-mode API testing without database dependencies, automated bug-check workflows, and patterns to catch AI blind spots where the same model writes and reviews code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "blueprint",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/blueprint",
+          "description": "Turn a one-line objective into a step-by-step construction plan for multi-session, multi-agent engineering projects. Each step has a self-contained context brief so a fresh agent can execute it cold. Includes adversarial review gate, dependency graph, parallel step detection, anti-pattern catalog, and plan mutation protocol. TRIGGER when: user requests a plan, blueprint, or roadmap for a complex multi-PR task, or describes work that needs multiple sessions. DO NOT TRIGGER when: task is completable in a single PR or fewer than 3 tool calls, or user says \"just do it\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "coding-standards",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/coding-standards",
+          "description": "Baseline cross-project coding conventions for naming, readability, immutability, and code-quality review. Use detailed frontend or backend skills for framework-specific patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "connections-optimizer",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/connections-optimizer",
+          "description": "Reorganize the user's X and LinkedIn network with review-first pruning, add/follow recommendations, and channel-specific warm outreach drafted in the user's real voice. Use when the user wants to clean up following lists, grow toward current priorities, or rebalance a social graph around higher-signal relationships.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cpp-coding-standards",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/cpp-coding-standards",
+          "description": "C++ coding standards based on the C++ Core Guidelines (isocpp.github.io). Use when writing, reviewing, or refactoring C++ code to enforce modern, safe, and idiomatic practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "customer-billing-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/customer-billing-ops",
+          "description": "Operate customer billing workflows such as subscriptions, refunds, churn triage, billing-portal recovery, and plan analysis using connected billing tools like Stripe. Use when the user needs to help a customer, inspect subscription state, or manage revenue-impacting billing operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deep-research",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/deep-research",
+          "description": "Multi-source deep research using firecrawl and exa MCPs. Searches the web, synthesizes findings, and delivers cited reports with source attribution. Use when the user wants thorough research on any topic with evidence and citations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "design-system",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/design-system",
+          "description": "Use this skill to generate or audit design systems, check visual consistency, and review PRs that touch styling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "energy-procurement",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/energy-procurement",
+          "description": "Codified expertise for electricity and gas procurement, tariff optimization, demand charge management, renewable PPA evaluation, and multi-facility energy cost management. Informed by energy procurement managers with 15+ years experience at large commercial and industrial consumers. Includes market structure analysis, hedging strategies, load profiling, and sustainability reporting frameworks. Use when procuring energy, optimizing tariffs, managing demand charges, evaluating PPAs, or developing energy strategies.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "exa-search",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/exa-search",
+          "description": "Neural search via Exa MCP for web, code, and company research. Use when the user needs web search, code examples, company intel, people lookup, or AI-powered deep research with Exa's neural search engine.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flutter-dart-code-review",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/flutter-dart-code-review",
+          "description": "Library-agnostic Flutter/Dart code review checklist covering widget best practices, state management patterns (BLoC, Riverpod, Provider, GetX, MobX, Signals), Dart idioms, performance, accessibility, security, and clean architecture.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gan-style-harness",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/gan-style-harness",
+          "description": "GAN-inspired Generator-Evaluator agent harness for building high-quality applications autonomously. Based on Anthropic's March 2026 harness design paper.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-workspace-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/google-workspace-ops",
+          "description": "Operate across Google Drive, Docs, Sheets, and Slides as one workflow surface for plans, trackers, decks, and shared documents. Use when the user needs to find, summarize, edit, migrate, or clean up Google Workspace assets without dropping to raw tool calls.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "inventory-demand-planning",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/inventory-demand-planning",
+          "description": "Codified expertise for demand forecasting, safety stock optimization, replenishment planning, and promotional lift estimation at multi-location retailers. Informed by demand planners with 15+ years experience managing hundreds of SKUs. Includes forecasting method selection, ABC/XYZ analysis, seasonal transition management, and vendor negotiation frameworks. Use when forecasting demand, setting safety stock, planning replenishment, managing promotions, or optimizing inventory levels.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "laravel-plugin-discovery",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/laravel-plugin-discovery",
+          "description": "Discover and evaluate Laravel packages via LaraPlugins.io MCP. Use when the user wants to find plugins, check package health, or assess Laravel/PHP compatibility.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "laravel-verification",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/laravel-verification",
+          "description": "Verification loop for Laravel projects: env checks, linting, static analysis, tests with coverage, security scans, and deployment readiness.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "market-research",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/market-research",
+          "description": "Conduct market research, competitive analysis, investor due diligence, and industry intelligence with source attribution and decision-oriented summaries. Use when the user wants market sizing, competitor comparisons, fund research, technology scans, or research that informs business decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "production-scheduling",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/production-scheduling",
+          "description": "Codified expertise for production scheduling, job sequencing, line balancing, changeover optimization, and bottleneck resolution in discrete and batch manufacturing. Informed by production schedulers with 15+ years experience. Includes TOC/drum-buffer-rope, SMED, OEE analysis, disruption response frameworks, and ERP/MES interaction patterns. Use when scheduling production, resolving bottlenecks, optimizing changeovers, responding to disruptions, or balancing manufacturing lines.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "quality-nonconformance",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/quality-nonconformance",
+          "description": "Codified expertise for quality control, non-conformance investigation, root cause analysis, corrective action, and supplier quality management in regulated manufacturing. Informed by quality engineers with 15+ years experience across FDA, IATF 16949, and AS9100 environments. Includes NCR lifecycle management, CAPA systems, SPC interpretation, and audit methodology. Use when investigating non-conformances, performing root cause analysis, managing CAPAs, interpreting SPC data, or handling supplier quality issues.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "research-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/research-ops",
+          "description": "Evidence-first current-state research workflow for ECC. Use when the user wants fresh facts, comparisons, enrichment, or a recommendation built from current public evidence and any supplied local context.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "santa-method",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/santa-method",
+          "description": "Multi-agent adversarial verification with convergence loop. Two independent review agents must both pass before output ships.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "search-first",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/search-first",
+          "description": "Research-before-coding workflow. Search for existing tools, libraries, and patterns before writing custom code. Invokes the researcher agent.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "security-review",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/security-review",
+          "description": "Use this skill when adding authentication, handling user input, working with secrets, creating API endpoints, or implementing payment/sensitive features. Provides comprehensive security checklist and patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "social-graph-ranker",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/social-graph-ranker",
+          "description": "Weighted social-graph ranking for warm intro discovery, bridge scoring, and network gap analysis across X and LinkedIn. Use when the user wants the reusable graph-ranking engine itself, not the broader outreach or network-maintenance workflow layered on top of it.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "springboot-verification",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/springboot-verification",
+          "description": "Verification loop for Spring Boot projects: build, static analysis, tests with coverage, security scans, and diff review before release or PR.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "affaan-m",
+        "repo": "everything-claude-code",
+        "repoUrl": "https://github.com/affaan-m/everything-claude-code.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "affaan-m-everything-claude-code-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from affaan-m/everything-claude-code.",
+      "author": "ASM (affaan-m/everything-claude-code)",
+      "createdAt": "2026-05-09T08:10:28.548Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "affaan-m",
+        "everything-claude-code"
+      ],
+      "skills": [
+        {
+          "name": "accessibility",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/accessibility",
+          "description": "Design, implement, and audit inclusive digital products using WCAG 2.2 Level AA",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-eval",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/agent-eval",
+          "description": "Head-to-head comparison of coding agents (Claude Code, Aider, Codex, etc.) on custom tasks with pass rate, cost, time, and consistency metrics",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-harness-construction",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/agent-harness-construction",
+          "description": "Design and optimize AI agent action spaces, tool definitions, and observation formatting for higher completion rates.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-introspection-debugging",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/agent-introspection-debugging",
+          "description": "Structured self-debugging workflow for AI agent failures using capture, diagnosis, contained recovery, and introspection reports.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-payment-x402",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/agent-payment-x402",
+          "description": "Add x402 payment execution to AI agents — per-task budgets, spending controls, and non-custodial wallets via MCP tools. Use when agents need to pay for APIs, services, or other agents.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-sort",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/agent-sort",
+          "description": "Build an evidence-backed ECC install plan for a specific repo by sorting skills, commands, rules, hooks, and extras into DAILY vs LIBRARY buckets using parallel repo-aware review passes. Use when ECC should be trimmed to what a project actually needs instead of loading the full bundle.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentic-engineering",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/agentic-engineering",
+          "description": "Operate as an agentic engineer using eval-first execution, decomposition, and cost-aware model routing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-first-engineering",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/ai-first-engineering",
+          "description": "Engineering operating model for teams where AI agents generate a large share of implementation output.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-regression-testing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/ai-regression-testing",
+          "description": "Regression testing strategies for AI-assisted development. Sandbox-mode API testing without database dependencies, automated bug-check workflows, and patterns to catch AI blind spots where the same model writes and reviews code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "android-clean-architecture",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/android-clean-architecture",
+          "description": "Clean Architecture patterns for Android and Kotlin Multiplatform projects — module structure, dependency rules, UseCases, Repositories, and data layer patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-connector-builder",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/api-connector-builder",
+          "description": "Build a new API connector or provider by matching the target repo's existing integration pattern exactly. Use when adding one more integration without inventing a second architecture.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "api-design",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/api-design",
+          "description": "REST API design patterns including resource naming, status codes, pagination, filtering, error responses, versioning, and rate limiting for production APIs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture-decision-records",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/architecture-decision-records",
+          "description": "Capture architectural decisions made during Claude Code sessions as structured ADRs. Auto-detects decision moments, records context, alternatives considered, and rationale. Maintains an ADR log so future developers understand why the codebase is shaped the way it is.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "article-writing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/article-writing",
+          "description": "Write articles, guides, blog posts, tutorials, newsletter issues, and other long-form content in a distinctive voice derived from supplied examples or brand guidance. Use when the user wants polished written content longer than a paragraph, especially when voice consistency, structure, and credibility matter.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "automation-audit-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/automation-audit-ops",
+          "description": "Evidence-first automation inventory and overlap audit workflow for ECC. Use when the user wants to know which jobs, hooks, connectors, MCP servers, or wrappers are live, broken, redundant, or missing before fixing anything.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autonomous-agent-harness",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/autonomous-agent-harness",
+          "description": "Transform Claude Code into a fully autonomous agent system with persistent memory, scheduled operations, computer use, and task queuing. Replaces standalone agent frameworks (Hermes, AutoGPT) by leveraging Claude Code's native crons, dispatch, MCP tools, and memory. Use when the user wants continuous autonomous operation, scheduled tasks, or a self-directing agent loop.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autonomous-loops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/autonomous-loops",
+          "description": "Patterns and architectures for autonomous Claude Code loops — from simple sequential pipelines to RFC-driven multi-agent DAG systems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "backend-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/backend-patterns",
+          "description": "Backend architecture patterns, API design, database optimization, and server-side best practices for Node.js, Express, and Next.js API routes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "benchmark",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/benchmark",
+          "description": "Use this skill to measure performance baselines, detect regressions before/after PRs, and compare stack alternatives.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "blueprint",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/blueprint",
+          "description": "Turn a one-line objective into a step-by-step construction plan for multi-session, multi-agent engineering projects. Each step has a self-contained context brief so a fresh agent can execute it cold. Includes adversarial review gate, dependency graph, parallel step detection, anti-pattern catalog, and plan mutation protocol. TRIGGER when: user requests a plan, blueprint, or roadmap for a complex multi-PR task, or describes work that needs multiple sessions. DO NOT TRIGGER when: task is completable in a single PR or fewer than 3 tool calls, or user says \"just do it\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brand-voice",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/brand-voice",
+          "description": "Build a source-derived writing style profile from real posts, essays, launch notes, docs, or site copy, then reuse that profile across content, outreach, and social workflows. Use when the user wants voice consistency without generic AI writing tropes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "browser-qa",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/browser-qa",
+          "description": "Use this skill to automate visual testing and UI interaction verification using browser automation after deploying features.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bun-runtime",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/bun-runtime",
+          "description": "Bun as runtime, package manager, bundler, and test runner. When to choose Bun vs Node, migration notes, and Vercel support.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "canary-watch",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/canary-watch",
+          "description": "Use this skill to monitor a deployed URL for regressions after deploys, merges, or dependency upgrades.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "carrier-relationship-management",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/carrier-relationship-management",
+          "description": "Codified expertise for managing carrier portfolios, negotiating freight rates, tracking carrier performance, allocating freight, and maintaining strategic carrier relationships. Informed by transportation managers with 15+ years experience. Includes scorecarding frameworks, RFP processes, market intelligence, and compliance vetting. Use when managing carriers, negotiating rates, evaluating carrier performance, or building freight strategies.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ck",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/ck",
+          "description": "Persistent per-project memory for Claude Code. Auto-loads project context on session start, tracks sessions with git activity, and writes to native memory. Commands run deterministic Node.js scripts — behavior is consistent across model versions.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "claude-devfleet",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/claude-devfleet",
+          "description": "Orchestrate multi-agent coding tasks via Claude DevFleet — plan projects, dispatch parallel agents in isolated worktrees, monitor progress, and read structured reports.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "click-path-audit",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/click-path-audit",
+          "description": "Trace every user-facing button/touchpoint through its full state change sequence to find bugs where functions individually work but cancel each other out, produce wrong final state, or leave the UI in an inconsistent state. Use when: systematic debugging found no bugs but users report broken buttons, or after any major refactor touching shared state stores.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "clickhouse-io",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/clickhouse-io",
+          "description": "ClickHouse database patterns, query optimization, analytics, and data engineering best practices for high-performance analytical workloads.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-tour",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/code-tour",
+          "description": "Create CodeTour `.tour` files — persona-targeted, step-by-step walkthroughs with real file and line anchors. Use for onboarding tours, architecture walkthroughs, PR tours, RCA tours, and structured \"explain how this works\" requests.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "codebase-onboarding",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/codebase-onboarding",
+          "description": "Analyze an unfamiliar codebase and generate a structured onboarding guide with architecture map, key entry points, conventions, and a starter CLAUDE.md. Use when joining a new project or setting up Claude Code for the first time in a repo.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "coding-standards",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/coding-standards",
+          "description": "Baseline cross-project coding conventions for naming, readability, immutability, and code-quality review. Use detailed frontend or backend skills for framework-specific patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "compose-multiplatform-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/compose-multiplatform-patterns",
+          "description": "Compose Multiplatform and Jetpack Compose patterns for KMP projects — state management, navigation, theming, performance, and platform-specific UI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "configure-ecc",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/configure-ecc",
+          "description": "Interactive installer for Everything Claude Code — guides users through selecting and installing skills and rules to user-level or project-level directories, verifies paths, and optionally optimizes installed files.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "connections-optimizer",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/connections-optimizer",
+          "description": "Reorganize the user's X and LinkedIn network with review-first pruning, add/follow recommendations, and channel-specific warm outreach drafted in the user's real voice. Use when the user wants to clean up following lists, grow toward current priorities, or rebalance a social graph around higher-signal relationships.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-engine",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/content-engine",
+          "description": "Create platform-native content systems for X, LinkedIn, TikTok, YouTube, newsletters, and repurposed multi-platform campaigns. Use when the user wants social posts, threads, scripts, content calendars, or one source asset adapted cleanly across platforms.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-hash-cache-pattern",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/content-hash-cache-pattern",
+          "description": "Cache expensive file processing results using SHA-256 content hashes — path-independent, auto-invalidating, with service layer separation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "context-budget",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/context-budget",
+          "description": "Audits Claude Code context window consumption across agents, skills, MCP servers, and rules. Identifies bloat, redundant components, and produces prioritized token-savings recommendations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "continuous-agent-loop",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/continuous-agent-loop",
+          "description": "Patterns for continuous autonomous agent loops with quality gates, evals, and recovery controls.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "continuous-learning",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/continuous-learning",
+          "description": "Automatically extract reusable patterns from Claude Code sessions and save them as learned skills for future use.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "continuous-learning-v2",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/continuous-learning-v2",
+          "description": "Instinct-based learning system that observes sessions via hooks, creates atomic instincts with confidence scoring, and evolves them into skills/commands/agents. v2.1 adds project-scoped instincts to prevent cross-project contamination.",
+          "version": "2.1.0"
+        },
+        {
+          "name": "cost-aware-llm-pipeline",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/cost-aware-llm-pipeline",
+          "description": "Cost optimization patterns for LLM API usage — model routing by task complexity, budget tracking, retry logic, and prompt caching.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "council",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/council",
+          "description": "Convene a four-voice council for ambiguous decisions, tradeoffs, and go/no-go calls. Use when multiple valid paths exist and you need structured disagreement before choosing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cpp-coding-standards",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/cpp-coding-standards",
+          "description": "C++ coding standards based on the C++ Core Guidelines (isocpp.github.io). Use when writing, reviewing, or refactoring C++ code to enforce modern, safe, and idiomatic practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cpp-testing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/cpp-testing",
+          "description": "Use only when writing/updating/fixing C++ tests, configuring GoogleTest/CTest, diagnosing failing or flaky tests, or adding coverage/sanitizers.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "crosspost",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/crosspost",
+          "description": "Multi-platform content distribution across X, LinkedIn, Threads, and Bluesky. Adapts content per platform using content-engine patterns. Never posts identical content cross-platform. Use when the user wants to distribute content across social platforms.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "csharp-testing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/csharp-testing",
+          "description": "C# and .NET testing patterns with xUnit, FluentAssertions, mocking, integration tests, and test organization best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "customer-billing-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/customer-billing-ops",
+          "description": "Operate customer billing workflows such as subscriptions, refunds, churn triage, billing-portal recovery, and plan analysis using connected billing tools like Stripe. Use when the user needs to help a customer, inspect subscription state, or manage revenue-impacting billing operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "customs-trade-compliance",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/customs-trade-compliance",
+          "description": "Codified expertise for customs documentation, tariff classification, duty optimization, restricted party screening, and regulatory compliance across multiple jurisdictions. Informed by trade compliance specialists with 15+ years experience. Includes HS classification logic, Incoterms application, FTA utilization, and penalty mitigation. Use when handling customs clearance, tariff classification, trade compliance, import/export documentation, or duty optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "dart-flutter-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/dart-flutter-patterns",
+          "description": "Production-ready Dart and Flutter patterns covering null safety, immutable state, async composition, widget architecture, popular state management frameworks (BLoC, Riverpod, Provider), GoRouter navigation, Dio networking, Freezed code generation, and clean architecture.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dashboard-builder",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/dashboard-builder",
+          "description": "Build monitoring dashboards that answer real operator questions for Grafana, SigNoz, and similar platforms. Use when turning metrics into a working dashboard instead of a vanity board.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "data-scraper-agent",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/data-scraper-agent",
+          "description": "Build a fully automated AI-powered data collection agent for any public source — job boards, prices, news, GitHub, sports, anything. Scrapes on a schedule, enriches data with a free LLM (Gemini Flash), stores results in Notion/Sheets/Supabase, and learns from user feedback. Runs 100% free on GitHub Actions. Use when the user wants to monitor, collect, or track any public data automatically.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "database-migrations",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/database-migrations",
+          "description": "Database migration best practices for schema changes, data migrations, rollbacks, and zero-downtime deployments across PostgreSQL, MySQL, and common ORMs (Prisma, Drizzle, Kysely, Django, TypeORM, golang-migrate).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deep-research",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/deep-research",
+          "description": "Multi-source deep research using firecrawl and exa MCPs. Searches the web, synthesizes findings, and delivers cited reports with source attribution. Use when the user wants thorough research on any topic with evidence and citations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "defi-amm-security",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/defi-amm-security",
+          "description": "Security checklist for Solidity AMM contracts, liquidity pools, and swap flows. Covers reentrancy, CEI ordering, donation or inflation attacks, oracle manipulation, slippage, admin controls, and integer math.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "deployment-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/deployment-patterns",
+          "description": "Deployment workflows, CI/CD pipeline patterns, Docker containerization, health checks, rollback strategies, and production readiness checklists for web applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "design-system",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/design-system",
+          "description": "Use this skill to generate or audit design systems, check visual consistency, and review PRs that touch styling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "django-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/django-patterns",
+          "description": "Django architecture patterns, REST API design with DRF, ORM best practices, caching, signals, middleware, and production-grade Django apps.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "django-security",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/django-security",
+          "description": "Django security best practices, authentication, authorization, CSRF protection, SQL injection prevention, XSS prevention, and secure deployment configurations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "django-tdd",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/django-tdd",
+          "description": "Django testing strategies with pytest-django, TDD methodology, factory_boy, mocking, coverage, and testing Django REST Framework APIs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "django-verification",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/django-verification",
+          "description": "Verification loop for Django projects: migrations, linting, tests with coverage, security scans, and deployment readiness checks before release or PR.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dmux-workflows",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/dmux-workflows",
+          "description": "Multi-agent orchestration using dmux (tmux pane manager for AI agents). Patterns for parallel agent workflows across Claude Code, Codex, OpenCode, and other harnesses. Use when running multiple agent sessions in parallel or coordinating multi-agent development workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docker-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/docker-patterns",
+          "description": "Docker and Docker Compose patterns for local development, container security, networking, volume strategies, and multi-service orchestration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "documentation-lookup",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/documentation-lookup",
+          "description": "Use up-to-date library and framework docs via Context7 MCP instead of training data. Activates for setup questions, API references, code examples, or when the user names a framework (e.g. React, Next.js, Prisma).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dotnet-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/dotnet-patterns",
+          "description": "Idiomatic C# and .NET patterns, conventions, dependency injection, async/await, and best practices for building robust, maintainable .NET applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "e2e-testing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/e2e-testing",
+          "description": "Playwright E2E testing patterns, Page Object Model, configuration, CI/CD integration, artifact management, and flaky test strategies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ecc-tools-cost-audit",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/ecc-tools-cost-audit",
+          "description": "Evidence-first ECC Tools burn and billing audit workflow. Use when investigating runaway PR creation, quota bypass, premium-model leakage, duplicate jobs, or GitHub App cost spikes in the ECC Tools repo.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "email-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/email-ops",
+          "description": "Evidence-first mailbox triage, drafting, send verification, and sent-mail-safe follow-up workflow for ECC. Use when the user wants to organize email, draft or send through the real mail surface, or prove what landed in Sent.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "energy-procurement",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/energy-procurement",
+          "description": "Codified expertise for electricity and gas procurement, tariff optimization, demand charge management, renewable PPA evaluation, and multi-facility energy cost management. Informed by energy procurement managers with 15+ years experience at large commercial and industrial consumers. Includes market structure analysis, hedging strategies, load profiling, and sustainability reporting frameworks. Use when procuring energy, optimizing tariffs, managing demand charges, evaluating PPAs, or developing energy strategies.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "enterprise-agent-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/enterprise-agent-ops",
+          "description": "Operate long-lived agent workloads with observability, security boundaries, and lifecycle management.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "eval-harness",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/eval-harness",
+          "description": "Formal evaluation framework for Claude Code sessions implementing eval-driven development (EDD) principles",
+          "version": "0.0.0"
+        },
+        {
+          "name": "everything-claude-code",
+          "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/everything-claude-code",
+          "description": "Development conventions and patterns for everything-claude-code. JavaScript project with conventional commits.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "everything-claude-code-conventions",
+          "installUrl": "github:affaan-m/everything-claude-code:.claude/skills/everything-claude-code",
+          "description": "Development conventions and patterns for everything-claude-code. JavaScript project with conventional commits.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "evm-token-decimals",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/evm-token-decimals",
+          "description": "Prevent silent decimal mismatch bugs across EVM chains. Covers runtime decimal lookup, chain-aware caching, bridged-token precision drift, and safe normalization for bots, dashboards, and DeFi tools.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "exa-search",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/exa-search",
+          "description": "Neural search via Exa MCP for web, code, and company research. Use when the user needs web search, code examples, company intel, people lookup, or AI-powered deep research with Exa's neural search engine.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fal-ai-media",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/fal-ai-media",
+          "description": "Unified media generation via fal.ai MCP — image, video, and audio. Covers text-to-image (Nano Banana), text/image-to-video (Seedance, Kling, Veo 3), text-to-speech (CSM-1B), and video-to-audio (ThinkSound). Use when the user wants to generate images, videos, or audio with AI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "finance-billing-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/finance-billing-ops",
+          "description": "Evidence-first revenue, pricing, refunds, team-billing, and billing-model truth workflow for ECC. Use when the user wants a sales snapshot, pricing comparison, duplicate-charge diagnosis, or code-backed billing reality instead of generic payments advice.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flutter-dart-code-review",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/flutter-dart-code-review",
+          "description": "Library-agnostic Flutter/Dart code review checklist covering widget best practices, state management patterns (BLoC, Riverpod, Provider, GetX, MobX, Signals), Dart idioms, performance, accessibility, security, and clean architecture.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "foundation-models-on-device",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/foundation-models-on-device",
+          "description": "Apple FoundationModels framework for on-device LLM — text generation, guided generation with @Generable, tool calling, and snapshot streaming in iOS 26+.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "frontend-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/frontend-patterns",
+          "description": "Frontend development patterns for React, Next.js, state management, performance optimization, and UI best practices.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "affaan-m",
+        "repo": "everything-claude-code",
+        "repoUrl": "https://github.com/affaan-m/everything-claude-code.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "affaan-m-everything-claude-code-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from affaan-m/everything-claude-code.",
+      "author": "ASM (affaan-m/everything-claude-code)",
+      "createdAt": "2026-05-09T08:10:28.548Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "affaan-m",
+        "everything-claude-code"
+      ],
+      "skills": [
+        {
+          "name": "accessibility",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/accessibility",
+          "description": "Design, implement, and audit inclusive digital products using WCAG 2.2 Level AA",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-harness-construction",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/agent-harness-construction",
+          "description": "Design and optimize AI agent action spaces, tool definitions, and observation formatting for higher completion rates.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-sort",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/agent-sort",
+          "description": "Build an evidence-backed ECC install plan for a specific repo by sorting skills, commands, rules, hooks, and extras into DAILY vs LIBRARY buckets using parallel repo-aware review passes. Use when ECC should be trimmed to what a project actually needs instead of loading the full bundle.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-connector-builder",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/api-connector-builder",
+          "description": "Build a new API connector or provider by matching the target repo's existing integration pattern exactly. Use when adding one more integration without inventing a second architecture.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "api-design",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/api-design",
+          "description": "REST API design patterns including resource naming, status codes, pagination, filtering, error responses, versioning, and rate limiting for production APIs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "article-writing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/article-writing",
+          "description": "Write articles, guides, blog posts, tutorials, newsletter issues, and other long-form content in a distinctive voice derived from supplied examples or brand guidance. Use when the user wants polished written content longer than a paragraph, especially when voice consistency, structure, and credibility matter.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autonomous-agent-harness",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/autonomous-agent-harness",
+          "description": "Transform Claude Code into a fully autonomous agent system with persistent memory, scheduled operations, computer use, and task queuing. Replaces standalone agent frameworks (Hermes, AutoGPT) by leveraging Claude Code's native crons, dispatch, MCP tools, and memory. Use when the user wants continuous autonomous operation, scheduled tasks, or a self-directing agent loop.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "backend-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/backend-patterns",
+          "description": "Backend architecture patterns, API design, database optimization, and server-side best practices for Node.js, Express, and Next.js API routes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brand-voice",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/brand-voice",
+          "description": "Build a source-derived writing style profile from real posts, essays, launch notes, docs, or site copy, then reuse that profile across content, outreach, and social workflows. Use when the user wants voice consistency without generic AI writing tropes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "browser-qa",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/browser-qa",
+          "description": "Use this skill to automate visual testing and UI interaction verification using browser automation after deploying features.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "carrier-relationship-management",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/carrier-relationship-management",
+          "description": "Codified expertise for managing carrier portfolios, negotiating freight rates, tracking carrier performance, allocating freight, and maintaining strategic carrier relationships. Informed by transportation managers with 15+ years experience. Includes scorecarding frameworks, RFP processes, market intelligence, and compliance vetting. Use when managing carriers, negotiating rates, evaluating carrier performance, or building freight strategies.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "click-path-audit",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/click-path-audit",
+          "description": "Trace every user-facing button/touchpoint through its full state change sequence to find bugs where functions individually work but cancel each other out, produce wrong final state, or leave the UI in an inconsistent state. Use when: systematic debugging found no bugs but users report broken buttons, or after any major refactor touching shared state stores.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "codebase-onboarding",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/codebase-onboarding",
+          "description": "Analyze an unfamiliar codebase and generate a structured onboarding guide with architecture map, key entry points, conventions, and a starter CLAUDE.md. Use when joining a new project or setting up Claude Code for the first time in a repo.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "coding-standards",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/coding-standards",
+          "description": "Baseline cross-project coding conventions for naming, readability, immutability, and code-quality review. Use detailed frontend or backend skills for framework-specific patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "compose-multiplatform-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/compose-multiplatform-patterns",
+          "description": "Compose Multiplatform and Jetpack Compose patterns for KMP projects — state management, navigation, theming, performance, and platform-specific UI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "configure-ecc",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/configure-ecc",
+          "description": "Interactive installer for Everything Claude Code — guides users through selecting and installing skills and rules to user-level or project-level directories, verifies paths, and optionally optimizes installed files.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "context-budget",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/context-budget",
+          "description": "Audits Claude Code context window consumption across agents, skills, MCP servers, and rules. Identifies bloat, redundant components, and produces prioritized token-savings recommendations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cpp-coding-standards",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/cpp-coding-standards",
+          "description": "C++ coding standards based on the C++ Core Guidelines (isocpp.github.io). Use when writing, reviewing, or refactoring C++ code to enforce modern, safe, and idiomatic practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dashboard-builder",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/dashboard-builder",
+          "description": "Build monitoring dashboards that answer real operator questions for Grafana, SigNoz, and similar platforms. Use when turning metrics into a working dashboard instead of a vanity board.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "data-scraper-agent",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/data-scraper-agent",
+          "description": "Build a fully automated AI-powered data collection agent for any public source — job boards, prices, news, GitHub, sports, anything. Scrapes on a schedule, enriches data with a free LLM (Gemini Flash), stores results in Notion/Sheets/Supabase, and learns from user feedback. Runs 100% free on GitHub Actions. Use when the user wants to monitor, collect, or track any public data automatically.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "defi-amm-security",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/defi-amm-security",
+          "description": "Security checklist for Solidity AMM contracts, liquidity pools, and swap flows. Covers reentrancy, CEI ordering, donation or inflation attacks, oracle manipulation, slippage, admin controls, and integer math.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "design-system",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/design-system",
+          "description": "Use this skill to generate or audit design systems, check visual consistency, and review PRs that touch styling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "django-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/django-patterns",
+          "description": "Django architecture patterns, REST API design with DRF, ORM best practices, caching, signals, middleware, and production-grade Django apps.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dmux-workflows",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/dmux-workflows",
+          "description": "Multi-agent orchestration using dmux (tmux pane manager for AI agents). Patterns for parallel agent workflows across Claude Code, Codex, OpenCode, and other harnesses. Use when running multiple agent sessions in parallel or coordinating multi-agent development workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "documentation-lookup",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/documentation-lookup",
+          "description": "Use up-to-date library and framework docs via Context7 MCP instead of training data. Activates for setup questions, API references, code examples, or when the user names a framework (e.g. React, Next.js, Prisma).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dotnet-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/dotnet-patterns",
+          "description": "Idiomatic C# and .NET patterns, conventions, dependency injection, async/await, and best practices for building robust, maintainable .NET applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "foundation-models-on-device",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/foundation-models-on-device",
+          "description": "Apple FoundationModels framework for on-device LLM — text generation, guided generation with @Generable, tool calling, and snapshot streaming in iOS 26+.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "frontend-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/frontend-patterns",
+          "description": "Frontend development patterns for React, Next.js, state management, performance optimization, and UI best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "frontend-slides",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/frontend-slides",
+          "description": "Create stunning, animation-rich HTML presentations from scratch or by converting PowerPoint files. Use when the user wants to build a presentation, convert a PPT/PPTX to web, or create slides for a talk/pitch. Helps non-designers discover their aesthetic through visual exploration rather than abstract choices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gan-style-harness",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/gan-style-harness",
+          "description": "GAN-inspired Generator-Evaluator agent harness for building high-quality applications autonomously. Based on Anthropic's March 2026 harness design paper.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "golang-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/golang-patterns",
+          "description": "Idiomatic Go patterns, best practices, and conventions for building robust, efficient, and maintainable Go applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "healthcare-emr-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/healthcare-emr-patterns",
+          "description": "EMR/EHR development patterns for healthcare applications. Clinical safety, encounter workflows, prescription generation, clinical decision support integration, and accessibility-first UI for medical data entry.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "healthcare-eval-harness",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/healthcare-eval-harness",
+          "description": "Patient safety evaluation harness for healthcare application deployments. Automated test suites for CDSS accuracy, PHI exposure, clinical workflow integrity, and integration compliance. Blocks deployments on safety failures.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "hexagonal-architecture",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/hexagonal-architecture",
+          "description": "Design, implement, and refactor Ports & Adapters systems with clear domain boundaries, dependency inversion, and testable use-case orchestration across TypeScript, Java, Kotlin, and Go services.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hipaa-compliance",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/hipaa-compliance",
+          "description": "HIPAA-specific entrypoint for healthcare privacy and security work. Use when a task is explicitly framed around HIPAA, PHI handling, covered entities, BAAs, breach posture, or US healthcare compliance requirements.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "hookify-rules",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/hookify-rules",
+          "description": "This skill should be used when the user asks to create a hookify rule, write a hook rule, configure hookify, add a hookify rule, or needs guidance on hookify rule syntax and patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "java-coding-standards",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/java-coding-standards",
+          "description": "Java coding standards for Spring Boot services: naming, immutability, Optional usage, streams, exceptions, generics, and project layout.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "jira-integration",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/jira-integration",
+          "description": "Use this skill when retrieving Jira tickets, analyzing requirements, updating ticket status, adding comments, or transitioning issues. Provides Jira API patterns via MCP or direct REST calls.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "jpa-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/jpa-patterns",
+          "description": "JPA/Hibernate patterns for entity design, relationships, query optimization, transactions, auditing, indexing, pagination, and pooling in Spring Boot.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "kotlin-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/kotlin-patterns",
+          "description": "Idiomatic Kotlin patterns, best practices, and conventions for building robust, efficient, and maintainable Kotlin applications with coroutines, null safety, and DSL builders.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "liquid-glass-design",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/liquid-glass-design",
+          "description": "iOS 26 Liquid Glass design system — dynamic glass material with blur, reflection, and interactive morphing for SwiftUI, UIKit, and WidgetKit.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "llm-trading-agent-security",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/llm-trading-agent-security",
+          "description": "Security patterns for autonomous trading agents with wallet or transaction authority. Covers prompt injection, spend limits, pre-send simulation, circuit breakers, MEV protection, and key handling.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "manim-video",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/manim-video",
+          "description": "Build reusable Manim explainers for technical concepts, graphs, system diagrams, and product walkthroughs, then hand off to the wider ECC video stack if needed. Use when the user wants a clean animated explainer rather than a generic talking-head script.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "mcp-server-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/mcp-server-patterns",
+          "description": "Build MCP servers with Node/TypeScript SDK — tools, resources, prompts, Zod validation, stdio vs Streamable HTTP. Use Context7 or official MCP docs for latest API.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "nanoclaw-repl",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/nanoclaw-repl",
+          "description": "Operate and extend NanoClaw v2, ECC's zero-dependency session-aware REPL built on claude -p.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "nutrient-document-processing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/nutrient-document-processing",
+          "description": "Process, convert, OCR, extract, redact, sign, and fill documents using the Nutrient DWS API. Works with PDFs, DOCX, XLSX, PPTX, HTML, and images.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "nuxt4-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/nuxt4-patterns",
+          "description": "Nuxt 4 app patterns for hydration safety, performance, route rules, lazy loading, and SSR-safe data fetching with useFetch and useAsyncData.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "perl-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/perl-patterns",
+          "description": "Modern Perl 5.36+ idioms, best practices, and conventions for building robust, maintainable Perl applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "postgres-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/postgres-patterns",
+          "description": "PostgreSQL database patterns for query optimization, schema design, indexing, and security. Based on Supabase best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "product-lens",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/product-lens",
+          "description": "Use this skill to validate the \"why\" before building, run product diagnostics, and pressure-test product direction before the request becomes an implementation contract.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "project-guidelines-example",
+          "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/project-guidelines-example",
+          "version": "0.0.0"
+        },
+        {
+          "name": "prompt-optimizer",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/prompt-optimizer",
+          "description": "Analyze raw prompts, identify intent and gaps, match ECC components (skills/commands/agents/hooks), and output a ready-to-paste optimized prompt. Advisory role only — never executes the task itself. TRIGGER when: user says \"optimize prompt\", \"improve my prompt\", \"how to write a prompt for\", \"help me prompt\", \"rewrite this prompt\", or explicitly asks to enhance prompt quality. Also triggers on Chinese equivalents: \"优化prompt\", \"改进prompt\", \"怎么写prompt\", \"帮我优化这个指令\". DO NOT TRIGGER when: user wants the task executed directly, or says \"just do it\" / \"直接做\". DO NOT TRIGGER when user says \"优化代码\", \"优化性能\", \"optimize performance\", \"optimize this code\" — those are refactoring/performance tasks, not prompt optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "python-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/python-patterns",
+          "description": "Pythonic idioms, PEP 8 standards, type hints, and best practices for building robust, efficient, and maintainable Python applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "python-testing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/python-testing",
+          "description": "Python testing strategies using pytest, TDD methodology, fixtures, mocking, parametrization, and coverage requirements.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pytorch-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/pytorch-patterns",
+          "description": "PyTorch deep learning patterns and best practices for building robust, efficient, and reproducible training pipelines, model architectures, and data loading.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "remotion-video-creation",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/remotion-video-creation",
+          "description": "Best practices for Remotion - Video creation in React. 29 domain-specific rules covering 3D, animations, audio, captions, charts, transitions, and more.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "repo-scan",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/repo-scan",
+          "description": "Cross-stack source code asset audit — classifies every file, detects embedded third-party libraries, and delivers actionable four-level verdicts per module with interactive HTML reports.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "research-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/research-ops",
+          "description": "Evidence-first current-state research workflow for ECC. Use when the user wants fresh facts, comparisons, enrichment, or a recommendation built from current public evidence and any supplied local context.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "rust-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/rust-patterns",
+          "description": "Idiomatic Rust patterns, ownership, error handling, traits, concurrency, and best practices for building safe, performant applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "skill-comply",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/skill-comply",
+          "description": "Visualize whether skills, rules, and agent definitions are actually followed — auto-generates scenarios at 3 prompt strictness levels, runs agents, classifies behavioral sequences, and reports compliance rates with full tool call timelines",
+          "version": "0.0.0"
+        },
+        {
+          "name": "skill-stocktake",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/skill-stocktake",
+          "description": "Use when auditing Claude skills and commands for quality. Supports Quick Scan (changed skills only) and Full Stocktake modes with sequential subagent batch evaluation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "springboot-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/springboot-patterns",
+          "description": "Spring Boot architecture patterns, REST API design, layered services, data access, caching, async processing, and logging. Use for Java Spring Boot backend work.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "springboot-verification",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/springboot-verification",
+          "description": "Verification loop for Spring Boot projects: build, static analysis, tests with coverage, security scans, and diff review before release or PR.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "swift-actor-persistence",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/swift-actor-persistence",
+          "description": "Thread-safe data persistence in Swift using actors — in-memory cache with file-backed storage, eliminating data races by design.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "swiftui-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/swiftui-patterns",
+          "description": "SwiftUI architecture patterns, state management with @Observable, view composition, navigation, performance optimization, and modern iOS/macOS UI best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "team-builder",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/team-builder",
+          "description": "Interactive agent picker for composing and dispatching parallel teams",
+          "version": "0.0.0"
+        },
+        {
+          "name": "token-budget-advisor",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/token-budget-advisor",
+          "description": "Offers the user an informed choice about how much response depth to consume before answering. Use this skill when the user explicitly wants to control response length, depth, or token budget. TRIGGER when: \"token budget\", \"token count\", \"token usage\", \"token limit\", \"response length\", \"answer depth\", \"short version\", \"brief answer\", \"detailed answer\", \"exhaustive answer\", \"respuesta corta vs larga\", \"cuántos tokens\", \"ahorrar tokens\", \"responde al 50%\", \"dame la versión corta\", \"quiero controlar cuánto usas\", or clear variants where the user is explicitly asking to control answer size or depth. DO NOT TRIGGER when: user has already specified a level in the current session (maintain it), the request is clearly a one-word answer, or \"token\" refers to auth/session/payment tokens rather than response size.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ui-demo",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/ui-demo",
+          "description": "Record polished UI demo videos using Playwright. Use when the user asks to create a demo, walkthrough, screen recording, or tutorial video of a web application. Produces WebM videos with visible cursor, natural pacing, and professional feel.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "video-editing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/video-editing",
+          "description": "AI-assisted video editing workflows for cutting, structuring, and augmenting real footage. Covers the full pipeline from raw capture through FFmpeg, Remotion, ElevenLabs, fal.ai, and final polish in Descript or CapCut. Use when the user wants to edit video, cut footage, create vlogs, or build video content.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "videodb",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/videodb",
+          "description": "See, Understand, Act on video and audio. See- ingest from local files, URLs, RTSP/live feeds, or live record desktop; return realtime context and playable stream links. Understand- extract frames, build visual/semantic/temporal indexes, and search moments with timestamps and auto-clips. Act- transcode and normalize (codec, fps, resolution, aspect ratio), perform timeline edits (subtitles, text/image overlays, branding, audio overlays, dubbing, translation), generate media assets (image, audio, video), and create real time alerts for events from live streams or desktop capture.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "affaan-m",
+        "repo": "everything-claude-code",
+        "repoUrl": "https://github.com/affaan-m/everything-claude-code.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "affaan-m-everything-claude-code-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from affaan-m/everything-claude-code.",
+      "author": "ASM (affaan-m/everything-claude-code)",
+      "createdAt": "2026-05-09T08:10:28.548Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "affaan-m",
+        "everything-claude-code"
+      ],
+      "skills": [
+        {
+          "name": "agent-introspection-debugging",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/agent-introspection-debugging",
+          "description": "Structured self-debugging workflow for AI agent failures using capture, diagnosis, contained recovery, and introspection reports.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-sort",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/agent-sort",
+          "description": "Build an evidence-backed ECC install plan for a specific repo by sorting skills, commands, rules, hooks, and extras into DAILY vs LIBRARY buckets using parallel repo-aware review passes. Use when ECC should be trimmed to what a project actually needs instead of loading the full bundle.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-regression-testing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/ai-regression-testing",
+          "description": "Regression testing strategies for AI-assisted development. Sandbox-mode API testing without database dependencies, automated bug-check workflows, and patterns to catch AI blind spots where the same model writes and reviews code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture-decision-records",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/architecture-decision-records",
+          "description": "Capture architectural decisions made during Claude Code sessions as structured ADRs. Auto-detects decision moments, records context, alternatives considered, and rationale. Maintains an ADR log so future developers understand why the codebase is shaped the way it is.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "article-writing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/article-writing",
+          "description": "Write articles, guides, blog posts, tutorials, newsletter issues, and other long-form content in a distinctive voice derived from supplied examples or brand guidance. Use when the user wants polished written content longer than a paragraph, especially when voice consistency, structure, and credibility matter.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "automation-audit-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/automation-audit-ops",
+          "description": "Evidence-first automation inventory and overlap audit workflow for ECC. Use when the user wants to know which jobs, hooks, connectors, MCP servers, or wrappers are live, broken, redundant, or missing before fixing anything.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autonomous-loops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/autonomous-loops",
+          "description": "Patterns and architectures for autonomous Claude Code loops — from simple sequential pipelines to RFC-driven multi-agent DAG systems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brand-voice",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/brand-voice",
+          "description": "Build a source-derived writing style profile from real posts, essays, launch notes, docs, or site copy, then reuse that profile across content, outreach, and social workflows. Use when the user wants voice consistency without generic AI writing tropes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "browser-qa",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/browser-qa",
+          "description": "Use this skill to automate visual testing and UI interaction verification using browser automation after deploying features.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "canary-watch",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/canary-watch",
+          "description": "Use this skill to monitor a deployed URL for regressions after deploys, merges, or dependency upgrades.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "click-path-audit",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/click-path-audit",
+          "description": "Trace every user-facing button/touchpoint through its full state change sequence to find bugs where functions individually work but cancel each other out, produce wrong final state, or leave the UI in an inconsistent state. Use when: systematic debugging found no bugs but users report broken buttons, or after any major refactor touching shared state stores.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "coding-standards",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/coding-standards",
+          "description": "Baseline cross-project coding conventions for naming, readability, immutability, and code-quality review. Use detailed frontend or backend skills for framework-specific patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "compose-multiplatform-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/compose-multiplatform-patterns",
+          "description": "Compose Multiplatform and Jetpack Compose patterns for KMP projects — state management, navigation, theming, performance, and platform-specific UI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "connections-optimizer",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/connections-optimizer",
+          "description": "Reorganize the user's X and LinkedIn network with review-first pruning, add/follow recommendations, and channel-specific warm outreach drafted in the user's real voice. Use when the user wants to clean up following lists, grow toward current priorities, or rebalance a social graph around higher-signal relationships.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-engine",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/content-engine",
+          "description": "Create platform-native content systems for X, LinkedIn, TikTok, YouTube, newsletters, and repurposed multi-platform campaigns. Use when the user wants social posts, threads, scripts, content calendars, or one source asset adapted cleanly across platforms.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cost-aware-llm-pipeline",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/cost-aware-llm-pipeline",
+          "description": "Cost optimization patterns for LLM API usage — model routing by task complexity, budget tracking, retry logic, and prompt caching.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "council",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/council",
+          "description": "Convene a four-voice council for ambiguous decisions, tradeoffs, and go/no-go calls. Use when multiple valid paths exist and you need structured disagreement before choosing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "crosspost",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/crosspost",
+          "description": "Multi-platform content distribution across X, LinkedIn, Threads, and Bluesky. Adapts content per platform using content-engine patterns. Never posts identical content cross-platform. Use when the user wants to distribute content across social platforms.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "customer-billing-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/customer-billing-ops",
+          "description": "Operate customer billing workflows such as subscriptions, refunds, churn triage, billing-portal recovery, and plan analysis using connected billing tools like Stripe. Use when the user needs to help a customer, inspect subscription state, or manage revenue-impacting billing operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "customs-trade-compliance",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/customs-trade-compliance",
+          "description": "Codified expertise for customs documentation, tariff classification, duty optimization, restricted party screening, and regulatory compliance across multiple jurisdictions. Informed by trade compliance specialists with 15+ years experience. Includes HS classification logic, Incoterms application, FTA utilization, and penalty mitigation. Use when handling customs clearance, tariff classification, trade compliance, import/export documentation, or duty optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "database-migrations",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/database-migrations",
+          "description": "Database migration best practices for schema changes, data migrations, rollbacks, and zero-downtime deployments across PostgreSQL, MySQL, and common ORMs (Prisma, Drizzle, Kysely, Django, TypeORM, golang-migrate).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deep-research",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/deep-research",
+          "description": "Multi-source deep research using firecrawl and exa MCPs. Searches the web, synthesizes findings, and delivers cited reports with source attribution. Use when the user wants thorough research on any topic with evidence and citations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deployment-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/deployment-patterns",
+          "description": "Deployment workflows, CI/CD pipeline patterns, Docker containerization, health checks, rollback strategies, and production readiness checklists for web applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "django-security",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/django-security",
+          "description": "Django security best practices, authentication, authorization, CSRF protection, SQL injection prevention, XSS prevention, and secure deployment configurations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "django-verification",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/django-verification",
+          "description": "Verification loop for Django projects: migrations, linting, tests with coverage, security scans, and deployment readiness checks before release or PR.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dmux-workflows",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/dmux-workflows",
+          "description": "Multi-agent orchestration using dmux (tmux pane manager for AI agents). Patterns for parallel agent workflows across Claude Code, Codex, OpenCode, and other harnesses. Use when running multiple agent sessions in parallel or coordinating multi-agent development workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docker-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/docker-patterns",
+          "description": "Docker and Docker Compose patterns for local development, container security, networking, volume strategies, and multi-service orchestration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "e2e-testing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/e2e-testing",
+          "description": "Playwright E2E testing patterns, Page Object Model, configuration, CI/CD integration, artifact management, and flaky test strategies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ecc-tools-cost-audit",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/ecc-tools-cost-audit",
+          "description": "Evidence-first ECC Tools burn and billing audit workflow. Use when investigating runaway PR creation, quota bypass, premium-model leakage, duplicate jobs, or GitHub App cost spikes in the ECC Tools repo.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "email-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/email-ops",
+          "description": "Evidence-first mailbox triage, drafting, send verification, and sent-mail-safe follow-up workflow for ECC. Use when the user wants to organize email, draft or send through the real mail surface, or prove what landed in Sent.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "energy-procurement",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/energy-procurement",
+          "description": "Codified expertise for electricity and gas procurement, tariff optimization, demand charge management, renewable PPA evaluation, and multi-facility energy cost management. Informed by energy procurement managers with 15+ years experience at large commercial and industrial consumers. Includes market structure analysis, hedging strategies, load profiling, and sustainability reporting frameworks. Use when procuring energy, optimizing tariffs, managing demand charges, evaluating PPAs, or developing energy strategies.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "eval-harness",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/eval-harness",
+          "description": "Formal evaluation framework for Claude Code sessions implementing eval-driven development (EDD) principles",
+          "version": "0.0.0"
+        },
+        {
+          "name": "evm-token-decimals",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/evm-token-decimals",
+          "description": "Prevent silent decimal mismatch bugs across EVM chains. Covers runtime decimal lookup, chain-aware caching, bridged-token precision drift, and safe normalization for bots, dashboards, and DeFi tools.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "finance-billing-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/finance-billing-ops",
+          "description": "Evidence-first revenue, pricing, refunds, team-billing, and billing-model truth workflow for ECC. Use when the user wants a sales snapshot, pricing comparison, duplicate-charge diagnosis, or code-backed billing reality instead of generic payments advice.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gateguard",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/gateguard",
+          "description": "Fact-forcing gate that blocks Edit/Write/Bash (including MultiEdit) and demands concrete investigation (importers, data schemas, user instruction) before allowing the action. Measurably improves output quality by +2.25 points vs ungated agents.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "git-workflow",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/git-workflow",
+          "description": "Git workflow patterns including branching strategies, commit conventions, merge vs rebase, conflict resolution, and collaborative development best practices for teams of all sizes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "github-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/github-ops",
+          "description": "GitHub repository operations, automation, and management. Issue triage, PR management, CI/CD operations, release management, and security monitoring using the gh CLI. Use when the user wants to manage GitHub issues, PRs, CI status, releases, contributors, stale items, or any GitHub operational task beyond simple git commands.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "golang-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/golang-patterns",
+          "description": "Idiomatic Go patterns, best practices, and conventions for building robust, efficient, and maintainable Go applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-workspace-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/google-workspace-ops",
+          "description": "Operate across Google Drive, Docs, Sheets, and Slides as one workflow surface for plans, trackers, decks, and shared documents. Use when the user needs to find, summarize, edit, migrate, or clean up Google Workspace assets without dropping to raw tool calls.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "healthcare-cdss-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/healthcare-cdss-patterns",
+          "description": "Clinical Decision Support System (CDSS) development patterns. Drug interaction checking, dose validation, clinical scoring (NEWS2, qSOFA), alert severity classification, and integration into EMR workflows.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "healthcare-emr-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/healthcare-emr-patterns",
+          "description": "EMR/EHR development patterns for healthcare applications. Clinical safety, encounter workflows, prescription generation, clinical decision support integration, and accessibility-first UI for medical data entry.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "healthcare-eval-harness",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/healthcare-eval-harness",
+          "description": "Patient safety evaluation harness for healthcare application deployments. Automated test suites for CDSS accuracy, PHI exposure, clinical workflow integrity, and integration compliance. Blocks deployments on safety failures.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "hermes-imports",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/hermes-imports",
+          "description": "Convert local Hermes operator workflows into sanitized ECC skills and release-pack artifacts. Use when preparing a Hermes workflow for public ECC reuse without leaking private workspace state, credentials, or local-only paths.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hipaa-compliance",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/hipaa-compliance",
+          "description": "HIPAA-specific entrypoint for healthcare privacy and security work. Use when a task is explicitly framed around HIPAA, PHI handling, covered entities, BAAs, breach posture, or US healthcare compliance requirements.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "investor-materials",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/investor-materials",
+          "description": "Create and update pitch decks, one-pagers, investor memos, accelerator applications, financial models, and fundraising materials. Use when the user needs investor-facing documents, projections, use-of-funds tables, milestone plans, or materials that must stay internally consistent across multiple fundraising assets.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "investor-outreach",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/investor-outreach",
+          "description": "Draft cold emails, warm intro blurbs, follow-ups, update emails, and investor communications for fundraising. Use when the user wants outreach to angels, VCs, strategic investors, or accelerators and needs concise, personalized, investor-facing messaging.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "kotlin-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/kotlin-patterns",
+          "description": "Idiomatic Kotlin patterns, best practices, and conventions for building robust, efficient, and maintainable Kotlin applications with coroutines, null safety, and DSL builders.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "laravel-security",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/laravel-security",
+          "description": "Laravel security best practices for authn/authz, validation, CSRF, mass assignment, file uploads, secrets, rate limiting, and secure deployment.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "laravel-verification",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/laravel-verification",
+          "description": "Verification loop for Laravel projects: env checks, linting, static analysis, tests with coverage, security scans, and deployment readiness.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "lead-intelligence",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/lead-intelligence",
+          "description": "AI-native lead intelligence and outreach pipeline. Replaces Apollo, Clay, and ZoomInfo with agent-powered signal scoring, mutual ranking, warm path discovery, source-derived voice modeling, and channel-specific outreach across email, LinkedIn, and X. Use when the user wants to find, qualify, and reach high-value contacts.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "llm-trading-agent-security",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/llm-trading-agent-security",
+          "description": "Security patterns for autonomous trading agents with wallet or transaction authority. Covers prompt injection, spend limits, pre-send simulation, circuit breakers, MEV protection, and key handling.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "logistics-exception-management",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/logistics-exception-management",
+          "description": "Codified expertise for handling freight exceptions, shipment delays, damages, losses, and carrier disputes. Informed by logistics professionals with 15+ years operational experience. Includes escalation protocols, carrier-specific behaviors, claims procedures, and judgment frameworks. Use when handling shipping exceptions, freight claims, delivery issues, or carrier disputes.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "market-research",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/market-research",
+          "description": "Conduct market research, competitive analysis, investor due diligence, and industry intelligence with source attribution and decision-oriented summaries. Use when the user wants market sizing, competitor comparisons, fund research, technology scans, or research that informs business decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "mcp-server-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/mcp-server-patterns",
+          "description": "Build MCP servers with Node/TypeScript SDK — tools, resources, prompts, Zod validation, stdio vs Streamable HTTP. Use Context7 or official MCP docs for latest API.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "messages-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/messages-ops",
+          "description": "Evidence-first live messaging workflow for ECC. Use when the user wants to read texts or DMs, recover a recent one-time code, inspect a thread before replying, or prove which message source was actually checked.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "nuxt4-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/nuxt4-patterns",
+          "description": "Nuxt 4 app patterns for hydration safety, performance, route rules, lazy loading, and SSR-safe data fetching with useFetch and useAsyncData.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "opensource-pipeline",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/opensource-pipeline",
+          "description": "Open-source pipeline: fork, sanitize, and package private projects for safe public release. Chains 3 agents (forker, sanitizer, packager). Triggers: '/opensource', 'open source this', 'make this public', 'prepare for open source'.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "perl-security",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/perl-security",
+          "description": "Comprehensive Perl security covering taint mode, input validation, safe process execution, DBI parameterized queries, web security (XSS/SQLi/CSRF), and perlcritic security policies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "product-capability",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/product-capability",
+          "description": "Translate PRD intent, roadmap asks, or product discussions into an implementation-ready capability plan that exposes constraints, invariants, interfaces, and unresolved decisions before multi-service work starts. Use when the user needs an ECC-native PRD-to-SRS lane instead of vague planning prose.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "production-scheduling",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/production-scheduling",
+          "description": "Codified expertise for production scheduling, job sequencing, line balancing, changeover optimization, and bottleneck resolution in discrete and batch manufacturing. Informed by production schedulers with 15+ years experience. Includes TOC/drum-buffer-rope, SMED, OEE analysis, disruption response frameworks, and ERP/MES interaction patterns. Use when scheduling production, resolving bottlenecks, optimizing changeovers, responding to disruptions, or balancing manufacturing lines.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "project-flow-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/project-flow-ops",
+          "description": "Operate execution flow across GitHub and Linear by triaging issues and pull requests, linking active work, and keeping GitHub public-facing while Linear remains the internal execution layer. Use when the user wants backlog control, PR triage, or GitHub-to-Linear coordination.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "prompt-optimizer",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/prompt-optimizer",
+          "description": "Analyze raw prompts, identify intent and gaps, match ECC components (skills/commands/agents/hooks), and output a ready-to-paste optimized prompt. Advisory role only — never executes the task itself. TRIGGER when: user says \"optimize prompt\", \"improve my prompt\", \"how to write a prompt for\", \"help me prompt\", \"rewrite this prompt\", or explicitly asks to enhance prompt quality. Also triggers on Chinese equivalents: \"优化prompt\", \"改进prompt\", \"怎么写prompt\", \"帮我优化这个指令\". DO NOT TRIGGER when: user wants the task executed directly, or says \"just do it\" / \"直接做\". DO NOT TRIGGER when user says \"优化代码\", \"优化性能\", \"optimize performance\", \"optimize this code\" — those are refactoring/performance tasks, not prompt optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "python-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/python-patterns",
+          "description": "Pythonic idioms, PEP 8 standards, type hints, and best practices for building robust, efficient, and maintainable Python applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pytorch-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/pytorch-patterns",
+          "description": "PyTorch deep learning patterns and best practices for building robust, efficient, and reproducible training pipelines, model architectures, and data loading.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ralphinho-rfc-pipeline",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/ralphinho-rfc-pipeline",
+          "description": "RFC-driven multi-agent DAG execution pattern with quality gates, merge queues, and work unit orchestration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "regex-vs-llm-structured-text",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/regex-vs-llm-structured-text",
+          "description": "Decision framework for choosing between regex and LLM when parsing structured text — start with regex, add LLM only for low-confidence edge cases.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "remotion-video-creation",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/remotion-video-creation",
+          "description": "Best practices for Remotion - Video creation in React. 29 domain-specific rules covering 3D, animations, audio, captions, charts, transitions, and more.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "research-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/research-ops",
+          "description": "Evidence-first current-state research workflow for ECC. Use when the user wants fresh facts, comparisons, enrichment, or a recommendation built from current public evidence and any supplied local context.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "returns-reverse-logistics",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/returns-reverse-logistics",
+          "description": "Codified expertise for returns authorization, receipt and inspection, disposition decisions, refund processing, fraud detection, and warranty claims management. Informed by returns operations managers with 15+ years experience. Includes grading frameworks, disposition economics, fraud pattern recognition, and vendor recovery processes. Use when handling product returns, reverse logistics, refund decisions, return fraud detection, or warranty claims.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "rules-distill",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/rules-distill",
+          "description": "Scan skills to extract cross-cutting principles and distill them into rules — append, revise, or create new rule files",
+          "version": "0.0.0"
+        },
+        {
+          "name": "search-first",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/search-first",
+          "description": "Research-before-coding workflow. Search for existing tools, libraries, and patterns before writing custom code. Invokes the researcher agent.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "social-graph-ranker",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/social-graph-ranker",
+          "description": "Weighted social-graph ranking for warm intro discovery, bridge scoring, and network gap analysis across X and LinkedIn. Use when the user wants the reusable graph-ranking engine itself, not the broader outreach or network-maintenance workflow layered on top of it.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "springboot-verification",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/springboot-verification",
+          "description": "Verification loop for Spring Boot projects: build, static analysis, tests with coverage, security scans, and diff review before release or PR.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "swift-concurrency-6-2",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/swift-concurrency-6-2",
+          "description": "Swift 6.2 Approachable Concurrency — single-threaded by default, @concurrent for explicit background offloading, isolated conformances for main actor types.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "tdd-workflow",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/tdd-workflow",
+          "description": "Use this skill when writing new features, fixing bugs, or refactoring code. Enforces test-driven development with 80%+ coverage including unit, integration, and E2E tests.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "terminal-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/terminal-ops",
+          "description": "Evidence-first repo execution workflow for ECC. Use when the user wants a command run, a repo checked, a CI failure debugged, or a narrow fix pushed with exact proof of what was executed and verified.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "token-budget-advisor",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/token-budget-advisor",
+          "description": "Offers the user an informed choice about how much response depth to consume before answering. Use this skill when the user explicitly wants to control response length, depth, or token budget. TRIGGER when: \"token budget\", \"token count\", \"token usage\", \"token limit\", \"response length\", \"answer depth\", \"short version\", \"brief answer\", \"detailed answer\", \"exhaustive answer\", \"respuesta corta vs larga\", \"cuántos tokens\", \"ahorrar tokens\", \"responde al 50%\", \"dame la versión corta\", \"quiero controlar cuánto usas\", or clear variants where the user is explicitly asking to control answer size or depth. DO NOT TRIGGER when: user has already specified a level in the current session (maintain it), the request is clearly a one-word answer, or \"token\" refers to auth/session/payment tokens rather than response size.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ui-demo",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/ui-demo",
+          "description": "Record polished UI demo videos using Playwright. Use when the user asks to create a demo, walkthrough, screen recording, or tutorial video of a web application. Produces WebM videos with visible cursor, natural pacing, and professional feel.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "unified-notifications-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/unified-notifications-ops",
+          "description": "Operate notifications as one ECC-native workflow across GitHub, Linear, desktop alerts, hooks, and connected communication surfaces. Use when the real problem is alert routing, deduplication, escalation, or inbox collapse.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "video-editing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/video-editing",
+          "description": "AI-assisted video editing workflows for cutting, structuring, and augmenting real footage. Covers the full pipeline from raw capture through FFmpeg, Remotion, ElevenLabs, fal.ai, and final polish in Descript or CapCut. Use when the user wants to edit video, cut footage, create vlogs, or build video content.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "affaan-m",
+        "repo": "everything-claude-code",
+        "repoUrl": "https://github.com/affaan-m/everything-claude-code.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "affaan-m-everything-claude-code-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from affaan-m/everything-claude-code.",
+      "author": "ASM (affaan-m/everything-claude-code)",
+      "createdAt": "2026-05-09T08:10:28.548Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "affaan-m",
+        "everything-claude-code"
+      ],
+      "skills": [
+        {
+          "name": "accessibility",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/accessibility",
+          "description": "Design, implement, and audit inclusive digital products using WCAG 2.2 Level AA",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-eval",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/agent-eval",
+          "description": "Head-to-head comparison of coding agents (Claude Code, Aider, Codex, etc.) on custom tasks with pass rate, cost, time, and consistency metrics",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-harness-construction",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/agent-harness-construction",
+          "description": "Design and optimize AI agent action spaces, tool definitions, and observation formatting for higher completion rates.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-introspection-debugging",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/agent-introspection-debugging",
+          "description": "Structured self-debugging workflow for AI agent failures using capture, diagnosis, contained recovery, and introspection reports.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-payment-x402",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/agent-payment-x402",
+          "description": "Add x402 payment execution to AI agents — per-task budgets, spending controls, and non-custodial wallets via MCP tools. Use when agents need to pay for APIs, services, or other agents.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-sort",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/agent-sort",
+          "description": "Build an evidence-backed ECC install plan for a specific repo by sorting skills, commands, rules, hooks, and extras into DAILY vs LIBRARY buckets using parallel repo-aware review passes. Use when ECC should be trimmed to what a project actually needs instead of loading the full bundle.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentic-engineering",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/agentic-engineering",
+          "description": "Operate as an agentic engineer using eval-first execution, decomposition, and cost-aware model routing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-first-engineering",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/ai-first-engineering",
+          "description": "Engineering operating model for teams where AI agents generate a large share of implementation output.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-regression-testing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/ai-regression-testing",
+          "description": "Regression testing strategies for AI-assisted development. Sandbox-mode API testing without database dependencies, automated bug-check workflows, and patterns to catch AI blind spots where the same model writes and reviews code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "android-clean-architecture",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/android-clean-architecture",
+          "description": "Clean Architecture patterns for Android and Kotlin Multiplatform projects — module structure, dependency rules, UseCases, Repositories, and data layer patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-connector-builder",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/api-connector-builder",
+          "description": "Build a new API connector or provider by matching the target repo's existing integration pattern exactly. Use when adding one more integration without inventing a second architecture.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "api-design",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/api-design",
+          "description": "REST API design patterns including resource naming, status codes, pagination, filtering, error responses, versioning, and rate limiting for production APIs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture-decision-records",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/architecture-decision-records",
+          "description": "Capture architectural decisions made during Claude Code sessions as structured ADRs. Auto-detects decision moments, records context, alternatives considered, and rationale. Maintains an ADR log so future developers understand why the codebase is shaped the way it is.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "article-writing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/article-writing",
+          "description": "Write articles, guides, blog posts, tutorials, newsletter issues, and other long-form content in a distinctive voice derived from supplied examples or brand guidance. Use when the user wants polished written content longer than a paragraph, especially when voice consistency, structure, and credibility matter.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "automation-audit-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/automation-audit-ops",
+          "description": "Evidence-first automation inventory and overlap audit workflow for ECC. Use when the user wants to know which jobs, hooks, connectors, MCP servers, or wrappers are live, broken, redundant, or missing before fixing anything.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autonomous-agent-harness",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/autonomous-agent-harness",
+          "description": "Transform Claude Code into a fully autonomous agent system with persistent memory, scheduled operations, computer use, and task queuing. Replaces standalone agent frameworks (Hermes, AutoGPT) by leveraging Claude Code's native crons, dispatch, MCP tools, and memory. Use when the user wants continuous autonomous operation, scheduled tasks, or a self-directing agent loop.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autonomous-loops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/autonomous-loops",
+          "description": "Patterns and architectures for autonomous Claude Code loops — from simple sequential pipelines to RFC-driven multi-agent DAG systems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "backend-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/backend-patterns",
+          "description": "Backend architecture patterns, API design, database optimization, and server-side best practices for Node.js, Express, and Next.js API routes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "benchmark",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/benchmark",
+          "description": "Use this skill to measure performance baselines, detect regressions before/after PRs, and compare stack alternatives.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "blueprint",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/blueprint",
+          "description": "Turn a one-line objective into a step-by-step construction plan for multi-session, multi-agent engineering projects. Each step has a self-contained context brief so a fresh agent can execute it cold. Includes adversarial review gate, dependency graph, parallel step detection, anti-pattern catalog, and plan mutation protocol. TRIGGER when: user requests a plan, blueprint, or roadmap for a complex multi-PR task, or describes work that needs multiple sessions. DO NOT TRIGGER when: task is completable in a single PR or fewer than 3 tool calls, or user says \"just do it\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brand-voice",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/brand-voice",
+          "description": "Build a source-derived writing style profile from real posts, essays, launch notes, docs, or site copy, then reuse that profile across content, outreach, and social workflows. Use when the user wants voice consistency without generic AI writing tropes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "browser-qa",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/browser-qa",
+          "description": "Use this skill to automate visual testing and UI interaction verification using browser automation after deploying features.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bun-runtime",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/bun-runtime",
+          "description": "Bun as runtime, package manager, bundler, and test runner. When to choose Bun vs Node, migration notes, and Vercel support.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "canary-watch",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/canary-watch",
+          "description": "Use this skill to monitor a deployed URL for regressions after deploys, merges, or dependency upgrades.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "carrier-relationship-management",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/carrier-relationship-management",
+          "description": "Codified expertise for managing carrier portfolios, negotiating freight rates, tracking carrier performance, allocating freight, and maintaining strategic carrier relationships. Informed by transportation managers with 15+ years experience. Includes scorecarding frameworks, RFP processes, market intelligence, and compliance vetting. Use when managing carriers, negotiating rates, evaluating carrier performance, or building freight strategies.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ck",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/ck",
+          "description": "Persistent per-project memory for Claude Code. Auto-loads project context on session start, tracks sessions with git activity, and writes to native memory. Commands run deterministic Node.js scripts — behavior is consistent across model versions.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "claude-devfleet",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/claude-devfleet",
+          "description": "Orchestrate multi-agent coding tasks via Claude DevFleet — plan projects, dispatch parallel agents in isolated worktrees, monitor progress, and read structured reports.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "click-path-audit",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/click-path-audit",
+          "description": "Trace every user-facing button/touchpoint through its full state change sequence to find bugs where functions individually work but cancel each other out, produce wrong final state, or leave the UI in an inconsistent state. Use when: systematic debugging found no bugs but users report broken buttons, or after any major refactor touching shared state stores.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "clickhouse-io",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/clickhouse-io",
+          "description": "ClickHouse database patterns, query optimization, analytics, and data engineering best practices for high-performance analytical workloads.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-tour",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/code-tour",
+          "description": "Create CodeTour `.tour` files — persona-targeted, step-by-step walkthroughs with real file and line anchors. Use for onboarding tours, architecture walkthroughs, PR tours, RCA tours, and structured \"explain how this works\" requests.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "codebase-onboarding",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/codebase-onboarding",
+          "description": "Analyze an unfamiliar codebase and generate a structured onboarding guide with architecture map, key entry points, conventions, and a starter CLAUDE.md. Use when joining a new project or setting up Claude Code for the first time in a repo.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "coding-standards",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/coding-standards",
+          "description": "Baseline cross-project coding conventions for naming, readability, immutability, and code-quality review. Use detailed frontend or backend skills for framework-specific patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "compose-multiplatform-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/compose-multiplatform-patterns",
+          "description": "Compose Multiplatform and Jetpack Compose patterns for KMP projects — state management, navigation, theming, performance, and platform-specific UI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "configure-ecc",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/configure-ecc",
+          "description": "Interactive installer for Everything Claude Code — guides users through selecting and installing skills and rules to user-level or project-level directories, verifies paths, and optionally optimizes installed files.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "connections-optimizer",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/connections-optimizer",
+          "description": "Reorganize the user's X and LinkedIn network with review-first pruning, add/follow recommendations, and channel-specific warm outreach drafted in the user's real voice. Use when the user wants to clean up following lists, grow toward current priorities, or rebalance a social graph around higher-signal relationships.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-engine",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/content-engine",
+          "description": "Create platform-native content systems for X, LinkedIn, TikTok, YouTube, newsletters, and repurposed multi-platform campaigns. Use when the user wants social posts, threads, scripts, content calendars, or one source asset adapted cleanly across platforms.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-hash-cache-pattern",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/content-hash-cache-pattern",
+          "description": "Cache expensive file processing results using SHA-256 content hashes — path-independent, auto-invalidating, with service layer separation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "context-budget",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/context-budget",
+          "description": "Audits Claude Code context window consumption across agents, skills, MCP servers, and rules. Identifies bloat, redundant components, and produces prioritized token-savings recommendations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "continuous-agent-loop",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/continuous-agent-loop",
+          "description": "Patterns for continuous autonomous agent loops with quality gates, evals, and recovery controls.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "continuous-learning",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/continuous-learning",
+          "description": "Automatically extract reusable patterns from Claude Code sessions and save them as learned skills for future use.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "continuous-learning-v2",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/continuous-learning-v2",
+          "description": "Instinct-based learning system that observes sessions via hooks, creates atomic instincts with confidence scoring, and evolves them into skills/commands/agents. v2.1 adds project-scoped instincts to prevent cross-project contamination.",
+          "version": "2.1.0"
+        },
+        {
+          "name": "cost-aware-llm-pipeline",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/cost-aware-llm-pipeline",
+          "description": "Cost optimization patterns for LLM API usage — model routing by task complexity, budget tracking, retry logic, and prompt caching.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "council",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/council",
+          "description": "Convene a four-voice council for ambiguous decisions, tradeoffs, and go/no-go calls. Use when multiple valid paths exist and you need structured disagreement before choosing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cpp-coding-standards",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/cpp-coding-standards",
+          "description": "C++ coding standards based on the C++ Core Guidelines (isocpp.github.io). Use when writing, reviewing, or refactoring C++ code to enforce modern, safe, and idiomatic practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cpp-testing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/cpp-testing",
+          "description": "Use only when writing/updating/fixing C++ tests, configuring GoogleTest/CTest, diagnosing failing or flaky tests, or adding coverage/sanitizers.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "crosspost",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/crosspost",
+          "description": "Multi-platform content distribution across X, LinkedIn, Threads, and Bluesky. Adapts content per platform using content-engine patterns. Never posts identical content cross-platform. Use when the user wants to distribute content across social platforms.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "csharp-testing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/csharp-testing",
+          "description": "C# and .NET testing patterns with xUnit, FluentAssertions, mocking, integration tests, and test organization best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "customer-billing-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/customer-billing-ops",
+          "description": "Operate customer billing workflows such as subscriptions, refunds, churn triage, billing-portal recovery, and plan analysis using connected billing tools like Stripe. Use when the user needs to help a customer, inspect subscription state, or manage revenue-impacting billing operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "customs-trade-compliance",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/customs-trade-compliance",
+          "description": "Codified expertise for customs documentation, tariff classification, duty optimization, restricted party screening, and regulatory compliance across multiple jurisdictions. Informed by trade compliance specialists with 15+ years experience. Includes HS classification logic, Incoterms application, FTA utilization, and penalty mitigation. Use when handling customs clearance, tariff classification, trade compliance, import/export documentation, or duty optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "dart-flutter-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/dart-flutter-patterns",
+          "description": "Production-ready Dart and Flutter patterns covering null safety, immutable state, async composition, widget architecture, popular state management frameworks (BLoC, Riverpod, Provider), GoRouter navigation, Dio networking, Freezed code generation, and clean architecture.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dashboard-builder",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/dashboard-builder",
+          "description": "Build monitoring dashboards that answer real operator questions for Grafana, SigNoz, and similar platforms. Use when turning metrics into a working dashboard instead of a vanity board.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "data-scraper-agent",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/data-scraper-agent",
+          "description": "Build a fully automated AI-powered data collection agent for any public source — job boards, prices, news, GitHub, sports, anything. Scrapes on a schedule, enriches data with a free LLM (Gemini Flash), stores results in Notion/Sheets/Supabase, and learns from user feedback. Runs 100% free on GitHub Actions. Use when the user wants to monitor, collect, or track any public data automatically.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "database-migrations",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/database-migrations",
+          "description": "Database migration best practices for schema changes, data migrations, rollbacks, and zero-downtime deployments across PostgreSQL, MySQL, and common ORMs (Prisma, Drizzle, Kysely, Django, TypeORM, golang-migrate).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deep-research",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/deep-research",
+          "description": "Multi-source deep research using firecrawl and exa MCPs. Searches the web, synthesizes findings, and delivers cited reports with source attribution. Use when the user wants thorough research on any topic with evidence and citations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "defi-amm-security",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/defi-amm-security",
+          "description": "Security checklist for Solidity AMM contracts, liquidity pools, and swap flows. Covers reentrancy, CEI ordering, donation or inflation attacks, oracle manipulation, slippage, admin controls, and integer math.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "deployment-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/deployment-patterns",
+          "description": "Deployment workflows, CI/CD pipeline patterns, Docker containerization, health checks, rollback strategies, and production readiness checklists for web applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "design-system",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/design-system",
+          "description": "Use this skill to generate or audit design systems, check visual consistency, and review PRs that touch styling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "django-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/django-patterns",
+          "description": "Django architecture patterns, REST API design with DRF, ORM best practices, caching, signals, middleware, and production-grade Django apps.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "django-security",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/django-security",
+          "description": "Django security best practices, authentication, authorization, CSRF protection, SQL injection prevention, XSS prevention, and secure deployment configurations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "django-tdd",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/django-tdd",
+          "description": "Django testing strategies with pytest-django, TDD methodology, factory_boy, mocking, coverage, and testing Django REST Framework APIs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "django-verification",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/django-verification",
+          "description": "Verification loop for Django projects: migrations, linting, tests with coverage, security scans, and deployment readiness checks before release or PR.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dmux-workflows",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/dmux-workflows",
+          "description": "Multi-agent orchestration using dmux (tmux pane manager for AI agents). Patterns for parallel agent workflows across Claude Code, Codex, OpenCode, and other harnesses. Use when running multiple agent sessions in parallel or coordinating multi-agent development workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docker-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/docker-patterns",
+          "description": "Docker and Docker Compose patterns for local development, container security, networking, volume strategies, and multi-service orchestration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "documentation-lookup",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/documentation-lookup",
+          "description": "Use up-to-date library and framework docs via Context7 MCP instead of training data. Activates for setup questions, API references, code examples, or when the user names a framework (e.g. React, Next.js, Prisma).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dotnet-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/dotnet-patterns",
+          "description": "Idiomatic C# and .NET patterns, conventions, dependency injection, async/await, and best practices for building robust, maintainable .NET applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "e2e-testing",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/e2e-testing",
+          "description": "Playwright E2E testing patterns, Page Object Model, configuration, CI/CD integration, artifact management, and flaky test strategies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ecc-tools-cost-audit",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/ecc-tools-cost-audit",
+          "description": "Evidence-first ECC Tools burn and billing audit workflow. Use when investigating runaway PR creation, quota bypass, premium-model leakage, duplicate jobs, or GitHub App cost spikes in the ECC Tools repo.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "email-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/email-ops",
+          "description": "Evidence-first mailbox triage, drafting, send verification, and sent-mail-safe follow-up workflow for ECC. Use when the user wants to organize email, draft or send through the real mail surface, or prove what landed in Sent.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "energy-procurement",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/energy-procurement",
+          "description": "Codified expertise for electricity and gas procurement, tariff optimization, demand charge management, renewable PPA evaluation, and multi-facility energy cost management. Informed by energy procurement managers with 15+ years experience at large commercial and industrial consumers. Includes market structure analysis, hedging strategies, load profiling, and sustainability reporting frameworks. Use when procuring energy, optimizing tariffs, managing demand charges, evaluating PPAs, or developing energy strategies.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "enterprise-agent-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/enterprise-agent-ops",
+          "description": "Operate long-lived agent workloads with observability, security boundaries, and lifecycle management.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "eval-harness",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/eval-harness",
+          "description": "Formal evaluation framework for Claude Code sessions implementing eval-driven development (EDD) principles",
+          "version": "0.0.0"
+        },
+        {
+          "name": "everything-claude-code",
+          "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/everything-claude-code",
+          "description": "Development conventions and patterns for everything-claude-code. JavaScript project with conventional commits.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "everything-claude-code-conventions",
+          "installUrl": "github:affaan-m/everything-claude-code:.claude/skills/everything-claude-code",
+          "description": "Development conventions and patterns for everything-claude-code. JavaScript project with conventional commits.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "evm-token-decimals",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/evm-token-decimals",
+          "description": "Prevent silent decimal mismatch bugs across EVM chains. Covers runtime decimal lookup, chain-aware caching, bridged-token precision drift, and safe normalization for bots, dashboards, and DeFi tools.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "exa-search",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/exa-search",
+          "description": "Neural search via Exa MCP for web, code, and company research. Use when the user needs web search, code examples, company intel, people lookup, or AI-powered deep research with Exa's neural search engine.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fal-ai-media",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/fal-ai-media",
+          "description": "Unified media generation via fal.ai MCP — image, video, and audio. Covers text-to-image (Nano Banana), text/image-to-video (Seedance, Kling, Veo 3), text-to-speech (CSM-1B), and video-to-audio (ThinkSound). Use when the user wants to generate images, videos, or audio with AI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "finance-billing-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/finance-billing-ops",
+          "description": "Evidence-first revenue, pricing, refunds, team-billing, and billing-model truth workflow for ECC. Use when the user wants a sales snapshot, pricing comparison, duplicate-charge diagnosis, or code-backed billing reality instead of generic payments advice.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flutter-dart-code-review",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/flutter-dart-code-review",
+          "description": "Library-agnostic Flutter/Dart code review checklist covering widget best practices, state management patterns (BLoC, Riverpod, Provider, GetX, MobX, Signals), Dart idioms, performance, accessibility, security, and clean architecture.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "foundation-models-on-device",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/foundation-models-on-device",
+          "description": "Apple FoundationModels framework for on-device LLM — text generation, guided generation with @Generable, tool calling, and snapshot streaming in iOS 26+.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "frontend-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/frontend-patterns",
+          "description": "Frontend development patterns for React, Next.js, state management, performance optimization, and UI best practices.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "affaan-m",
+        "repo": "everything-claude-code",
+        "repoUrl": "https://github.com/affaan-m/everything-claude-code.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "affaan-m-everything-claude-code-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from affaan-m/everything-claude-code.",
+      "author": "ASM (affaan-m/everything-claude-code)",
+      "createdAt": "2026-05-09T08:10:28.548Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "affaan-m",
+        "everything-claude-code"
+      ],
+      "skills": [
+        {
+          "name": "accessibility",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/accessibility",
+          "description": "Design, implement, and audit inclusive digital products using WCAG 2.2 Level AA",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-design",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/api-design",
+          "description": "REST API design patterns including resource naming, status codes, pagination, filtering, error responses, versioning, and rate limiting for production APIs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "carrier-relationship-management",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/carrier-relationship-management",
+          "description": "Codified expertise for managing carrier portfolios, negotiating freight rates, tracking carrier performance, allocating freight, and maintaining strategic carrier relationships. Informed by transportation managers with 15+ years experience. Includes scorecarding frameworks, RFP processes, market intelligence, and compliance vetting. Use when managing carriers, negotiating rates, evaluating carrier performance, or building freight strategies.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "customer-billing-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/customer-billing-ops",
+          "description": "Operate customer billing workflows such as subscriptions, refunds, churn triage, billing-portal recovery, and plan analysis using connected billing tools like Stripe. Use when the user needs to help a customer, inspect subscription state, or manage revenue-impacting billing operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dart-flutter-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/dart-flutter-patterns",
+          "description": "Production-ready Dart and Flutter patterns covering null safety, immutable state, async composition, widget architecture, popular state management frameworks (BLoC, Riverpod, Provider), GoRouter navigation, Dio networking, Freezed code generation, and clean architecture.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deployment-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/deployment-patterns",
+          "description": "Deployment workflows, CI/CD pipeline patterns, Docker containerization, health checks, rollback strategies, and production readiness checklists for web applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "django-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/django-patterns",
+          "description": "Django architecture patterns, REST API design with DRF, ORM best practices, caching, signals, middleware, and production-grade Django apps.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "energy-procurement",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/energy-procurement",
+          "description": "Codified expertise for electricity and gas procurement, tariff optimization, demand charge management, renewable PPA evaluation, and multi-facility energy cost management. Informed by energy procurement managers with 15+ years experience at large commercial and industrial consumers. Includes market structure analysis, hedging strategies, load profiling, and sustainability reporting frameworks. Use when procuring energy, optimizing tariffs, managing demand charges, evaluating PPAs, or developing energy strategies.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "finance-billing-ops",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/finance-billing-ops",
+          "description": "Evidence-first revenue, pricing, refunds, team-billing, and billing-model truth workflow for ECC. Use when the user wants a sales snapshot, pricing comparison, duplicate-charge diagnosis, or code-backed billing reality instead of generic payments advice.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "inventory-demand-planning",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/inventory-demand-planning",
+          "description": "Codified expertise for demand forecasting, safety stock optimization, replenishment planning, and promotional lift estimation at multi-location retailers. Informed by demand planners with 15+ years experience managing hundreds of SKUs. Includes forecasting method selection, ABC/XYZ analysis, seasonal transition management, and vendor negotiation frameworks. Use when forecasting demand, setting safety stock, planning replenishment, managing promotions, or optimizing inventory levels.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "laravel-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/laravel-patterns",
+          "description": "Laravel architecture patterns, routing/controllers, Eloquent ORM, service layers, queues, events, caching, and API resources for production apps.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "manim-video",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/manim-video",
+          "description": "Build reusable Manim explainers for technical concepts, graphs, system diagrams, and product walkthroughs, then hand off to the wider ECC video stack if needed. Use when the user wants a clean animated explainer rather than a generic talking-head script.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "market-research",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/market-research",
+          "description": "Conduct market research, competitive analysis, investor due diligence, and industry intelligence with source attribution and decision-oriented summaries. Use when the user wants market sizing, competitor comparisons, fund research, technology scans, or research that informs business decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "nestjs-patterns",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/nestjs-patterns",
+          "description": "NestJS architecture patterns for modules, controllers, providers, DTO validation, guards, interceptors, config, and production-grade TypeScript backends.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "product-capability",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/product-capability",
+          "description": "Translate PRD intent, roadmap asks, or product discussions into an implementation-ready capability plan that exposes constraints, invariants, interfaces, and unresolved decisions before multi-service work starts. Use when the user needs an ECC-native PRD-to-SRS lane instead of vague planning prose.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "product-lens",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/product-lens",
+          "description": "Use this skill to validate the \"why\" before building, run product diagnostics, and pressure-test product direction before the request becomes an implementation contract.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "production-scheduling",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/production-scheduling",
+          "description": "Codified expertise for production scheduling, job sequencing, line balancing, changeover optimization, and bottleneck resolution in discrete and batch manufacturing. Informed by production schedulers with 15+ years experience. Includes TOC/drum-buffer-rope, SMED, OEE analysis, disruption response frameworks, and ERP/MES interaction patterns. Use when scheduling production, resolving bottlenecks, optimizing changeovers, responding to disruptions, or balancing manufacturing lines.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "returns-reverse-logistics",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/returns-reverse-logistics",
+          "description": "Codified expertise for returns authorization, receipt and inspection, disposition decisions, refund processing, fraud detection, and warranty claims management. Informed by returns operations managers with 15+ years experience. Includes grading frameworks, disposition economics, fraud pattern recognition, and vendor recovery processes. Use when handling product returns, reverse logistics, refund decisions, return fraud detection, or warranty claims.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "safety-guard",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/safety-guard",
+          "description": "Use this skill to prevent destructive operations when working on production systems or running agents autonomously.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "seo",
+          "installUrl": "github:affaan-m/everything-claude-code:skills/seo",
+          "description": "Audit, plan, and implement SEO improvements across technical SEO, on-page optimization, structured data, Core Web Vitals, and content strategy. Use when the user wants better search visibility, SEO remediation, schema markup, sitemap/robots work, or keyword mapping.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "affaan-m",
+        "repo": "everything-claude-code",
+        "repoUrl": "https://github.com/affaan-m/everything-claude-code.git"
+      },
+      "inferred": true
     }
   ]
 }

--- a/data/skill-index/alirezarezvani_claude-skills.json
+++ b/data/skill-index/alirezarezvani_claude-skills.json
@@ -39598,5 +39598,4009 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "alirezarezvani-claude-skills-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from alirezarezvani/claude-skills.",
+      "author": "ASM (alirezarezvani/claude-skills)",
+      "createdAt": "2026-05-09T08:10:59.479Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "alirezarezvani",
+        "claude-skills"
+      ],
+      "skills": [
+        {
+          "name": "a11y-audit",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/a11y-audit/skills/a11y-audit",
+          "description": "Accessibility audit skill for scanning, fixing, and verifying WCAG 2.2 Level A and AA compliance across React, Next.js, Vue, Angular, Svelte, and plain HTML codebases. Use when auditing accessibility, fixing a11y violations, checking color contrast, generating compliance reports, or integrating accessibility checks into CI/CD pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ab-test-setup",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ab-test-setup",
+          "description": "When the user wants to plan, design, or implement an A/B test or experiment. Also use when the user mentions \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"conversion experiment,\" \"statistical significance,\" or \"test this.\" For tracking implementation, see analytics-tracking.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ad-creative",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ad-creative",
+          "description": "When the user needs to generate, iterate, or scale ad creative for paid advertising. Use when they say 'write ad copy,' 'generate headlines,' 'create ad variations,' 'bulk creative,' 'iterate on ads,' 'ad copy validation,' 'RSA headlines,' 'Meta ad copy,' 'LinkedIn ad,' or 'creative testing.' This is pure creative production — distinct from paid-ads (campaign strategy). Use ad-creative when you need the copy, not the campaign plan.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "agent-protocol",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agent-protocol",
+          "description": "Inter-agent communication protocol for C-suite agent teams. Defines invocation syntax, loop prevention, isolation rules, and response formats. Use when C-suite agents need to query each other, coordinate cross-functional analysis, or run board meetings with multiple agent roles.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ai-seo",
+          "description": "Optimize content to get cited by AI search engines — ChatGPT, Perplexity, Google AI Overviews, Claude, Gemini, Copilot. Use when you want your content to appear in AI-generated answers, not just ranked in blue links. Triggers: 'optimize for AI search', 'get cited by ChatGPT', 'AI Overviews', 'Perplexity citations', 'AI SEO', 'generative search', 'LLM visibility', 'GEO' (generative engine optimization). NOT for traditional SEO ranking (use seo-audit). NOT for content creation (use content-production).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "analytics-tracking",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/analytics-tracking",
+          "description": "Set up, audit, and debug analytics tracking implementation — GA4, Google Tag Manager, event taxonomy, conversion tracking, and data quality. Use when building a tracking plan from scratch, auditing existing analytics for gaps or errors, debugging missing events, or setting up GTM. Trigger keywords: GA4 setup, Google Tag Manager, GTM, event tracking, analytics implementation, conversion tracking, tracking plan, event taxonomy, custom dimensions, UTM tracking, analytics audit, missing events, tracking broken. NOT for analyzing marketing campaign data — use campaign-analytics for that. NOT for BI dashboards — use product-analytics for in-product event analysis.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-store-optimization",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/app-store-optimization",
+          "description": "App Store Optimization (ASO) toolkit for researching keywords, analyzing competitor rankings, generating metadata suggestions, and improving app visibility on Apple App Store and Google Play Store. Use when the user asks about ASO, app store rankings, app metadata, app titles and descriptions, app store listings, app visibility, or mobile app marketing on iOS or Android. Supports keyword research and scoring, competitor keyword analysis, metadata optimization, A/B test planning, launch checklists, and tracking ranking changes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autoresearch-agent",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/autoresearch-agent/skills/autoresearch-agent",
+          "description": "Autonomous experiment loop that optimizes any file by a measurable metric. Inspired by Karpathy's autoresearch. The agent edits a target file, runs a fixed evaluation, keeps improvements (git commit), discards failures (git reset), and loops indefinitely. Use when: user wants to optimize code speed, reduce bundle/image size, improve test pass rate, optimize prompts, improve content quality (headlines, copy, CTR), or run any measurable improvement loop. Requires: a target file, an evaluation command that outputs a metric, and a git repo.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "board-meeting",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/board-meeting",
+          "description": "Multi-agent board meeting protocol for strategic decisions. Runs a structured 6-phase deliberation: context loading, independent C-suite contributions (isolated, no cross-pollination), critic analysis, synthesis, founder review, and decision extraction. Use when the user invokes /cs:board, calls a board meeting, or wants structured multi-perspective executive deliberation on a strategic question.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "brand-guidelines",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/brand-guidelines",
+          "description": "When the user wants to apply, document, or enforce brand guidelines for any product or company. Also use when the user mentions 'brand guidelines,' 'brand colors,' 'typography,' 'logo usage,' 'brand voice,' 'visual identity,' 'tone of voice,' 'brand standards,' 'style guide,' 'brand consistency,' or 'company design standards.' Covers color systems, typography, logo rules, imagery guidelines, and tone matrix for any brand — including Anthropic's official identity.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "browserstack",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/browserstack",
+          "description": "Run tests on BrowserStack. Use when user mentions \"browserstack\", \"cross-browser\", \"cloud testing\", \"browser matrix\", \"test on safari\", \"test on firefox\", or \"browser compatibility\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "business-growth-skills",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/business-growth-skills",
+          "description": "4 business growth agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Customer success (health scoring, churn), sales engineer (RFP), revenue operations (pipeline, GTM), contract & proposal writer. Python tools (stdlib-only).",
+          "version": "1.1.0"
+        },
+        {
+          "name": "c-level-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/c-level-skills",
+          "description": "10 C-level advisory agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO, Executive Mentor. Multi-role board meetings, strategy routing, structured recommendations. For founders needing executive-level decision support.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "campaign-analytics",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/campaign-analytics",
+          "description": "Analyzes campaign performance with multi-touch attribution, funnel conversion analysis, and ROI calculation for marketing optimization. Use when analyzing marketing campaigns, ad performance, attribution models, conversion rates, or calculating marketing ROI, ROAS, CPA, and campaign metrics across channels.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ciso-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ciso-advisor",
+          "description": "Security leadership for growth-stage companies. Risk quantification in dollars, compliance roadmap (SOC 2/ISO 27001/HIPAA/GDPR), security architecture strategy, incident response leadership, and board-level security reporting. Use when building security programs, justifying security budget, selecting compliance frameworks, managing incidents, assessing vendor risk, or when user mentions CISO, security strategy, compliance roadmap, zero trust, or board security reporting.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cmo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cmo-advisor",
+          "description": "Marketing leadership for scaling companies. Brand positioning, growth model design, marketing budget allocation, and marketing org design. Use when designing brand strategy, selecting growth models (PLG vs sales-led vs community-led), allocating marketing budgets, building marketing teams, or when user mentions CMO, brand strategy, growth model, CAC, LTV, channel mix, or marketing ROI.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cold-email",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cold-email",
+          "description": "When the user wants to write, improve, or build a sequence of B2B cold outreach emails to prospects who haven't asked to hear from them. Use when the user mentions 'cold email,' 'cold outreach,' 'prospecting emails,' 'SDR emails,' 'sales emails,' 'first touch email,' 'follow-up sequence,' or 'email prospecting.' Also use when they share an email draft that sounds too sales-y and needs to be humanized. Distinct from email-sequence (lifecycle/nurture to opted-in subscribers) — this is unsolicited outreach to new prospects. NOT for lifecycle emails, newsletters, or drip campaigns (use email-sequence).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitive-intel",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitive-intel",
+          "description": "Systematic competitor tracking that feeds CMO positioning, CRO battlecards, and CPO roadmap decisions. Use when analyzing competitors, building sales battlecards, tracking market moves, positioning against alternatives, or when user mentions competitive intelligence, competitive analysis, competitor research, battlecards, win/loss, or market positioning.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitive-teardown",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitive-teardown",
+          "description": "Analyzes competitor products and companies by synthesizing data from pricing pages, app store reviews, job postings, SEO signals, and social media into structured competitive intelligence. Produces feature comparison matrices scored across 12 dimensions, SWOT analyses, positioning maps, UX audits, pricing model breakdowns, action item roadmaps, and stakeholder presentation templates. Use when conducting competitor analysis, comparing products against competitors, researching the competitive landscape, building battle cards for sales, preparing for a product strategy or roadmap session, responding to a competitor's new feature or pricing change, or performing a quarterly competitive review.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "competitor-alternatives",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitor-alternatives",
+          "description": "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'switch from competitor,' or 'comparison content.' Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. Emphasizes deep research, modular content architecture, and varied section types beyond feature tables.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "confluence-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/confluence-expert",
+          "description": "Atlassian Confluence expert for creating and managing spaces, knowledge bases, and documentation. Configures space permissions and hierarchies, creates page templates with macros, sets up documentation taxonomies, designs page layouts, and manages content governance. Use when users need to build or restructure a Confluence space, design page hierarchies with permission structures, author or standardise documentation templates, embed Jira reports in pages, run knowledge base audits, or establish documentation standards and collaborative workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-creator",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-creator",
+          "description": "Deprecated redirect skill that routes legacy 'content creator' requests to the correct specialist. Use when a user invokes 'content creator', asks to write a blog post, article, guide, or brand voice analysis (routes to content-production), or asks to plan content, build a topic cluster, or create a content calendar (routes to content-strategy). Does not handle requests directly — identifies user intent and redirects to content-production for writing/SEO/brand-voice tasks or content-strategy for planning tasks.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "content-humanizer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-humanizer",
+          "description": "Makes AI-generated content sound genuinely human — not just cleaned up, but alive. Use when content feels robotic, uses too many AI clichés, lacks personality, or reads like it was written by committee. Triggers: 'this sounds like AI', 'make it more human', 'add personality', 'it feels generic', 'sounds robotic', 'fix AI writing', 'inject our voice'. NOT for initial content creation (use content-production). NOT for SEO optimization (use content-production Mode 3).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-production",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-production",
+          "description": "Full content production pipeline — takes a topic from blank page to published-ready piece. Use when you need to execute content: write a blog post, article, or guide end-to-end. Triggers: 'write a post about', 'draft an article', 'create content for', 'help me write', 'I need a blog post'. NOT for content strategy or calendar planning (use content-strategy). NOT for repurposing existing content (use content-repurposing). NOT for social captions only.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-strategy",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-strategy",
+          "description": "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions \\\"content strategy,\\\" \\\"what should I write about,\\\" \\\"content ideas,\\\" \\\"blog strategy,\\\" \\\"topic clusters,\\\" or \\\"content planning.\\\" For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "copy-editing",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/copy-editing",
+          "description": "When the user wants to edit, review, or improve existing marketing copy. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' or 'copy sweep.' This skill provides a systematic approach to editing marketing copy through multiple focused passes.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "copywriting",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/copywriting",
+          "description": "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \\\"write copy for,\\\" \\\"improve this copy,\\\" \\\"rewrite this page,\\\" \\\"marketing copy,\\\" \\\"headline help,\\\" or \\\"CTA copy.\\\" For email copy, see email-sequence. For popup copy, see popup-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cro-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cro-advisor",
+          "description": "Revenue leadership for B2B SaaS companies. Revenue forecasting, sales model design, pricing strategy, net revenue retention, and sales team scaling. Use when designing the revenue engine, setting quotas, modeling NRR, evaluating pricing, building board forecasts, or when user mentions CRO, chief revenue officer, revenue strategy, sales model, ARR growth, NRR, expansion revenue, churn, pricing strategy, or sales capacity.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cs-content-creator",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-content-creator",
+          "description": "AI-powered content creation specialist for brand voice consistency, SEO optimization, and multi-platform content strategy",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-demand-gen-specialist",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-demand-gen-specialist",
+          "description": "Demand generation and customer acquisition specialist for lead generation, conversion optimization, and multi-channel acquisition campaigns",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-engineering-lead",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-engineering-lead",
+          "description": "Engineering Team Lead agent for coordinating QA, security, data engineering, ML, and frontend/backend teams. Orchestrates engineering-team skills for team-level technical decisions. Spawn when users need team coordination, tech stack evaluation, incident response, or cross-functional engineering work.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-growth-strategist",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-growth-strategist",
+          "description": "Growth Strategist agent for revenue operations, sales engineering, customer success, and business development. Orchestrates business-growth skills. Spawn when users need pipeline analysis, churn prevention, expansion scoring, sales demos, or proposal writing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-onboard",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cs-onboard",
+          "description": "Founder onboarding interview that captures company context across 7 dimensions. Invoke with /cs:setup for initial interview or /cs:update for quarterly refresh. Generates ~/.claude/company-context.md used by all C-suite advisor skills.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cs-wiki-ingestor",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-wiki-ingestor",
+          "description": "Dispatched sub-agent that ingests a new source into an LLM Wiki vault. Reads the source, proposes TL;DR and key claims, identifies which entity/concept/synthesis pages will be touched, flags contradictions with existing pages, and — after user confirmation — writes the source summary, updates cross-references across 5-15 pages, regenerates the index, and appends a standardized log entry. Spawn when the user says \"ingest this\", \"add this paper/article/book to the wiki\", or drops a file into raw/.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-wiki-librarian",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-wiki-librarian",
+          "description": "Dispatched sub-agent that answers queries against an LLM Wiki vault. Reads index.md first, drills into 3-10 relevant pages across categories, synthesizes an answer with inline [[wikilink]] citations, and offers to file the answer back into the wiki as a new comparison or synthesis page. Spawn when the user asks a substantive question the wiki might answer, says \"what does the wiki say about X\", \"compare A and B across my sources\", or wants to explore a topic.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-wiki-linter",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-wiki-linter",
+          "description": "Dispatched sub-agent that runs a periodic health check on an LLM Wiki vault. Runs mechanical checks via scripts (orphans, broken links, stale pages, missing frontmatter, duplicate titles, log gaps), does semantic checks (contradictions, stale claims, cross-reference gaps, concepts missing their own page), and produces a markdown report with suggested actions. Spawn weekly, after batch ingests, or when the user says \"check the wiki\" / \"lint my wiki\" / \"audit the vault\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "customer-success-manager",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/customer-success-manager",
+          "description": "Monitors customer health, predicts churn risk, and identifies expansion opportunities using weighted scoring models for SaaS customer success. Use when analyzing customer accounts, reviewing retention metrics, scoring at-risk customers, or when the user mentions churn, customer health scores, upsell opportunities, expansion revenue, retention analysis, or customer analytics. Runs three Python CLI tools to produce deterministic health scores, churn risk tiers, and prioritized expansion recommendations across Enterprise, Mid-Market, and SMB segments.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "demo-video",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/demo-video/skills/demo-video",
+          "description": "Use when the user asks to create a demo video, product walkthrough, feature showcase, animated presentation, marketing video, or GIF from screenshots or scene descriptions. Orchestrates playwright, ffmpeg, and edge-tts MCPs to produce polished video content.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "email-sequence",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/email-sequence",
+          "description": "When the user wants to create or optimize an email sequence, drip campaign, automated email flow, or lifecycle email program. Also use when the user mentions \"email sequence,\" \"drip campaign,\" \"nurture sequence,\" \"onboarding emails,\" \"welcome sequence,\" \"re-engagement emails,\" \"email automation,\" or \"lifecycle emails.\" For in-app onboarding, see onboarding-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "epic-design",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/epic-design",
+          "description": "Build immersive, cinematic 2.5D interactive websites using scroll storytelling, parallax depth, text animations, and premium scroll effects — no WebGL required. Use this skill for any web design task: landing pages, product sites, hero sections, scroll animations, parallax, sticky sections, section overlaps, floating products between sections, clip-path reveals, text that flies in from sides, words that light up on scroll, curtain drops, iris opens, card stacks, bleed typography, and any site that should feel cinematic or premium. Trigger on phrases like \"make it feel alive\", \"Apple-style animation\", \"sections that overlap\", \"product rises between sections\", \"immersive\", \"scrollytelling\", or any scroll-driven visual effect. Covers 45+ techniques across 8 categories. Always inspects, judges, and plans assets before coding. Use aggressively for ANY web design task.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "focused-fix",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/focused-fix",
+          "description": "Use when the user asks to fix, debug, or make a specific feature/module/area work end-to-end. Triggers: 'make X work', 'fix the Y feature', 'the Z module is broken', 'focus on [area]'. Not for quick single-bug fixes — this is for systematic deep-dive repair across all files and dependencies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "form-cro",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/form-cro",
+          "description": "When the user wants to optimize any form that is NOT signup/registration — including lead capture forms, contact forms, demo request forms, application forms, survey forms, or checkout forms. Also use when the user mentions \"form optimization,\" \"lead form conversions,\" \"form friction,\" \"form fields,\" \"form completion rate,\" or \"contact form.\" For signup/registration forms, see signup-flow-cro. For popups containing forms, see popup-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "founder-coach",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/founder-coach",
+          "description": "Personal leadership development for founders and first-time CEOs. Covers founder archetype identification, delegation frameworks, energy management, CEO calendar audits, leadership style evolution, blind spot identification, imposter syndrome, founder mental health, and succession planning. Use when a founder feels like the bottleneck, struggles to delegate, is burning out, transitioning from IC to executive, managing a board, or when user mentions founder mode, CEO growth, leadership development, delegation, burnout, or imposter syndrome.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "free-tool-strategy",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/free-tool-strategy",
+          "description": "When the user wants to build a free tool for marketing — lead generation, SEO value, or brand awareness. Use when they mention 'engineering as marketing,' 'free tool,' 'calculator,' 'generator,' 'checker,' 'grader,' 'marketing tool,' 'lead gen tool,' 'build something for traffic,' 'interactive tool,' or 'free resource.' Covers idea evaluation, tool design, and launch strategy. For pure SEO content strategy (no tool), use seo-audit or content-strategy instead.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "full-page-screenshot",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/full-page-screenshot",
+          "description": "Use when the user asks to capture a full-page screenshot, long screenshot, or complete page capture of a web page. Handles SPA scroll containers, lazy-loaded images, and very tall pages via Chrome DevTools Protocol with zero external dependencies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Growth Marketer",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/growth-marketer",
+          "description": "Growth marketing specialist for bootstrapped startups and indie hackers. Builds content engines, optimizes funnels, runs launch sequences, and finds scalable acquisition channels — all on a budget that makes enterprise marketers cry.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "internal-narrative",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/internal-narrative",
+          "description": "Build and maintain one coherent company story across all audiences — employees, investors, customers, candidates, and partners. Detects narrative contradictions and ensures the same truth is framed for each audience's needs. Use when preparing investor updates, all-hands presentations, board communications, recruiting narratives, crisis communications, or when user mentions company narrative, messaging consistency, storytelling, all-hands, investor update, or crisis communication.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "landing-page-generator",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/landing-page-generator",
+          "description": "Generates high-converting landing pages as complete Next.js/React (TSX) components with Tailwind CSS. Creates hero sections, feature grids, pricing tables, FAQ accordions, testimonial blocks, and CTA sections using proven copy frameworks (PAS, AIDA, BAB). Outputs SEO meta tags, structured data, and performance-optimised code targeting Core Web Vitals (LCP < 1s, CLS < 0.1). Use when the user asks to create a landing page, marketing page, homepage, single-page site, lead capture page, campaign page, promo page, or conversion-optimised web page — or when they want to A/B test landing page variants or replace a static page with one designed to convert.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "llm-wiki",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/llm-wiki/skills/llm-wiki",
+          "description": "Use when building or maintaining a persistent personal knowledge base (second brain) in Obsidian where an LLM incrementally ingests sources, updates entity/concept pages, maintains cross-references, and keeps a synthesis current. Triggers include \"second brain\", \"Obsidian wiki\", \"personal knowledge management\", \"ingest this paper/article/book\", \"build a research wiki\", \"compound knowledge\", \"Memex\", or whenever the user wants knowledge to accumulate across sessions instead of being re-derived by RAG on every query.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "loop",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/autoresearch-agent/skills/loop",
+          "description": "Start an autonomous experiment loop with user-selected interval (10min, 1h, daily, weekly, monthly). Uses CronCreate for scheduling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "marketing-context",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-context",
+          "description": "Create and maintain the marketing context document that all marketing skills read before starting. Use when the user mentions 'marketing context,' 'brand voice,' 'set up context,' 'target audience,' 'ICP,' 'style guide,' 'who is my customer,' 'positioning,' or wants to avoid repeating foundational information across marketing tasks. Run this at the start of any new project before using other marketing skills.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "marketing-demand-acquisition",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-demand-acquisition",
+          "description": "Creates demand generation campaigns, optimizes paid ad spend across LinkedIn, Google, and Meta, develops SEO strategies, and structures partnership programs for Series A+ startups scaling internationally. Use when planning marketing strategy, growth marketing, advertising campaigns, PPC optimization, lead generation, pipeline generation, or startup marketing budgets. Covers multi-channel acquisition (Google Ads, LinkedIn Ads, Meta Ads), CAC analysis, MQL/SQL workflows, attribution modeling, technical SEO, and co-marketing partnerships for hybrid PLG/Sales-Led motions in EU/US/Canada markets.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "marketing-ideas",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-ideas",
+          "description": "When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the user asks for 'marketing ideas,' 'growth ideas,' 'how to market,' 'marketing strategies,' 'marketing tactics,' 'ways to promote,' or 'ideas to grow.' This skill provides 139 proven marketing approaches organized by category.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "marketing-ops",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-ops",
+          "description": "Central router for the marketing skill ecosystem. Use when unsure which marketing skill to use, when orchestrating a multi-skill campaign, or when coordinating across content, SEO, CRO, channels, and analytics. Also use when the user mentions 'marketing help,' 'campaign plan,' 'what should I do next,' 'marketing priorities,' or 'coordinate marketing.'",
+          "version": "1.0.0"
+        },
+        {
+          "name": "marketing-psychology",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-psychology",
+          "description": "When the user wants to apply psychological principles, mental models, or behavioral science to marketing. Also use when the user mentions 'psychology,' 'mental models,' 'cognitive bias,' 'persuasion,' 'behavioral science,' 'why people buy,' 'decision-making,' or 'consumer behavior.' This skill provides 70+ mental models organized for marketing application.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "marketing-skills",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-skills",
+          "description": "42 marketing agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw, and 6 more coding agents. 7 pods: content, SEO, CRO, channels, growth, intelligence, sales. Foundation context + orchestration router. 27 Python tools (stdlib-only).",
+          "version": "2.0.0"
+        },
+        {
+          "name": "marketing-strategy-pmm",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-strategy-pmm",
+          "description": "Product marketing skill for positioning, GTM strategy, competitive intelligence, and product launches. Use when the user asks about product positioning, go-to-market planning, competitive analysis, target audience definition, ICP definition, market research, launch plans, or sales enablement. Covers April Dunford positioning, ICP definition, competitive battlecards, launch playbooks, and international market entry. Produces deliverables including positioning statements, battlecard documents, launch plans, and go-to-market strategies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "meeting-analyzer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/meeting-analyzer",
+          "description": "Analyzes meeting transcripts and recordings to surface behavioral patterns, communication anti-patterns, and actionable coaching feedback. Use this skill whenever the user uploads or points to meeting transcripts (.txt, .md, .vtt, .srt, .docx), asks about their communication habits, wants feedback on how they run meetings, requests speaking ratio analysis, mentions filler words or conflict avoidance, or wants to compare their communication across time periods. Also trigger when users mention tools like Granola, Otter, Fireflies, or Zoom transcripts. Even if the user just says \"look at my meetings\" or \"how do I come across in meetings\" — use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ms365-tenant-manager",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ms365-tenant-manager",
+          "description": "Microsoft 365 tenant administration for Global Administrators. Automate M365 tenant setup, Office 365 admin tasks, Azure AD user management, Exchange Online configuration, Teams administration, and security policies. Generate PowerShell scripts for bulk operations, Conditional Access policies, license management, and compliance reporting. Use for M365 tenant manager, Office 365 admin, Azure AD users, Global Administrator, tenant configuration, or Microsoft 365 automation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "onboarding-cro",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/onboarding-cro",
+          "description": "When the user wants to optimize post-signup onboarding, user activation, first-run experience, or time-to-value. Also use when the user mentions \"onboarding flow,\" \"activation rate,\" \"user activation,\" \"first-run experience,\" \"empty states,\" \"onboarding checklist,\" \"aha moment,\" or \"new user experience.\" For signup/registration optimization, see signup-flow-cro. For ongoing email sequences, see email-sequence.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "org-health-diagnostic",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/org-health-diagnostic",
+          "description": "Cross-functional organizational health check combining signals from all C-suite roles. Scores 8 dimensions on a traffic-light scale with drill-down recommendations. Use when assessing overall company health, preparing for board reviews, identifying at-risk functions, or when user mentions org health, health check, or health dashboard.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "page-cro",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/page-cro",
+          "description": "When the user wants to optimize, improve, or increase conversions on any marketing page — including homepage, landing pages, pricing pages, feature pages, or blog posts. Also use when the user says \"CRO,\" \"conversion rate optimization,\" \"this page isn't converting,\" \"improve conversions,\" or \"why isn't this page working.\" For signup/registration flows, see signup-flow-cro. For post-signup activation, see onboarding-cro. For forms outside of signup, see form-cro. For popups/modals, see popup-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "paid-ads",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/paid-ads",
+          "description": "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions 'PPC,' 'paid media,' 'ad copy,' 'ad creative,' 'ROAS,' 'CPA,' 'ad campaign,' 'retargeting,' or 'audience targeting.' This skill covers campaign strategy, ad creation, audience targeting, and optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "paywall-upgrade-cro",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/paywall-upgrade-cro",
+          "description": "When the user wants to create or optimize in-app paywalls, upgrade screens, upsell modals, or feature gates. Also use when the user mentions \"paywall,\" \"upgrade screen,\" \"upgrade modal,\" \"upsell,\" \"feature gate,\" \"convert free to paid,\" \"freemium conversion,\" \"trial expiration screen,\" \"limit reached screen,\" \"plan upgrade prompt,\" or \"in-app pricing.\" Distinct from public pricing pages (see page-cro) — this skill focuses on in-product upgrade moments where the user has already experienced value.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "plugin-audit",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/plugin-audit",
+          "description": "Comprehensive audit pipeline for skills, plugins, agents, and commands. Validates structure, quality, security, marketplace compliance, cross-platform compatibility, and ecosystem integration. Runs all built-in validation tools, invokes domain-appropriate agents for code review, and produces a pass/fail gate report. Usage: /plugin-audit <skill-path>",
+          "version": "0.0.0"
+        },
+        {
+          "name": "popup-cro",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/popup-cro",
+          "description": "When the user wants to create or optimize popups, modals, overlays, slide-ins, or banners for conversion purposes. Also use when the user mentions \"exit intent,\" \"popup conversions,\" \"modal optimization,\" \"lead capture popup,\" \"email popup,\" \"announcement banner,\" or \"overlay.\" For forms outside of popups, see form-cro. For general page conversion optimization, see page-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "pricing-strategy",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/pricing-strategy",
+          "description": "Design, optimize, and communicate SaaS pricing — tier structure, value metrics, pricing pages, and price increase strategy. Use when building a pricing model from scratch, redesigning existing pricing, planning a price increase, or improving a pricing page. Trigger keywords: pricing tiers, pricing page, price increase, packaging, value metric, per seat pricing, usage-based pricing, freemium, good-better-best, pricing strategy, monetization, pricing page conversion, Van Westendorp. NOT for broader product strategy — use product-strategist for that. NOT for customer success or renewals — use customer-success-manager for expansion revenue.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "product-analytics",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/product-analytics",
+          "description": "Use when defining product KPIs, building metric dashboards, running cohort or retention analysis, or interpreting feature adoption trends across product stages.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "product-strategist",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/product-strategist",
+          "description": "Strategic product leadership toolkit for Head of Product covering OKR cascade generation, quarterly planning, competitive landscape analysis, product vision documents, and team scaling proposals. Use when creating quarterly OKR documents, defining product goals or KPIs, building product roadmaps, running competitive analysis, drafting team structure or hiring plans, aligning product strategy across engineering and design, or generating cascaded goal hierarchies from company to team level.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "programmatic-seo",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/programmatic-seo",
+          "description": "When the user wants to create SEO-driven pages at scale using templates and data. Also use when the user mentions \"programmatic SEO,\" \"template pages,\" \"pages at scale,\" \"directory pages,\" \"location pages,\" \"[keyword] + [city] pages,\" \"comparison pages,\" \"integration pages,\" or \"building many pages for SEO.\" For auditing existing SEO issues, see seo-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "prompt-engineer-toolkit",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/prompt-engineer-toolkit",
+          "description": "Analyzes and rewrites prompts for better AI output, creates reusable prompt templates for marketing use cases (ad copy, email campaigns, social media), and structures end-to-end AI content workflows. Use when the user wants to improve prompts for AI-assisted marketing, build prompt templates, or optimize AI content workflows. Also use when the user mentions 'prompt engineering,' 'improve my prompts,' 'AI writing quality,' 'prompt templates,' or 'AI content workflow.'",
+          "version": "1.0.0"
+        },
+        {
+          "name": "red-team",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/red-team",
+          "description": "Use when planning or executing authorized red team engagements, attack path analysis, or offensive security simulations. Covers MITRE ATT&CK kill-chain planning, technique scoring, choke point identification, OPSEC risk assessment, and crown jewel targeting.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "referral-program",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/referral-program",
+          "description": "When the user wants to design, launch, or optimize a referral or affiliate program. Use when they mention 'referral program,' 'affiliate program,' 'word of mouth,' 'refer a friend,' 'incentive program,' 'customer referrals,' 'brand ambassador,' 'partner program,' 'referral link,' or 'growth through referrals.' Covers program mechanics, incentive design, and optimization — not just the idea of referrals but the actual system.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "regulatory-affairs-head",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/regulatory-affairs-head",
+          "description": "Senior Regulatory Affairs Manager for HealthTech and MedTech companies. Prepares FDA 510(k), De Novo, and PMA submission packages; analyzes regulatory pathways for new medical devices; drafts responses to FDA deficiency letters and Notified Body queries; develops CE marking technical documentation under EU MDR 2017/745; coordinates multi-market approval strategies across FDA, EU, Health Canada, PMDA, and NMPA; and maintains regulatory intelligence on evolving standards. Use when users need to plan or execute FDA submissions, navigate 510(k) or PMA approval processes, achieve CE marking, prepare pre-submission meeting materials, write regulatory strategy documents, respond to agency queries, or manage compliance documentation for medical device market access.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "revenue-operations",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/revenue-operations",
+          "description": "Analyzes sales pipeline health, revenue forecasting accuracy, and go-to-market efficiency metrics for SaaS revenue optimization. Use when analyzing sales pipeline coverage, forecasting revenue, evaluating go-to-market performance, reviewing sales metrics, assessing pipeline analysis, tracking forecast accuracy with MAPE, calculating GTM efficiency, or measuring sales efficiency and unit economics for SaaS teams.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "sales-engineer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/sales-engineer",
+          "description": "Analyzes RFP/RFI responses for coverage gaps, builds competitive feature comparison matrices, and plans proof-of-concept (POC) engagements for pre-sales engineering. Use when responding to RFPs, bids, or proposal requests; comparing product features against competitors; planning or scoring a customer POC or sales demo; preparing a technical proposal; or performing win/loss competitor analysis. Handles tasks described as 'RFP response', 'bid response', 'proposal response', 'competitor comparison', 'feature matrix', 'POC planning', 'sales demo prep', or 'pre-sales engineering'.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scenario-war-room",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/scenario-war-room",
+          "description": "Cross-functional what-if modeling for cascading multi-variable scenarios. Unlike single-assumption stress testing, this models compound adversity across all business functions simultaneously. Use when facing complex risk scenarios, strategic decisions with major downside, or when the user asks 'what if X AND Y both happen?'",
+          "version": "1.0.0"
+        },
+        {
+          "name": "schema-markup",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/schema-markup",
+          "description": "When the user wants to implement, audit, or validate structured data (schema markup) on their website. Use when the user mentions 'structured data,' 'schema.org,' 'JSON-LD,' 'rich results,' 'rich snippets,' 'schema markup,' 'FAQ schema,' 'Product schema,' 'HowTo schema,' or 'structured data errors in Search Console.' Also use when someone asks why their content isn't showing rich results or wants to improve AI search visibility. NOT for general SEO audits (use seo-audit) or technical SEO crawl issues (use site-architecture).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "self-eval",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/self-eval",
+          "description": "Honestly evaluate AI work quality using a two-axis scoring system. Use after completing a task, code review, or work session to get an unbiased assessment. Detects score inflation, forces devil's advocate reasoning, and persists scores across sessions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "senior-architect",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-architect",
+          "description": "This skill should be used when the user asks to \"design system architecture\", \"evaluate microservices vs monolith\", \"create architecture diagrams\", \"analyze dependencies\", \"choose a database\", \"plan for scalability\", \"make technical decisions\", or \"review system design\". Use for architecture decision records (ADRs), tech stack evaluation, system design reviews, dependency analysis, and generating architecture diagrams in Mermaid, PlantUML, or ASCII format.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "alirezarezvani",
+        "repo": "claude-skills",
+        "repoUrl": "https://github.com/alirezarezvani/claude-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "alirezarezvani-claude-skills-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from alirezarezvani/claude-skills.",
+      "author": "ASM (alirezarezvani/claude-skills)",
+      "createdAt": "2026-05-09T08:10:59.479Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "alirezarezvani",
+        "claude-skills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-setup",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ab-test-setup",
+          "description": "When the user wants to plan, design, or implement an A/B test or experiment. Also use when the user mentions \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"conversion experiment,\" \"statistical significance,\" or \"test this.\" For tracking implementation, see analytics-tracking.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ad-creative",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ad-creative",
+          "description": "When the user needs to generate, iterate, or scale ad creative for paid advertising. Use when they say 'write ad copy,' 'generate headlines,' 'create ad variations,' 'bulk creative,' 'iterate on ads,' 'ad copy validation,' 'RSA headlines,' 'Meta ad copy,' 'LinkedIn ad,' or 'creative testing.' This is pure creative production — distinct from paid-ads (campaign strategy). Use ad-creative when you need the copy, not the campaign plan.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "Agent Name",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/README",
+          "description": "What this agent does and when to activate it.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agenthub",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub/skills/agenthub",
+          "description": "Multi-agent collaboration plugin that spawns N parallel subagents competing on the same task via git worktree isolation. Agents work independently, results are evaluated by metric or LLM judge, and the best branch is merged. Use when: user wants multiple approaches tried in parallel — code optimization, content variation, research exploration, or any task that benefits from parallel competition. Requires: a git repo.",
+          "version": "2.1.2"
+        },
+        {
+          "name": "agile-product-owner",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agile-product-owner/skills/agile-product-owner",
+          "description": "Agile product ownership for backlog management and sprint execution. Covers user story writing, acceptance criteria, sprint planning, and velocity tracking. Use for writing user stories, creating acceptance criteria, planning sprints, estimating story points, breaking down epics, or prioritizing backlog.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ai-seo",
+          "description": "Optimize content to get cited by AI search engines — ChatGPT, Perplexity, Google AI Overviews, Claude, Gemini, Copilot. Use when you want your content to appear in AI-generated answers, not just ranked in blue links. Triggers: 'optimize for AI search', 'get cited by ChatGPT', 'AI Overviews', 'Perplexity citations', 'AI SEO', 'generative search', 'LLM visibility', 'GEO' (generative engine optimization). NOT for traditional SEO ranking (use seo-audit). NOT for content creation (use content-production).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "atlassian-templates",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/atlassian-templates",
+          "description": "Atlassian Template and Files Creator/Modifier expert for creating, modifying, and managing Jira and Confluence templates, blueprints, custom layouts, reusable components, and standardized content structures. Use when building org-wide templates, custom blueprints, page layouts, and automated content generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autoresearch-agent",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/autoresearch-agent/skills/autoresearch-agent",
+          "description": "Autonomous experiment loop that optimizes any file by a measurable metric. Inspired by Karpathy's autoresearch. The agent edits a target file, runs a fixed evaluation, keeps improvements (git commit), discards failures (git reset), and loops indefinitely. Use when: user wants to optimize code speed, reduce bundle/image size, improve test pass rate, optimize prompts, improve content quality (headlines, copy, CTR), or run any measurable improvement loop. Requires: a target file, an evaluation command that outputs a metric, and a git repo.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "board",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub/skills/board",
+          "description": "Read, write, and browse the AgentHub message board for agent coordination.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "board-meeting",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/board-meeting",
+          "description": "Multi-agent board meeting protocol for strategic decisions. Runs a structured 6-phase deliberation: context loading, independent C-suite contributions (isolated, no cross-pollination), critic analysis, synthesis, founder review, and decision extraction. Use when the user invokes /cs:board, calls a board meeting, or wants structured multi-perspective executive deliberation on a strategic question.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "business-growth-skills",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/business-growth-skills",
+          "description": "4 business growth agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Customer success (health scoring, churn), sales engineer (RFP), revenue operations (pipeline, GTM), contract & proposal writer. Python tools (stdlib-only).",
+          "version": "1.1.0"
+        },
+        {
+          "name": "code-to-prd",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-to-prd/skills/code-to-prd",
+          "description": "Reverse-engineer any codebase into a complete Product Requirements Document (PRD). Analyzes routes, components, state management, API integrations, and user interactions to produce business-readable documentation detailed enough for engineers or AI agents to fully reconstruct every page and endpoint. Works with frontend frameworks (React, Vue, Angular, Svelte, Next.js, Nuxt), backend frameworks (NestJS, Django, Express, FastAPI), and fullstack applications. Trigger when users mention: generate PRD, reverse-engineer requirements, code to documentation, extract product specs from code, document page logic, analyze page fields and interactions, create a functional inventory, write requirements from an existing codebase, document API endpoints, or analyze backend routes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cold-email",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cold-email",
+          "description": "When the user wants to write, improve, or build a sequence of B2B cold outreach emails to prospects who haven't asked to hear from them. Use when the user mentions 'cold email,' 'cold outreach,' 'prospecting emails,' 'SDR emails,' 'sales emails,' 'first touch email,' 'follow-up sequence,' or 'email prospecting.' Also use when they share an email draft that sounds too sales-y and needs to be humanized. Distinct from email-sequence (lifecycle/nurture to opted-in subscribers) — this is unsolicited outreach to new prospects. NOT for lifecycle emails, newsletters, or drip campaigns (use email-sequence).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitor-alternatives",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitor-alternatives",
+          "description": "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'switch from competitor,' or 'comparison content.' Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. Emphasizes deep research, modular content architecture, and varied section types beyond feature tables.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "confluence-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/confluence-expert",
+          "description": "Atlassian Confluence expert for creating and managing spaces, knowledge bases, and documentation. Configures space permissions and hierarchies, creates page templates with macros, sets up documentation taxonomies, designs page layouts, and manages content governance. Use when users need to build or restructure a Confluence space, design page hierarchies with permission structures, author or standardise documentation templates, embed Jira reports in pages, run knowledge base audits, or establish documentation standards and collaborative workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Content Strategist",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/content-strategist",
+          "description": "Builds content engines that rank, convert, and compound. Thinks in systems — topic clusters, not individual posts. Every piece earns its place or gets killed.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-creator",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-creator",
+          "description": "Deprecated redirect skill that routes legacy 'content creator' requests to the correct specialist. Use when a user invokes 'content creator', asks to write a blog post, article, guide, or brand voice analysis (routes to content-production), or asks to plan content, build a topic cluster, or create a content calendar (routes to content-strategy). Does not handle requests directly — identifies user intent and redirects to content-production for writing/SEO/brand-voice tasks or content-strategy for planning tasks.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "content-humanizer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-humanizer",
+          "description": "Makes AI-generated content sound genuinely human — not just cleaned up, but alive. Use when content feels robotic, uses too many AI clichés, lacks personality, or reads like it was written by committee. Triggers: 'this sounds like AI', 'make it more human', 'add personality', 'it feels generic', 'sounds robotic', 'fix AI writing', 'inject our voice'. NOT for initial content creation (use content-production). NOT for SEO optimization (use content-production Mode 3).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-production",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-production",
+          "description": "Full content production pipeline — takes a topic from blank page to published-ready piece. Use when you need to execute content: write a blog post, article, or guide end-to-end. Triggers: 'write a post about', 'draft an article', 'create content for', 'help me write', 'I need a blog post'. NOT for content strategy or calendar planning (use content-strategy). NOT for repurposing existing content (use content-repurposing). NOT for social captions only.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-strategy",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-strategy",
+          "description": "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions \\\"content strategy,\\\" \\\"what should I write about,\\\" \\\"content ideas,\\\" \\\"blog strategy,\\\" \\\"topic clusters,\\\" or \\\"content planning.\\\" For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "contract-and-proposal-writer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/contract-and-proposal-writer",
+          "description": "Contract & Proposal Writer",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copy-editing",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/copy-editing",
+          "description": "When the user wants to edit, review, or improve existing marketing copy. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' or 'copy sweep.' This skill provides a systematic approach to editing marketing copy through multiple focused passes.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "copywriting",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/copywriting",
+          "description": "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \\\"write copy for,\\\" \\\"improve this copy,\\\" \\\"rewrite this page,\\\" \\\"marketing copy,\\\" \\\"headline help,\\\" or \\\"CTA copy.\\\" For email copy, see email-sequence. For popup copy, see popup-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cs-content-creator",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-content-creator",
+          "description": "AI-powered content creation specialist for brand voice consistency, SEO optimization, and multi-platform content strategy",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-growth-strategist",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-growth-strategist",
+          "description": "Growth Strategist agent for revenue operations, sales engineering, customer success, and business development. Orchestrates business-growth skills. Spawn when users need pipeline analysis, churn prevention, expansion scoring, sales demos, or proposal writing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-quality-regulatory",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-quality-regulatory",
+          "description": "Quality & Regulatory agent for ISO 13485 QMS, MDR compliance, FDA submissions, GDPR/DSGVO, and ISMS audits. Orchestrates ra-qm-team skills. Spawn when users need regulatory strategy, audit preparation, CAPA management, risk management, or compliance documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-wiki-ingestor",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-wiki-ingestor",
+          "description": "Dispatched sub-agent that ingests a new source into an LLM Wiki vault. Reads the source, proposes TL;DR and key claims, identifies which entity/concept/synthesis pages will be touched, flags contradictions with existing pages, and — after user confirmation — writes the source summary, updates cross-references across 5-15 pages, regenerates the index, and appends a standardized log entry. Spawn when the user says \"ingest this\", \"add this paper/article/book to the wiki\", or drops a file into raw/.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-wiki-librarian",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-wiki-librarian",
+          "description": "Dispatched sub-agent that answers queries against an LLM Wiki vault. Reads index.md first, drills into 3-10 relevant pages across categories, synthesizes an answer with inline [[wikilink]] citations, and offers to file the answer back into the wiki as a new comparison or synthesis page. Spawn when the user asks a substantive question the wiki might answer, says \"what does the wiki say about X\", \"compare A and B across my sources\", or wants to explore a topic.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "demo-video",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/demo-video/skills/demo-video",
+          "description": "Use when the user asks to create a demo video, product walkthrough, feature showcase, animated presentation, marketing video, or GIF from screenshots or scene descriptions. Orchestrates playwright, ffmpeg, and edge-tts MCPs to produce polished video content.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "experiment-designer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/experiment-designer",
+          "description": "Use when planning product experiments, writing testable hypotheses, estimating sample size, prioritizing tests, or interpreting A/B outcomes with practical statistical rigor.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "extract",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/self-improving-agent/skills/extract",
+          "description": "Turn a proven pattern or debugging solution into a standalone reusable skill with SKILL.md, reference docs, and examples.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "free-tool-strategy",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/free-tool-strategy",
+          "description": "When the user wants to build a free tool for marketing — lead generation, SEO value, or brand awareness. Use when they mention 'engineering as marketing,' 'free tool,' 'calculator,' 'generator,' 'checker,' 'grader,' 'marketing tool,' 'lead gen tool,' 'build something for traffic,' 'interactive tool,' or 'free resource.' Covers idea evaluation, tool design, and launch strategy. For pure SEO content strategy (no tool), use seo-audit or content-strategy instead.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "gdpr-dsgvo-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/gdpr-dsgvo-expert",
+          "description": "GDPR and German DSGVO compliance automation. Scans codebases for privacy risks, generates DPIA documentation, tracks data subject rights requests. Use for GDPR compliance assessments, privacy audits, data protection planning, DPIA generation, and data subject rights management.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "generate",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/generate",
+          "description": "Generate Playwright tests. Use when user says \"write tests\", \"generate tests\", \"add tests for\", \"test this component\", \"e2e test\", \"create test for\", \"test this page\", or \"test this feature\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-workspace-cli",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/google-workspace-cli/skills/google-workspace-cli",
+          "description": "Google Workspace administration via the gws CLI. Install, authenticate, and automate Gmail, Drive, Sheets, Calendar, Docs, Chat, and Tasks. Run security audits, execute 43 built-in recipes, and use 10 persona bundles. Use for Google Workspace admin, gws CLI setup, Gmail automation, Drive management, or Calendar scheduling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Growth Marketer",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/growth-marketer",
+          "description": "Growth marketing specialist for bootstrapped startups and indie hackers. Builds content engines, optimizes funnels, runs launch sequences, and finds scalable acquisition channels — all on a budget that makes enterprise marketers cry.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "isms-audit-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/isms-audit-expert",
+          "description": "Information Security Management System (ISMS) audit expert for ISO 27001 compliance verification, security control assessment, and certification support. Use when the user mentions ISO 27001, ISMS audit, Annex A controls, Statement of Applicability (SOA), gap analysis, nonconformity management, internal audit, surveillance audit, or security certification preparation. Helps review control implementation evidence, document audit findings, classify nonconformities, generate risk-based audit plans, map controls to Annex A requirements, prepare Stage 1 and Stage 2 audit documentation, and support corrective action workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "karpathy-coder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/karpathy-coder/skills/karpathy-coder",
+          "description": "Use when writing, reviewing, or committing code to enforce Karpathy's 4 coding principles — surface assumptions before coding, keep it simple, make surgical changes, define verifiable goals. Triggers on \"review my diff\", \"check complexity\", \"am I overcomplicating this\", \"karpathy check\", \"before I commit\", or any code quality concern where the LLM might be overcoding.",
+          "version": "2.3.0"
+        },
+        {
+          "name": "landing-page-generator",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/landing-page-generator",
+          "description": "Generates high-converting landing pages as complete Next.js/React (TSX) components with Tailwind CSS. Creates hero sections, feature grids, pricing tables, FAQ accordions, testimonial blocks, and CTA sections using proven copy frameworks (PAS, AIDA, BAB). Outputs SEO meta tags, structured data, and performance-optimised code targeting Core Web Vitals (LCP < 1s, CLS < 0.1). Use when the user asks to create a landing page, marketing page, homepage, single-page site, lead capture page, campaign page, promo page, or conversion-optimised web page — or when they want to A/B test landing page variants or replace a static page with one designed to convert.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "llm-wiki",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/llm-wiki/skills/llm-wiki",
+          "description": "Use when building or maintaining a persistent personal knowledge base (second brain) in Obsidian where an LLM incrementally ingests sources, updates entity/concept pages, maintains cross-references, and keeps a synthesis current. Triggers include \"second brain\", \"Obsidian wiki\", \"personal knowledge management\", \"ingest this paper/article/book\", \"build a research wiki\", \"compound knowledge\", \"Memex\", or whenever the user wants knowledge to accumulate across sessions instead of being re-derived by RAG on every query.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "marketing-ops",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-ops",
+          "description": "Central router for the marketing skill ecosystem. Use when unsure which marketing skill to use, when orchestrating a multi-skill campaign, or when coordinating across content, SEO, CRO, channels, and analytics. Also use when the user mentions 'marketing help,' 'campaign plan,' 'what should I do next,' 'marketing priorities,' or 'coordinate marketing.'",
+          "version": "1.0.0"
+        },
+        {
+          "name": "marketing-skills",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-skills",
+          "description": "42 marketing agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw, and 6 more coding agents. 7 pods: content, SEO, CRO, channels, growth, intelligence, sales. Foundation context + orchestration router. 27 Python tools (stdlib-only).",
+          "version": "2.0.0"
+        },
+        {
+          "name": "mdr-745-specialist",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/mdr-745-specialist",
+          "description": "EU MDR 2017/745 compliance specialist for medical device classification, technical documentation, clinical evidence, and post-market surveillance. Covers Annex VIII classification rules, Annex II/III technical files, Annex XIV clinical evaluation, and EUDAMED integration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "page-cro",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/page-cro",
+          "description": "When the user wants to optimize, improve, or increase conversions on any marketing page — including homepage, landing pages, pricing pages, feature pages, or blog posts. Also use when the user says \"CRO,\" \"conversion rate optimization,\" \"this page isn't converting,\" \"improve conversions,\" or \"why isn't this page working.\" For signup/registration flows, see signup-flow-cro. For post-signup activation, see onboarding-cro. For forms outside of signup, see form-cro. For popups/modals, see popup-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "paid-ads",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/paid-ads",
+          "description": "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions 'PPC,' 'paid media,' 'ad copy,' 'ad creative,' 'ROAS,' 'CPA,' 'ad campaign,' 'retargeting,' or 'audience targeting.' This skill covers campaign strategy, ad creation, audience targeting, and optimization.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "Product Manager",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/product-manager",
+          "description": "Ships outcomes, not features. Writes specs engineers actually read. Prioritizes ruthlessly. Kills darlings when the data says so. Operates at the intersection of user needs, business goals, and engineering reality.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "product-manager-toolkit",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/product-manager-toolkit",
+          "description": "Comprehensive toolkit for product managers including RICE prioritization, customer interview analysis, PRD templates, discovery frameworks, and go-to-market strategies. Use for feature prioritization, user research synthesis, requirement documentation, and product strategy development.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "product-strategist",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/product-strategist",
+          "description": "Strategic product leadership toolkit for Head of Product covering OKR cascade generation, quarterly planning, competitive landscape analysis, product vision documents, and team scaling proposals. Use when creating quarterly OKR documents, defining product goals or KPIs, building product roadmaps, running competitive analysis, drafting team structure or hiring plans, aligning product strategy across engineering and design, or generating cascaded goal hierarchies from company to team level.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "prompt-engineer-toolkit",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/prompt-engineer-toolkit",
+          "description": "Analyzes and rewrites prompts for better AI output, creates reusable prompt templates for marketing use cases (ad copy, email campaigns, social media), and structures end-to-end AI content workflows. Use when the user wants to improve prompts for AI-assisted marketing, build prompt templates, or optimize AI content workflows. Also use when the user mentions 'prompt engineering,' 'improve my prompts,' 'AI writing quality,' 'prompt templates,' or 'AI content workflow.'",
+          "version": "1.0.0"
+        },
+        {
+          "name": "prompt-governance",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/prompt-governance/skills/prompt-governance",
+          "description": "Use when managing prompts in production at scale: versioning prompts, running A/B tests on prompts, building prompt registries, preventing prompt regressions, or creating eval pipelines for production AI features. Triggers: 'manage prompts in production', 'prompt versioning', 'prompt regression', 'prompt A/B test', 'prompt registry', 'eval pipeline'. NOT for writing or improving individual prompts (use senior-prompt-engineer). NOT for RAG pipeline design (use rag-architect). NOT for LLM cost reduction (use llm-cost-optimizer).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "quality-documentation-manager",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/quality-documentation-manager",
+          "description": "Document control system management for medical device QMS. Covers document numbering, version control, change management, and 21 CFR Part 11 compliance. Use for document control procedures, change control workflow, document numbering, version management, electronic signature compliance, or regulatory documentation review.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "quality-manager-qms-iso13485",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/quality-manager-qms-iso13485",
+          "description": "ISO 13485 Quality Management System implementation and maintenance for medical device organizations. Provides QMS design, documentation control, internal auditing, CAPA management, and certification support. Use when working with medical device quality systems, preparing for ISO 13485 audits, managing regulatory compliance documentation, setting up corrective actions, or building audit preparation programs. Useful for quality management, audit preparation, regulatory compliance, medical device documentation, and corrective action workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "regulatory-affairs-head",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/regulatory-affairs-head",
+          "description": "Senior Regulatory Affairs Manager for HealthTech and MedTech companies. Prepares FDA 510(k), De Novo, and PMA submission packages; analyzes regulatory pathways for new medical devices; drafts responses to FDA deficiency letters and Notified Body queries; develops CE marking technical documentation under EU MDR 2017/745; coordinates multi-market approval strategies across FDA, EU, Health Canada, PMDA, and NMPA; and maintains regulatory intelligence on evolving standards. Use when users need to plan or execute FDA submissions, navigate 510(k) or PMA approval processes, achieve CE marking, prepare pre-submission meeting materials, write regulatory strategy documents, respond to agency queries, or manage compliance documentation for medical device market access.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "research-summarizer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/research-summarizer/skills/research-summarizer",
+          "description": "Structured research summarization agent skill for non-dev users. Handles academic papers, web articles, reports, and documentation. Extracts key findings, generates comparative analyses, and produces properly formatted citations. Use when: user wants to summarize a research paper, compare multiple sources, extract citations from documents, or create structured research briefs. Plugin for Claude Code, Codex, Gemini CLI, and OpenClaw.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "sales-engineer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/sales-engineer",
+          "description": "Analyzes RFP/RFI responses for coverage gaps, builds competitive feature comparison matrices, and plans proof-of-concept (POC) engagements for pre-sales engineering. Use when responding to RFPs, bids, or proposal requests; comparing product features against competitors; planning or scoring a customer POC or sales demo; preparing a technical proposal; or performing win/loss competitor analysis. Handles tasks described as 'RFP response', 'bid response', 'proposal response', 'competitor comparison', 'feature matrix', 'POC planning', 'sales demo prep', or 'pre-sales engineering'.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "schema-markup",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/schema-markup",
+          "description": "When the user wants to implement, audit, or validate structured data (schema markup) on their website. Use when the user mentions 'structured data,' 'schema.org,' 'JSON-LD,' 'rich results,' 'rich snippets,' 'schema markup,' 'FAQ schema,' 'Product schema,' 'HowTo schema,' or 'structured data errors in Search Console.' Also use when someone asks why their content isn't showing rich results or wants to improve AI search visibility. NOT for general SEO audits (use seo-audit) or technical SEO crawl issues (use site-architecture).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "senior-qa",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-qa",
+          "description": "Generates unit tests, integration tests, and E2E tests for React/Next.js applications. Scans components to create Jest + React Testing Library test stubs, analyzes Istanbul/LCOV coverage reports to surface gaps, scaffolds Playwright test files from Next.js routes, mocks API calls with MSW, creates test fixtures, and configures test runners. Use when the user asks to \"generate tests\", \"write unit tests\", \"analyze test coverage\", \"scaffold E2E tests\", \"set up Playwright\", \"configure Jest\", \"implement testing patterns\", or \"improve test quality\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "seo-auditor",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/seo-auditor",
+          "description": "Scan and optimize documentation files for SEO. Audits README.md files and docs/ pages for meta tags, headings, keywords, readability, duplicate content, and broken links. Applies fixes, updates sitemap.xml, and generates a report. Usage: /seo-auditor [path]",
+          "version": "0.0.0"
+        },
+        {
+          "name": "site-architecture",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/site-architecture",
+          "description": "When the user wants to audit, redesign, or plan their website's structure, URL hierarchy, navigation design, or internal linking strategy. Use when the user mentions 'site architecture,' 'URL structure,' 'internal links,' 'site navigation,' 'breadcrumbs,' 'topic clusters,' 'hub pages,' 'orphan pages,' 'silo structure,' 'information architecture,' or 'website reorganization.' Also use when someone has SEO problems and the root cause is structural (not content or schema). NOT for content strategy decisions about what to write (use content-strategy) or for schema markup (use schema-markup).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "snowflake-development",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/snowflake-development/skills/snowflake-development",
+          "description": "Use when writing Snowflake SQL, building data pipelines with Dynamic Tables or Streams/Tasks, using Cortex AI functions, creating Cortex Agents, writing Snowpark Python, configuring dbt for Snowflake, or troubleshooting Snowflake errors.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "social-content",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/social-content",
+          "description": "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, or other platforms. Also use when the user mentions 'LinkedIn post,' 'Twitter thread,' 'social media,' 'content calendar,' 'social scheduling,' 'engagement,' or 'viral content.' This skill covers content creation, repurposing, and platform-specific strategies.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "social-media-manager",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/social-media-manager",
+          "description": "When the user wants to develop social media strategy, plan content calendars, manage community engagement, or grow their social presence across platforms. Also use when the user mentions 'social media strategy,' 'social calendar,' 'community management,' 'social media plan,' 'grow followers,' 'engagement rate,' 'social media audit,' or 'which platforms should I use.' For writing individual social posts, see social-content. For analyzing social performance data, see social-media-analyzer.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "spec-driven-workflow",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/spec-driven-workflow",
+          "description": "Use when the user asks to write specs before code, define acceptance criteria, plan features before implementation, generate tests from specifications, or follow spec-first development practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "sql-database-assistant",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/sql-database-assistant",
+          "description": "Use when the user asks to write SQL queries, optimize database performance, generate migrations, explore database schemas, or work with ORMs like Prisma, Drizzle, TypeORM, or SQLAlchemy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "statistical-analyst",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/statistical-analyst/skills/statistical-analyst",
+          "description": "Run hypothesis tests, analyze A/B experiment results, calculate sample sizes, and interpret statistical significance with effect sizes. Use when you need to validate whether observed differences are real, size an experiment correctly before launch, or interpret test results with confidence.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "tc-tracker",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/tc-tracker",
+          "description": "Use when the user asks to track technical changes, create change records, manage TC lifecycles, or hand off work between AI sessions. Covers init/create/update/status/resume/close/export workflows for structured code change documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "tdd-guide",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/tdd-guide",
+          "description": "Test-driven development skill for writing unit tests, generating test fixtures and mocks, analyzing coverage gaps, and guiding red-green-refactor workflows across Jest, Pytest, JUnit, Vitest, and Mocha. Use when the user asks to write tests, improve test coverage, practice TDD, generate mocks or stubs, or mentions testing frameworks like Jest, pytest, or JUnit.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "team-communications",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/team-communications",
+          "description": "Write internal company communications — 3P updates (Progress/Plans/Problems), company-wide newsletters, FAQ roundups, incident reports, leadership updates, status reports, project updates, and general internal comms. Use this skill any time the user asks to draft, edit, or format something meant for internal audiences. Trigger on keywords like \"3P\", \"weekly update\", \"newsletter\", \"FAQ\", \"internal comms\", \"status report\", \"company update\", \"team update\", \"incident report\", or any request to summarize work for leadership, teammates, or the broader company. Even casual requests like \"write my update\" or \"summarize what my team did this week\" should trigger this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "threat-detection",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/threat-detection",
+          "description": "Use when hunting for threats in an environment, analyzing IOCs, or detecting behavioral anomalies in telemetry. Covers hypothesis-driven threat hunting, IOC sweep generation, z-score anomaly detection, and MITRE ATT&CK-mapped signal prioritization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ui-design-system",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ui-design-system",
+          "description": "UI design system toolkit for Senior UI Designer including design token generation, component documentation, responsive design calculations, and developer handoff tools. Use for creating design systems, maintaining visual consistency, and facilitating design-dev collaboration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ux-researcher-designer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ux-researcher-designer",
+          "description": "UX research and design toolkit for Senior UX Designer/Researcher including data-driven persona generation, journey mapping, usability testing frameworks, and research synthesis. Use for user research, persona creation, journey mapping, and design validation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "video-content-strategist",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/video-content-strategist/skills/video-content-strategist",
+          "description": "Use when planning video content strategy, writing video scripts, optimizing YouTube channels, building short-form video pipelines (Reels, TikTok, Shorts), or repurposing long-form content into video. Triggers: 'start a YouTube channel', 'video content strategy', 'write a video script', 'repurpose into video', 'YouTube SEO', 'short-form video'. NOT for written blog content (use content-production). NOT for social captions without video (use social-media-manager).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "wiki-ingest",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/wiki-ingest",
+          "description": "Ingest a source file from raw/ into the LLM Wiki — read, discuss, write summary page, update cross-references across 5-15 pages, regenerate index, append to log. Usage /wiki-ingest <path-to-source>",
+          "version": "0.0.0"
+        },
+        {
+          "name": "wiki-query",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/wiki-query",
+          "description": "Query the LLM Wiki — reads index.md first, drills into 3-10 relevant pages, synthesizes an answer with inline [[wikilink]] citations, and offers to file the answer back as a new comparison or synthesis page. Usage /wiki-query \"<question>",
+          "version": "0.0.0"
+        },
+        {
+          "name": "x-twitter-growth",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/x-twitter-growth",
+          "description": "X/Twitter growth engine for building audience, crafting viral content, and analyzing engagement. Use when the user wants to grow on X/Twitter, write tweets or threads, analyze their X profile, research competitors on X, plan a posting strategy, or optimize engagement. Complements social-content (generic multi-platform) with X-specific depth: algorithm mechanics, thread engineering, reply strategy, profile optimization, and competitive intelligence via web search.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "alirezarezvani",
+        "repo": "claude-skills",
+        "repoUrl": "https://github.com/alirezarezvani/claude-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "alirezarezvani-claude-skills-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from alirezarezvani/claude-skills.",
+      "author": "ASM (alirezarezvani/claude-skills)",
+      "createdAt": "2026-05-09T08:10:59.479Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "alirezarezvani",
+        "claude-skills"
+      ],
+      "skills": [
+        {
+          "name": "a11y-audit",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/a11y-audit/skills/a11y-audit",
+          "description": "Accessibility audit skill for scanning, fixing, and verifying WCAG 2.2 Level A and AA compliance across React, Next.js, Vue, Angular, Svelte, and plain HTML codebases. Use when auditing accessibility, fixing a11y violations, checking color contrast, generating compliance reports, or integrating accessibility checks into CI/CD pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "adversarial-reviewer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/adversarial-reviewer",
+          "description": "Adversarial code review that breaks the self-review monoculture. Use when you want a genuinely critical review of recent changes, before merging a PR, or when you suspect Claude is being too agreeable about code quality. Forces perspective shifts through hostile reviewer personas that catch blind spots the author's mental model shares with the reviewer.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "agent-protocol",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agent-protocol",
+          "description": "Inter-agent communication protocol for C-suite agent teams. Defines invocation syntax, loop prevention, isolation rules, and response formats. Use when C-suite agents need to query each other, coordinate cross-functional analysis, or run board meetings with multiple agent roles.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "agenthub",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub/skills/agenthub",
+          "description": "Multi-agent collaboration plugin that spawns N parallel subagents competing on the same task via git worktree isolation. Agents work independently, results are evaluated by metric or LLM judge, and the best branch is merged. Use when: user wants multiple approaches tried in parallel — code optimization, content variation, research exploration, or any task that benefits from parallel competition. Requires: a git repo.",
+          "version": "2.1.2"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ai-seo",
+          "description": "Optimize content to get cited by AI search engines — ChatGPT, Perplexity, Google AI Overviews, Claude, Gemini, Copilot. Use when you want your content to appear in AI-generated answers, not just ranked in blue links. Triggers: 'optimize for AI search', 'get cited by ChatGPT', 'AI Overviews', 'Perplexity citations', 'AI SEO', 'generative search', 'LLM visibility', 'GEO' (generative engine optimization). NOT for traditional SEO ranking (use seo-audit). NOT for content creation (use content-production).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "analytics-tracking",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/analytics-tracking",
+          "description": "Set up, audit, and debug analytics tracking implementation — GA4, Google Tag Manager, event taxonomy, conversion tracking, and data quality. Use when building a tracking plan from scratch, auditing existing analytics for gaps or errors, debugging missing events, or setting up GTM. Trigger keywords: GA4 setup, Google Tag Manager, GTM, event tracking, analytics implementation, conversion tracking, tracking plan, event taxonomy, custom dimensions, UTM tracking, analytics audit, missing events, tracking broken. NOT for analyzing marketing campaign data — use campaign-analytics for that. NOT for BI dashboards — use product-analytics for in-product event analysis.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "api-design-reviewer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/api-design-reviewer",
+          "description": "API Design Reviewer",
+          "version": "0.0.0"
+        },
+        {
+          "name": "app-store-optimization",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/app-store-optimization",
+          "description": "App Store Optimization (ASO) toolkit for researching keywords, analyzing competitor rankings, generating metadata suggestions, and improving app visibility on Apple App Store and Google Play Store. Use when the user asks about ASO, app store rankings, app metadata, app titles and descriptions, app store listings, app visibility, or mobile app marketing on iOS or Android. Supports keyword research and scoring, competitor keyword analysis, metadata optimization, A/B test planning, launch checklists, and tracking ranking changes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "atlassian-admin",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/atlassian-admin",
+          "description": "Atlassian Administrator for managing and organizing Atlassian products (Jira, Confluence, Bitbucket, Trello), users, permissions, security, integrations, system configuration, and org-wide governance. Use when asked to add users to Jira, change Confluence permissions, configure access control, update admin settings, manage Atlassian groups, set up SSO, install marketplace apps, review security policies, or handle any org-wide Atlassian administration task.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autoresearch-agent",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/autoresearch-agent/skills/autoresearch-agent",
+          "description": "Autonomous experiment loop that optimizes any file by a measurable metric. Inspired by Karpathy's autoresearch. The agent edits a target file, runs a fixed evaluation, keeps improvements (git commit), discards failures (git reset), and loops indefinitely. Use when: user wants to optimize code speed, reduce bundle/image size, improve test pass rate, optimize prompts, improve content quality (headlines, copy, CTR), or run any measurable improvement loop. Requires: a target file, an evaluation command that outputs a metric, and a git repo.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "board-deck-builder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/board-deck-builder",
+          "description": "Assembles comprehensive board and investor update decks by pulling perspectives from all C-suite roles. Use when preparing board meetings, investor updates, quarterly business reviews, or fundraising narratives. Covers structure, narrative framework, bad news delivery, and common mistakes.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "board-meeting",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/board-meeting",
+          "description": "Multi-agent board meeting protocol for strategic decisions. Runs a structured 6-phase deliberation: context loading, independent C-suite contributions (isolated, no cross-pollination), critic analysis, synthesis, founder review, and decision extraction. Use when the user invokes /cs:board, calls a board meeting, or wants structured multi-perspective executive deliberation on a strategic question.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "business-investment-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/business-investment-advisor/skills/business-investment-advisor",
+          "description": "Business investment analysis and capital allocation advisor. Use when evaluating whether to invest in equipment, real estate, a new business, hiring, technology, or any capital expenditure. Also use for ROI calculations, IRR, NPV, payback period, build vs buy decisions, lease vs buy analysis, vendor evaluation, or deciding where to allocate limited budget for maximum return.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "campaign-analytics",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/campaign-analytics",
+          "description": "Analyzes campaign performance with multi-touch attribution, funnel conversion analysis, and ROI calculation for marketing optimization. Use when analyzing marketing campaigns, ad performance, attribution models, conversion rates, or calculating marketing ROI, ROAS, CPA, and campaign metrics across channels.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "capa-officer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/capa-officer",
+          "description": "CAPA system management for medical device QMS. Covers root cause analysis, corrective action planning, effectiveness verification, and CAPA metrics. Use for CAPA investigations, 5-Why analysis, fishbone diagrams, root cause determination, corrective action tracking, effectiveness verification, or CAPA program optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "challenge",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/executive-mentor/skills/challenge",
+          "description": "/em -challenge — Pre-Mortem Plan Analysis",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-reviewer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-reviewer",
+          "description": "Code review automation for TypeScript, JavaScript, Python, Go, Swift, Kotlin. Analyzes PRs for complexity and risk, checks code quality for SOLID violations and code smells, generates review reports. Use when reviewing pull requests, analyzing code quality, identifying issues, generating review checklists.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-tour",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-tour/skills/code-tour",
+          "description": "Use when the user asks to create a CodeTour .tour file — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. Trigger for: create a tour, onboarding tour, architecture tour, PR review tour, explain how X works, vibe check, RCA tour, contributor guide, or any structured code walkthrough request.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "command-guide",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/command-guide",
+          "description": "Claude Code Command Selection Guide - Automatically recommend and select the right commands, agents, and skills in Claude Code. Use when: (1) user is unsure which command or tool to use, (2) needs to decide which agent/skill best fits the current task, (3) querying usage scenarios for /plan, /tdd, /compact, /loop and other commands, (4) understanding when to invoke planner, code-reviewer, build-error-resolver and other agents, (5) needs command cheat sheet or decision flowchart. Triggers: \"which command to use\", \"which agent\", \"command selection\", \"how to use /plan\", \"when to use /compact\", \"agent selection guide\", \"command cheat sheet\", \"skill recommendation\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "competitive-intel",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitive-intel",
+          "description": "Systematic competitor tracking that feeds CMO positioning, CRO battlecards, and CPO roadmap decisions. Use when analyzing competitors, building sales battlecards, tracking market moves, positioning against alternatives, or when user mentions competitive intelligence, competitive analysis, competitor research, battlecards, win/loss, or market positioning.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitive-matrix",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/competitive-matrix",
+          "description": "Build competitive analysis matrices with scoring and gap analysis. Usage: /competitive-matrix <analyze> [options]",
+          "version": "0.0.0"
+        },
+        {
+          "name": "competitive-teardown",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitive-teardown",
+          "description": "Analyzes competitor products and companies by synthesizing data from pricing pages, app store reviews, job postings, SEO signals, and social media into structured competitive intelligence. Produces feature comparison matrices scored across 12 dimensions, SWOT analyses, positioning maps, UX audits, pricing model breakdowns, action item roadmaps, and stakeholder presentation templates. Use when conducting competitor analysis, comparing products against competitors, researching the competitive landscape, building battle cards for sales, preparing for a product strategy or roadmap session, responding to a competitor's new feature or pricing change, or performing a quarterly competitive review.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "competitor-alternatives",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitor-alternatives",
+          "description": "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'switch from competitor,' or 'comparison content.' Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. Emphasizes deep research, modular content architecture, and varied section types beyond feature tables.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-creator",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-creator",
+          "description": "Deprecated redirect skill that routes legacy 'content creator' requests to the correct specialist. Use when a user invokes 'content creator', asks to write a blog post, article, guide, or brand voice analysis (routes to content-production), or asks to plan content, build a topic cluster, or create a content calendar (routes to content-strategy). Does not handle requests directly — identifies user intent and redirects to content-production for writing/SEO/brand-voice tasks or content-strategy for planning tasks.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "copy-editing",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/copy-editing",
+          "description": "When the user wants to edit, review, or improve existing marketing copy. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' or 'copy sweep.' This skill provides a systematic approach to editing marketing copy through multiple focused passes.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cs-financial-analyst",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-financial-analyst",
+          "description": "Financial Analyst agent for DCF valuation, financial modeling, budgeting, forecasting, and SaaS metrics (ARR, MRR, churn, CAC, LTV, NRR). Orchestrates finance skills. Spawn when users need financial analysis, valuation models, budget planning, ratio analysis, SaaS health checks, or unit economics projections.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-growth-strategist",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-growth-strategist",
+          "description": "Growth Strategist agent for revenue operations, sales engineering, customer success, and business development. Orchestrates business-growth skills. Spawn when users need pipeline analysis, churn prevention, expansion scoring, sales demos, or proposal writing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-karpathy-reviewer",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-karpathy-reviewer",
+          "description": "Reviews staged git changes against Karpathy's 4 coding principles. Runs complexity_checker on changed files, diff_surgeon on the diff, and produces a verdict with specific fix recommendations. Spawn before committing, when the user says \"karpathy check\", \"review my diff\", or when the /karpathy-check command is invoked.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-product-strategist",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-product-strategist",
+          "description": "Product strategy agent for quarterly OKR planning, competitive landscape analysis, product vision development, and strategy pivot evaluation",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-senior-engineer",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-senior-engineer",
+          "description": "Senior Engineer agent for architecture decisions, code review, DevOps, and API design. Orchestrates engineering and engineering-team skills for technical implementation work. Spawn when users need system design, code quality review, CI/CD pipeline setup, or infrastructure decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-ux-researcher",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-ux-researcher",
+          "description": "UX research agent for research planning, persona generation, journey mapping, and usability test analysis",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-wiki-ingestor",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-wiki-ingestor",
+          "description": "Dispatched sub-agent that ingests a new source into an LLM Wiki vault. Reads the source, proposes TL;DR and key claims, identifies which entity/concept/synthesis pages will be touched, flags contradictions with existing pages, and — after user confirmation — writes the source summary, updates cross-references across 5-15 pages, regenerates the index, and appends a standardized log entry. Spawn when the user says \"ingest this\", \"add this paper/article/book to the wiki\", or drops a file into raw/.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-wiki-librarian",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-wiki-librarian",
+          "description": "Dispatched sub-agent that answers queries against an LLM Wiki vault. Reads index.md first, drills into 3-10 relevant pages across categories, synthesizes an answer with inline [[wikilink]] citations, and offers to file the answer back into the wiki as a new comparison or synthesis page. Spawn when the user asks a substantive question the wiki might answer, says \"what does the wiki say about X\", \"compare A and B across my sources\", or wants to explore a topic.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "customer-success-manager",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/customer-success-manager",
+          "description": "Monitors customer health, predicts churn risk, and identifies expansion opportunities using weighted scoring models for SaaS customer success. Use when analyzing customer accounts, reviewing retention metrics, scoring at-risk customers, or when the user mentions churn, customer health scores, upsell opportunities, expansion revenue, retention analysis, or customer analytics. Runs three Python CLI tools to produce deterministic health scores, churn risk tiers, and prioritized expansion recommendations across Enterprise, Mid-Market, and SMB segments.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "decision-logger",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/decision-logger",
+          "description": "Two-layer memory architecture for board meeting decisions. Manages raw transcripts (Layer 1) and approved decisions (Layer 2). Use when logging decisions after a board meeting, reviewing past decisions with /cs:decisions, or checking overdue action items with /cs:review. Invoked automatically by the board-meeting skill after Phase 5 founder approval.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "eval",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub/skills/eval",
+          "description": "Evaluate and rank agent results by metric or LLM judge for an AgentHub session.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "finance-skills",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/finance-skills",
+          "description": "Financial analyst agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Ratio analysis, DCF valuation, budget variance, rolling forecasts. 4 Python tools (stdlib-only).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "financial-analyst",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/financial-analyst",
+          "description": "Performs financial ratio analysis, DCF valuation, budget variance analysis, and rolling forecast construction for strategic decision-making. Use when analyzing financial statements, building valuation models, assessing budget variances, or constructing financial projections and forecasts. Also applicable when users mention financial modeling, cash flow analysis, company valuation, financial projections, or spreadsheet analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "financial-health",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/financial-health",
+          "description": "Run financial ratio analysis, DCF valuation, budget variance analysis, and rolling forecasts. Usage: /financial-health <ratios|dcf|budget|forecast> <data.json>",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-workspace",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/google-workspace",
+          "description": "Google Workspace CLI operations: setup diagnostics, security audit, recipe discovery, and output analysis. Usage: /google-workspace <setup|audit|recipe|analyze> [options]",
+          "version": "0.0.0"
+        },
+        {
+          "name": "isms-audit-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/isms-audit-expert",
+          "description": "Information Security Management System (ISMS) audit expert for ISO 27001 compliance verification, security control assessment, and certification support. Use when the user mentions ISO 27001, ISMS audit, Annex A controls, Statement of Applicability (SOA), gap analysis, nonconformity management, internal audit, surveillance audit, or security certification preparation. Helps review control implementation evidence, document audit findings, classify nonconformities, generate risk-based audit plans, map controls to Annex A requirements, prepare Stage 1 and Stage 2 audit documentation, and support corrective action workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "karpathy-check",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/karpathy-check",
+          "description": "Run Karpathy's 4-principle review on staged changes or the last commit. Checks complexity, diff noise, hidden assumptions, and goal verification. Usage /karpathy-check [--last-commit]",
+          "version": "0.0.0"
+        },
+        {
+          "name": "karpathy-coder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/karpathy-coder/skills/karpathy-coder",
+          "description": "Use when writing, reviewing, or committing code to enforce Karpathy's 4 coding principles — surface assumptions before coding, keep it simple, make surgical changes, define verifiable goals. Triggers on \"review my diff\", \"check complexity\", \"am I overcomplicating this\", \"karpathy check\", \"before I commit\", or any code quality concern where the LLM might be overcoding.",
+          "version": "2.3.0"
+        },
+        {
+          "name": "llm-wiki",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/llm-wiki/skills/llm-wiki",
+          "description": "Use when building or maintaining a persistent personal knowledge base (second brain) in Obsidian where an LLM incrementally ingests sources, updates entity/concept pages, maintains cross-references, and keeps a synthesis current. Triggers include \"second brain\", \"Obsidian wiki\", \"personal knowledge management\", \"ingest this paper/article/book\", \"build a research wiki\", \"compound knowledge\", \"Memex\", or whenever the user wants knowledge to accumulate across sessions instead of being re-derived by RAG on every query.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "loop",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/autoresearch-agent/skills/loop",
+          "description": "Start an autonomous experiment loop with user-selected interval (10min, 1h, daily, weekly, monthly). Uses CronCreate for scheduling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "marketing-demand-acquisition",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-demand-acquisition",
+          "description": "Creates demand generation campaigns, optimizes paid ad spend across LinkedIn, Google, and Meta, develops SEO strategies, and structures partnership programs for Series A+ startups scaling internationally. Use when planning marketing strategy, growth marketing, advertising campaigns, PPC optimization, lead generation, pipeline generation, or startup marketing budgets. Covers multi-channel acquisition (Google Ads, LinkedIn Ads, Meta Ads), CAC analysis, MQL/SQL workflows, attribution modeling, technical SEO, and co-marketing partnerships for hybrid PLG/Sales-Led motions in EU/US/Canada markets.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "marketing-strategy-pmm",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-strategy-pmm",
+          "description": "Product marketing skill for positioning, GTM strategy, competitive intelligence, and product launches. Use when the user asks about product positioning, go-to-market planning, competitive analysis, target audience definition, ICP definition, market research, launch plans, or sales enablement. Covers April Dunford positioning, ICP definition, competitive battlecards, launch playbooks, and international market entry. Produces deliverables including positioning statements, battlecard documents, launch plans, and go-to-market strategies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "meeting-analyzer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/meeting-analyzer",
+          "description": "Analyzes meeting transcripts and recordings to surface behavioral patterns, communication anti-patterns, and actionable coaching feedback. Use this skill whenever the user uploads or points to meeting transcripts (.txt, .md, .vtt, .srt, .docx), asks about their communication habits, wants feedback on how they run meetings, requests speaking ratio analysis, mentions filler words or conflict avoidance, or wants to compare their communication across time periods. Also trigger when users mention tools like Granola, Otter, Fireflies, or Zoom transcripts. Even if the user just says \"look at my meetings\" or \"how do I come across in meetings\" — use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "org-health-diagnostic",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/org-health-diagnostic",
+          "description": "Cross-functional organizational health check combining signals from all C-suite roles. Scores 8 dimensions on a traffic-light scale with drill-down recommendations. Use when assessing overall company health, preparing for board reviews, identifying at-risk functions, or when user mentions org health, health check, or health dashboard.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "persona",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/persona",
+          "description": "Generate data-driven user personas for UX research and product design. Usage: /persona generate [options]",
+          "version": "0.0.0"
+        },
+        {
+          "name": "plugin-audit",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/plugin-audit",
+          "description": "Comprehensive audit pipeline for skills, plugins, agents, and commands. Validates structure, quality, security, marketplace compliance, cross-platform compatibility, and ecosystem integration. Runs all built-in validation tools, invokes domain-appropriate agents for code review, and produces a pass/fail gate report. Usage: /plugin-audit <skill-path>",
+          "version": "0.0.0"
+        },
+        {
+          "name": "postmortem",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/executive-mentor/skills/postmortem",
+          "description": "/em -postmortem — Honest Analysis of What Went Wrong",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pr-review-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/pr-review-expert",
+          "description": "Use when the user asks to review pull requests, analyze code changes, check for security issues in PRs, or assess code quality of diffs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "product-analytics",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/product-analytics",
+          "description": "Use when defining product KPIs, building metric dashboards, running cohort or retention analysis, or interpreting feature adoption trends across product stages.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "product-manager-toolkit",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/product-manager-toolkit",
+          "description": "Comprehensive toolkit for product managers including RICE prioritization, customer interview analysis, PRD templates, discovery frameworks, and go-to-market strategies. Use for feature prioritization, user research synthesis, requirement documentation, and product strategy development.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "product-skills",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/product-skills",
+          "description": "10 product agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. PM toolkit (RICE), agile PO, product strategist (OKR), UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, research summarizer. Python tools (stdlib-only).",
+          "version": "1.1.0"
+        },
+        {
+          "name": "product-strategist",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/product-strategist",
+          "description": "Strategic product leadership toolkit for Head of Product covering OKR cascade generation, quarterly planning, competitive landscape analysis, product vision documents, and team scaling proposals. Use when creating quarterly OKR documents, defining product goals or KPIs, building product roadmaps, running competitive analysis, drafting team structure or hiring plans, aligning product strategy across engineering and design, or generating cascaded goal hierarchies from company to team level.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "project-health",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/project-health",
+          "description": "Portfolio health dashboard and risk matrix analysis. Usage: /project-health <dashboard|risk> [options]",
+          "version": "0.0.0"
+        },
+        {
+          "name": "quality-documentation-manager",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/quality-documentation-manager",
+          "description": "Document control system management for medical device QMS. Covers document numbering, version control, change management, and 21 CFR Part 11 compliance. Use for document control procedures, change control workflow, document numbering, version management, electronic signature compliance, or regulatory documentation review.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "quality-manager-qmr",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/quality-manager-qmr",
+          "description": "Senior Quality Manager Responsible Person (QMR) for HealthTech and MedTech companies. Provides quality system governance, management review leadership, regulatory compliance oversight, and quality performance monitoring per ISO 13485 Clause 5.5.2.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "red-team",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/red-team",
+          "description": "Use when planning or executing authorized red team engagements, attack path analysis, or offensive security simulations. Covers MITRE ATT&CK kill-chain planning, technique scoring, choke point identification, OPSEC risk assessment, and crown jewel targeting.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "report",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/report",
+          "description": "Generate test report. Use when user says \"test report\", \"results summary\", \"test status\", \"show results\", \"test dashboard\", or \"how did tests go\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "research-summarizer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/research-summarizer/skills/research-summarizer",
+          "description": "Structured research summarization agent skill for non-dev users. Handles academic papers, web articles, reports, and documentation. Extracts key findings, generates comparative analyses, and produces properly formatted citations. Use when: user wants to summarize a research paper, compare multiple sources, extract citations from documents, or create structured research briefs. Plugin for Claude Code, Codex, Gemini CLI, and OpenClaw.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "resume",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/autoresearch-agent/skills/resume",
+          "description": "Resume a paused experiment. Checkout the experiment branch, read results history, continue iterating.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "revenue-operations",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/revenue-operations",
+          "description": "Analyzes sales pipeline health, revenue forecasting accuracy, and go-to-market efficiency metrics for SaaS revenue optimization. Use when analyzing sales pipeline coverage, forecasting revenue, evaluating go-to-market performance, reviewing sales metrics, assessing pipeline analysis, tracking forecast accuracy with MAPE, calculating GTM efficiency, or measuring sales efficiency and unit economics for SaaS teams.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "review",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/review",
+          "description": "Review Playwright tests for quality. Use when user says \"review tests\", \"check test quality\", \"audit tests\", \"improve tests\", \"test code review\", or \"playwright best practices check\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "risk-management-specialist",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/risk-management-specialist",
+          "description": "Medical device risk management specialist implementing ISO 14971 throughout product lifecycle. Provides risk analysis, risk evaluation, risk control, and post-production information analysis. Use when user mentions risk management, ISO 14971, risk analysis, FMEA, fault tree analysis, hazard identification, risk control, risk matrix, benefit-risk analysis, residual risk, risk acceptability, or post-market risk.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "sales-engineer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/sales-engineer",
+          "description": "Analyzes RFP/RFI responses for coverage gaps, builds competitive feature comparison matrices, and plans proof-of-concept (POC) engagements for pre-sales engineering. Use when responding to RFPs, bids, or proposal requests; comparing product features against competitors; planning or scoring a customer POC or sales demo; preparing a technical proposal; or performing win/loss competitor analysis. Handles tasks described as 'RFP response', 'bid response', 'proposal response', 'competitor comparison', 'feature matrix', 'POC planning', 'sales demo prep', or 'pre-sales engineering'.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scrum-master",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/scrum-master",
+          "description": "Advanced Scrum Master skill for data-driven agile team analysis and coaching. Use when the user asks about sprint planning, velocity tracking, retrospectives, standup facilitation, backlog grooming, story points, burndown charts, blocker resolution, or agile team health. Runs Python scripts to analyse sprint JSON exports from Jira or similar tools: velocity_analyzer.py for Monte Carlo sprint forecasting, sprint_health_scorer.py for multi-dimension health scoring, and retrospective_analyzer.py for action-item and theme tracking. Produces confidence-interval forecasts, health grade reports, and improvement-velocity trends for high-performing Scrum teams.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "security-pen-testing",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/security-pen-testing",
+          "description": "Use when the user asks to perform security audits, penetration testing, vulnerability scanning, OWASP Top 10 checks, or offensive security assessments. Covers static analysis, dependency scanning, secret detection, API security testing, and pen test report generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "self-eval",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/self-eval",
+          "description": "Honestly evaluate AI work quality using a two-axis scoring system. Use after completing a task, code review, or work session to get an unbiased assessment. Detects score inflation, forces devil's advocate reasoning, and persists scores across sessions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "self-improving-agent",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/self-improving-agent/skills/self-improving-agent",
+          "description": "Curate Claude Code's auto-memory into durable project knowledge. Analyze MEMORY.md for patterns, promote proven learnings to CLAUDE.md and .claude/rules/, extract recurring solutions into reusable skills. Use when: (1) reviewing what Claude has learned about your project, (2) graduating a pattern from notes to enforced rules, (3) turning a debugging solution into a skill, (4) checking memory health and capacity.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "senior-architect",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-architect",
+          "description": "This skill should be used when the user asks to \"design system architecture\", \"evaluate microservices vs monolith\", \"create architecture diagrams\", \"analyze dependencies\", \"choose a database\", \"plan for scalability\", \"make technical decisions\", or \"review system design\". Use for architecture decision records (ADRs), tech stack evaluation, system design reviews, dependency analysis, and generating architecture diagrams in Mermaid, PlantUML, or ASCII format.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "senior-backend",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-backend",
+          "description": "Designs and implements backend systems including REST APIs, microservices, database architectures, authentication flows, and security hardening. Use when the user asks to \"design REST APIs\", \"optimize database queries\", \"implement authentication\", \"build microservices\", \"review backend code\", \"set up GraphQL\", \"handle database migrations\", or \"load test APIs\". Covers Node.js/Express/Fastify development, PostgreSQL optimization, API security, and backend architecture patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "senior-data-scientist",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-data-scientist",
+          "description": "World-class senior data scientist skill specialising in statistical modeling, experiment design, causal inference, and predictive analytics. Covers A/B testing (sample sizing, two-proportion z-tests, Bonferroni correction), difference-in-differences, feature engineering pipelines (Scikit-learn, XGBoost), cross-validated model evaluation (AUC-ROC, AUC-PR, SHAP), and MLflow experiment tracking — using Python (NumPy, Pandas, Scikit-learn), R, and SQL. Use when designing or analysing controlled experiments, building and evaluating classification or regression models, performing causal analysis on observational data, engineering features for structured tabular datasets, or translating statistical findings into data-driven business decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "senior-frontend",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-frontend",
+          "description": "Frontend development skill for React, Next.js, TypeScript, and Tailwind CSS applications. Use when building React components, optimizing Next.js performance, analyzing bundle sizes, scaffolding frontend projects, implementing accessibility, or reviewing frontend code quality.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "senior-fullstack",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-fullstack",
+          "description": "Fullstack development toolkit with project scaffolding for Next.js, FastAPI, MERN, and Django stacks, code quality analysis with security and complexity scoring, and stack selection guidance. Use when the user asks to \"scaffold a new project\", \"create a Next.js app\", \"set up FastAPI with React\", \"analyze code quality\", \"audit my codebase\", \"what stack should I use\", \"generate project boilerplate\", or mentions fullstack development, project setup, or tech stack comparison.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "senior-ml-engineer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-ml-engineer",
+          "description": "ML engineering skill for productionizing models, building MLOps pipelines, and integrating LLMs. Covers model deployment, feature stores, drift monitoring, RAG systems, and cost optimization. Use when the user asks about deploying ML models to production, setting up MLOps infrastructure (MLflow, Kubeflow, Kubernetes, Docker), monitoring model performance or drift, building RAG pipelines, or integrating LLM APIs with retry logic and cost controls. Focused on production and operational concerns rather than model research or initial training.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "senior-pm",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-pm",
+          "description": "Senior Project Manager for enterprise software, SaaS, and digital transformation projects. Specializes in portfolio management, quantitative risk analysis, resource optimization, stakeholder alignment, and executive reporting. Uses advanced methodologies including EMV analysis, Monte Carlo simulation, WSJF prioritization, and multi-dimensional health scoring. Use when a user needs help with project plans, project status reports, risk assessments, resource allocation, project roadmaps, milestone tracking, team capacity planning, portfolio health reviews, program management, or executive-level project reporting — especially for enterprise-scale initiatives with multiple workstreams, complex dependencies, or multi-million dollar budgets.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "senior-prompt-engineer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-prompt-engineer",
+          "description": "This skill should be used when the user asks to \"optimize prompts\", \"design prompt templates\", \"evaluate LLM outputs\", \"build agentic systems\", \"implement RAG\", \"create few-shot examples\", \"analyze token usage\", or \"design AI workflows\". Use for prompt engineering patterns, LLM evaluation frameworks, agent architectures, and structured output design.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "alirezarezvani",
+        "repo": "claude-skills",
+        "repoUrl": "https://github.com/alirezarezvani/claude-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "alirezarezvani-claude-skills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from alirezarezvani/claude-skills.",
+      "author": "ASM (alirezarezvani/claude-skills)",
+      "createdAt": "2026-05-09T08:10:59.479Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "alirezarezvani",
+        "claude-skills"
+      ],
+      "skills": [
+        {
+          "name": "a11y-audit",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/a11y-audit/skills/a11y-audit",
+          "description": "Accessibility audit skill for scanning, fixing, and verifying WCAG 2.2 Level A and AA compliance across React, Next.js, Vue, Angular, Svelte, and plain HTML codebases. Use when auditing accessibility, fixing a11y violations, checking color contrast, generating compliance reports, or integrating accessibility checks into CI/CD pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ab-test-setup",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ab-test-setup",
+          "description": "When the user wants to plan, design, or implement an A/B test or experiment. Also use when the user mentions \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"conversion experiment,\" \"statistical significance,\" or \"test this.\" For tracking implementation, see analytics-tracking.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ad-creative",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ad-creative",
+          "description": "When the user needs to generate, iterate, or scale ad creative for paid advertising. Use when they say 'write ad copy,' 'generate headlines,' 'create ad variations,' 'bulk creative,' 'iterate on ads,' 'ad copy validation,' 'RSA headlines,' 'Meta ad copy,' 'LinkedIn ad,' or 'creative testing.' This is pure creative production — distinct from paid-ads (campaign strategy). Use ad-creative when you need the copy, not the campaign plan.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "adversarial-reviewer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/adversarial-reviewer",
+          "description": "Adversarial code review that breaks the self-review monoculture. Use when you want a genuinely critical review of recent changes, before merging a PR, or when you suspect Claude is being too agreeable about code quality. Forces perspective shifts through hostile reviewer personas that catch blind spots the author's mental model shares with the reviewer.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "agent-designer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agent-designer",
+          "description": "Use when the user asks to design multi-agent systems, create agent architectures, define agent communication patterns, or build autonomous agent workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-protocol",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agent-protocol",
+          "description": "Inter-agent communication protocol for C-suite agent teams. Defines invocation syntax, loop prevention, isolation rules, and response formats. Use when C-suite agents need to query each other, coordinate cross-functional analysis, or run board meetings with multiple agent roles.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "agent-workflow-designer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agent-workflow-designer",
+          "description": "Agent Workflow Designer",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agenthub",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub/skills/agenthub",
+          "description": "Multi-agent collaboration plugin that spawns N parallel subagents competing on the same task via git worktree isolation. Agents work independently, results are evaluated by metric or LLM judge, and the best branch is merged. Use when: user wants multiple approaches tried in parallel — code optimization, content variation, research exploration, or any task that benefits from parallel competition. Requires: a git repo.",
+          "version": "2.1.2"
+        },
+        {
+          "name": "agile-product-owner",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agile-product-owner/skills/agile-product-owner",
+          "description": "Agile product ownership for backlog management and sprint execution. Covers user story writing, acceptance criteria, sprint planning, and velocity tracking. Use for writing user stories, creating acceptance criteria, planning sprints, estimating story points, breaking down epics, or prioritizing backlog.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-security",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ai-security",
+          "description": "Use when assessing AI/ML systems for prompt injection, jailbreak vulnerabilities, model inversion risk, data poisoning exposure, or agent tool abuse. Covers MITRE ATLAS technique mapping, injection signature detection, and adversarial robustness scoring.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ai-seo",
+          "description": "Optimize content to get cited by AI search engines — ChatGPT, Perplexity, Google AI Overviews, Claude, Gemini, Copilot. Use when you want your content to appear in AI-generated answers, not just ranked in blue links. Triggers: 'optimize for AI search', 'get cited by ChatGPT', 'AI Overviews', 'Perplexity citations', 'AI SEO', 'generative search', 'LLM visibility', 'GEO' (generative engine optimization). NOT for traditional SEO ranking (use seo-audit). NOT for content creation (use content-production).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "analytics-tracking",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/analytics-tracking",
+          "description": "Set up, audit, and debug analytics tracking implementation — GA4, Google Tag Manager, event taxonomy, conversion tracking, and data quality. Use when building a tracking plan from scratch, auditing existing analytics for gaps or errors, debugging missing events, or setting up GTM. Trigger keywords: GA4 setup, Google Tag Manager, GTM, event tracking, analytics implementation, conversion tracking, tracking plan, event taxonomy, custom dimensions, UTM tracking, analytics audit, missing events, tracking broken. NOT for analyzing marketing campaign data — use campaign-analytics for that. NOT for BI dashboards — use product-analytics for in-product event analysis.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "api-design-reviewer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/api-design-reviewer",
+          "description": "API Design Reviewer",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-test-suite-builder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/api-test-suite-builder",
+          "description": "Use when the user asks to generate API tests, create integration test suites, test REST endpoints, or build contract tests.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "app-store-optimization",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/app-store-optimization",
+          "description": "App Store Optimization (ASO) toolkit for researching keywords, analyzing competitor rankings, generating metadata suggestions, and improving app visibility on Apple App Store and Google Play Store. Use when the user asks about ASO, app store rankings, app metadata, app titles and descriptions, app store listings, app visibility, or mobile app marketing on iOS or Android. Supports keyword research and scoring, competitor keyword analysis, metadata optimization, A/B test planning, launch checklists, and tracking ranking changes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apple-hig-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/apple-hig-expert/skills/apple-hig-expert",
+          "description": "Expert guidance on Apple Human Interface Guidelines (HIG). Covers iOS, macOS, and visionOS with 2026 Liquid Glass aesthetics and accessibility-first design.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "atlassian-admin",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/atlassian-admin",
+          "description": "Atlassian Administrator for managing and organizing Atlassian products (Jira, Confluence, Bitbucket, Trello), users, permissions, security, integrations, system configuration, and org-wide governance. Use when asked to add users to Jira, change Confluence permissions, configure access control, update admin settings, manage Atlassian groups, set up SSO, install marketplace apps, review security policies, or handle any org-wide Atlassian administration task.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "atlassian-templates",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/atlassian-templates",
+          "description": "Atlassian Template and Files Creator/Modifier expert for creating, modifying, and managing Jira and Confluence templates, blueprints, custom layouts, reusable components, and standardized content structures. Use when building org-wide templates, custom blueprints, page layouts, and automated content generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autoresearch-agent",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/autoresearch-agent/skills/autoresearch-agent",
+          "description": "Autonomous experiment loop that optimizes any file by a measurable metric. Inspired by Karpathy's autoresearch. The agent edits a target file, runs a fixed evaluation, keeps improvements (git commit), discards failures (git reset), and loops indefinitely. Use when: user wants to optimize code speed, reduce bundle/image size, improve test pass rate, optimize prompts, improve content quality (headlines, copy, CTR), or run any measurable improvement loop. Requires: a target file, an evaluation command that outputs a metric, and a git repo.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "aws-solution-architect",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/aws-solution-architect",
+          "description": "Design AWS architectures for startups using serverless patterns and IaC templates. Use when asked to design serverless architecture, create CloudFormation templates, optimize AWS costs, set up CI/CD pipelines, or migrate to AWS. Covers Lambda, API Gateway, DynamoDB, ECS, Aurora, and cost optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-cloud-architect",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/azure-cloud-architect",
+          "description": "Design Azure architectures for startups and enterprises. Use when asked to design Azure infrastructure, create Bicep/ARM templates, optimize Azure costs, set up Azure DevOps pipelines, or migrate to Azure. Covers AKS, App Service, Azure Functions, Cosmos DB, and cost optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "behuman",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/behuman/skills/behuman",
+          "description": "Use when the user wants more human-like AI responses — less robotic, less listy, more authentic. Triggers: 'behuman', 'be real', 'like a human', 'more human', 'less AI', 'talk like a person', 'mirror mode', 'stop being so AI', or when conversations are emotionally charged (grief, job loss, relationship advice, fear). NOT for technical questions, code generation, or factual lookups.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "board",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub/skills/board",
+          "description": "Read, write, and browse the AgentHub message board for agent coordination.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "board-deck-builder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/board-deck-builder",
+          "description": "Assembles comprehensive board and investor update decks by pulling perspectives from all C-suite roles. Use when preparing board meetings, investor updates, quarterly business reviews, or fundraising narratives. Covers structure, narrative framework, bad news delivery, and common mistakes.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "board-meeting",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/board-meeting",
+          "description": "Multi-agent board meeting protocol for strategic decisions. Runs a structured 6-phase deliberation: context loading, independent C-suite contributions (isolated, no cross-pollination), critic analysis, synthesis, founder review, and decision extraction. Use when the user invokes /cs:board, calls a board meeting, or wants structured multi-perspective executive deliberation on a strategic question.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "board-prep",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/executive-mentor/skills/board-prep",
+          "description": "/em -board-prep — Board Meeting Preparation",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brand-guidelines",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/brand-guidelines",
+          "description": "When the user wants to apply, document, or enforce brand guidelines for any product or company. Also use when the user mentions 'brand guidelines,' 'brand colors,' 'typography,' 'logo usage,' 'brand voice,' 'visual identity,' 'tone of voice,' 'brand standards,' 'style guide,' 'brand consistency,' or 'company design standards.' Covers color systems, typography, logo rules, imagery guidelines, and tone matrix for any brand — including Anthropic's official identity.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "browser-automation",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/browser-automation",
+          "description": "Use when the user asks to automate browser tasks, scrape websites, fill forms, capture screenshots, extract structured data from web pages, or build web automation workflows. NOT for testing — use playwright-pro for that.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "browserstack",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/browserstack",
+          "description": "Run tests on BrowserStack. Use when user mentions \"browserstack\", \"cross-browser\", \"cloud testing\", \"browser matrix\", \"test on safari\", \"test on firefox\", or \"browser compatibility\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "business-growth-skills",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/business-growth-skills",
+          "description": "4 business growth agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Customer success (health scoring, churn), sales engineer (RFP), revenue operations (pipeline, GTM), contract & proposal writer. Python tools (stdlib-only).",
+          "version": "1.1.0"
+        },
+        {
+          "name": "business-investment-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/business-investment-advisor/skills/business-investment-advisor",
+          "description": "Business investment analysis and capital allocation advisor. Use when evaluating whether to invest in equipment, real estate, a new business, hiring, technology, or any capital expenditure. Also use for ROI calculations, IRR, NPV, payback period, build vs buy decisions, lease vs buy analysis, vendor evaluation, or deciding where to allocate limited budget for maximum return.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "c-level-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/c-level-skills",
+          "description": "10 C-level advisory agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO, Executive Mentor. Multi-role board meetings, strategy routing, structured recommendations. For founders needing executive-level decision support.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "campaign-analytics",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/campaign-analytics",
+          "description": "Analyzes campaign performance with multi-touch attribution, funnel conversion analysis, and ROI calculation for marketing optimization. Use when analyzing marketing campaigns, ad performance, attribution models, conversion rates, or calculating marketing ROI, ROAS, CPA, and campaign metrics across channels.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "capa-officer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/capa-officer",
+          "description": "CAPA system management for medical device QMS. Covers root cause analysis, corrective action planning, effectiveness verification, and CAPA metrics. Use for CAPA investigations, 5-Why analysis, fishbone diagrams, root cause determination, corrective action tracking, effectiveness verification, or CAPA program optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ceo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ceo-advisor",
+          "description": "Executive leadership guidance for strategic decision-making, organizational development, and stakeholder management. Use when planning strategy, preparing board presentations, managing investors, developing organizational culture, making executive decisions, fundraising, or when user mentions CEO, strategic planning, board meetings, investor updates, organizational leadership, or executive strategy.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "cfo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cfo-advisor",
+          "description": "Financial leadership for startups and scaling companies. Financial modeling, unit economics, fundraising strategy, cash management, and board financial packages. Use when building financial models, analyzing unit economics, planning fundraising, managing cash runway, preparing board materials, or when user mentions CFO, burn rate, runway, fundraising, unit economics, LTV, CAC, term sheets, or financial strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "challenge",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/executive-mentor/skills/challenge",
+          "description": "/em -challenge — Pre-Mortem Plan Analysis",
+          "version": "0.0.0"
+        },
+        {
+          "name": "change-management",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/change-management",
+          "description": "Framework for rolling out organizational changes without chaos. Covers the ADKAR model adapted for startups, communication templates, resistance patterns, and change fatigue management. Handles process changes, org restructures, strategy pivots, and culture changes. Use when announcing a reorg, switching tools, pivoting strategy, killing a product, changing leadership, or when user mentions change management, change rollout, managing resistance, org change, reorg, or pivot communication.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "changelog-generator",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/changelog-generator",
+          "description": "Changelog Generator",
+          "version": "0.0.0"
+        },
+        {
+          "name": "chief-of-staff",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/chief-of-staff",
+          "description": "C-suite orchestration layer. Routes founder questions to the right advisor role(s), triggers multi-role board meetings for complex decisions, synthesizes outputs, and tracks decisions. Every C-suite interaction starts here. Loads company context automatically.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "chro-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/chro-advisor",
+          "description": "People leadership for scaling companies. Hiring strategy, compensation design, org structure, culture, and retention. Use when building hiring plans, designing comp frameworks, restructuring teams, managing performance, building culture, or when user mentions CHRO, HR, people strategy, talent, headcount, compensation, org design, retention, or performance management.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "churn-prevention",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/churn-prevention",
+          "description": "Reduce voluntary and involuntary churn through cancel flow design, save offers, exit surveys, and dunning sequences. Use when designing or optimizing a cancel flow, building save offers, setting up dunning emails, or reducing failed-payment churn. Trigger keywords: cancel flow, churn reduction, save offers, dunning, exit survey, payment recovery, win-back, involuntary churn, failed payments, cancel page. NOT for customer health scoring or expansion revenue — use customer-success-manager for that.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ci-cd-pipeline-builder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ci-cd-pipeline-builder",
+          "description": "CI/CD Pipeline Builder",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ciso-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ciso-advisor",
+          "description": "Security leadership for growth-stage companies. Risk quantification in dollars, compliance roadmap (SOC 2/ISO 27001/HIPAA/GDPR), security architecture strategy, incident response leadership, and board-level security reporting. Use when building security programs, justifying security budget, selecting compliance frameworks, managing incidents, assessing vendor risk, or when user mentions CISO, security strategy, compliance roadmap, zero trust, or board security reporting.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cloud-security",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cloud-security",
+          "description": "Use when assessing cloud infrastructure for security misconfigurations, IAM privilege escalation paths, S3 public exposure, open security group rules, or IaC security gaps. Covers AWS, Azure, and GCP posture assessment with MITRE ATT&CK mapping.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cmo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cmo-advisor",
+          "description": "Marketing leadership for scaling companies. Brand positioning, growth model design, marketing budget allocation, and marketing org design. Use when designing brand strategy, selecting growth models (PLG vs sales-led vs community-led), allocating marketing budgets, building marketing teams, or when user mentions CMO, brand strategy, growth model, CAC, LTV, channel mix, or marketing ROI.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "code-reviewer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-reviewer",
+          "description": "Code review automation for TypeScript, JavaScript, Python, Go, Swift, Kotlin. Analyzes PRs for complexity and risk, checks code quality for SOLID violations and code smells, generates review reports. Use when reviewing pull requests, analyzing code quality, identifying issues, generating review checklists.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-to-prd",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-to-prd/skills/code-to-prd",
+          "description": "Reverse-engineer any codebase into a complete Product Requirements Document (PRD). Analyzes routes, components, state management, API integrations, and user interactions to produce business-readable documentation detailed enough for engineers or AI agents to fully reconstruct every page and endpoint. Works with frontend frameworks (React, Vue, Angular, Svelte, Next.js, Nuxt), backend frameworks (NestJS, Django, Express, FastAPI), and fullstack applications. Trigger when users mention: generate PRD, reverse-engineer requirements, code to documentation, extract product specs from code, document page logic, analyze page fields and interactions, create a functional inventory, write requirements from an existing codebase, document API endpoints, or analyze backend routes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-tour",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-tour/skills/code-tour",
+          "description": "Use when the user asks to create a CodeTour .tour file — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. Trigger for: create a tour, onboarding tour, architecture tour, PR review tour, explain how X works, vibe check, RCA tour, contributor guide, or any structured code walkthrough request.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "codebase-onboarding",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/codebase-onboarding",
+          "description": "Codebase Onboarding",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cold-email",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cold-email",
+          "description": "When the user wants to write, improve, or build a sequence of B2B cold outreach emails to prospects who haven't asked to hear from them. Use when the user mentions 'cold email,' 'cold outreach,' 'prospecting emails,' 'SDR emails,' 'sales emails,' 'first touch email,' 'follow-up sequence,' or 'email prospecting.' Also use when they share an email draft that sounds too sales-y and needs to be humanized. Distinct from email-sequence (lifecycle/nurture to opted-in subscribers) — this is unsolicited outreach to new prospects. NOT for lifecycle emails, newsletters, or drip campaigns (use email-sequence).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "command-guide",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/command-guide",
+          "description": "Claude Code Command Selection Guide - Automatically recommend and select the right commands, agents, and skills in Claude Code. Use when: (1) user is unsure which command or tool to use, (2) needs to decide which agent/skill best fits the current task, (3) querying usage scenarios for /plan, /tdd, /compact, /loop and other commands, (4) understanding when to invoke planner, code-reviewer, build-error-resolver and other agents, (5) needs command cheat sheet or decision flowchart. Triggers: \"which command to use\", \"which agent\", \"command selection\", \"how to use /plan\", \"when to use /compact\", \"agent selection guide\", \"command cheat sheet\", \"skill recommendation\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "company-os",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/company-os",
+          "description": "The meta-framework for how a company runs — the connective tissue between all C-suite roles. Covers operating system selection (EOS, Scaling Up, OKR-native, hybrid), accountability charts, scorecards, meeting pulse, issue resolution, and 90-day rocks. Use when setting up company operations, selecting a management framework, designing meeting rhythms, building accountability systems, implementing OKRs, or when user mentions EOS, Scaling Up, operating system, L10 meetings, rocks, scorecard, accountability chart, or quarterly planning.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitive-intel",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitive-intel",
+          "description": "Systematic competitor tracking that feeds CMO positioning, CRO battlecards, and CPO roadmap decisions. Use when analyzing competitors, building sales battlecards, tracking market moves, positioning against alternatives, or when user mentions competitive intelligence, competitive analysis, competitor research, battlecards, win/loss, or market positioning.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitive-matrix",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/competitive-matrix",
+          "description": "Build competitive analysis matrices with scoring and gap analysis. Usage: /competitive-matrix <analyze> [options]",
+          "version": "0.0.0"
+        },
+        {
+          "name": "competitive-teardown",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitive-teardown",
+          "description": "Analyzes competitor products and companies by synthesizing data from pricing pages, app store reviews, job postings, SEO signals, and social media into structured competitive intelligence. Produces feature comparison matrices scored across 12 dimensions, SWOT analyses, positioning maps, UX audits, pricing model breakdowns, action item roadmaps, and stakeholder presentation templates. Use when conducting competitor analysis, comparing products against competitors, researching the competitive landscape, building battle cards for sales, preparing for a product strategy or roadmap session, responding to a competitor's new feature or pricing change, or performing a quarterly competitive review.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "competitor-alternatives",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitor-alternatives",
+          "description": "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'switch from competitor,' or 'comparison content.' Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. Emphasizes deep research, modular content architecture, and varied section types beyond feature tables.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "confluence-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/confluence-expert",
+          "description": "Atlassian Confluence expert for creating and managing spaces, knowledge bases, and documentation. Configures space permissions and hierarchies, creates page templates with macros, sets up documentation taxonomies, designs page layouts, and manages content governance. Use when users need to build or restructure a Confluence space, design page hierarchies with permission structures, author or standardise documentation templates, embed Jira reports in pages, run knowledge base audits, or establish documentation standards and collaborative workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Content Strategist",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/content-strategist",
+          "description": "Builds content engines that rank, convert, and compound. Thinks in systems — topic clusters, not individual posts. Every piece earns its place or gets killed.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-creator",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-creator",
+          "description": "Deprecated redirect skill that routes legacy 'content creator' requests to the correct specialist. Use when a user invokes 'content creator', asks to write a blog post, article, guide, or brand voice analysis (routes to content-production), or asks to plan content, build a topic cluster, or create a content calendar (routes to content-strategy). Does not handle requests directly — identifies user intent and redirects to content-production for writing/SEO/brand-voice tasks or content-strategy for planning tasks.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "content-humanizer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-humanizer",
+          "description": "Makes AI-generated content sound genuinely human — not just cleaned up, but alive. Use when content feels robotic, uses too many AI clichés, lacks personality, or reads like it was written by committee. Triggers: 'this sounds like AI', 'make it more human', 'add personality', 'it feels generic', 'sounds robotic', 'fix AI writing', 'inject our voice'. NOT for initial content creation (use content-production). NOT for SEO optimization (use content-production Mode 3).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-production",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-production",
+          "description": "Full content production pipeline — takes a topic from blank page to published-ready piece. Use when you need to execute content: write a blog post, article, or guide end-to-end. Triggers: 'write a post about', 'draft an article', 'create content for', 'help me write', 'I need a blog post'. NOT for content strategy or calendar planning (use content-strategy). NOT for repurposing existing content (use content-repurposing). NOT for social captions only.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-strategy",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-strategy",
+          "description": "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions \\\"content strategy,\\\" \\\"what should I write about,\\\" \\\"content ideas,\\\" \\\"blog strategy,\\\" \\\"topic clusters,\\\" or \\\"content planning.\\\" For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "context-engine",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/context-engine",
+          "description": "Loads and manages company context for all C-suite advisor skills. Reads ~/.claude/company-context.md, detects stale context (>90 days), enriches context during conversations, and enforces privacy/anonymization rules before external API calls.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "contract-and-proposal-writer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/contract-and-proposal-writer",
+          "description": "Contract & Proposal Writer",
+          "version": "0.0.0"
+        },
+        {
+          "name": "coo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/coo-advisor",
+          "description": "Operations leadership for scaling companies. Process design, OKR execution, operational cadence, and scaling playbooks. Use when designing operations, setting up OKRs, building processes, scaling teams, analyzing bottlenecks, planning operational cadence, or when user mentions COO, operations, process improvement, OKRs, scaling, operational efficiency, or execution.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "copy-editing",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/copy-editing",
+          "description": "When the user wants to edit, review, or improve existing marketing copy. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' or 'copy sweep.' This skill provides a systematic approach to editing marketing copy through multiple focused passes.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "copywriting",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/copywriting",
+          "description": "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \\\"write copy for,\\\" \\\"improve this copy,\\\" \\\"rewrite this page,\\\" \\\"marketing copy,\\\" \\\"headline help,\\\" or \\\"CTA copy.\\\" For email copy, see email-sequence. For popup copy, see popup-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "coverage",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/coverage",
+          "description": "Analyze test coverage gaps. Use when user says \"test coverage\", \"what's not tested\", \"coverage gaps\", \"missing tests\", \"coverage report\", or \"what needs testing\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cpo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cpo-advisor",
+          "description": "Product leadership for scaling companies. Product vision, portfolio strategy, product-market fit, and product org design. Use when setting product vision, managing a product portfolio, measuring PMF, designing product teams, prioritizing at the portfolio level, reporting to the board on product, or when user mentions CPO, product strategy, product-market fit, product organization, portfolio prioritization, or roadmap strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cro-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cro-advisor",
+          "description": "Revenue leadership for B2B SaaS companies. Revenue forecasting, sales model design, pricing strategy, net revenue retention, and sales team scaling. Use when designing the revenue engine, setting quotas, modeling NRR, evaluating pricing, building board forecasts, or when user mentions CRO, chief revenue officer, revenue strategy, sales model, ARR growth, NRR, expansion revenue, churn, pricing strategy, or sales capacity.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cs-cto-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-cto-advisor",
+          "description": "Technical leadership advisor for CTOs covering technology strategy, team scaling, architecture decisions, and engineering excellence",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-karpathy-reviewer",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-karpathy-reviewer",
+          "description": "Reviews staged git changes against Karpathy's 4 coding principles. Runs complexity_checker on changed files, diff_surgeon on the diff, and produces a verdict with specific fix recommendations. Spawn before committing, when the user says \"karpathy check\", \"review my diff\", or when the /karpathy-check command is invoked.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-onboard",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cs-onboard",
+          "description": "Founder onboarding interview that captures company context across 7 dimensions. Invoke with /cs:setup for initial interview or /cs:update for quarterly refresh. Generates ~/.claude/company-context.md used by all C-suite advisor skills.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cs-product-analyst",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-product-analyst",
+          "description": "Product analytics agent for KPI definition, dashboard setup, experiment design, and test result interpretation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-senior-engineer",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-senior-engineer",
+          "description": "Senior Engineer agent for architecture decisions, code review, DevOps, and API design. Orchestrates engineering and engineering-team skills for technical implementation work. Spawn when users need system design, code quality review, CI/CD pipeline setup, or infrastructure decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-ux-researcher",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-ux-researcher",
+          "description": "UX research agent for research planning, persona generation, journey mapping, and usability test analysis",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-workspace-admin",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-workspace-admin",
+          "description": "Google Workspace administration agent using the gws CLI. Orchestrates workspace setup, Gmail/Drive/Sheets/Calendar automation, security audits, and recipe execution. Spawn when users need Google Workspace automation, gws CLI help, or workspace administration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cto-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cto-advisor",
+          "description": "Technical leadership guidance for engineering teams, architecture decisions, and technology strategy. Use when assessing technical debt, scaling engineering teams, evaluating technologies, making architecture decisions, establishing engineering metrics, or when user mentions CTO, tech debt, technical debt, team scaling, architecture decisions, technology evaluation, engineering metrics, DORA metrics, or technology strategy.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "culture-architect",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/culture-architect",
+          "description": "Build, measure, and evolve company culture as operational behavior — not wall posters. Covers mission/vision/values workshops, values-to-behaviors translation, culture code creation, culture health assessment, and cultural rituals by stage. Use when building company values, assessing culture health, designing cultural rituals, creating culture codes, handling culture clashes, or when user mentions culture, values, culture debt, founder culture, or culture code.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "alirezarezvani",
+        "repo": "claude-skills",
+        "repoUrl": "https://github.com/alirezarezvani/claude-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "alirezarezvani-claude-skills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from alirezarezvani/claude-skills.",
+      "author": "ASM (alirezarezvani/claude-skills)",
+      "createdAt": "2026-05-09T08:10:59.479Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "alirezarezvani",
+        "claude-skills"
+      ],
+      "skills": [
+        {
+          "name": "a11y-audit",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/a11y-audit/skills/a11y-audit",
+          "description": "Accessibility audit skill for scanning, fixing, and verifying WCAG 2.2 Level A and AA compliance across React, Next.js, Vue, Angular, Svelte, and plain HTML codebases. Use when auditing accessibility, fixing a11y violations, checking color contrast, generating compliance reports, or integrating accessibility checks into CI/CD pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ab-test-setup",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ab-test-setup",
+          "description": "When the user wants to plan, design, or implement an A/B test or experiment. Also use when the user mentions \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"conversion experiment,\" \"statistical significance,\" or \"test this.\" For tracking implementation, see analytics-tracking.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "adversarial-reviewer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/adversarial-reviewer",
+          "description": "Adversarial code review that breaks the self-review monoculture. Use when you want a genuinely critical review of recent changes, before merging a PR, or when you suspect Claude is being too agreeable about code quality. Forces perspective shifts through hostile reviewer personas that catch blind spots the author's mental model shares with the reviewer.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "agent-designer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agent-designer",
+          "description": "Use when the user asks to design multi-agent systems, create agent architectures, define agent communication patterns, or build autonomous agent workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-protocol",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agent-protocol",
+          "description": "Inter-agent communication protocol for C-suite agent teams. Defines invocation syntax, loop prevention, isolation rules, and response formats. Use when C-suite agents need to query each other, coordinate cross-functional analysis, or run board meetings with multiple agent roles.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "agent-workflow-designer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agent-workflow-designer",
+          "description": "Agent Workflow Designer",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agenthub",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub/skills/agenthub",
+          "description": "Multi-agent collaboration plugin that spawns N parallel subagents competing on the same task via git worktree isolation. Agents work independently, results are evaluated by metric or LLM judge, and the best branch is merged. Use when: user wants multiple approaches tried in parallel — code optimization, content variation, research exploration, or any task that benefits from parallel competition. Requires: a git repo.",
+          "version": "2.1.2"
+        },
+        {
+          "name": "analytics-tracking",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/analytics-tracking",
+          "description": "Set up, audit, and debug analytics tracking implementation — GA4, Google Tag Manager, event taxonomy, conversion tracking, and data quality. Use when building a tracking plan from scratch, auditing existing analytics for gaps or errors, debugging missing events, or setting up GTM. Trigger keywords: GA4 setup, Google Tag Manager, GTM, event tracking, analytics implementation, conversion tracking, tracking plan, event taxonomy, custom dimensions, UTM tracking, analytics audit, missing events, tracking broken. NOT for analyzing marketing campaign data — use campaign-analytics for that. NOT for BI dashboards — use product-analytics for in-product event analysis.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "api-design-reviewer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/api-design-reviewer",
+          "description": "API Design Reviewer",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-test-suite-builder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/api-test-suite-builder",
+          "description": "Use when the user asks to generate API tests, create integration test suites, test REST endpoints, or build contract tests.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apple-hig-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/apple-hig-expert/skills/apple-hig-expert",
+          "description": "Expert guidance on Apple Human Interface Guidelines (HIG). Covers iOS, macOS, and visionOS with 2026 Liquid Glass aesthetics and accessibility-first design.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "atlassian-templates",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/atlassian-templates",
+          "description": "Atlassian Template and Files Creator/Modifier expert for creating, modifying, and managing Jira and Confluence templates, blueprints, custom layouts, reusable components, and standardized content structures. Use when building org-wide templates, custom blueprints, page layouts, and automated content generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autoresearch-agent",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/autoresearch-agent/skills/autoresearch-agent",
+          "description": "Autonomous experiment loop that optimizes any file by a measurable metric. Inspired by Karpathy's autoresearch. The agent edits a target file, runs a fixed evaluation, keeps improvements (git commit), discards failures (git reset), and loops indefinitely. Use when: user wants to optimize code speed, reduce bundle/image size, improve test pass rate, optimize prompts, improve content quality (headlines, copy, CTR), or run any measurable improvement loop. Requires: a target file, an evaluation command that outputs a metric, and a git repo.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "aws-solution-architect",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/aws-solution-architect",
+          "description": "Design AWS architectures for startups using serverless patterns and IaC templates. Use when asked to design serverless architecture, create CloudFormation templates, optimize AWS costs, set up CI/CD pipelines, or migrate to AWS. Covers Lambda, API Gateway, DynamoDB, ECS, Aurora, and cost optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-cloud-architect",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/azure-cloud-architect",
+          "description": "Design Azure architectures for startups and enterprises. Use when asked to design Azure infrastructure, create Bicep/ARM templates, optimize Azure costs, set up Azure DevOps pipelines, or migrate to Azure. Covers AKS, App Service, Azure Functions, Cosmos DB, and cost optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "board-deck-builder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/board-deck-builder",
+          "description": "Assembles comprehensive board and investor update decks by pulling perspectives from all C-suite roles. Use when preparing board meetings, investor updates, quarterly business reviews, or fundraising narratives. Covers structure, narrative framework, bad news delivery, and common mistakes.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "board-meeting",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/board-meeting",
+          "description": "Multi-agent board meeting protocol for strategic decisions. Runs a structured 6-phase deliberation: context loading, independent C-suite contributions (isolated, no cross-pollination), critic analysis, synthesis, founder review, and decision extraction. Use when the user invokes /cs:board, calls a board meeting, or wants structured multi-perspective executive deliberation on a strategic question.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "brand-guidelines",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/brand-guidelines",
+          "description": "When the user wants to apply, document, or enforce brand guidelines for any product or company. Also use when the user mentions 'brand guidelines,' 'brand colors,' 'typography,' 'logo usage,' 'brand voice,' 'visual identity,' 'tone of voice,' 'brand standards,' 'style guide,' 'brand consistency,' or 'company design standards.' Covers color systems, typography, logo rules, imagery guidelines, and tone matrix for any brand — including Anthropic's official identity.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "browser-automation",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/browser-automation",
+          "description": "Use when the user asks to automate browser tasks, scrape websites, fill forms, capture screenshots, extract structured data from web pages, or build web automation workflows. NOT for testing — use playwright-pro for that.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "business-investment-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/business-investment-advisor/skills/business-investment-advisor",
+          "description": "Business investment analysis and capital allocation advisor. Use when evaluating whether to invest in equipment, real estate, a new business, hiring, technology, or any capital expenditure. Also use for ROI calculations, IRR, NPV, payback period, build vs buy decisions, lease vs buy analysis, vendor evaluation, or deciding where to allocate limited budget for maximum return.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ceo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ceo-advisor",
+          "description": "Executive leadership guidance for strategic decision-making, organizational development, and stakeholder management. Use when planning strategy, preparing board presentations, managing investors, developing organizational culture, making executive decisions, fundraising, or when user mentions CEO, strategic planning, board meetings, investor updates, organizational leadership, or executive strategy.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "cfo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cfo-advisor",
+          "description": "Financial leadership for startups and scaling companies. Financial modeling, unit economics, fundraising strategy, cash management, and board financial packages. Use when building financial models, analyzing unit economics, planning fundraising, managing cash runway, preparing board materials, or when user mentions CFO, burn rate, runway, fundraising, unit economics, LTV, CAC, term sheets, or financial strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "chief-of-staff",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/chief-of-staff",
+          "description": "C-suite orchestration layer. Routes founder questions to the right advisor role(s), triggers multi-role board meetings for complex decisions, synthesizes outputs, and tracks decisions. Every C-suite interaction starts here. Loads company context automatically.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "chro-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/chro-advisor",
+          "description": "People leadership for scaling companies. Hiring strategy, compensation design, org structure, culture, and retention. Use when building hiring plans, designing comp frameworks, restructuring teams, managing performance, building culture, or when user mentions CHRO, HR, people strategy, talent, headcount, compensation, org design, retention, or performance management.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "churn-prevention",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/churn-prevention",
+          "description": "Reduce voluntary and involuntary churn through cancel flow design, save offers, exit surveys, and dunning sequences. Use when designing or optimizing a cancel flow, building save offers, setting up dunning emails, or reducing failed-payment churn. Trigger keywords: cancel flow, churn reduction, save offers, dunning, exit survey, payment recovery, win-back, involuntary churn, failed payments, cancel page. NOT for customer health scoring or expansion revenue — use customer-success-manager for that.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ci-cd-pipeline-builder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ci-cd-pipeline-builder",
+          "description": "CI/CD Pipeline Builder",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ciso-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ciso-advisor",
+          "description": "Security leadership for growth-stage companies. Risk quantification in dollars, compliance roadmap (SOC 2/ISO 27001/HIPAA/GDPR), security architecture strategy, incident response leadership, and board-level security reporting. Use when building security programs, justifying security budget, selecting compliance frameworks, managing incidents, assessing vendor risk, or when user mentions CISO, security strategy, compliance roadmap, zero trust, or board security reporting.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cmo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cmo-advisor",
+          "description": "Marketing leadership for scaling companies. Brand positioning, growth model design, marketing budget allocation, and marketing org design. Use when designing brand strategy, selecting growth models (PLG vs sales-led vs community-led), allocating marketing budgets, building marketing teams, or when user mentions CMO, brand strategy, growth model, CAC, LTV, channel mix, or marketing ROI.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "code-to-prd",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-to-prd/skills/code-to-prd",
+          "description": "Reverse-engineer any codebase into a complete Product Requirements Document (PRD). Analyzes routes, components, state management, API integrations, and user interactions to produce business-readable documentation detailed enough for engineers or AI agents to fully reconstruct every page and endpoint. Works with frontend frameworks (React, Vue, Angular, Svelte, Next.js, Nuxt), backend frameworks (NestJS, Django, Express, FastAPI), and fullstack applications. Trigger when users mention: generate PRD, reverse-engineer requirements, code to documentation, extract product specs from code, document page logic, analyze page fields and interactions, create a functional inventory, write requirements from an existing codebase, document API endpoints, or analyze backend routes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-tour",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-tour/skills/code-tour",
+          "description": "Use when the user asks to create a CodeTour .tour file — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. Trigger for: create a tour, onboarding tour, architecture tour, PR review tour, explain how X works, vibe check, RCA tour, contributor guide, or any structured code walkthrough request.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cold-email",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cold-email",
+          "description": "When the user wants to write, improve, or build a sequence of B2B cold outreach emails to prospects who haven't asked to hear from them. Use when the user mentions 'cold email,' 'cold outreach,' 'prospecting emails,' 'SDR emails,' 'sales emails,' 'first touch email,' 'follow-up sequence,' or 'email prospecting.' Also use when they share an email draft that sounds too sales-y and needs to be humanized. Distinct from email-sequence (lifecycle/nurture to opted-in subscribers) — this is unsolicited outreach to new prospects. NOT for lifecycle emails, newsletters, or drip campaigns (use email-sequence).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "command-guide",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/command-guide",
+          "description": "Claude Code Command Selection Guide - Automatically recommend and select the right commands, agents, and skills in Claude Code. Use when: (1) user is unsure which command or tool to use, (2) needs to decide which agent/skill best fits the current task, (3) querying usage scenarios for /plan, /tdd, /compact, /loop and other commands, (4) understanding when to invoke planner, code-reviewer, build-error-resolver and other agents, (5) needs command cheat sheet or decision flowchart. Triggers: \"which command to use\", \"which agent\", \"command selection\", \"how to use /plan\", \"when to use /compact\", \"agent selection guide\", \"command cheat sheet\", \"skill recommendation\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "company-os",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/company-os",
+          "description": "The meta-framework for how a company runs — the connective tissue between all C-suite roles. Covers operating system selection (EOS, Scaling Up, OKR-native, hybrid), accountability charts, scorecards, meeting pulse, issue resolution, and 90-day rocks. Use when setting up company operations, selecting a management framework, designing meeting rhythms, building accountability systems, implementing OKRs, or when user mentions EOS, Scaling Up, operating system, L10 meetings, rocks, scorecard, accountability chart, or quarterly planning.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitive-intel",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitive-intel",
+          "description": "Systematic competitor tracking that feeds CMO positioning, CRO battlecards, and CPO roadmap decisions. Use when analyzing competitors, building sales battlecards, tracking market moves, positioning against alternatives, or when user mentions competitive intelligence, competitive analysis, competitor research, battlecards, win/loss, or market positioning.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitive-matrix",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/competitive-matrix",
+          "description": "Build competitive analysis matrices with scoring and gap analysis. Usage: /competitive-matrix <analyze> [options]",
+          "version": "0.0.0"
+        },
+        {
+          "name": "competitive-teardown",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitive-teardown",
+          "description": "Analyzes competitor products and companies by synthesizing data from pricing pages, app store reviews, job postings, SEO signals, and social media into structured competitive intelligence. Produces feature comparison matrices scored across 12 dimensions, SWOT analyses, positioning maps, UX audits, pricing model breakdowns, action item roadmaps, and stakeholder presentation templates. Use when conducting competitor analysis, comparing products against competitors, researching the competitive landscape, building battle cards for sales, preparing for a product strategy or roadmap session, responding to a competitor's new feature or pricing change, or performing a quarterly competitive review.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "competitor-alternatives",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitor-alternatives",
+          "description": "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'switch from competitor,' or 'comparison content.' Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. Emphasizes deep research, modular content architecture, and varied section types beyond feature tables.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "confluence-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/confluence-expert",
+          "description": "Atlassian Confluence expert for creating and managing spaces, knowledge bases, and documentation. Configures space permissions and hierarchies, creates page templates with macros, sets up documentation taxonomies, designs page layouts, and manages content governance. Use when users need to build or restructure a Confluence space, design page hierarchies with permission structures, author or standardise documentation templates, embed Jira reports in pages, run knowledge base audits, or establish documentation standards and collaborative workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Content Strategist",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/content-strategist",
+          "description": "Builds content engines that rank, convert, and compound. Thinks in systems — topic clusters, not individual posts. Every piece earns its place or gets killed.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-creator",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-creator",
+          "description": "Deprecated redirect skill that routes legacy 'content creator' requests to the correct specialist. Use when a user invokes 'content creator', asks to write a blog post, article, guide, or brand voice analysis (routes to content-production), or asks to plan content, build a topic cluster, or create a content calendar (routes to content-strategy). Does not handle requests directly — identifies user intent and redirects to content-production for writing/SEO/brand-voice tasks or content-strategy for planning tasks.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "content-humanizer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-humanizer",
+          "description": "Makes AI-generated content sound genuinely human — not just cleaned up, but alive. Use when content feels robotic, uses too many AI clichés, lacks personality, or reads like it was written by committee. Triggers: 'this sounds like AI', 'make it more human', 'add personality', 'it feels generic', 'sounds robotic', 'fix AI writing', 'inject our voice'. NOT for initial content creation (use content-production). NOT for SEO optimization (use content-production Mode 3).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-production",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-production",
+          "description": "Full content production pipeline — takes a topic from blank page to published-ready piece. Use when you need to execute content: write a blog post, article, or guide end-to-end. Triggers: 'write a post about', 'draft an article', 'create content for', 'help me write', 'I need a blog post'. NOT for content strategy or calendar planning (use content-strategy). NOT for repurposing existing content (use content-repurposing). NOT for social captions only.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "context-engine",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/context-engine",
+          "description": "Loads and manages company context for all C-suite advisor skills. Reads ~/.claude/company-context.md, detects stale context (>90 days), enriches context during conversations, and enforces privacy/anonymization rules before external API calls.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "coo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/coo-advisor",
+          "description": "Operations leadership for scaling companies. Process design, OKR execution, operational cadence, and scaling playbooks. Use when designing operations, setting up OKRs, building processes, scaling teams, analyzing bottlenecks, planning operational cadence, or when user mentions COO, operations, process improvement, OKRs, scaling, operational efficiency, or execution.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "copywriting",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/copywriting",
+          "description": "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \\\"write copy for,\\\" \\\"improve this copy,\\\" \\\"rewrite this page,\\\" \\\"marketing copy,\\\" \\\"headline help,\\\" or \\\"CTA copy.\\\" For email copy, see email-sequence. For popup copy, see popup-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cpo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cpo-advisor",
+          "description": "Product leadership for scaling companies. Product vision, portfolio strategy, product-market fit, and product org design. Use when setting product vision, managing a product portfolio, measuring PMF, designing product teams, prioritizing at the portfolio level, reporting to the board on product, or when user mentions CPO, product strategy, product-market fit, product organization, portfolio prioritization, or roadmap strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cro-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cro-advisor",
+          "description": "Revenue leadership for B2B SaaS companies. Revenue forecasting, sales model design, pricing strategy, net revenue retention, and sales team scaling. Use when designing the revenue engine, setting quotas, modeling NRR, evaluating pricing, building board forecasts, or when user mentions CRO, chief revenue officer, revenue strategy, sales model, ARR growth, NRR, expansion revenue, churn, pricing strategy, or sales capacity.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cs-content-creator",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-content-creator",
+          "description": "AI-powered content creation specialist for brand voice consistency, SEO optimization, and multi-platform content strategy",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-demand-gen-specialist",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-demand-gen-specialist",
+          "description": "Demand generation and customer acquisition specialist for lead generation, conversion optimization, and multi-channel acquisition campaigns",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-engineering-lead",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-engineering-lead",
+          "description": "Engineering Team Lead agent for coordinating QA, security, data engineering, ML, and frontend/backend teams. Orchestrates engineering-team skills for team-level technical decisions. Spawn when users need team coordination, tech stack evaluation, incident response, or cross-functional engineering work.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-onboard",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cs-onboard",
+          "description": "Founder onboarding interview that captures company context across 7 dimensions. Invoke with /cs:setup for initial interview or /cs:update for quarterly refresh. Generates ~/.claude/company-context.md used by all C-suite advisor skills.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cs-product-analyst",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-product-analyst",
+          "description": "Product analytics agent for KPI definition, dashboard setup, experiment design, and test result interpretation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-senior-engineer",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-senior-engineer",
+          "description": "Senior Engineer agent for architecture decisions, code review, DevOps, and API design. Orchestrates engineering and engineering-team skills for technical implementation work. Spawn when users need system design, code quality review, CI/CD pipeline setup, or infrastructure decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-ux-researcher",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-ux-researcher",
+          "description": "UX research agent for research planning, persona generation, journey mapping, and usability test analysis",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cto-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cto-advisor",
+          "description": "Technical leadership guidance for engineering teams, architecture decisions, and technology strategy. Use when assessing technical debt, scaling engineering teams, evaluating technologies, making architecture decisions, establishing engineering metrics, or when user mentions CTO, tech debt, technical debt, team scaling, architecture decisions, technology evaluation, engineering metrics, DORA metrics, or technology strategy.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "culture-architect",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/culture-architect",
+          "description": "Build, measure, and evolve company culture as operational behavior — not wall posters. Covers mission/vision/values workshops, values-to-behaviors translation, culture code creation, culture health assessment, and cultural rituals by stage. Use when building company values, assessing culture health, designing cultural rituals, creating culture codes, handling culture clashes, or when user mentions culture, values, culture debt, founder culture, or culture code.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "database-designer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/database-designer",
+          "description": "Use when the user asks to design database schemas, plan data migrations, optimize queries, choose between SQL and NoSQL, or model data relationships.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "database-schema-designer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/database-schema-designer",
+          "description": "Use when the user asks to create ERD diagrams, normalize database schemas, design table relationships, or plan schema migrations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "DevOps Engineer",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/devops-engineer",
+          "description": "Builds infrastructure that scales without babysitting. Automates everything worth automating. Monitors before it breaks. Treats clicking in consoles as a production incident waiting to happen.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docker-development",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/docker-development/skills/docker-development",
+          "description": "Docker and container development agent skill and plugin for Dockerfile optimization, docker-compose orchestration, multi-stage builds, and container security hardening. Use when: user wants to optimize a Dockerfile, create or improve docker-compose configurations, implement multi-stage builds, audit container security, reduce image size, or follow container best practices. Covers build performance, layer caching, secret management, and production-ready container patterns.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "email-template-builder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/email-template-builder",
+          "description": "Email Template Builder",
+          "version": "0.0.0"
+        },
+        {
+          "name": "engineering-advanced-skills",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/engineering-advanced-skills",
+          "description": "25 advanced engineering agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Agent design, RAG, MCP servers, CI/CD, database design, observability, security auditing, release management, platform ops.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "engineering-skills",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/engineering-skills",
+          "description": "23 engineering agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw, and 6 more tools. Architecture, frontend, backend, QA, DevOps, security, AI/ML, data engineering, Playwright, Stripe, AWS, MS365. 30+ Python tools (stdlib-only).",
+          "version": "1.1.0"
+        },
+        {
+          "name": "epic-design",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/epic-design",
+          "description": "Build immersive, cinematic 2.5D interactive websites using scroll storytelling, parallax depth, text animations, and premium scroll effects — no WebGL required. Use this skill for any web design task: landing pages, product sites, hero sections, scroll animations, parallax, sticky sections, section overlaps, floating products between sections, clip-path reveals, text that flies in from sides, words that light up on scroll, curtain drops, iris opens, card stacks, bleed typography, and any site that should feel cinematic or premium. Trigger on phrases like \"make it feel alive\", \"Apple-style animation\", \"sections that overlap\", \"product rises between sections\", \"immersive\", \"scrollytelling\", or any scroll-driven visual effect. Covers 45+ techniques across 8 categories. Always inspects, judges, and plans assets before coding. Use aggressively for ANY web design task.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "experiment-designer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/experiment-designer",
+          "description": "Use when planning product experiments, writing testable hypotheses, estimating sample size, prioritizing tests, or interpreting A/B outcomes with practical statistical rigor.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fda-consultant-specialist",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/fda-consultant-specialist",
+          "description": "FDA regulatory consultant for medical device companies. Provides 510(k)/PMA/De Novo pathway guidance, QSR (21 CFR 820) compliance, HIPAA assessments, and device cybersecurity. Use when user mentions FDA submission, 510(k), PMA, De Novo, QSR, premarket, predicate device, substantial equivalence, HIPAA medical device, or FDA cybersecurity.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Finance Lead",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/finance-lead",
+          "description": "Startup CFO who builds models that survive contact with reality. Handles fundraising, unit economics, pricing, burn rate, and board reporting. Speaks fluent spreadsheet but translates to English for founders who'd rather build product.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "financial-analyst",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/financial-analyst",
+          "description": "Performs financial ratio analysis, DCF valuation, budget variance analysis, and rolling forecast construction for strategic decision-making. Use when analyzing financial statements, building valuation models, assessing budget variances, or constructing financial projections and forecasts. Also applicable when users mention financial modeling, cash flow analysis, company valuation, financial projections, or spreadsheet analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "focused-fix",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/focused-fix",
+          "description": "Use when the user asks to fix, debug, or make a specific feature/module/area work end-to-end. Triggers: 'make X work', 'fix the Y feature', 'the Z module is broken', 'focus on [area]'. Not for quick single-bug fixes — this is for systematic deep-dive repair across all files and dependencies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "free-tool-strategy",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/free-tool-strategy",
+          "description": "When the user wants to build a free tool for marketing — lead generation, SEO value, or brand awareness. Use when they mention 'engineering as marketing,' 'free tool,' 'calculator,' 'generator,' 'checker,' 'grader,' 'marketing tool,' 'lead gen tool,' 'build something for traffic,' 'interactive tool,' or 'free resource.' Covers idea evaluation, tool design, and launch strategy. For pure SEO content strategy (no tool), use seo-audit or content-strategy instead.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "gcp-cloud-architect",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/gcp-cloud-architect",
+          "description": "Design GCP architectures for startups and enterprises. Use when asked to design Google Cloud infrastructure, deploy to GKE or Cloud Run, configure BigQuery pipelines, optimize GCP costs, or migrate to GCP. Covers Cloud Run, GKE, Cloud Functions, Cloud SQL, BigQuery, and cost optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "generate",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/generate",
+          "description": "Generate Playwright tests. Use when user says \"write tests\", \"generate tests\", \"add tests for\", \"test this component\", \"e2e test\", \"create test for\", \"test this page\", or \"test this feature\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-workspace-cli",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/google-workspace-cli/skills/google-workspace-cli",
+          "description": "Google Workspace administration via the gws CLI. Install, authenticate, and automate Gmail, Drive, Sheets, Calendar, Docs, Chat, and Tasks. Run security audits, execute 43 built-in recipes, and use 10 persona bundles. Use for Google Workspace admin, gws CLI setup, Gmail automation, Drive management, or Calendar scheduling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Growth Marketer",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/growth-marketer",
+          "description": "Growth marketing specialist for bootstrapped startups and indie hackers. Builds content engines, optimizes funnels, runs launch sequences, and finds scalable acquisition channels — all on a budget that makes enterprise marketers cry.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "helm-chart-builder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/helm-chart-builder/skills/helm-chart-builder",
+          "description": "Helm chart development agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw — chart scaffolding, values design, template patterns, dependency management, security hardening, and chart testing. Use when: user wants to create or improve Helm charts, design values.yaml files, implement template helpers, audit chart security (RBAC, network policies, pod security), manage subcharts, or run helm lint/test.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "information-security-manager-iso27001",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/information-security-manager-iso27001",
+          "description": "ISO 27001 ISMS implementation and cybersecurity governance for HealthTech and MedTech companies. Use for ISMS design, security risk assessment, control implementation, ISO 27001 certification, security audits, incident response, and compliance verification. Covers ISO 27001, ISO 27002, healthcare security, and medical device cybersecurity.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "internal-narrative",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/internal-narrative",
+          "description": "Build and maintain one coherent company story across all audiences — employees, investors, customers, candidates, and partners. Detects narrative contradictions and ensures the same truth is framed for each audience's needs. Use when preparing investor updates, all-hands presentations, board communications, recruiting narratives, crisis communications, or when user mentions company narrative, messaging consistency, storytelling, all-hands, investor update, or crisis communication.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "interview-system-designer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/interview-system-designer",
+          "description": "This skill should be used when the user asks to \"design interview processes\", \"create hiring pipelines\", \"calibrate interview loops\", \"generate interview questions\", \"design competency matrices\", \"analyze interviewer bias\", \"create scoring rubrics\", \"build question banks\", or \"optimize hiring systems\". Use for designing role-specific interview loops, competency assessments, and hiring calibration systems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "intl-expansion",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/intl-expansion",
+          "description": "International market expansion strategy. Market selection, entry modes, localization, regulatory compliance, and go-to-market by region. Use when expanding to new countries, evaluating international markets, planning localization, or building regional teams.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "isms-audit-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/isms-audit-expert",
+          "description": "Information Security Management System (ISMS) audit expert for ISO 27001 compliance verification, security control assessment, and certification support. Use when the user mentions ISO 27001, ISMS audit, Annex A controls, Statement of Applicability (SOA), gap analysis, nonconformity management, internal audit, surveillance audit, or security certification preparation. Helps review control implementation evidence, document audit findings, classify nonconformities, generate risk-based audit plans, map controls to Annex A requirements, prepare Stage 1 and Stage 2 audit documentation, and support corrective action workflows.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "alirezarezvani",
+        "repo": "claude-skills",
+        "repoUrl": "https://github.com/alirezarezvani/claude-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "alirezarezvani-claude-skills-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from alirezarezvani/claude-skills.",
+      "author": "ASM (alirezarezvani/claude-skills)",
+      "createdAt": "2026-05-09T08:10:59.479Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "alirezarezvani",
+        "claude-skills"
+      ],
+      "skills": [
+        {
+          "name": "a11y-audit",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/a11y-audit/skills/a11y-audit",
+          "description": "Accessibility audit skill for scanning, fixing, and verifying WCAG 2.2 Level A and AA compliance across React, Next.js, Vue, Angular, Svelte, and plain HTML codebases. Use when auditing accessibility, fixing a11y violations, checking color contrast, generating compliance reports, or integrating accessibility checks into CI/CD pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-designer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agent-designer",
+          "description": "Use when the user asks to design multi-agent systems, create agent architectures, define agent communication patterns, or build autonomous agent workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-workflow-designer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agent-workflow-designer",
+          "description": "Agent Workflow Designer",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agile-product-owner",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agile-product-owner/skills/agile-product-owner",
+          "description": "Agile product ownership for backlog management and sprint execution. Covers user story writing, acceptance criteria, sprint planning, and velocity tracking. Use for writing user stories, creating acceptance criteria, planning sprints, estimating story points, breaking down epics, or prioritizing backlog.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ai-seo",
+          "description": "Optimize content to get cited by AI search engines — ChatGPT, Perplexity, Google AI Overviews, Claude, Gemini, Copilot. Use when you want your content to appear in AI-generated answers, not just ranked in blue links. Triggers: 'optimize for AI search', 'get cited by ChatGPT', 'AI Overviews', 'Perplexity citations', 'AI SEO', 'generative search', 'LLM visibility', 'GEO' (generative engine optimization). NOT for traditional SEO ranking (use seo-audit). NOT for content creation (use content-production).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "atlassian-admin",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/atlassian-admin",
+          "description": "Atlassian Administrator for managing and organizing Atlassian products (Jira, Confluence, Bitbucket, Trello), users, permissions, security, integrations, system configuration, and org-wide governance. Use when asked to add users to Jira, change Confluence permissions, configure access control, update admin settings, manage Atlassian groups, set up SSO, install marketplace apps, review security policies, or handle any org-wide Atlassian administration task.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-solution-architect",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/aws-solution-architect",
+          "description": "Design AWS architectures for startups using serverless patterns and IaC templates. Use when asked to design serverless architecture, create CloudFormation templates, optimize AWS costs, set up CI/CD pipelines, or migrate to AWS. Covers Lambda, API Gateway, DynamoDB, ECS, Aurora, and cost optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-cloud-architect",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/azure-cloud-architect",
+          "description": "Design Azure architectures for startups and enterprises. Use when asked to design Azure infrastructure, create Bicep/ARM templates, optimize Azure costs, set up Azure DevOps pipelines, or migrate to Azure. Covers AKS, App Service, Azure Functions, Cosmos DB, and cost optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "board-meeting",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/board-meeting",
+          "description": "Multi-agent board meeting protocol for strategic decisions. Runs a structured 6-phase deliberation: context loading, independent C-suite contributions (isolated, no cross-pollination), critic analysis, synthesis, founder review, and decision extraction. Use when the user invokes /cs:board, calls a board meeting, or wants structured multi-perspective executive deliberation on a strategic question.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "brand-guidelines",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/brand-guidelines",
+          "description": "When the user wants to apply, document, or enforce brand guidelines for any product or company. Also use when the user mentions 'brand guidelines,' 'brand colors,' 'typography,' 'logo usage,' 'brand voice,' 'visual identity,' 'tone of voice,' 'brand standards,' 'style guide,' 'brand consistency,' or 'company design standards.' Covers color systems, typography, logo rules, imagery guidelines, and tone matrix for any brand — including Anthropic's official identity.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "browser-automation",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/browser-automation",
+          "description": "Use when the user asks to automate browser tasks, scrape websites, fill forms, capture screenshots, extract structured data from web pages, or build web automation workflows. NOT for testing — use playwright-pro for that.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "browserstack",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/browserstack",
+          "description": "Run tests on BrowserStack. Use when user mentions \"browserstack\", \"cross-browser\", \"cloud testing\", \"browser matrix\", \"test on safari\", \"test on firefox\", or \"browser compatibility\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "business-growth-skills",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/business-growth-skills",
+          "description": "4 business growth agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Customer success (health scoring, churn), sales engineer (RFP), revenue operations (pipeline, GTM), contract & proposal writer. Python tools (stdlib-only).",
+          "version": "1.1.0"
+        },
+        {
+          "name": "business-investment-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/business-investment-advisor/skills/business-investment-advisor",
+          "description": "Business investment analysis and capital allocation advisor. Use when evaluating whether to invest in equipment, real estate, a new business, hiring, technology, or any capital expenditure. Also use for ROI calculations, IRR, NPV, payback period, build vs buy decisions, lease vs buy analysis, vendor evaluation, or deciding where to allocate limited budget for maximum return.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "c-level-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/c-level-skills",
+          "description": "10 C-level advisory agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO, Executive Mentor. Multi-role board meetings, strategy routing, structured recommendations. For founders needing executive-level decision support.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "ceo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ceo-advisor",
+          "description": "Executive leadership guidance for strategic decision-making, organizational development, and stakeholder management. Use when planning strategy, preparing board presentations, managing investors, developing organizational culture, making executive decisions, fundraising, or when user mentions CEO, strategic planning, board meetings, investor updates, organizational leadership, or executive strategy.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "cfo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cfo-advisor",
+          "description": "Financial leadership for startups and scaling companies. Financial modeling, unit economics, fundraising strategy, cash management, and board financial packages. Use when building financial models, analyzing unit economics, planning fundraising, managing cash runway, preparing board materials, or when user mentions CFO, burn rate, runway, fundraising, unit economics, LTV, CAC, term sheets, or financial strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "change-management",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/change-management",
+          "description": "Framework for rolling out organizational changes without chaos. Covers the ADKAR model adapted for startups, communication templates, resistance patterns, and change fatigue management. Handles process changes, org restructures, strategy pivots, and culture changes. Use when announcing a reorg, switching tools, pivoting strategy, killing a product, changing leadership, or when user mentions change management, change rollout, managing resistance, org change, reorg, or pivot communication.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "chief-of-staff",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/chief-of-staff",
+          "description": "C-suite orchestration layer. Routes founder questions to the right advisor role(s), triggers multi-role board meetings for complex decisions, synthesizes outputs, and tracks decisions. Every C-suite interaction starts here. Loads company context automatically.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "churn-prevention",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/churn-prevention",
+          "description": "Reduce voluntary and involuntary churn through cancel flow design, save offers, exit surveys, and dunning sequences. Use when designing or optimizing a cancel flow, building save offers, setting up dunning emails, or reducing failed-payment churn. Trigger keywords: cancel flow, churn reduction, save offers, dunning, exit survey, payment recovery, win-back, involuntary churn, failed payments, cancel page. NOT for customer health scoring or expansion revenue — use customer-success-manager for that.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ci-cd-pipeline-builder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ci-cd-pipeline-builder",
+          "description": "CI/CD Pipeline Builder",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ciso-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ciso-advisor",
+          "description": "Security leadership for growth-stage companies. Risk quantification in dollars, compliance roadmap (SOC 2/ISO 27001/HIPAA/GDPR), security architecture strategy, incident response leadership, and board-level security reporting. Use when building security programs, justifying security budget, selecting compliance frameworks, managing incidents, assessing vendor risk, or when user mentions CISO, security strategy, compliance roadmap, zero trust, or board security reporting.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cloud-security",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cloud-security",
+          "description": "Use when assessing cloud infrastructure for security misconfigurations, IAM privilege escalation paths, S3 public exposure, open security group rules, or IaC security gaps. Covers AWS, Azure, and GCP posture assessment with MITRE ATT&CK mapping.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cold-email",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cold-email",
+          "description": "When the user wants to write, improve, or build a sequence of B2B cold outreach emails to prospects who haven't asked to hear from them. Use when the user mentions 'cold email,' 'cold outreach,' 'prospecting emails,' 'SDR emails,' 'sales emails,' 'first touch email,' 'follow-up sequence,' or 'email prospecting.' Also use when they share an email draft that sounds too sales-y and needs to be humanized. Distinct from email-sequence (lifecycle/nurture to opted-in subscribers) — this is unsolicited outreach to new prospects. NOT for lifecycle emails, newsletters, or drip campaigns (use email-sequence).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "command-guide",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/command-guide",
+          "description": "Claude Code Command Selection Guide - Automatically recommend and select the right commands, agents, and skills in Claude Code. Use when: (1) user is unsure which command or tool to use, (2) needs to decide which agent/skill best fits the current task, (3) querying usage scenarios for /plan, /tdd, /compact, /loop and other commands, (4) understanding when to invoke planner, code-reviewer, build-error-resolver and other agents, (5) needs command cheat sheet or decision flowchart. Triggers: \"which command to use\", \"which agent\", \"command selection\", \"how to use /plan\", \"when to use /compact\", \"agent selection guide\", \"command cheat sheet\", \"skill recommendation\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "competitive-intel",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitive-intel",
+          "description": "Systematic competitor tracking that feeds CMO positioning, CRO battlecards, and CPO roadmap decisions. Use when analyzing competitors, building sales battlecards, tracking market moves, positioning against alternatives, or when user mentions competitive intelligence, competitive analysis, competitor research, battlecards, win/loss, or market positioning.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitive-teardown",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitive-teardown",
+          "description": "Analyzes competitor products and companies by synthesizing data from pricing pages, app store reviews, job postings, SEO signals, and social media into structured competitive intelligence. Produces feature comparison matrices scored across 12 dimensions, SWOT analyses, positioning maps, UX audits, pricing model breakdowns, action item roadmaps, and stakeholder presentation templates. Use when conducting competitor analysis, comparing products against competitors, researching the competitive landscape, building battle cards for sales, preparing for a product strategy or roadmap session, responding to a competitor's new feature or pricing change, or performing a quarterly competitive review.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "confluence-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/confluence-expert",
+          "description": "Atlassian Confluence expert for creating and managing spaces, knowledge bases, and documentation. Configures space permissions and hierarchies, creates page templates with macros, sets up documentation taxonomies, designs page layouts, and manages content governance. Use when users need to build or restructure a Confluence space, design page hierarchies with permission structures, author or standardise documentation templates, embed Jira reports in pages, run knowledge base audits, or establish documentation standards and collaborative workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-creator",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-creator",
+          "description": "Deprecated redirect skill that routes legacy 'content creator' requests to the correct specialist. Use when a user invokes 'content creator', asks to write a blog post, article, guide, or brand voice analysis (routes to content-production), or asks to plan content, build a topic cluster, or create a content calendar (routes to content-strategy). Does not handle requests directly — identifies user intent and redirects to content-production for writing/SEO/brand-voice tasks or content-strategy for planning tasks.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "content-production",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-production",
+          "description": "Full content production pipeline — takes a topic from blank page to published-ready piece. Use when you need to execute content: write a blog post, article, or guide end-to-end. Triggers: 'write a post about', 'draft an article', 'create content for', 'help me write', 'I need a blog post'. NOT for content strategy or calendar planning (use content-strategy). NOT for repurposing existing content (use content-repurposing). NOT for social captions only.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-strategy",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-strategy",
+          "description": "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions \\\"content strategy,\\\" \\\"what should I write about,\\\" \\\"content ideas,\\\" \\\"blog strategy,\\\" \\\"topic clusters,\\\" or \\\"content planning.\\\" For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "coo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/coo-advisor",
+          "description": "Operations leadership for scaling companies. Process design, OKR execution, operational cadence, and scaling playbooks. Use when designing operations, setting up OKRs, building processes, scaling teams, analyzing bottlenecks, planning operational cadence, or when user mentions COO, operations, process improvement, OKRs, scaling, operational efficiency, or execution.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "copywriting",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/copywriting",
+          "description": "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \\\"write copy for,\\\" \\\"improve this copy,\\\" \\\"rewrite this page,\\\" \\\"marketing copy,\\\" \\\"headline help,\\\" or \\\"CTA copy.\\\" For email copy, see email-sequence. For popup copy, see popup-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cro-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cro-advisor",
+          "description": "Revenue leadership for B2B SaaS companies. Revenue forecasting, sales model design, pricing strategy, net revenue retention, and sales team scaling. Use when designing the revenue engine, setting quotas, modeling NRR, evaluating pricing, building board forecasts, or when user mentions CRO, chief revenue officer, revenue strategy, sales model, ARR growth, NRR, expansion revenue, churn, pricing strategy, or sales capacity.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cs-content-creator",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-content-creator",
+          "description": "AI-powered content creation specialist for brand voice consistency, SEO optimization, and multi-platform content strategy",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-cto-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-cto-advisor",
+          "description": "Technical leadership advisor for CTOs covering technology strategy, team scaling, architecture decisions, and engineering excellence",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-demand-gen-specialist",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-demand-gen-specialist",
+          "description": "Demand generation and customer acquisition specialist for lead generation, conversion optimization, and multi-channel acquisition campaigns",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-engineering-lead",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-engineering-lead",
+          "description": "Engineering Team Lead agent for coordinating QA, security, data engineering, ML, and frontend/backend teams. Orchestrates engineering-team skills for team-level technical decisions. Spawn when users need team coordination, tech stack evaluation, incident response, or cross-functional engineering work.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-financial-analyst",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-financial-analyst",
+          "description": "Financial Analyst agent for DCF valuation, financial modeling, budgeting, forecasting, and SaaS metrics (ARR, MRR, churn, CAC, LTV, NRR). Orchestrates finance skills. Spawn when users need financial analysis, valuation models, budget planning, ratio analysis, SaaS health checks, or unit economics projections.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-growth-strategist",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-growth-strategist",
+          "description": "Growth Strategist agent for revenue operations, sales engineering, customer success, and business development. Orchestrates business-growth skills. Spawn when users need pipeline analysis, churn prevention, expansion scoring, sales demos, or proposal writing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-karpathy-reviewer",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-karpathy-reviewer",
+          "description": "Reviews staged git changes against Karpathy's 4 coding principles. Runs complexity_checker on changed files, diff_surgeon on the diff, and produces a verdict with specific fix recommendations. Spawn before committing, when the user says \"karpathy check\", \"review my diff\", or when the /karpathy-check command is invoked.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-project-manager",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-project-manager",
+          "description": "Project Manager agent for sprint planning, Jira/Confluence workflows, Scrum ceremonies, and stakeholder reporting. Orchestrates project-management skills.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-senior-engineer",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-senior-engineer",
+          "description": "Senior Engineer agent for architecture decisions, code review, DevOps, and API design. Orchestrates engineering and engineering-team skills for technical implementation work. Spawn when users need system design, code quality review, CI/CD pipeline setup, or infrastructure decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-wiki-librarian",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-wiki-librarian",
+          "description": "Dispatched sub-agent that answers queries against an LLM Wiki vault. Reads index.md first, drills into 3-10 relevant pages across categories, synthesizes an answer with inline [[wikilink]] citations, and offers to file the answer back into the wiki as a new comparison or synthesis page. Spawn when the user asks a substantive question the wiki might answer, says \"what does the wiki say about X\", \"compare A and B across my sources\", or wants to explore a topic.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-workspace-admin",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-workspace-admin",
+          "description": "Google Workspace administration agent using the gws CLI. Orchestrates workspace setup, Gmail/Drive/Sheets/Calendar automation, security audits, and recipe execution. Spawn when users need Google Workspace automation, gws CLI help, or workspace administration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cto-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cto-advisor",
+          "description": "Technical leadership guidance for engineering teams, architecture decisions, and technology strategy. Use when assessing technical debt, scaling engineering teams, evaluating technologies, making architecture decisions, establishing engineering metrics, or when user mentions CTO, tech debt, technical debt, team scaling, architecture decisions, technology evaluation, engineering metrics, DORA metrics, or technology strategy.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "decision-logger",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/decision-logger",
+          "description": "Two-layer memory architecture for board meeting decisions. Manages raw transcripts (Layer 1) and approved decisions (Layer 2). Use when logging decisions after a board meeting, reviewing past decisions with /cs:decisions, or checking overdue action items with /cs:review. Invoked automatically by the board-meeting skill after Phase 5 founder approval.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "DevOps Engineer",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/devops-engineer",
+          "description": "Builds infrastructure that scales without babysitting. Automates everything worth automating. Monitors before it breaks. Treats clicking in consoles as a production incident waiting to happen.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docker-development",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/docker-development/skills/docker-development",
+          "description": "Docker and container development agent skill and plugin for Dockerfile optimization, docker-compose orchestration, multi-stage builds, and container security hardening. Use when: user wants to optimize a Dockerfile, create or improve docker-compose configurations, implement multi-stage builds, audit container security, reduce image size, or follow container best practices. Covers build performance, layer caching, secret management, and production-ready container patterns.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "engineering-advanced-skills",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/engineering-advanced-skills",
+          "description": "25 advanced engineering agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Agent design, RAG, MCP servers, CI/CD, database design, observability, security auditing, release management, platform ops.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "engineering-skills",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/engineering-skills",
+          "description": "23 engineering agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw, and 6 more tools. Architecture, frontend, backend, QA, DevOps, security, AI/ML, data engineering, Playwright, Stripe, AWS, MS365. 30+ Python tools (stdlib-only).",
+          "version": "1.1.0"
+        },
+        {
+          "name": "epic-design",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/epic-design",
+          "description": "Build immersive, cinematic 2.5D interactive websites using scroll storytelling, parallax depth, text animations, and premium scroll effects — no WebGL required. Use this skill for any web design task: landing pages, product sites, hero sections, scroll animations, parallax, sticky sections, section overlaps, floating products between sections, clip-path reveals, text that flies in from sides, words that light up on scroll, curtain drops, iris opens, card stacks, bleed typography, and any site that should feel cinematic or premium. Trigger on phrases like \"make it feel alive\", \"Apple-style animation\", \"sections that overlap\", \"product rises between sections\", \"immersive\", \"scrollytelling\", or any scroll-driven visual effect. Covers 45+ techniques across 8 categories. Always inspects, judges, and plans assets before coding. Use aggressively for ANY web design task.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "executive-mentor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/executive-mentor/skills/executive-mentor",
+          "description": "Adversarial thinking partner for founders and executives. Stress-tests plans, prepares for brutal board meetings, dissects decisions with no good options, and forces honest post-mortems. Use when you need someone to find the holes before the board does, make a decision you've been avoiding, or understand what actually went wrong.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "fda-consultant-specialist",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/fda-consultant-specialist",
+          "description": "FDA regulatory consultant for medical device companies. Provides 510(k)/PMA/De Novo pathway guidance, QSR (21 CFR 820) compliance, HIPAA assessments, and device cybersecurity. Use when user mentions FDA submission, 510(k), PMA, De Novo, QSR, premarket, predicate device, substantial equivalence, HIPAA medical device, or FDA cybersecurity.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Finance Lead",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/finance-lead",
+          "description": "Startup CFO who builds models that survive contact with reality. Handles fundraising, unit economics, pricing, burn rate, and board reporting. Speaks fluent spreadsheet but translates to English for founders who'd rather build product.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "finance-skills",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/finance-skills",
+          "description": "Financial analyst agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Ratio analysis, DCF valuation, budget variance, rolling forecasts. 4 Python tools (stdlib-only).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "financial-analyst",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/financial-analyst",
+          "description": "Performs financial ratio analysis, DCF valuation, budget variance analysis, and rolling forecast construction for strategic decision-making. Use when analyzing financial statements, building valuation models, assessing budget variances, or constructing financial projections and forecasts. Also applicable when users mention financial modeling, cash flow analysis, company valuation, financial projections, or spreadsheet analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "financial-health",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/financial-health",
+          "description": "Run financial ratio analysis, DCF valuation, budget variance analysis, and rolling forecasts. Usage: /financial-health <ratios|dcf|budget|forecast> <data.json>",
+          "version": "0.0.0"
+        },
+        {
+          "name": "focused-fix",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/focused-fix",
+          "description": "Use when the user asks to fix, debug, or make a specific feature/module/area work end-to-end. Triggers: 'make X work', 'fix the Y feature', 'the Z module is broken', 'focus on [area]'. Not for quick single-bug fixes — this is for systematic deep-dive repair across all files and dependencies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "full-page-screenshot",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/full-page-screenshot",
+          "description": "Use when the user asks to capture a full-page screenshot, long screenshot, or complete page capture of a web page. Handles SPA scroll containers, lazy-loaded images, and very tall pages via Chrome DevTools Protocol with zero external dependencies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gcp-cloud-architect",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/gcp-cloud-architect",
+          "description": "Design GCP architectures for startups and enterprises. Use when asked to design Google Cloud infrastructure, deploy to GKE or Cloud Run, configure BigQuery pipelines, optimize GCP costs, or migrate to GCP. Covers Cloud Run, GKE, Cloud Functions, Cloud SQL, BigQuery, and cost optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-workspace",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/google-workspace",
+          "description": "Google Workspace CLI operations: setup diagnostics, security audit, recipe discovery, and output analysis. Usage: /google-workspace <setup|audit|recipe|analyze> [options]",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-workspace-cli",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/google-workspace-cli/skills/google-workspace-cli",
+          "description": "Google Workspace administration via the gws CLI. Install, authenticate, and automate Gmail, Drive, Sheets, Calendar, Docs, Chat, and Tasks. Run security audits, execute 43 built-in recipes, and use 10 persona bundles. Use for Google Workspace admin, gws CLI setup, Gmail automation, Drive management, or Calendar scheduling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Growth Marketer",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/growth-marketer",
+          "description": "Growth marketing specialist for bootstrapped startups and indie hackers. Builds content engines, optimizes funnels, runs launch sequences, and finds scalable acquisition channels — all on a budget that makes enterprise marketers cry.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hard-call",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/executive-mentor/skills/hard-call",
+          "description": "/em -hard-call — Framework for Decisions With No Good Options",
+          "version": "0.0.0"
+        },
+        {
+          "name": "helm-chart-builder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/helm-chart-builder/skills/helm-chart-builder",
+          "description": "Helm chart development agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw — chart scaffolding, values design, template patterns, dependency management, security hardening, and chart testing. Use when: user wants to create or improve Helm charts, design values.yaml files, implement template helpers, audit chart security (RBAC, network policies, pod security), manage subcharts, or run helm lint/test.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "incident-commander",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/incident-commander",
+          "description": "Incident Commander Skill",
+          "version": "0.0.0"
+        },
+        {
+          "name": "incident-response",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/incident-response",
+          "description": "Use when a security incident has been detected or declared and needs classification, triage, escalation path determination, and forensic evidence collection. Covers SEV1-SEV4 classification, false positive filtering, incident taxonomy, and NIST SP 800-61 lifecycle.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "information-security-manager-iso27001",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/information-security-manager-iso27001",
+          "description": "ISO 27001 ISMS implementation and cybersecurity governance for HealthTech and MedTech companies. Use for ISMS design, security risk assessment, control implementation, ISO 27001 certification, security audits, incident response, and compliance verification. Covers ISO 27001, ISO 27002, healthcare security, and medical device cybersecurity.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "interview-system-designer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/interview-system-designer",
+          "description": "This skill should be used when the user asks to \"design interview processes\", \"create hiring pipelines\", \"calibrate interview loops\", \"generate interview questions\", \"design competency matrices\", \"analyze interviewer bias\", \"create scoring rubrics\", \"build question banks\", or \"optimize hiring systems\". Use for designing role-specific interview loops, competency assessments, and hiring calibration systems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "isms-audit-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/isms-audit-expert",
+          "description": "Information Security Management System (ISMS) audit expert for ISO 27001 compliance verification, security control assessment, and certification support. Use when the user mentions ISO 27001, ISMS audit, Annex A controls, Statement of Applicability (SOA), gap analysis, nonconformity management, internal audit, surveillance audit, or security certification preparation. Helps review control implementation evidence, document audit findings, classify nonconformities, generate risk-based audit plans, map controls to Annex A requirements, prepare Stage 1 and Stage 2 audit documentation, and support corrective action workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "jira-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/jira-expert",
+          "description": "Atlassian Jira expert for creating and managing projects, planning, product discovery, JQL queries, workflows, custom fields, automation, reporting, and all Jira features. Use for Jira project setup, configuration, advanced search, dashboard creation, workflow design, and technical Jira operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "karpathy-check",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/karpathy-check",
+          "description": "Run Karpathy's 4-principle review on staged changes or the last commit. Checks complexity, diff noise, hidden assumptions, and goal verification. Usage /karpathy-check [--last-commit]",
+          "version": "0.0.0"
+        },
+        {
+          "name": "karpathy-coder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/karpathy-coder/skills/karpathy-coder",
+          "description": "Use when writing, reviewing, or committing code to enforce Karpathy's 4 coding principles — surface assumptions before coding, keep it simple, make surgical changes, define verifiable goals. Triggers on \"review my diff\", \"check complexity\", \"am I overcomplicating this\", \"karpathy check\", \"before I commit\", or any code quality concern where the LLM might be overcoding.",
+          "version": "2.3.0"
+        },
+        {
+          "name": "landing-page-generator",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/landing-page-generator",
+          "description": "Generates high-converting landing pages as complete Next.js/React (TSX) components with Tailwind CSS. Creates hero sections, feature grids, pricing tables, FAQ accordions, testimonial blocks, and CTA sections using proven copy frameworks (PAS, AIDA, BAB). Outputs SEO meta tags, structured data, and performance-optimised code targeting Core Web Vitals (LCP < 1s, CLS < 0.1). Use when the user asks to create a landing page, marketing page, homepage, single-page site, lead capture page, campaign page, promo page, or conversion-optimised web page — or when they want to A/B test landing page variants or replace a static page with one designed to convert.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "launch-strategy",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/launch-strategy",
+          "description": "When the user wants to plan a product launch, feature announcement, or release strategy. Also use when the user mentions 'launch,' 'Product Hunt,' 'feature release,' 'announcement,' 'go-to-market,' 'beta launch,' 'early access,' 'waitlist,' 'product update,' 'GTM plan,' 'launch checklist,' or 'launch momentum.' This skill covers phased launches, channel strategy, and ongoing launch momentum.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "llm-cost-optimizer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/llm-cost-optimizer/skills/llm-cost-optimizer",
+          "description": "Use proactively whenever LLM API costs come up -- or should. Triggers include: 'my AI costs are too high', 'optimize token usage', 'which model should I use', 'LLM spend is out of control', 'implement prompt caching', 'we're about to launch an AI feature', 'build me an AI endpoint'. Don't wait for an explicit cost complaint -- if someone is building an AI feature, designing an LLM endpoint, or choosing between models, cost architecture belongs in the conversation. Apply immediately when any of these are true: a system prompt appears that exceeds a few hundred tokens, all requests are hitting the same model, max_tokens is not set, or no per-feature cost logging exists. NOT for RAG pipeline design (use rag-architect). NOT for improving prompt quality or effectiveness (use senior-prompt-engineer).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "marketing-demand-acquisition",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-demand-acquisition",
+          "description": "Creates demand generation campaigns, optimizes paid ad spend across LinkedIn, Google, and Meta, develops SEO strategies, and structures partnership programs for Series A+ startups scaling internationally. Use when planning marketing strategy, growth marketing, advertising campaigns, PPC optimization, lead generation, pipeline generation, or startup marketing budgets. Covers multi-channel acquisition (Google Ads, LinkedIn Ads, Meta Ads), CAC analysis, MQL/SQL workflows, attribution modeling, technical SEO, and co-marketing partnerships for hybrid PLG/Sales-Led motions in EU/US/Canada markets.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "marketing-psychology",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-psychology",
+          "description": "When the user wants to apply psychological principles, mental models, or behavioral science to marketing. Also use when the user mentions 'psychology,' 'mental models,' 'cognitive bias,' 'persuasion,' 'behavioral science,' 'why people buy,' 'decision-making,' or 'consumer behavior.' This skill provides 70+ mental models organized for marketing application.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "mdr-745-specialist",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/mdr-745-specialist",
+          "description": "EU MDR 2017/745 compliance specialist for medical device classification, technical documentation, clinical evidence, and post-market surveillance. Covers Annex VIII classification rules, Annex II/III technical files, Annex XIV clinical evaluation, and EUDAMED integration.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "alirezarezvani",
+        "repo": "claude-skills",
+        "repoUrl": "https://github.com/alirezarezvani/claude-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "alirezarezvani-claude-skills-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from alirezarezvani/claude-skills.",
+      "author": "ASM (alirezarezvani/claude-skills)",
+      "createdAt": "2026-05-09T08:10:59.479Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "alirezarezvani",
+        "claude-skills"
+      ],
+      "skills": [
+        {
+          "name": "a11y-audit",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/a11y-audit/skills/a11y-audit",
+          "description": "Accessibility audit skill for scanning, fixing, and verifying WCAG 2.2 Level A and AA compliance across React, Next.js, Vue, Angular, Svelte, and plain HTML codebases. Use when auditing accessibility, fixing a11y violations, checking color contrast, generating compliance reports, or integrating accessibility checks into CI/CD pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ab-test-setup",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ab-test-setup",
+          "description": "When the user wants to plan, design, or implement an A/B test or experiment. Also use when the user mentions \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"conversion experiment,\" \"statistical significance,\" or \"test this.\" For tracking implementation, see analytics-tracking.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ad-creative",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ad-creative",
+          "description": "When the user needs to generate, iterate, or scale ad creative for paid advertising. Use when they say 'write ad copy,' 'generate headlines,' 'create ad variations,' 'bulk creative,' 'iterate on ads,' 'ad copy validation,' 'RSA headlines,' 'Meta ad copy,' 'LinkedIn ad,' or 'creative testing.' This is pure creative production — distinct from paid-ads (campaign strategy). Use ad-creative when you need the copy, not the campaign plan.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "adversarial-reviewer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/adversarial-reviewer",
+          "description": "Adversarial code review that breaks the self-review monoculture. Use when you want a genuinely critical review of recent changes, before merging a PR, or when you suspect Claude is being too agreeable about code quality. Forces perspective shifts through hostile reviewer personas that catch blind spots the author's mental model shares with the reviewer.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "Agent Name",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/README",
+          "description": "What this agent does and when to activate it.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-designer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agent-designer",
+          "description": "Use when the user asks to design multi-agent systems, create agent architectures, define agent communication patterns, or build autonomous agent workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-protocol",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agent-protocol",
+          "description": "Inter-agent communication protocol for C-suite agent teams. Defines invocation syntax, loop prevention, isolation rules, and response formats. Use when C-suite agents need to query each other, coordinate cross-functional analysis, or run board meetings with multiple agent roles.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "agent-workflow-designer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agent-workflow-designer",
+          "description": "Agent Workflow Designer",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agenthub",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub/skills/agenthub",
+          "description": "Multi-agent collaboration plugin that spawns N parallel subagents competing on the same task via git worktree isolation. Agents work independently, results are evaluated by metric or LLM judge, and the best branch is merged. Use when: user wants multiple approaches tried in parallel — code optimization, content variation, research exploration, or any task that benefits from parallel competition. Requires: a git repo.",
+          "version": "2.1.2"
+        },
+        {
+          "name": "agile-product-owner",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agile-product-owner/skills/agile-product-owner",
+          "description": "Agile product ownership for backlog management and sprint execution. Covers user story writing, acceptance criteria, sprint planning, and velocity tracking. Use for writing user stories, creating acceptance criteria, planning sprints, estimating story points, breaking down epics, or prioritizing backlog.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-security",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ai-security",
+          "description": "Use when assessing AI/ML systems for prompt injection, jailbreak vulnerabilities, model inversion risk, data poisoning exposure, or agent tool abuse. Covers MITRE ATLAS technique mapping, injection signature detection, and adversarial robustness scoring.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ai-seo",
+          "description": "Optimize content to get cited by AI search engines — ChatGPT, Perplexity, Google AI Overviews, Claude, Gemini, Copilot. Use when you want your content to appear in AI-generated answers, not just ranked in blue links. Triggers: 'optimize for AI search', 'get cited by ChatGPT', 'AI Overviews', 'Perplexity citations', 'AI SEO', 'generative search', 'LLM visibility', 'GEO' (generative engine optimization). NOT for traditional SEO ranking (use seo-audit). NOT for content creation (use content-production).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "analytics-tracking",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/analytics-tracking",
+          "description": "Set up, audit, and debug analytics tracking implementation — GA4, Google Tag Manager, event taxonomy, conversion tracking, and data quality. Use when building a tracking plan from scratch, auditing existing analytics for gaps or errors, debugging missing events, or setting up GTM. Trigger keywords: GA4 setup, Google Tag Manager, GTM, event tracking, analytics implementation, conversion tracking, tracking plan, event taxonomy, custom dimensions, UTM tracking, analytics audit, missing events, tracking broken. NOT for analyzing marketing campaign data — use campaign-analytics for that. NOT for BI dashboards — use product-analytics for in-product event analysis.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "api-design-reviewer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/api-design-reviewer",
+          "description": "API Design Reviewer",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-test-suite-builder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/api-test-suite-builder",
+          "description": "Use when the user asks to generate API tests, create integration test suites, test REST endpoints, or build contract tests.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "app-store-optimization",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/app-store-optimization",
+          "description": "App Store Optimization (ASO) toolkit for researching keywords, analyzing competitor rankings, generating metadata suggestions, and improving app visibility on Apple App Store and Google Play Store. Use when the user asks about ASO, app store rankings, app metadata, app titles and descriptions, app store listings, app visibility, or mobile app marketing on iOS or Android. Supports keyword research and scoring, competitor keyword analysis, metadata optimization, A/B test planning, launch checklists, and tracking ranking changes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apple-hig-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/apple-hig-expert/skills/apple-hig-expert",
+          "description": "Expert guidance on Apple Human Interface Guidelines (HIG). Covers iOS, macOS, and visionOS with 2026 Liquid Glass aesthetics and accessibility-first design.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "atlassian-admin",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/atlassian-admin",
+          "description": "Atlassian Administrator for managing and organizing Atlassian products (Jira, Confluence, Bitbucket, Trello), users, permissions, security, integrations, system configuration, and org-wide governance. Use when asked to add users to Jira, change Confluence permissions, configure access control, update admin settings, manage Atlassian groups, set up SSO, install marketplace apps, review security policies, or handle any org-wide Atlassian administration task.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "atlassian-templates",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/atlassian-templates",
+          "description": "Atlassian Template and Files Creator/Modifier expert for creating, modifying, and managing Jira and Confluence templates, blueprints, custom layouts, reusable components, and standardized content structures. Use when building org-wide templates, custom blueprints, page layouts, and automated content generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autoresearch-agent",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/autoresearch-agent/skills/autoresearch-agent",
+          "description": "Autonomous experiment loop that optimizes any file by a measurable metric. Inspired by Karpathy's autoresearch. The agent edits a target file, runs a fixed evaluation, keeps improvements (git commit), discards failures (git reset), and loops indefinitely. Use when: user wants to optimize code speed, reduce bundle/image size, improve test pass rate, optimize prompts, improve content quality (headlines, copy, CTR), or run any measurable improvement loop. Requires: a target file, an evaluation command that outputs a metric, and a git repo.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "aws-solution-architect",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/aws-solution-architect",
+          "description": "Design AWS architectures for startups using serverless patterns and IaC templates. Use when asked to design serverless architecture, create CloudFormation templates, optimize AWS costs, set up CI/CD pipelines, or migrate to AWS. Covers Lambda, API Gateway, DynamoDB, ECS, Aurora, and cost optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-cloud-architect",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/azure-cloud-architect",
+          "description": "Design Azure architectures for startups and enterprises. Use when asked to design Azure infrastructure, create Bicep/ARM templates, optimize Azure costs, set up Azure DevOps pipelines, or migrate to Azure. Covers AKS, App Service, Azure Functions, Cosmos DB, and cost optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "behuman",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/behuman/skills/behuman",
+          "description": "Use when the user wants more human-like AI responses — less robotic, less listy, more authentic. Triggers: 'behuman', 'be real', 'like a human', 'more human', 'less AI', 'talk like a person', 'mirror mode', 'stop being so AI', or when conversations are emotionally charged (grief, job loss, relationship advice, fear). NOT for technical questions, code generation, or factual lookups.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "board",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub/skills/board",
+          "description": "Read, write, and browse the AgentHub message board for agent coordination.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "board-deck-builder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/board-deck-builder",
+          "description": "Assembles comprehensive board and investor update decks by pulling perspectives from all C-suite roles. Use when preparing board meetings, investor updates, quarterly business reviews, or fundraising narratives. Covers structure, narrative framework, bad news delivery, and common mistakes.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "board-meeting",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/board-meeting",
+          "description": "Multi-agent board meeting protocol for strategic decisions. Runs a structured 6-phase deliberation: context loading, independent C-suite contributions (isolated, no cross-pollination), critic analysis, synthesis, founder review, and decision extraction. Use when the user invokes /cs:board, calls a board meeting, or wants structured multi-perspective executive deliberation on a strategic question.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "board-prep",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/executive-mentor/skills/board-prep",
+          "description": "/em -board-prep — Board Meeting Preparation",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brand-guidelines",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/brand-guidelines",
+          "description": "When the user wants to apply, document, or enforce brand guidelines for any product or company. Also use when the user mentions 'brand guidelines,' 'brand colors,' 'typography,' 'logo usage,' 'brand voice,' 'visual identity,' 'tone of voice,' 'brand standards,' 'style guide,' 'brand consistency,' or 'company design standards.' Covers color systems, typography, logo rules, imagery guidelines, and tone matrix for any brand — including Anthropic's official identity.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "browser-automation",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/browser-automation",
+          "description": "Use when the user asks to automate browser tasks, scrape websites, fill forms, capture screenshots, extract structured data from web pages, or build web automation workflows. NOT for testing — use playwright-pro for that.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "browserstack",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/browserstack",
+          "description": "Run tests on BrowserStack. Use when user mentions \"browserstack\", \"cross-browser\", \"cloud testing\", \"browser matrix\", \"test on safari\", \"test on firefox\", or \"browser compatibility\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "business-growth-skills",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/business-growth-skills",
+          "description": "4 business growth agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Customer success (health scoring, churn), sales engineer (RFP), revenue operations (pipeline, GTM), contract & proposal writer. Python tools (stdlib-only).",
+          "version": "1.1.0"
+        },
+        {
+          "name": "business-investment-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/business-investment-advisor/skills/business-investment-advisor",
+          "description": "Business investment analysis and capital allocation advisor. Use when evaluating whether to invest in equipment, real estate, a new business, hiring, technology, or any capital expenditure. Also use for ROI calculations, IRR, NPV, payback period, build vs buy decisions, lease vs buy analysis, vendor evaluation, or deciding where to allocate limited budget for maximum return.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "c-level-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/c-level-skills",
+          "description": "10 C-level advisory agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO, Executive Mentor. Multi-role board meetings, strategy routing, structured recommendations. For founders needing executive-level decision support.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "campaign-analytics",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/campaign-analytics",
+          "description": "Analyzes campaign performance with multi-touch attribution, funnel conversion analysis, and ROI calculation for marketing optimization. Use when analyzing marketing campaigns, ad performance, attribution models, conversion rates, or calculating marketing ROI, ROAS, CPA, and campaign metrics across channels.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "capa-officer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/capa-officer",
+          "description": "CAPA system management for medical device QMS. Covers root cause analysis, corrective action planning, effectiveness verification, and CAPA metrics. Use for CAPA investigations, 5-Why analysis, fishbone diagrams, root cause determination, corrective action tracking, effectiveness verification, or CAPA program optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ceo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ceo-advisor",
+          "description": "Executive leadership guidance for strategic decision-making, organizational development, and stakeholder management. Use when planning strategy, preparing board presentations, managing investors, developing organizational culture, making executive decisions, fundraising, or when user mentions CEO, strategic planning, board meetings, investor updates, organizational leadership, or executive strategy.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "cfo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cfo-advisor",
+          "description": "Financial leadership for startups and scaling companies. Financial modeling, unit economics, fundraising strategy, cash management, and board financial packages. Use when building financial models, analyzing unit economics, planning fundraising, managing cash runway, preparing board materials, or when user mentions CFO, burn rate, runway, fundraising, unit economics, LTV, CAC, term sheets, or financial strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "challenge",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/executive-mentor/skills/challenge",
+          "description": "/em -challenge — Pre-Mortem Plan Analysis",
+          "version": "0.0.0"
+        },
+        {
+          "name": "change-management",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/change-management",
+          "description": "Framework for rolling out organizational changes without chaos. Covers the ADKAR model adapted for startups, communication templates, resistance patterns, and change fatigue management. Handles process changes, org restructures, strategy pivots, and culture changes. Use when announcing a reorg, switching tools, pivoting strategy, killing a product, changing leadership, or when user mentions change management, change rollout, managing resistance, org change, reorg, or pivot communication.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "changelog",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/changelog",
+          "description": "Generate changelogs from git history and validate conventional commits. Usage: /changelog <generate|lint> [options]",
+          "version": "0.0.0"
+        },
+        {
+          "name": "changelog-generator",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/changelog-generator",
+          "description": "Changelog Generator",
+          "version": "0.0.0"
+        },
+        {
+          "name": "chief-of-staff",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/chief-of-staff",
+          "description": "C-suite orchestration layer. Routes founder questions to the right advisor role(s), triggers multi-role board meetings for complex decisions, synthesizes outputs, and tracks decisions. Every C-suite interaction starts here. Loads company context automatically.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "chro-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/chro-advisor",
+          "description": "People leadership for scaling companies. Hiring strategy, compensation design, org structure, culture, and retention. Use when building hiring plans, designing comp frameworks, restructuring teams, managing performance, building culture, or when user mentions CHRO, HR, people strategy, talent, headcount, compensation, org design, retention, or performance management.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "churn-prevention",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/churn-prevention",
+          "description": "Reduce voluntary and involuntary churn through cancel flow design, save offers, exit surveys, and dunning sequences. Use when designing or optimizing a cancel flow, building save offers, setting up dunning emails, or reducing failed-payment churn. Trigger keywords: cancel flow, churn reduction, save offers, dunning, exit survey, payment recovery, win-back, involuntary churn, failed payments, cancel page. NOT for customer health scoring or expansion revenue — use customer-success-manager for that.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ci-cd-pipeline-builder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ci-cd-pipeline-builder",
+          "description": "CI/CD Pipeline Builder",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ciso-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ciso-advisor",
+          "description": "Security leadership for growth-stage companies. Risk quantification in dollars, compliance roadmap (SOC 2/ISO 27001/HIPAA/GDPR), security architecture strategy, incident response leadership, and board-level security reporting. Use when building security programs, justifying security budget, selecting compliance frameworks, managing incidents, assessing vendor risk, or when user mentions CISO, security strategy, compliance roadmap, zero trust, or board security reporting.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cloud-security",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cloud-security",
+          "description": "Use when assessing cloud infrastructure for security misconfigurations, IAM privilege escalation paths, S3 public exposure, open security group rules, or IaC security gaps. Covers AWS, Azure, and GCP posture assessment with MITRE ATT&CK mapping.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cmo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cmo-advisor",
+          "description": "Marketing leadership for scaling companies. Brand positioning, growth model design, marketing budget allocation, and marketing org design. Use when designing brand strategy, selecting growth models (PLG vs sales-led vs community-led), allocating marketing budgets, building marketing teams, or when user mentions CMO, brand strategy, growth model, CAC, LTV, channel mix, or marketing ROI.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "code-reviewer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-reviewer",
+          "description": "Code review automation for TypeScript, JavaScript, Python, Go, Swift, Kotlin. Analyzes PRs for complexity and risk, checks code quality for SOLID violations and code smells, generates review reports. Use when reviewing pull requests, analyzing code quality, identifying issues, generating review checklists.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-to-prd",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-to-prd/skills/code-to-prd",
+          "description": "Reverse-engineer any codebase into a complete Product Requirements Document (PRD). Analyzes routes, components, state management, API integrations, and user interactions to produce business-readable documentation detailed enough for engineers or AI agents to fully reconstruct every page and endpoint. Works with frontend frameworks (React, Vue, Angular, Svelte, Next.js, Nuxt), backend frameworks (NestJS, Django, Express, FastAPI), and fullstack applications. Trigger when users mention: generate PRD, reverse-engineer requirements, code to documentation, extract product specs from code, document page logic, analyze page fields and interactions, create a functional inventory, write requirements from an existing codebase, document API endpoints, or analyze backend routes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-tour",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-tour/skills/code-tour",
+          "description": "Use when the user asks to create a CodeTour .tour file — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. Trigger for: create a tour, onboarding tour, architecture tour, PR review tour, explain how X works, vibe check, RCA tour, contributor guide, or any structured code walkthrough request.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "codebase-onboarding",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/codebase-onboarding",
+          "description": "Codebase Onboarding",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cold-email",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cold-email",
+          "description": "When the user wants to write, improve, or build a sequence of B2B cold outreach emails to prospects who haven't asked to hear from them. Use when the user mentions 'cold email,' 'cold outreach,' 'prospecting emails,' 'SDR emails,' 'sales emails,' 'first touch email,' 'follow-up sequence,' or 'email prospecting.' Also use when they share an email draft that sounds too sales-y and needs to be humanized. Distinct from email-sequence (lifecycle/nurture to opted-in subscribers) — this is unsolicited outreach to new prospects. NOT for lifecycle emails, newsletters, or drip campaigns (use email-sequence).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "command-guide",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/command-guide",
+          "description": "Claude Code Command Selection Guide - Automatically recommend and select the right commands, agents, and skills in Claude Code. Use when: (1) user is unsure which command or tool to use, (2) needs to decide which agent/skill best fits the current task, (3) querying usage scenarios for /plan, /tdd, /compact, /loop and other commands, (4) understanding when to invoke planner, code-reviewer, build-error-resolver and other agents, (5) needs command cheat sheet or decision flowchart. Triggers: \"which command to use\", \"which agent\", \"command selection\", \"how to use /plan\", \"when to use /compact\", \"agent selection guide\", \"command cheat sheet\", \"skill recommendation\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "company-os",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/company-os",
+          "description": "The meta-framework for how a company runs — the connective tissue between all C-suite roles. Covers operating system selection (EOS, Scaling Up, OKR-native, hybrid), accountability charts, scorecards, meeting pulse, issue resolution, and 90-day rocks. Use when setting up company operations, selecting a management framework, designing meeting rhythms, building accountability systems, implementing OKRs, or when user mentions EOS, Scaling Up, operating system, L10 meetings, rocks, scorecard, accountability chart, or quarterly planning.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitive-intel",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitive-intel",
+          "description": "Systematic competitor tracking that feeds CMO positioning, CRO battlecards, and CPO roadmap decisions. Use when analyzing competitors, building sales battlecards, tracking market moves, positioning against alternatives, or when user mentions competitive intelligence, competitive analysis, competitor research, battlecards, win/loss, or market positioning.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitive-matrix",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/competitive-matrix",
+          "description": "Build competitive analysis matrices with scoring and gap analysis. Usage: /competitive-matrix <analyze> [options]",
+          "version": "0.0.0"
+        },
+        {
+          "name": "competitive-teardown",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitive-teardown",
+          "description": "Analyzes competitor products and companies by synthesizing data from pricing pages, app store reviews, job postings, SEO signals, and social media into structured competitive intelligence. Produces feature comparison matrices scored across 12 dimensions, SWOT analyses, positioning maps, UX audits, pricing model breakdowns, action item roadmaps, and stakeholder presentation templates. Use when conducting competitor analysis, comparing products against competitors, researching the competitive landscape, building battle cards for sales, preparing for a product strategy or roadmap session, responding to a competitor's new feature or pricing change, or performing a quarterly competitive review.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "competitor-alternatives",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitor-alternatives",
+          "description": "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'switch from competitor,' or 'comparison content.' Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. Emphasizes deep research, modular content architecture, and varied section types beyond feature tables.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "confluence-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/confluence-expert",
+          "description": "Atlassian Confluence expert for creating and managing spaces, knowledge bases, and documentation. Configures space permissions and hierarchies, creates page templates with macros, sets up documentation taxonomies, designs page layouts, and manages content governance. Use when users need to build or restructure a Confluence space, design page hierarchies with permission structures, author or standardise documentation templates, embed Jira reports in pages, run knowledge base audits, or establish documentation standards and collaborative workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Content Strategist",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/content-strategist",
+          "description": "Builds content engines that rank, convert, and compound. Thinks in systems — topic clusters, not individual posts. Every piece earns its place or gets killed.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-creator",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-creator",
+          "description": "Deprecated redirect skill that routes legacy 'content creator' requests to the correct specialist. Use when a user invokes 'content creator', asks to write a blog post, article, guide, or brand voice analysis (routes to content-production), or asks to plan content, build a topic cluster, or create a content calendar (routes to content-strategy). Does not handle requests directly — identifies user intent and redirects to content-production for writing/SEO/brand-voice tasks or content-strategy for planning tasks.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "content-humanizer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-humanizer",
+          "description": "Makes AI-generated content sound genuinely human — not just cleaned up, but alive. Use when content feels robotic, uses too many AI clichés, lacks personality, or reads like it was written by committee. Triggers: 'this sounds like AI', 'make it more human', 'add personality', 'it feels generic', 'sounds robotic', 'fix AI writing', 'inject our voice'. NOT for initial content creation (use content-production). NOT for SEO optimization (use content-production Mode 3).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-production",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-production",
+          "description": "Full content production pipeline — takes a topic from blank page to published-ready piece. Use when you need to execute content: write a blog post, article, or guide end-to-end. Triggers: 'write a post about', 'draft an article', 'create content for', 'help me write', 'I need a blog post'. NOT for content strategy or calendar planning (use content-strategy). NOT for repurposing existing content (use content-repurposing). NOT for social captions only.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-strategy",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-strategy",
+          "description": "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions \\\"content strategy,\\\" \\\"what should I write about,\\\" \\\"content ideas,\\\" \\\"blog strategy,\\\" \\\"topic clusters,\\\" or \\\"content planning.\\\" For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "context-engine",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/context-engine",
+          "description": "Loads and manages company context for all C-suite advisor skills. Reads ~/.claude/company-context.md, detects stale context (>90 days), enriches context during conversations, and enforces privacy/anonymization rules before external API calls.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "contract-and-proposal-writer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/contract-and-proposal-writer",
+          "description": "Contract & Proposal Writer",
+          "version": "0.0.0"
+        },
+        {
+          "name": "coo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/coo-advisor",
+          "description": "Operations leadership for scaling companies. Process design, OKR execution, operational cadence, and scaling playbooks. Use when designing operations, setting up OKRs, building processes, scaling teams, analyzing bottlenecks, planning operational cadence, or when user mentions COO, operations, process improvement, OKRs, scaling, operational efficiency, or execution.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "copy-editing",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/copy-editing",
+          "description": "When the user wants to edit, review, or improve existing marketing copy. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' or 'copy sweep.' This skill provides a systematic approach to editing marketing copy through multiple focused passes.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "copywriting",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/copywriting",
+          "description": "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \\\"write copy for,\\\" \\\"improve this copy,\\\" \\\"rewrite this page,\\\" \\\"marketing copy,\\\" \\\"headline help,\\\" or \\\"CTA copy.\\\" For email copy, see email-sequence. For popup copy, see popup-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "coverage",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/coverage",
+          "description": "Analyze test coverage gaps. Use when user says \"test coverage\", \"what's not tested\", \"coverage gaps\", \"missing tests\", \"coverage report\", or \"what needs testing\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cpo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cpo-advisor",
+          "description": "Product leadership for scaling companies. Product vision, portfolio strategy, product-market fit, and product org design. Use when setting product vision, managing a product portfolio, measuring PMF, designing product teams, prioritizing at the portfolio level, reporting to the board on product, or when user mentions CPO, product strategy, product-market fit, product organization, portfolio prioritization, or roadmap strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cro-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cro-advisor",
+          "description": "Revenue leadership for B2B SaaS companies. Revenue forecasting, sales model design, pricing strategy, net revenue retention, and sales team scaling. Use when designing the revenue engine, setting quotas, modeling NRR, evaluating pricing, building board forecasts, or when user mentions CRO, chief revenue officer, revenue strategy, sales model, ARR growth, NRR, expansion revenue, churn, pricing strategy, or sales capacity.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cs-agile-product-owner",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-agile-product-owner",
+          "description": "Agile product owner agent for epic breakdown, sprint planning, backlog refinement, and INVEST-compliant user story generation",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-ceo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-ceo-advisor",
+          "description": "Strategic leadership advisor for CEOs covering vision, strategy, board management, investor relations, and organizational culture",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-content-creator",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-content-creator",
+          "description": "AI-powered content creation specialist for brand voice consistency, SEO optimization, and multi-platform content strategy",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-cto-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-cto-advisor",
+          "description": "Technical leadership advisor for CTOs covering technology strategy, team scaling, architecture decisions, and engineering excellence",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-demand-gen-specialist",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-demand-gen-specialist",
+          "description": "Demand generation and customer acquisition specialist for lead generation, conversion optimization, and multi-channel acquisition campaigns",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-engineering-lead",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-engineering-lead",
+          "description": "Engineering Team Lead agent for coordinating QA, security, data engineering, ML, and frontend/backend teams. Orchestrates engineering-team skills for team-level technical decisions. Spawn when users need team coordination, tech stack evaluation, incident response, or cross-functional engineering work.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-financial-analyst",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-financial-analyst",
+          "description": "Financial Analyst agent for DCF valuation, financial modeling, budgeting, forecasting, and SaaS metrics (ARR, MRR, churn, CAC, LTV, NRR). Orchestrates finance skills. Spawn when users need financial analysis, valuation models, budget planning, ratio analysis, SaaS health checks, or unit economics projections.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "alirezarezvani",
+        "repo": "claude-skills",
+        "repoUrl": "https://github.com/alirezarezvani/claude-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "alirezarezvani-claude-skills-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from alirezarezvani/claude-skills.",
+      "author": "ASM (alirezarezvani/claude-skills)",
+      "createdAt": "2026-05-09T08:10:59.479Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "alirezarezvani",
+        "claude-skills"
+      ],
+      "skills": [
+        {
+          "name": "ad-creative",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ad-creative",
+          "description": "When the user needs to generate, iterate, or scale ad creative for paid advertising. Use when they say 'write ad copy,' 'generate headlines,' 'create ad variations,' 'bulk creative,' 'iterate on ads,' 'ad copy validation,' 'RSA headlines,' 'Meta ad copy,' 'LinkedIn ad,' or 'creative testing.' This is pure creative production — distinct from paid-ads (campaign strategy). Use ad-creative when you need the copy, not the campaign plan.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "agile-product-owner",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agile-product-owner/skills/agile-product-owner",
+          "description": "Agile product ownership for backlog management and sprint execution. Covers user story writing, acceptance criteria, sprint planning, and velocity tracking. Use for writing user stories, creating acceptance criteria, planning sprints, estimating story points, breaking down epics, or prioritizing backlog.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ai-seo",
+          "description": "Optimize content to get cited by AI search engines — ChatGPT, Perplexity, Google AI Overviews, Claude, Gemini, Copilot. Use when you want your content to appear in AI-generated answers, not just ranked in blue links. Triggers: 'optimize for AI search', 'get cited by ChatGPT', 'AI Overviews', 'Perplexity citations', 'AI SEO', 'generative search', 'LLM visibility', 'GEO' (generative engine optimization). NOT for traditional SEO ranking (use seo-audit). NOT for content creation (use content-production).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "analytics-tracking",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/analytics-tracking",
+          "description": "Set up, audit, and debug analytics tracking implementation — GA4, Google Tag Manager, event taxonomy, conversion tracking, and data quality. Use when building a tracking plan from scratch, auditing existing analytics for gaps or errors, debugging missing events, or setting up GTM. Trigger keywords: GA4 setup, Google Tag Manager, GTM, event tracking, analytics implementation, conversion tracking, tracking plan, event taxonomy, custom dimensions, UTM tracking, analytics audit, missing events, tracking broken. NOT for analyzing marketing campaign data — use campaign-analytics for that. NOT for BI dashboards — use product-analytics for in-product event analysis.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "app-store-optimization",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/app-store-optimization",
+          "description": "App Store Optimization (ASO) toolkit for researching keywords, analyzing competitor rankings, generating metadata suggestions, and improving app visibility on Apple App Store and Google Play Store. Use when the user asks about ASO, app store rankings, app metadata, app titles and descriptions, app store listings, app visibility, or mobile app marketing on iOS or Android. Supports keyword research and scoring, competitor keyword analysis, metadata optimization, A/B test planning, launch checklists, and tracking ranking changes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "atlassian-admin",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/atlassian-admin",
+          "description": "Atlassian Administrator for managing and organizing Atlassian products (Jira, Confluence, Bitbucket, Trello), users, permissions, security, integrations, system configuration, and org-wide governance. Use when asked to add users to Jira, change Confluence permissions, configure access control, update admin settings, manage Atlassian groups, set up SSO, install marketplace apps, review security policies, or handle any org-wide Atlassian administration task.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-solution-architect",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/aws-solution-architect",
+          "description": "Design AWS architectures for startups using serverless patterns and IaC templates. Use when asked to design serverless architecture, create CloudFormation templates, optimize AWS costs, set up CI/CD pipelines, or migrate to AWS. Covers Lambda, API Gateway, DynamoDB, ECS, Aurora, and cost optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-cloud-architect",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/azure-cloud-architect",
+          "description": "Design Azure architectures for startups and enterprises. Use when asked to design Azure infrastructure, create Bicep/ARM templates, optimize Azure costs, set up Azure DevOps pipelines, or migrate to Azure. Covers AKS, App Service, Azure Functions, Cosmos DB, and cost optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "board-deck-builder",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/board-deck-builder",
+          "description": "Assembles comprehensive board and investor update decks by pulling perspectives from all C-suite roles. Use when preparing board meetings, investor updates, quarterly business reviews, or fundraising narratives. Covers structure, narrative framework, bad news delivery, and common mistakes.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "brand-guidelines",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/brand-guidelines",
+          "description": "When the user wants to apply, document, or enforce brand guidelines for any product or company. Also use when the user mentions 'brand guidelines,' 'brand colors,' 'typography,' 'logo usage,' 'brand voice,' 'visual identity,' 'tone of voice,' 'brand standards,' 'style guide,' 'brand consistency,' or 'company design standards.' Covers color systems, typography, logo rules, imagery guidelines, and tone matrix for any brand — including Anthropic's official identity.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "business-growth-skills",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/business-growth-skills",
+          "description": "4 business growth agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Customer success (health scoring, churn), sales engineer (RFP), revenue operations (pipeline, GTM), contract & proposal writer. Python tools (stdlib-only).",
+          "version": "1.1.0"
+        },
+        {
+          "name": "business-investment-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/business-investment-advisor/skills/business-investment-advisor",
+          "description": "Business investment analysis and capital allocation advisor. Use when evaluating whether to invest in equipment, real estate, a new business, hiring, technology, or any capital expenditure. Also use for ROI calculations, IRR, NPV, payback period, build vs buy decisions, lease vs buy analysis, vendor evaluation, or deciding where to allocate limited budget for maximum return.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "c-level-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/c-level-skills",
+          "description": "10 C-level advisory agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO, Executive Mentor. Multi-role board meetings, strategy routing, structured recommendations. For founders needing executive-level decision support.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "campaign-analytics",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/campaign-analytics",
+          "description": "Analyzes campaign performance with multi-touch attribution, funnel conversion analysis, and ROI calculation for marketing optimization. Use when analyzing marketing campaigns, ad performance, attribution models, conversion rates, or calculating marketing ROI, ROAS, CPA, and campaign metrics across channels.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "capa-officer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/capa-officer",
+          "description": "CAPA system management for medical device QMS. Covers root cause analysis, corrective action planning, effectiveness verification, and CAPA metrics. Use for CAPA investigations, 5-Why analysis, fishbone diagrams, root cause determination, corrective action tracking, effectiveness verification, or CAPA program optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ceo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ceo-advisor",
+          "description": "Executive leadership guidance for strategic decision-making, organizational development, and stakeholder management. Use when planning strategy, preparing board presentations, managing investors, developing organizational culture, making executive decisions, fundraising, or when user mentions CEO, strategic planning, board meetings, investor updates, organizational leadership, or executive strategy.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "cfo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cfo-advisor",
+          "description": "Financial leadership for startups and scaling companies. Financial modeling, unit economics, fundraising strategy, cash management, and board financial packages. Use when building financial models, analyzing unit economics, planning fundraising, managing cash runway, preparing board materials, or when user mentions CFO, burn rate, runway, fundraising, unit economics, LTV, CAC, term sheets, or financial strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "change-management",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/change-management",
+          "description": "Framework for rolling out organizational changes without chaos. Covers the ADKAR model adapted for startups, communication templates, resistance patterns, and change fatigue management. Handles process changes, org restructures, strategy pivots, and culture changes. Use when announcing a reorg, switching tools, pivoting strategy, killing a product, changing leadership, or when user mentions change management, change rollout, managing resistance, org change, reorg, or pivot communication.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "chro-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/chro-advisor",
+          "description": "People leadership for scaling companies. Hiring strategy, compensation design, org structure, culture, and retention. Use when building hiring plans, designing comp frameworks, restructuring teams, managing performance, building culture, or when user mentions CHRO, HR, people strategy, talent, headcount, compensation, org design, retention, or performance management.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "churn-prevention",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/churn-prevention",
+          "description": "Reduce voluntary and involuntary churn through cancel flow design, save offers, exit surveys, and dunning sequences. Use when designing or optimizing a cancel flow, building save offers, setting up dunning emails, or reducing failed-payment churn. Trigger keywords: cancel flow, churn reduction, save offers, dunning, exit survey, payment recovery, win-back, involuntary churn, failed payments, cancel page. NOT for customer health scoring or expansion revenue — use customer-success-manager for that.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ciso-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ciso-advisor",
+          "description": "Security leadership for growth-stage companies. Risk quantification in dollars, compliance roadmap (SOC 2/ISO 27001/HIPAA/GDPR), security architecture strategy, incident response leadership, and board-level security reporting. Use when building security programs, justifying security budget, selecting compliance frameworks, managing incidents, assessing vendor risk, or when user mentions CISO, security strategy, compliance roadmap, zero trust, or board security reporting.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cmo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cmo-advisor",
+          "description": "Marketing leadership for scaling companies. Brand positioning, growth model design, marketing budget allocation, and marketing org design. Use when designing brand strategy, selecting growth models (PLG vs sales-led vs community-led), allocating marketing budgets, building marketing teams, or when user mentions CMO, brand strategy, growth model, CAC, LTV, channel mix, or marketing ROI.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "code-to-prd",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-to-prd/skills/code-to-prd",
+          "description": "Reverse-engineer any codebase into a complete Product Requirements Document (PRD). Analyzes routes, components, state management, API integrations, and user interactions to produce business-readable documentation detailed enough for engineers or AI agents to fully reconstruct every page and endpoint. Works with frontend frameworks (React, Vue, Angular, Svelte, Next.js, Nuxt), backend frameworks (NestJS, Django, Express, FastAPI), and fullstack applications. Trigger when users mention: generate PRD, reverse-engineer requirements, code to documentation, extract product specs from code, document page logic, analyze page fields and interactions, create a functional inventory, write requirements from an existing codebase, document API endpoints, or analyze backend routes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cold-email",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cold-email",
+          "description": "When the user wants to write, improve, or build a sequence of B2B cold outreach emails to prospects who haven't asked to hear from them. Use when the user mentions 'cold email,' 'cold outreach,' 'prospecting emails,' 'SDR emails,' 'sales emails,' 'first touch email,' 'follow-up sequence,' or 'email prospecting.' Also use when they share an email draft that sounds too sales-y and needs to be humanized. Distinct from email-sequence (lifecycle/nurture to opted-in subscribers) — this is unsolicited outreach to new prospects. NOT for lifecycle emails, newsletters, or drip campaigns (use email-sequence).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "company-os",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/company-os",
+          "description": "The meta-framework for how a company runs — the connective tissue between all C-suite roles. Covers operating system selection (EOS, Scaling Up, OKR-native, hybrid), accountability charts, scorecards, meeting pulse, issue resolution, and 90-day rocks. Use when setting up company operations, selecting a management framework, designing meeting rhythms, building accountability systems, implementing OKRs, or when user mentions EOS, Scaling Up, operating system, L10 meetings, rocks, scorecard, accountability chart, or quarterly planning.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitive-intel",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitive-intel",
+          "description": "Systematic competitor tracking that feeds CMO positioning, CRO battlecards, and CPO roadmap decisions. Use when analyzing competitors, building sales battlecards, tracking market moves, positioning against alternatives, or when user mentions competitive intelligence, competitive analysis, competitor research, battlecards, win/loss, or market positioning.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitive-teardown",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitive-teardown",
+          "description": "Analyzes competitor products and companies by synthesizing data from pricing pages, app store reviews, job postings, SEO signals, and social media into structured competitive intelligence. Produces feature comparison matrices scored across 12 dimensions, SWOT analyses, positioning maps, UX audits, pricing model breakdowns, action item roadmaps, and stakeholder presentation templates. Use when conducting competitor analysis, comparing products against competitors, researching the competitive landscape, building battle cards for sales, preparing for a product strategy or roadmap session, responding to a competitor's new feature or pricing change, or performing a quarterly competitive review.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "competitor-alternatives",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitor-alternatives",
+          "description": "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'switch from competitor,' or 'comparison content.' Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. Emphasizes deep research, modular content architecture, and varied section types beyond feature tables.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-creator",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-creator",
+          "description": "Deprecated redirect skill that routes legacy 'content creator' requests to the correct specialist. Use when a user invokes 'content creator', asks to write a blog post, article, guide, or brand voice analysis (routes to content-production), or asks to plan content, build a topic cluster, or create a content calendar (routes to content-strategy). Does not handle requests directly — identifies user intent and redirects to content-production for writing/SEO/brand-voice tasks or content-strategy for planning tasks.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "content-humanizer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-humanizer",
+          "description": "Makes AI-generated content sound genuinely human — not just cleaned up, but alive. Use when content feels robotic, uses too many AI clichés, lacks personality, or reads like it was written by committee. Triggers: 'this sounds like AI', 'make it more human', 'add personality', 'it feels generic', 'sounds robotic', 'fix AI writing', 'inject our voice'. NOT for initial content creation (use content-production). NOT for SEO optimization (use content-production Mode 3).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-production",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-production",
+          "description": "Full content production pipeline — takes a topic from blank page to published-ready piece. Use when you need to execute content: write a blog post, article, or guide end-to-end. Triggers: 'write a post about', 'draft an article', 'create content for', 'help me write', 'I need a blog post'. NOT for content strategy or calendar planning (use content-strategy). NOT for repurposing existing content (use content-repurposing). NOT for social captions only.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-strategy",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-strategy",
+          "description": "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions \\\"content strategy,\\\" \\\"what should I write about,\\\" \\\"content ideas,\\\" \\\"blog strategy,\\\" \\\"topic clusters,\\\" or \\\"content planning.\\\" For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "coo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/coo-advisor",
+          "description": "Operations leadership for scaling companies. Process design, OKR execution, operational cadence, and scaling playbooks. Use when designing operations, setting up OKRs, building processes, scaling teams, analyzing bottlenecks, planning operational cadence, or when user mentions COO, operations, process improvement, OKRs, scaling, operational efficiency, or execution.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "copy-editing",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/copy-editing",
+          "description": "When the user wants to edit, review, or improve existing marketing copy. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' or 'copy sweep.' This skill provides a systematic approach to editing marketing copy through multiple focused passes.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "copywriting",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/copywriting",
+          "description": "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \\\"write copy for,\\\" \\\"improve this copy,\\\" \\\"rewrite this page,\\\" \\\"marketing copy,\\\" \\\"headline help,\\\" or \\\"CTA copy.\\\" For email copy, see email-sequence. For popup copy, see popup-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cpo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cpo-advisor",
+          "description": "Product leadership for scaling companies. Product vision, portfolio strategy, product-market fit, and product org design. Use when setting product vision, managing a product portfolio, measuring PMF, designing product teams, prioritizing at the portfolio level, reporting to the board on product, or when user mentions CPO, product strategy, product-market fit, product organization, portfolio prioritization, or roadmap strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cro-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cro-advisor",
+          "description": "Revenue leadership for B2B SaaS companies. Revenue forecasting, sales model design, pricing strategy, net revenue retention, and sales team scaling. Use when designing the revenue engine, setting quotas, modeling NRR, evaluating pricing, building board forecasts, or when user mentions CRO, chief revenue officer, revenue strategy, sales model, ARR growth, NRR, expansion revenue, churn, pricing strategy, or sales capacity.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cs-agile-product-owner",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-agile-product-owner",
+          "description": "Agile product owner agent for epic breakdown, sprint planning, backlog refinement, and INVEST-compliant user story generation",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-ceo-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-ceo-advisor",
+          "description": "Strategic leadership advisor for CEOs covering vision, strategy, board management, investor relations, and organizational culture",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-content-creator",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-content-creator",
+          "description": "AI-powered content creation specialist for brand voice consistency, SEO optimization, and multi-platform content strategy",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-cto-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-cto-advisor",
+          "description": "Technical leadership advisor for CTOs covering technology strategy, team scaling, architecture decisions, and engineering excellence",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-demand-gen-specialist",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-demand-gen-specialist",
+          "description": "Demand generation and customer acquisition specialist for lead generation, conversion optimization, and multi-channel acquisition campaigns",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-financial-analyst",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-financial-analyst",
+          "description": "Financial Analyst agent for DCF valuation, financial modeling, budgeting, forecasting, and SaaS metrics (ARR, MRR, churn, CAC, LTV, NRR). Orchestrates finance skills. Spawn when users need financial analysis, valuation models, budget planning, ratio analysis, SaaS health checks, or unit economics projections.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-growth-strategist",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-growth-strategist",
+          "description": "Growth Strategist agent for revenue operations, sales engineering, customer success, and business development. Orchestrates business-growth skills. Spawn when users need pipeline analysis, churn prevention, expansion scoring, sales demos, or proposal writing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-product-analyst",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-product-analyst",
+          "description": "Product analytics agent for KPI definition, dashboard setup, experiment design, and test result interpretation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-product-manager",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-product-manager",
+          "description": "Product management agent for feature prioritization, customer discovery, PRD development, and roadmap planning using RICE framework",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-product-strategist",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-product-strategist",
+          "description": "Product strategy agent for quarterly OKR planning, competitive landscape analysis, product vision development, and strategy pivot evaluation",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-project-manager",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-project-manager",
+          "description": "Project Manager agent for sprint planning, Jira/Confluence workflows, Scrum ceremonies, and stakeholder reporting. Orchestrates project-management skills.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-quality-regulatory",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-quality-regulatory",
+          "description": "Quality & Regulatory agent for ISO 13485 QMS, MDR compliance, FDA submissions, GDPR/DSGVO, and ISMS audits. Orchestrates ra-qm-team skills. Spawn when users need regulatory strategy, audit preparation, CAPA management, risk management, or compliance documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cs-ux-researcher",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-ux-researcher",
+          "description": "UX research agent for research planning, persona generation, journey mapping, and usability test analysis",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cto-advisor",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cto-advisor",
+          "description": "Technical leadership guidance for engineering teams, architecture decisions, and technology strategy. Use when assessing technical debt, scaling engineering teams, evaluating technologies, making architecture decisions, establishing engineering metrics, or when user mentions CTO, tech debt, technical debt, team scaling, architecture decisions, technology evaluation, engineering metrics, DORA metrics, or technology strategy.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "customer-success-manager",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/customer-success-manager",
+          "description": "Monitors customer health, predicts churn risk, and identifies expansion opportunities using weighted scoring models for SaaS customer success. Use when analyzing customer accounts, reviewing retention metrics, scoring at-risk customers, or when the user mentions churn, customer health scores, upsell opportunities, expansion revenue, retention analysis, or customer analytics. Runs three Python CLI tools to produce deterministic health scores, churn risk tiers, and prioritized expansion recommendations across Enterprise, Mid-Market, and SMB segments.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "demo-video",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/demo-video/skills/demo-video",
+          "description": "Use when the user asks to create a demo video, product walkthrough, feature showcase, animated presentation, marketing video, or GIF from screenshots or scene descriptions. Orchestrates playwright, ffmpeg, and edge-tts MCPs to produce polished video content.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "DevOps Engineer",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/devops-engineer",
+          "description": "Builds infrastructure that scales without babysitting. Automates everything worth automating. Monitors before it breaks. Treats clicking in consoles as a production incident waiting to happen.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docker-development",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/docker-development/skills/docker-development",
+          "description": "Docker and container development agent skill and plugin for Dockerfile optimization, docker-compose orchestration, multi-stage builds, and container security hardening. Use when: user wants to optimize a Dockerfile, create or improve docker-compose configurations, implement multi-stage builds, audit container security, reduce image size, or follow container best practices. Covers build performance, layer caching, secret management, and production-ready container patterns.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "epic-design",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/epic-design",
+          "description": "Build immersive, cinematic 2.5D interactive websites using scroll storytelling, parallax depth, text animations, and premium scroll effects — no WebGL required. Use this skill for any web design task: landing pages, product sites, hero sections, scroll animations, parallax, sticky sections, section overlaps, floating products between sections, clip-path reveals, text that flies in from sides, words that light up on scroll, curtain drops, iris opens, card stacks, bleed typography, and any site that should feel cinematic or premium. Trigger on phrases like \"make it feel alive\", \"Apple-style animation\", \"sections that overlap\", \"product rises between sections\", \"immersive\", \"scrollytelling\", or any scroll-driven visual effect. Covers 45+ techniques across 8 categories. Always inspects, judges, and plans assets before coding. Use aggressively for ANY web design task.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "experiment-designer",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/experiment-designer",
+          "description": "Use when planning product experiments, writing testable hypotheses, estimating sample size, prioritizing tests, or interpreting A/B outcomes with practical statistical rigor.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fda-consultant-specialist",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/fda-consultant-specialist",
+          "description": "FDA regulatory consultant for medical device companies. Provides 510(k)/PMA/De Novo pathway guidance, QSR (21 CFR 820) compliance, HIPAA assessments, and device cybersecurity. Use when user mentions FDA submission, 510(k), PMA, De Novo, QSR, premarket, predicate device, substantial equivalence, HIPAA medical device, or FDA cybersecurity.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Finance Lead",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/finance-lead",
+          "description": "Startup CFO who builds models that survive contact with reality. Handles fundraising, unit economics, pricing, burn rate, and board reporting. Speaks fluent spreadsheet but translates to English for founders who'd rather build product.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "finance-skills",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/finance-skills",
+          "description": "Financial analyst agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Ratio analysis, DCF valuation, budget variance, rolling forecasts. 4 Python tools (stdlib-only).",
+          "version": "1.0.0"
+        },
+        {
+          "name": "founder-coach",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/founder-coach",
+          "description": "Personal leadership development for founders and first-time CEOs. Covers founder archetype identification, delegation frameworks, energy management, CEO calendar audits, leadership style evolution, blind spot identification, imposter syndrome, founder mental health, and succession planning. Use when a founder feels like the bottleneck, struggles to delegate, is burning out, transitioning from IC to executive, managing a board, or when user mentions founder mode, CEO growth, leadership development, delegation, burnout, or imposter syndrome.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "free-tool-strategy",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/free-tool-strategy",
+          "description": "When the user wants to build a free tool for marketing — lead generation, SEO value, or brand awareness. Use when they mention 'engineering as marketing,' 'free tool,' 'calculator,' 'generator,' 'checker,' 'grader,' 'marketing tool,' 'lead gen tool,' 'build something for traffic,' 'interactive tool,' or 'free resource.' Covers idea evaluation, tool design, and launch strategy. For pure SEO content strategy (no tool), use seo-audit or content-strategy instead.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "gcp-cloud-architect",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/gcp-cloud-architect",
+          "description": "Design GCP architectures for startups and enterprises. Use when asked to design Google Cloud infrastructure, deploy to GKE or Cloud Run, configure BigQuery pipelines, optimize GCP costs, or migrate to GCP. Covers Cloud Run, GKE, Cloud Functions, Cloud SQL, BigQuery, and cost optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gdpr-dsgvo-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/gdpr-dsgvo-expert",
+          "description": "GDPR and German DSGVO compliance automation. Scans codebases for privacy risks, generates DPIA documentation, tracks data subject rights requests. Use for GDPR compliance assessments, privacy audits, data protection planning, DPIA generation, and data subject rights management.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "Growth Marketer",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/growth-marketer",
+          "description": "Growth marketing specialist for bootstrapped startups and indie hackers. Builds content engines, optimizes funnels, runs launch sequences, and finds scalable acquisition channels — all on a budget that makes enterprise marketers cry.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "internal-narrative",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/internal-narrative",
+          "description": "Build and maintain one coherent company story across all audiences — employees, investors, customers, candidates, and partners. Detects narrative contradictions and ensures the same truth is framed for each audience's needs. Use when preparing investor updates, all-hands presentations, board communications, recruiting narratives, crisis communications, or when user mentions company narrative, messaging consistency, storytelling, all-hands, investor update, or crisis communication.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "intl-expansion",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/intl-expansion",
+          "description": "International market expansion strategy. Market selection, entry modes, localization, regulatory compliance, and go-to-market by region. Use when expanding to new countries, evaluating international markets, planning localization, or building regional teams.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "jira-expert",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/jira-expert",
+          "description": "Atlassian Jira expert for creating and managing projects, planning, product discovery, JQL queries, workflows, custom fields, automation, reporting, and all Jira features. Use for Jira project setup, configuration, advanced search, dashboard creation, workflow design, and technical Jira operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "landing-page-generator",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/landing-page-generator",
+          "description": "Generates high-converting landing pages as complete Next.js/React (TSX) components with Tailwind CSS. Creates hero sections, feature grids, pricing tables, FAQ accordions, testimonial blocks, and CTA sections using proven copy frameworks (PAS, AIDA, BAB). Outputs SEO meta tags, structured data, and performance-optimised code targeting Core Web Vitals (LCP < 1s, CLS < 0.1). Use when the user asks to create a landing page, marketing page, homepage, single-page site, lead capture page, campaign page, promo page, or conversion-optimised web page — or when they want to A/B test landing page variants or replace a static page with one designed to convert.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "launch-strategy",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/launch-strategy",
+          "description": "When the user wants to plan a product launch, feature announcement, or release strategy. Also use when the user mentions 'launch,' 'Product Hunt,' 'feature release,' 'announcement,' 'go-to-market,' 'beta launch,' 'early access,' 'waitlist,' 'product update,' 'GTM plan,' 'launch checklist,' or 'launch momentum.' This skill covers phased launches, channel strategy, and ongoing launch momentum.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ma-playbook",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ma-playbook",
+          "description": "M&A strategy for acquiring companies or being acquired. Due diligence, valuation, integration, and deal structure. Use when evaluating acquisitions, preparing for acquisition, M&A due diligence, integration planning, or deal negotiation.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "marketing-context",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-context",
+          "description": "Create and maintain the marketing context document that all marketing skills read before starting. Use when the user mentions 'marketing context,' 'brand voice,' 'set up context,' 'target audience,' 'ICP,' 'style guide,' 'who is my customer,' 'positioning,' or wants to avoid repeating foundational information across marketing tasks. Run this at the start of any new project before using other marketing skills.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "marketing-demand-acquisition",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-demand-acquisition",
+          "description": "Creates demand generation campaigns, optimizes paid ad spend across LinkedIn, Google, and Meta, develops SEO strategies, and structures partnership programs for Series A+ startups scaling internationally. Use when planning marketing strategy, growth marketing, advertising campaigns, PPC optimization, lead generation, pipeline generation, or startup marketing budgets. Covers multi-channel acquisition (Google Ads, LinkedIn Ads, Meta Ads), CAC analysis, MQL/SQL workflows, attribution modeling, technical SEO, and co-marketing partnerships for hybrid PLG/Sales-Led motions in EU/US/Canada markets.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "marketing-ideas",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-ideas",
+          "description": "When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the user asks for 'marketing ideas,' 'growth ideas,' 'how to market,' 'marketing strategies,' 'marketing tactics,' 'ways to promote,' or 'ideas to grow.' This skill provides 139 proven marketing approaches organized by category.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "marketing-ops",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-ops",
+          "description": "Central router for the marketing skill ecosystem. Use when unsure which marketing skill to use, when orchestrating a multi-skill campaign, or when coordinating across content, SEO, CRO, channels, and analytics. Also use when the user mentions 'marketing help,' 'campaign plan,' 'what should I do next,' 'marketing priorities,' or 'coordinate marketing.'",
+          "version": "1.0.0"
+        },
+        {
+          "name": "marketing-psychology",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-psychology",
+          "description": "When the user wants to apply psychological principles, mental models, or behavioral science to marketing. Also use when the user mentions 'psychology,' 'mental models,' 'cognitive bias,' 'persuasion,' 'behavioral science,' 'why people buy,' 'decision-making,' or 'consumer behavior.' This skill provides 70+ mental models organized for marketing application.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "marketing-skills",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-skills",
+          "description": "42 marketing agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw, and 6 more coding agents. 7 pods: content, SEO, CRO, channels, growth, intelligence, sales. Foundation context + orchestration router. 27 Python tools (stdlib-only).",
+          "version": "2.0.0"
+        },
+        {
+          "name": "marketing-strategy-pmm",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-strategy-pmm",
+          "description": "Product marketing skill for positioning, GTM strategy, competitive intelligence, and product launches. Use when the user asks about product positioning, go-to-market planning, competitive analysis, target audience definition, ICP definition, market research, launch plans, or sales enablement. Covers April Dunford positioning, ICP definition, competitive battlecards, launch playbooks, and international market entry. Produces deliverables including positioning statements, battlecard documents, launch plans, and go-to-market strategies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "mdr-745-specialist",
+          "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/mdr-745-specialist",
+          "description": "EU MDR 2017/745 compliance specialist for medical device classification, technical documentation, clinical evidence, and post-market surveillance. Covers Annex VIII classification rules, Annex II/III technical files, Annex XIV clinical evaluation, and EUDAMED integration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "okr",
+          "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/okr",
+          "description": "Generate OKR cascades from company strategy to team objectives. Usage: /okr generate <strategy>",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "alirezarezvani",
+        "repo": "claude-skills",
+        "repoUrl": "https://github.com/alirezarezvani/claude-skills.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/anthropics_skills.json
+++ b/data/skill-index/anthropics_skills.json
@@ -2471,5 +2471,481 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "anthropics-skills-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from anthropics/skills.",
+      "author": "ASM (anthropics/skills)",
+      "createdAt": "2026-05-09T08:10:25.972Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "anthropics",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "algorithmic-art",
+          "installUrl": "github:anthropics/skills:skills/algorithmic-art",
+          "description": "Creating algorithmic art using p5.js with seeded randomness and interactive parameter exploration. Use this when users request creating art using code, generative art, algorithmic art, flow fields, or particle systems. Create original algorithmic art rather than copying existing artists' work to avoid copyright violations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brand-guidelines",
+          "installUrl": "github:anthropics/skills:skills/brand-guidelines",
+          "description": "Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "canvas-design",
+          "installUrl": "github:anthropics/skills:skills/canvas-design",
+          "description": "Create beautiful visual art in .png and .pdf documents using design philosophy. You should use this skill when the user asks to create a poster, piece of art, design, or other static piece. Create original visual designs, never copying existing artists' work to avoid copyright violations.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "anthropics",
+        "repo": "skills",
+        "repoUrl": "https://github.com/anthropics/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "anthropics-skills-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from anthropics/skills.",
+      "author": "ASM (anthropics/skills)",
+      "createdAt": "2026-05-09T08:10:25.972Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "anthropics",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "algorithmic-art",
+          "installUrl": "github:anthropics/skills:skills/algorithmic-art",
+          "description": "Creating algorithmic art using p5.js with seeded randomness and interactive parameter exploration. Use this when users request creating art using code, generative art, algorithmic art, flow fields, or particle systems. Create original algorithmic art rather than copying existing artists' work to avoid copyright violations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "canvas-design",
+          "installUrl": "github:anthropics/skills:skills/canvas-design",
+          "description": "Create beautiful visual art in .png and .pdf documents using design philosophy. You should use this skill when the user asks to create a poster, piece of art, design, or other static piece. Create original visual designs, never copying existing artists' work to avoid copyright violations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "doc-coauthoring",
+          "installUrl": "github:anthropics/skills:skills/doc-coauthoring",
+          "description": "Guide users through a structured workflow for co-authoring documentation. Use when user wants to write documentation, proposals, technical specs, decision docs, or similar structured content. This workflow helps users efficiently transfer context, refine content through iteration, and verify the doc works for readers. Trigger when user mentions writing docs, creating proposals, drafting specs, or similar documentation tasks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docx",
+          "installUrl": "github:anthropics/skills:skills/docx",
+          "description": "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of 'Word doc', 'word document', '.docx', or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting or reorganizing content from .docx files, inserting or replacing images in documents, performing find-and-replace in Word files, working with tracked changes or comments, or converting content into a polished Word document. If the user asks for a 'report', 'memo', 'letter', 'template', or similar deliverable as a Word or .docx file, use this skill. Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks unrelated to document generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "internal-comms",
+          "installUrl": "github:anthropics/skills:skills/internal-comms",
+          "description": "A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pptx",
+          "installUrl": "github:anthropics/skills:skills/pptx",
+          "description": "Use this skill any time a .pptx file is involved in any way — as input, output, or both. This includes: creating slide decks, pitch decks, or presentations; reading, parsing, or extracting text from any .pptx file (even if the extracted content will be used elsewhere, like in an email or summary); editing, modifying, or updating existing presentations; combining or splitting slide files; working with templates, layouts, speaker notes, or comments. Trigger whenever the user mentions \\\"deck,\\\" \\\"slides,\\\" \\\"presentation,\\\" or references a .pptx filename, regardless of what they plan to do with the content afterward. If a .pptx file needs to be opened, created, or touched, use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "theme-factory",
+          "installUrl": "github:anthropics/skills:skills/theme-factory",
+          "description": "Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been creating, or can generate a new theme on-the-fly.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "anthropics",
+        "repo": "skills",
+        "repoUrl": "https://github.com/anthropics/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "anthropics-skills-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from anthropics/skills.",
+      "author": "ASM (anthropics/skills)",
+      "createdAt": "2026-05-09T08:10:25.972Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "anthropics",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "claude-api",
+          "installUrl": "github:anthropics/skills:skills/claude-api",
+          "description": "Build, debug, and optimize Claude API / Anthropic SDK apps. Apps built with this skill should include prompt caching. Also handles migrating existing Claude API code between Claude model versions (4.5 → 4.6, 4.6 → 4.7, retired-model replacements). TRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`; user asks for the Claude API, Anthropic SDK, or Managed Agents; user adds/modifies/tunes a Claude feature (caching, thinking, compaction, tool use, batch, files, citations, memory) or model (Opus/Sonnet/Haiku) in a file; questions about prompt caching / cache hit rate in an Anthropic SDK project. SKIP: file imports `openai`/other-provider SDK, filename like `*-openai.py`/`*-generic.py`, provider-neutral code, general programming/ML.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "doc-coauthoring",
+          "installUrl": "github:anthropics/skills:skills/doc-coauthoring",
+          "description": "Guide users through a structured workflow for co-authoring documentation. Use when user wants to write documentation, proposals, technical specs, decision docs, or similar structured content. This workflow helps users efficiently transfer context, refine content through iteration, and verify the doc works for readers. Trigger when user mentions writing docs, creating proposals, drafting specs, or similar documentation tasks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pptx",
+          "installUrl": "github:anthropics/skills:skills/pptx",
+          "description": "Use this skill any time a .pptx file is involved in any way — as input, output, or both. This includes: creating slide decks, pitch decks, or presentations; reading, parsing, or extracting text from any .pptx file (even if the extracted content will be used elsewhere, like in an email or summary); editing, modifying, or updating existing presentations; combining or splitting slide files; working with templates, layouts, speaker notes, or comments. Trigger whenever the user mentions \\\"deck,\\\" \\\"slides,\\\" \\\"presentation,\\\" or references a .pptx filename, regardless of what they plan to do with the content afterward. If a .pptx file needs to be opened, created, or touched, use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "skill-creator",
+          "installUrl": "github:anthropics/skills:skills/skill-creator",
+          "description": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "webapp-testing",
+          "installUrl": "github:anthropics/skills:skills/webapp-testing",
+          "description": "Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "anthropics",
+        "repo": "skills",
+        "repoUrl": "https://github.com/anthropics/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "anthropics-skills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from anthropics/skills.",
+      "author": "ASM (anthropics/skills)",
+      "createdAt": "2026-05-09T08:10:25.972Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "anthropics",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "algorithmic-art",
+          "installUrl": "github:anthropics/skills:skills/algorithmic-art",
+          "description": "Creating algorithmic art using p5.js with seeded randomness and interactive parameter exploration. Use this when users request creating art using code, generative art, algorithmic art, flow fields, or particle systems. Create original algorithmic art rather than copying existing artists' work to avoid copyright violations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "claude-api",
+          "installUrl": "github:anthropics/skills:skills/claude-api",
+          "description": "Build, debug, and optimize Claude API / Anthropic SDK apps. Apps built with this skill should include prompt caching. Also handles migrating existing Claude API code between Claude model versions (4.5 → 4.6, 4.6 → 4.7, retired-model replacements). TRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`; user asks for the Claude API, Anthropic SDK, or Managed Agents; user adds/modifies/tunes a Claude feature (caching, thinking, compaction, tool use, batch, files, citations, memory) or model (Opus/Sonnet/Haiku) in a file; questions about prompt caching / cache hit rate in an Anthropic SDK project. SKIP: file imports `openai`/other-provider SDK, filename like `*-openai.py`/`*-generic.py`, provider-neutral code, general programming/ML.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docx",
+          "installUrl": "github:anthropics/skills:skills/docx",
+          "description": "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of 'Word doc', 'word document', '.docx', or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting or reorganizing content from .docx files, inserting or replacing images in documents, performing find-and-replace in Word files, working with tracked changes or comments, or converting content into a polished Word document. If the user asks for a 'report', 'memo', 'letter', 'template', or similar deliverable as a Word or .docx file, use this skill. Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks unrelated to document generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "frontend-design",
+          "installUrl": "github:anthropics/skills:skills/frontend-design",
+          "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "mcp-builder",
+          "installUrl": "github:anthropics/skills:skills/mcp-builder",
+          "description": "Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "skill-creator",
+          "installUrl": "github:anthropics/skills:skills/skill-creator",
+          "description": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "web-artifacts-builder",
+          "installUrl": "github:anthropics/skills:skills/web-artifacts-builder",
+          "description": "Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui). Use for complex artifacts requiring state management, routing, or shadcn/ui components - not for simple single-file HTML/JSX artifacts.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "webapp-testing",
+          "installUrl": "github:anthropics/skills:skills/webapp-testing",
+          "description": "Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "xlsx",
+          "installUrl": "github:anthropics/skills:skills/xlsx",
+          "description": "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .csv, or .tsv file (e.g., adding columns, computing formulas, formatting, charting, cleaning messy data); create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger especially when the user references a spreadsheet file by name or path — even casually (like \\\"the xlsx in my downloads\\\") — and wants something done to it or produced from it. Also trigger for cleaning or restructuring messy tabular data files (malformed rows, misplaced headers, junk data) into proper spreadsheets. The deliverable must be a spreadsheet file. Do NOT trigger when the primary deliverable is a Word document, HTML report, standalone Python script, database pipeline, or Google Sheets API integration, even if tabular data is involved.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "anthropics",
+        "repo": "skills",
+        "repoUrl": "https://github.com/anthropics/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "anthropics-skills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from anthropics/skills.",
+      "author": "ASM (anthropics/skills)",
+      "createdAt": "2026-05-09T08:10:25.972Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "anthropics",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "brand-guidelines",
+          "installUrl": "github:anthropics/skills:skills/brand-guidelines",
+          "description": "Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "canvas-design",
+          "installUrl": "github:anthropics/skills:skills/canvas-design",
+          "description": "Create beautiful visual art in .png and .pdf documents using design philosophy. You should use this skill when the user asks to create a poster, piece of art, design, or other static piece. Create original visual designs, never copying existing artists' work to avoid copyright violations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "claude-api",
+          "installUrl": "github:anthropics/skills:skills/claude-api",
+          "description": "Build, debug, and optimize Claude API / Anthropic SDK apps. Apps built with this skill should include prompt caching. Also handles migrating existing Claude API code between Claude model versions (4.5 → 4.6, 4.6 → 4.7, retired-model replacements). TRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`; user asks for the Claude API, Anthropic SDK, or Managed Agents; user adds/modifies/tunes a Claude feature (caching, thinking, compaction, tool use, batch, files, citations, memory) or model (Opus/Sonnet/Haiku) in a file; questions about prompt caching / cache hit rate in an Anthropic SDK project. SKIP: file imports `openai`/other-provider SDK, filename like `*-openai.py`/`*-generic.py`, provider-neutral code, general programming/ML.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "doc-coauthoring",
+          "installUrl": "github:anthropics/skills:skills/doc-coauthoring",
+          "description": "Guide users through a structured workflow for co-authoring documentation. Use when user wants to write documentation, proposals, technical specs, decision docs, or similar structured content. This workflow helps users efficiently transfer context, refine content through iteration, and verify the doc works for readers. Trigger when user mentions writing docs, creating proposals, drafting specs, or similar documentation tasks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "frontend-design",
+          "installUrl": "github:anthropics/skills:skills/frontend-design",
+          "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "mcp-builder",
+          "installUrl": "github:anthropics/skills:skills/mcp-builder",
+          "description": "Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pptx",
+          "installUrl": "github:anthropics/skills:skills/pptx",
+          "description": "Use this skill any time a .pptx file is involved in any way — as input, output, or both. This includes: creating slide decks, pitch decks, or presentations; reading, parsing, or extracting text from any .pptx file (even if the extracted content will be used elsewhere, like in an email or summary); editing, modifying, or updating existing presentations; combining or splitting slide files; working with templates, layouts, speaker notes, or comments. Trigger whenever the user mentions \\\"deck,\\\" \\\"slides,\\\" \\\"presentation,\\\" or references a .pptx filename, regardless of what they plan to do with the content afterward. If a .pptx file needs to be opened, created, or touched, use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "theme-factory",
+          "installUrl": "github:anthropics/skills:skills/theme-factory",
+          "description": "Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been creating, or can generate a new theme on-the-fly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "web-artifacts-builder",
+          "installUrl": "github:anthropics/skills:skills/web-artifacts-builder",
+          "description": "Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui). Use for complex artifacts requiring state management, routing, or shadcn/ui components - not for simple single-file HTML/JSX artifacts.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "webapp-testing",
+          "installUrl": "github:anthropics/skills:skills/webapp-testing",
+          "description": "Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "xlsx",
+          "installUrl": "github:anthropics/skills:skills/xlsx",
+          "description": "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .csv, or .tsv file (e.g., adding columns, computing formulas, formatting, charting, cleaning messy data); create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger especially when the user references a spreadsheet file by name or path — even casually (like \\\"the xlsx in my downloads\\\") — and wants something done to it or produced from it. Also trigger for cleaning or restructuring messy tabular data files (malformed rows, misplaced headers, junk data) into proper spreadsheets. The deliverable must be a spreadsheet file. Do NOT trigger when the primary deliverable is a Word document, HTML report, standalone Python script, database pipeline, or Google Sheets API integration, even if tabular data is involved.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "anthropics",
+        "repo": "skills",
+        "repoUrl": "https://github.com/anthropics/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "anthropics-skills-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from anthropics/skills.",
+      "author": "ASM (anthropics/skills)",
+      "createdAt": "2026-05-09T08:10:25.972Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "anthropics",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "brand-guidelines",
+          "installUrl": "github:anthropics/skills:skills/brand-guidelines",
+          "description": "Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "claude-api",
+          "installUrl": "github:anthropics/skills:skills/claude-api",
+          "description": "Build, debug, and optimize Claude API / Anthropic SDK apps. Apps built with this skill should include prompt caching. Also handles migrating existing Claude API code between Claude model versions (4.5 → 4.6, 4.6 → 4.7, retired-model replacements). TRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`; user asks for the Claude API, Anthropic SDK, or Managed Agents; user adds/modifies/tunes a Claude feature (caching, thinking, compaction, tool use, batch, files, citations, memory) or model (Opus/Sonnet/Haiku) in a file; questions about prompt caching / cache hit rate in an Anthropic SDK project. SKIP: file imports `openai`/other-provider SDK, filename like `*-openai.py`/`*-generic.py`, provider-neutral code, general programming/ML.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "doc-coauthoring",
+          "installUrl": "github:anthropics/skills:skills/doc-coauthoring",
+          "description": "Guide users through a structured workflow for co-authoring documentation. Use when user wants to write documentation, proposals, technical specs, decision docs, or similar structured content. This workflow helps users efficiently transfer context, refine content through iteration, and verify the doc works for readers. Trigger when user mentions writing docs, creating proposals, drafting specs, or similar documentation tasks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docx",
+          "installUrl": "github:anthropics/skills:skills/docx",
+          "description": "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of 'Word doc', 'word document', '.docx', or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting or reorganizing content from .docx files, inserting or replacing images in documents, performing find-and-replace in Word files, working with tracked changes or comments, or converting content into a polished Word document. If the user asks for a 'report', 'memo', 'letter', 'template', or similar deliverable as a Word or .docx file, use this skill. Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks unrelated to document generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "internal-comms",
+          "installUrl": "github:anthropics/skills:skills/internal-comms",
+          "description": "A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "xlsx",
+          "installUrl": "github:anthropics/skills:skills/xlsx",
+          "description": "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .csv, or .tsv file (e.g., adding columns, computing formulas, formatting, charting, cleaning messy data); create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger especially when the user references a spreadsheet file by name or path — even casually (like \\\"the xlsx in my downloads\\\") — and wants something done to it or produced from it. Also trigger for cleaning or restructuring messy tabular data files (malformed rows, misplaced headers, junk data) into proper spreadsheets. The deliverable must be a spreadsheet file. Do NOT trigger when the primary deliverable is a Word document, HTML report, standalone Python script, database pipeline, or Google Sheets API integration, even if tabular data is involved.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "anthropics",
+        "repo": "skills",
+        "repoUrl": "https://github.com/anthropics/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "anthropics-skills-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from anthropics/skills.",
+      "author": "ASM (anthropics/skills)",
+      "createdAt": "2026-05-09T08:10:25.972Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "anthropics",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "claude-api",
+          "installUrl": "github:anthropics/skills:skills/claude-api",
+          "description": "Build, debug, and optimize Claude API / Anthropic SDK apps. Apps built with this skill should include prompt caching. Also handles migrating existing Claude API code between Claude model versions (4.5 → 4.6, 4.6 → 4.7, retired-model replacements). TRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`; user asks for the Claude API, Anthropic SDK, or Managed Agents; user adds/modifies/tunes a Claude feature (caching, thinking, compaction, tool use, batch, files, citations, memory) or model (Opus/Sonnet/Haiku) in a file; questions about prompt caching / cache hit rate in an Anthropic SDK project. SKIP: file imports `openai`/other-provider SDK, filename like `*-openai.py`/`*-generic.py`, provider-neutral code, general programming/ML.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "frontend-design",
+          "installUrl": "github:anthropics/skills:skills/frontend-design",
+          "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "internal-comms",
+          "installUrl": "github:anthropics/skills:skills/internal-comms",
+          "description": "A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "mcp-builder",
+          "installUrl": "github:anthropics/skills:skills/mcp-builder",
+          "description": "Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pptx",
+          "installUrl": "github:anthropics/skills:skills/pptx",
+          "description": "Use this skill any time a .pptx file is involved in any way — as input, output, or both. This includes: creating slide decks, pitch decks, or presentations; reading, parsing, or extracting text from any .pptx file (even if the extracted content will be used elsewhere, like in an email or summary); editing, modifying, or updating existing presentations; combining or splitting slide files; working with templates, layouts, speaker notes, or comments. Trigger whenever the user mentions \\\"deck,\\\" \\\"slides,\\\" \\\"presentation,\\\" or references a .pptx filename, regardless of what they plan to do with the content afterward. If a .pptx file needs to be opened, created, or touched, use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "skill-creator",
+          "installUrl": "github:anthropics/skills:skills/skill-creator",
+          "description": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "slack-gif-creator",
+          "installUrl": "github:anthropics/skills:skills/slack-gif-creator",
+          "description": "Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like \"make me a GIF of X doing Y for Slack.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "template-skill",
+          "installUrl": "github:anthropics/skills:template",
+          "description": "Replace with description of the skill and when Claude should use it.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "web-artifacts-builder",
+          "installUrl": "github:anthropics/skills:skills/web-artifacts-builder",
+          "description": "Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui). Use for complex artifacts requiring state management, routing, or shadcn/ui components - not for simple single-file HTML/JSX artifacts.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "xlsx",
+          "installUrl": "github:anthropics/skills:skills/xlsx",
+          "description": "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .csv, or .tsv file (e.g., adding columns, computing formulas, formatting, charting, cleaning messy data); create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger especially when the user references a spreadsheet file by name or path — even casually (like \\\"the xlsx in my downloads\\\") — and wants something done to it or produced from it. Also trigger for cleaning or restructuring messy tabular data files (malformed rows, misplaced headers, junk data) into proper spreadsheets. The deliverable must be a spreadsheet file. Do NOT trigger when the primary deliverable is a Word document, HTML report, standalone Python script, database pipeline, or Google Sheets API integration, even if tabular data is involved.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "anthropics",
+        "repo": "skills",
+        "repoUrl": "https://github.com/anthropics/skills.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/bytedance_deer-flow.json
+++ b/data/skill-index/bytedance_deer-flow.json
@@ -3019,5 +3019,613 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "bytedance-deer-flow-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from bytedance/deer-flow.",
+      "author": "ASM (bytedance/deer-flow)",
+      "createdAt": "2026-05-09T08:10:49.340Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "bytedance",
+        "deer-flow"
+      ],
+      "skills": [
+        {
+          "name": "consulting-analysis",
+          "installUrl": "github:bytedance/deer-flow:skills/public/consulting-analysis",
+          "description": "Use this skill when the user requests to generate, create, or write professional research reports including but not limited to market analysis, consumer insights, brand analysis, financial analysis, industry research, competitive intelligence, investment due diligence, or any consulting-grade analytical report. This skill operates in two phases — (1) generating a structured analysis framework with chapter skeleton, data query requirements, and analysis logic, and (2) after data collection by other skills, producing the final consulting-grade report with structured narratives, embedded charts, and strategic insights.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "systematic-literature-review",
+          "installUrl": "github:bytedance/deer-flow:skills/public/systematic-literature-review",
+          "description": "Use this skill when the user wants a systematic literature review, survey, or synthesis across multiple academic papers on a topic. Also covers annotated bibliographies and cross-paper comparisons. Searches arXiv and outputs reports in APA, IEEE, or BibTeX format. Not for single-paper tasks — use academic-paper-review for reviewing one paper.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "bytedance",
+        "repo": "deer-flow",
+        "repoUrl": "https://github.com/bytedance/deer-flow.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "bytedance-deer-flow-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from bytedance/deer-flow.",
+      "author": "ASM (bytedance/deer-flow)",
+      "createdAt": "2026-05-09T08:10:49.340Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "bytedance",
+        "deer-flow"
+      ],
+      "skills": [
+        {
+          "name": "academic-paper-review",
+          "installUrl": "github:bytedance/deer-flow:skills/public/academic-paper-review",
+          "description": "Use this skill when the user requests to review, analyze, critique, or summarize academic papers, research articles, preprints, or scientific publications. Supports comprehensive structured reviews covering methodology assessment, contribution evaluation, literature positioning, and constructive feedback generation. Trigger on queries involving paper URLs, uploaded PDFs, arXiv links, or requests like \"review this paper\", \"analyze this research\", \"summarize this study\", or \"write a peer review\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-documentation",
+          "installUrl": "github:bytedance/deer-flow:skills/public/code-documentation",
+          "description": "Use this skill when the user requests to generate, create, or improve documentation for code, APIs, libraries, repositories, or software projects. Supports README generation, API reference documentation, inline code comments, architecture documentation, changelog generation, and developer guides. Trigger on requests like \"document this code\", \"create a README\", \"generate API docs\", \"write developer guide\", or when analyzing codebases for documentation purposes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "consulting-analysis",
+          "installUrl": "github:bytedance/deer-flow:skills/public/consulting-analysis",
+          "description": "Use this skill when the user requests to generate, create, or write professional research reports including but not limited to market analysis, consumer insights, brand analysis, financial analysis, industry research, competitive intelligence, investment due diligence, or any consulting-grade analytical report. This skill operates in two phases — (1) generating a structured analysis framework with chapter skeleton, data query requirements, and analysis logic, and (2) after data collection by other skills, producing the final consulting-grade report with structured narratives, embedded charts, and strategic insights.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deep-research",
+          "installUrl": "github:bytedance/deer-flow:skills/public/deep-research",
+          "description": "Use this skill instead of WebSearch for ANY question requiring web research. Trigger on queries like \"what is X\", \"explain X\", \"compare X and Y\", \"research X\", or before content generation tasks. Provides systematic multi-angle research methodology instead of single superficial searches. Use this proactively when the user's question needs online information.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "image-generation",
+          "installUrl": "github:bytedance/deer-flow:skills/public/image-generation",
+          "description": "Use this skill when the user requests to generate, create, imagine, or visualize images including characters, scenes, products, or any visual content. Supports structured prompts and reference images for guided generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "newsletter-generation",
+          "installUrl": "github:bytedance/deer-flow:skills/public/newsletter-generation",
+          "description": "Use this skill when the user requests to generate, create, write, or draft a newsletter, email digest, weekly roundup, industry briefing, or curated content summary. Supports topic-based research, content curation from multiple sources, and professional formatting for email or web distribution. Trigger on requests like \"create a newsletter about X\", \"write a weekly digest\", \"generate a tech roundup\", or \"curate news about Y\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "podcast-generation",
+          "installUrl": "github:bytedance/deer-flow:skills/public/podcast-generation",
+          "description": "Use this skill when the user requests to generate, create, or produce podcasts from text content. Converts written content into a two-host conversational podcast audio format with natural dialogue.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "systematic-literature-review",
+          "installUrl": "github:bytedance/deer-flow:skills/public/systematic-literature-review",
+          "description": "Use this skill when the user wants a systematic literature review, survey, or synthesis across multiple academic papers on a topic. Also covers annotated bibliographies and cross-paper comparisons. Searches arXiv and outputs reports in APA, IEEE, or BibTeX format. Not for single-paper tasks — use academic-paper-review for reviewing one paper.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "bytedance",
+        "repo": "deer-flow",
+        "repoUrl": "https://github.com/bytedance/deer-flow.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "bytedance-deer-flow-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from bytedance/deer-flow.",
+      "author": "ASM (bytedance/deer-flow)",
+      "createdAt": "2026-05-09T08:10:49.340Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "bytedance",
+        "deer-flow"
+      ],
+      "skills": [
+        {
+          "name": "academic-paper-review",
+          "installUrl": "github:bytedance/deer-flow:skills/public/academic-paper-review",
+          "description": "Use this skill when the user requests to review, analyze, critique, or summarize academic papers, research articles, preprints, or scientific publications. Supports comprehensive structured reviews covering methodology assessment, contribution evaluation, literature positioning, and constructive feedback generation. Trigger on queries involving paper URLs, uploaded PDFs, arXiv links, or requests like \"review this paper\", \"analyze this research\", \"summarize this study\", or \"write a peer review\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "claude-to-deerflow",
+          "installUrl": "github:bytedance/deer-flow:skills/public/claude-to-deerflow",
+          "description": "Interact with DeerFlow AI agent platform via its HTTP API. Use this skill when the user wants to send messages or questions to DeerFlow for research/analysis, start a DeerFlow conversation thread, check DeerFlow status or health, list available models/skills/agents in DeerFlow, manage DeerFlow memory, upload files to DeerFlow threads, or delegate complex research tasks to DeerFlow. Also use when the user mentions deerflow, deer flow, or wants to run a deep research task that DeerFlow can handle.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "consulting-analysis",
+          "installUrl": "github:bytedance/deer-flow:skills/public/consulting-analysis",
+          "description": "Use this skill when the user requests to generate, create, or write professional research reports including but not limited to market analysis, consumer insights, brand analysis, financial analysis, industry research, competitive intelligence, investment due diligence, or any consulting-grade analytical report. This skill operates in two phases — (1) generating a structured analysis framework with chapter skeleton, data query requirements, and analysis logic, and (2) after data collection by other skills, producing the final consulting-grade report with structured narratives, embedded charts, and strategic insights.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "data-analysis",
+          "installUrl": "github:bytedance/deer-flow:skills/public/data-analysis",
+          "description": "Use this skill when the user uploads Excel (.xlsx/.xls) or CSV files and wants to perform data analysis, generate statistics, create summaries, pivot tables, SQL queries, or any form of structured data exploration. Supports multi-sheet Excel workbooks, aggregation, filtering, joins, and exporting results to CSV/JSON/Markdown.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deep-research",
+          "installUrl": "github:bytedance/deer-flow:skills/public/deep-research",
+          "description": "Use this skill instead of WebSearch for ANY question requiring web research. Trigger on queries like \"what is X\", \"explain X\", \"compare X and Y\", \"research X\", or before content generation tasks. Provides systematic multi-angle research methodology instead of single superficial searches. Use this proactively when the user's question needs online information.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "github-deep-research",
+          "installUrl": "github:bytedance/deer-flow:skills/public/github-deep-research",
+          "description": "Conduct multi-round deep research on any GitHub Repo. Use when users request comprehensive analysis, timeline reconstruction, competitive analysis, or in-depth investigation of GitHub. Produces structured markdown reports with executive summaries, chronological timelines, metrics analysis, and Mermaid diagrams. Triggers on Github repository URL or open source projects.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "newsletter-generation",
+          "installUrl": "github:bytedance/deer-flow:skills/public/newsletter-generation",
+          "description": "Use this skill when the user requests to generate, create, write, or draft a newsletter, email digest, weekly roundup, industry briefing, or curated content summary. Supports topic-based research, content curation from multiple sources, and professional formatting for email or web distribution. Trigger on requests like \"create a newsletter about X\", \"write a weekly digest\", \"generate a tech roundup\", or \"curate news about Y\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "skill-creator",
+          "installUrl": "github:bytedance/deer-flow:skills/public/skill-creator",
+          "description": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "smoke-test",
+          "installUrl": "github:bytedance/deer-flow:.agent/skills/smoke-test",
+          "description": "End-to-end smoke test skill for DeerFlow. Guides through: 1) Pulling latest code, 2) Docker OR Local installation and deployment (user preference, default to Local if Docker network issues), 3) Service availability verification, 4) Health check, 5) Final test report. Use when the user says \"run smoke test\", \"smoke test deployment\", \"verify installation\", \"test service availability\", \"end-to-end test\", or similar.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "systematic-literature-review",
+          "installUrl": "github:bytedance/deer-flow:skills/public/systematic-literature-review",
+          "description": "Use this skill when the user wants a systematic literature review, survey, or synthesis across multiple academic papers on a topic. Also covers annotated bibliographies and cross-paper comparisons. Searches arXiv and outputs reports in APA, IEEE, or BibTeX format. Not for single-paper tasks — use academic-paper-review for reviewing one paper.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "vercel-deploy",
+          "installUrl": "github:bytedance/deer-flow:skills/public/vercel-deploy-claimable",
+          "description": "Deploy applications and websites to Vercel. Use this skill when the user requests deployment actions such as \"Deploy my app\", \"Deploy this to production\", \"Create a preview deployment\", \"Deploy and give me the link\", or \"Push this live\". No authentication required - returns preview URL and claimable deployment link.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "web-design-guidelines",
+          "installUrl": "github:bytedance/deer-flow:skills/public/web-design-guidelines",
+          "description": "Review UI code for Web Interface Guidelines compliance. Use when asked to \"review my UI\", \"check accessibility\", \"audit design\", \"review UX\", or \"check my site against best practices\".",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "bytedance",
+        "repo": "deer-flow",
+        "repoUrl": "https://github.com/bytedance/deer-flow.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "bytedance-deer-flow-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from bytedance/deer-flow.",
+      "author": "ASM (bytedance/deer-flow)",
+      "createdAt": "2026-05-09T08:10:49.340Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "bytedance",
+        "deer-flow"
+      ],
+      "skills": [
+        {
+          "name": "academic-paper-review",
+          "installUrl": "github:bytedance/deer-flow:skills/public/academic-paper-review",
+          "description": "Use this skill when the user requests to review, analyze, critique, or summarize academic papers, research articles, preprints, or scientific publications. Supports comprehensive structured reviews covering methodology assessment, contribution evaluation, literature positioning, and constructive feedback generation. Trigger on queries involving paper URLs, uploaded PDFs, arXiv links, or requests like \"review this paper\", \"analyze this research\", \"summarize this study\", or \"write a peer review\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "chart-visualization",
+          "installUrl": "github:bytedance/deer-flow:skills/public/chart-visualization",
+          "description": "This skill should be used when the user wants to visualize data. It intelligently selects the most suitable chart type from 26 available options, extracts parameters based on detailed specifications, and generates a chart image using a JavaScript script.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "claude-to-deerflow",
+          "installUrl": "github:bytedance/deer-flow:skills/public/claude-to-deerflow",
+          "description": "Interact with DeerFlow AI agent platform via its HTTP API. Use this skill when the user wants to send messages or questions to DeerFlow for research/analysis, start a DeerFlow conversation thread, check DeerFlow status or health, list available models/skills/agents in DeerFlow, manage DeerFlow memory, upload files to DeerFlow threads, or delegate complex research tasks to DeerFlow. Also use when the user mentions deerflow, deer flow, or wants to run a deep research task that DeerFlow can handle.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-documentation",
+          "installUrl": "github:bytedance/deer-flow:skills/public/code-documentation",
+          "description": "Use this skill when the user requests to generate, create, or improve documentation for code, APIs, libraries, repositories, or software projects. Supports README generation, API reference documentation, inline code comments, architecture documentation, changelog generation, and developer guides. Trigger on requests like \"document this code\", \"create a README\", \"generate API docs\", \"write developer guide\", or when analyzing codebases for documentation purposes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "frontend-design",
+          "installUrl": "github:bytedance/deer-flow:skills/public/frontend-design",
+          "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "skill-creator",
+          "installUrl": "github:bytedance/deer-flow:skills/public/skill-creator",
+          "description": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "smoke-test",
+          "installUrl": "github:bytedance/deer-flow:.agent/skills/smoke-test",
+          "description": "End-to-end smoke test skill for DeerFlow. Guides through: 1) Pulling latest code, 2) Docker OR Local installation and deployment (user preference, default to Local if Docker network issues), 3) Service availability verification, 4) Health check, 5) Final test report. Use when the user says \"run smoke test\", \"smoke test deployment\", \"verify installation\", \"test service availability\", \"end-to-end test\", or similar.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "systematic-literature-review",
+          "installUrl": "github:bytedance/deer-flow:skills/public/systematic-literature-review",
+          "description": "Use this skill when the user wants a systematic literature review, survey, or synthesis across multiple academic papers on a topic. Also covers annotated bibliographies and cross-paper comparisons. Searches arXiv and outputs reports in APA, IEEE, or BibTeX format. Not for single-paper tasks — use academic-paper-review for reviewing one paper.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "vercel-deploy",
+          "installUrl": "github:bytedance/deer-flow:skills/public/vercel-deploy-claimable",
+          "description": "Deploy applications and websites to Vercel. Use this skill when the user requests deployment actions such as \"Deploy my app\", \"Deploy this to production\", \"Create a preview deployment\", \"Deploy and give me the link\", or \"Push this live\". No authentication required - returns preview URL and claimable deployment link.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "web-design-guidelines",
+          "installUrl": "github:bytedance/deer-flow:skills/public/web-design-guidelines",
+          "description": "Review UI code for Web Interface Guidelines compliance. Use when asked to \"review my UI\", \"check accessibility\", \"audit design\", \"review UX\", or \"check my site against best practices\".",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "bytedance",
+        "repo": "deer-flow",
+        "repoUrl": "https://github.com/bytedance/deer-flow.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "bytedance-deer-flow-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from bytedance/deer-flow.",
+      "author": "ASM (bytedance/deer-flow)",
+      "createdAt": "2026-05-09T08:10:49.340Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "bytedance",
+        "deer-flow"
+      ],
+      "skills": [
+        {
+          "name": "chart-visualization",
+          "installUrl": "github:bytedance/deer-flow:skills/public/chart-visualization",
+          "description": "This skill should be used when the user wants to visualize data. It intelligently selects the most suitable chart type from 26 available options, extracts parameters based on detailed specifications, and generates a chart image using a JavaScript script.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-documentation",
+          "installUrl": "github:bytedance/deer-flow:skills/public/code-documentation",
+          "description": "Use this skill when the user requests to generate, create, or improve documentation for code, APIs, libraries, repositories, or software projects. Supports README generation, API reference documentation, inline code comments, architecture documentation, changelog generation, and developer guides. Trigger on requests like \"document this code\", \"create a README\", \"generate API docs\", \"write developer guide\", or when analyzing codebases for documentation purposes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "consulting-analysis",
+          "installUrl": "github:bytedance/deer-flow:skills/public/consulting-analysis",
+          "description": "Use this skill when the user requests to generate, create, or write professional research reports including but not limited to market analysis, consumer insights, brand analysis, financial analysis, industry research, competitive intelligence, investment due diligence, or any consulting-grade analytical report. This skill operates in two phases — (1) generating a structured analysis framework with chapter skeleton, data query requirements, and analysis logic, and (2) after data collection by other skills, producing the final consulting-grade report with structured narratives, embedded charts, and strategic insights.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deep-research",
+          "installUrl": "github:bytedance/deer-flow:skills/public/deep-research",
+          "description": "Use this skill instead of WebSearch for ANY question requiring web research. Trigger on queries like \"what is X\", \"explain X\", \"compare X and Y\", \"research X\", or before content generation tasks. Provides systematic multi-angle research methodology instead of single superficial searches. Use this proactively when the user's question needs online information.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "frontend-design",
+          "installUrl": "github:bytedance/deer-flow:skills/public/frontend-design",
+          "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "image-generation",
+          "installUrl": "github:bytedance/deer-flow:skills/public/image-generation",
+          "description": "Use this skill when the user requests to generate, create, imagine, or visualize images including characters, scenes, products, or any visual content. Supports structured prompts and reference images for guided generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ppt-generation",
+          "installUrl": "github:bytedance/deer-flow:skills/public/ppt-generation",
+          "description": "Use this skill when the user requests to generate, create, or make presentations (PPT/PPTX). Creates visually rich slides by generating images for each slide and composing them into a PowerPoint file.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "smoke-test",
+          "installUrl": "github:bytedance/deer-flow:.agent/skills/smoke-test",
+          "description": "End-to-end smoke test skill for DeerFlow. Guides through: 1) Pulling latest code, 2) Docker OR Local installation and deployment (user preference, default to Local if Docker network issues), 3) Service availability verification, 4) Health check, 5) Final test report. Use when the user says \"run smoke test\", \"smoke test deployment\", \"verify installation\", \"test service availability\", \"end-to-end test\", or similar.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "vercel-deploy",
+          "installUrl": "github:bytedance/deer-flow:skills/public/vercel-deploy-claimable",
+          "description": "Deploy applications and websites to Vercel. Use this skill when the user requests deployment actions such as \"Deploy my app\", \"Deploy this to production\", \"Create a preview deployment\", \"Deploy and give me the link\", or \"Push this live\". No authentication required - returns preview URL and claimable deployment link.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "video-generation",
+          "installUrl": "github:bytedance/deer-flow:skills/public/video-generation",
+          "description": "Use this skill when the user requests to generate, create, or imagine videos. Supports structured prompts and reference image for guided generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "web-design-guidelines",
+          "installUrl": "github:bytedance/deer-flow:skills/public/web-design-guidelines",
+          "description": "Review UI code for Web Interface Guidelines compliance. Use when asked to \"review my UI\", \"check accessibility\", \"audit design\", \"review UX\", or \"check my site against best practices\".",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "bytedance",
+        "repo": "deer-flow",
+        "repoUrl": "https://github.com/bytedance/deer-flow.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "bytedance-deer-flow-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from bytedance/deer-flow.",
+      "author": "ASM (bytedance/deer-flow)",
+      "createdAt": "2026-05-09T08:10:49.340Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "bytedance",
+        "deer-flow"
+      ],
+      "skills": [
+        {
+          "name": "academic-paper-review",
+          "installUrl": "github:bytedance/deer-flow:skills/public/academic-paper-review",
+          "description": "Use this skill when the user requests to review, analyze, critique, or summarize academic papers, research articles, preprints, or scientific publications. Supports comprehensive structured reviews covering methodology assessment, contribution evaluation, literature positioning, and constructive feedback generation. Trigger on queries involving paper URLs, uploaded PDFs, arXiv links, or requests like \"review this paper\", \"analyze this research\", \"summarize this study\", or \"write a peer review\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "chart-visualization",
+          "installUrl": "github:bytedance/deer-flow:skills/public/chart-visualization",
+          "description": "This skill should be used when the user wants to visualize data. It intelligently selects the most suitable chart type from 26 available options, extracts parameters based on detailed specifications, and generates a chart image using a JavaScript script.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "consulting-analysis",
+          "installUrl": "github:bytedance/deer-flow:skills/public/consulting-analysis",
+          "description": "Use this skill when the user requests to generate, create, or write professional research reports including but not limited to market analysis, consumer insights, brand analysis, financial analysis, industry research, competitive intelligence, investment due diligence, or any consulting-grade analytical report. This skill operates in two phases — (1) generating a structured analysis framework with chapter skeleton, data query requirements, and analysis logic, and (2) after data collection by other skills, producing the final consulting-grade report with structured narratives, embedded charts, and strategic insights.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deep-research",
+          "installUrl": "github:bytedance/deer-flow:skills/public/deep-research",
+          "description": "Use this skill instead of WebSearch for ANY question requiring web research. Trigger on queries like \"what is X\", \"explain X\", \"compare X and Y\", \"research X\", or before content generation tasks. Provides systematic multi-angle research methodology instead of single superficial searches. Use this proactively when the user's question needs online information.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "smoke-test",
+          "installUrl": "github:bytedance/deer-flow:.agent/skills/smoke-test",
+          "description": "End-to-end smoke test skill for DeerFlow. Guides through: 1) Pulling latest code, 2) Docker OR Local installation and deployment (user preference, default to Local if Docker network issues), 3) Service availability verification, 4) Health check, 5) Final test report. Use when the user says \"run smoke test\", \"smoke test deployment\", \"verify installation\", \"test service availability\", \"end-to-end test\", or similar.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "vercel-deploy",
+          "installUrl": "github:bytedance/deer-flow:skills/public/vercel-deploy-claimable",
+          "description": "Deploy applications and websites to Vercel. Use this skill when the user requests deployment actions such as \"Deploy my app\", \"Deploy this to production\", \"Create a preview deployment\", \"Deploy and give me the link\", or \"Push this live\". No authentication required - returns preview URL and claimable deployment link.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "bytedance",
+        "repo": "deer-flow",
+        "repoUrl": "https://github.com/bytedance/deer-flow.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "bytedance-deer-flow-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from bytedance/deer-flow.",
+      "author": "ASM (bytedance/deer-flow)",
+      "createdAt": "2026-05-09T08:10:49.340Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "bytedance",
+        "deer-flow"
+      ],
+      "skills": [
+        {
+          "name": "bootstrap",
+          "installUrl": "github:bytedance/deer-flow:skills/public/bootstrap",
+          "description": "Generate a personalized SOUL.md through a warm, adaptive onboarding conversation. Trigger when the user wants to create, set up, or initialize their AI partner's identity — e.g., \"create my SOUL.md\", \"bootstrap my agent\", \"set up my AI partner\", \"define who you are\", \"let's do onboarding\", \"personalize this AI\", \"make you mine\", or when a SOUL.md is missing. Also trigger for updates: \"update my SOUL.md\", \"change my AI's personality\", \"tweak the soul\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "chart-visualization",
+          "installUrl": "github:bytedance/deer-flow:skills/public/chart-visualization",
+          "description": "This skill should be used when the user wants to visualize data. It intelligently selects the most suitable chart type from 26 available options, extracts parameters based on detailed specifications, and generates a chart image using a JavaScript script.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "claude-to-deerflow",
+          "installUrl": "github:bytedance/deer-flow:skills/public/claude-to-deerflow",
+          "description": "Interact with DeerFlow AI agent platform via its HTTP API. Use this skill when the user wants to send messages or questions to DeerFlow for research/analysis, start a DeerFlow conversation thread, check DeerFlow status or health, list available models/skills/agents in DeerFlow, manage DeerFlow memory, upload files to DeerFlow threads, or delegate complex research tasks to DeerFlow. Also use when the user mentions deerflow, deer flow, or wants to run a deep research task that DeerFlow can handle.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "consulting-analysis",
+          "installUrl": "github:bytedance/deer-flow:skills/public/consulting-analysis",
+          "description": "Use this skill when the user requests to generate, create, or write professional research reports including but not limited to market analysis, consumer insights, brand analysis, financial analysis, industry research, competitive intelligence, investment due diligence, or any consulting-grade analytical report. This skill operates in two phases — (1) generating a structured analysis framework with chapter skeleton, data query requirements, and analysis logic, and (2) after data collection by other skills, producing the final consulting-grade report with structured narratives, embedded charts, and strategic insights.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "data-analysis",
+          "installUrl": "github:bytedance/deer-flow:skills/public/data-analysis",
+          "description": "Use this skill when the user uploads Excel (.xlsx/.xls) or CSV files and wants to perform data analysis, generate statistics, create summaries, pivot tables, SQL queries, or any form of structured data exploration. Supports multi-sheet Excel workbooks, aggregation, filtering, joins, and exporting results to CSV/JSON/Markdown.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deep-research",
+          "installUrl": "github:bytedance/deer-flow:skills/public/deep-research",
+          "description": "Use this skill instead of WebSearch for ANY question requiring web research. Trigger on queries like \"what is X\", \"explain X\", \"compare X and Y\", \"research X\", or before content generation tasks. Provides systematic multi-angle research methodology instead of single superficial searches. Use this proactively when the user's question needs online information.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "find-skills",
+          "installUrl": "github:bytedance/deer-flow:skills/public/find-skills",
+          "description": "Helps users discover and install agent skills when they ask questions like \"how do I do X\", \"find a skill for X\", \"is there a skill that can...\", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "frontend-design",
+          "installUrl": "github:bytedance/deer-flow:skills/public/frontend-design",
+          "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "github-deep-research",
+          "installUrl": "github:bytedance/deer-flow:skills/public/github-deep-research",
+          "description": "Conduct multi-round deep research on any GitHub Repo. Use when users request comprehensive analysis, timeline reconstruction, competitive analysis, or in-depth investigation of GitHub. Produces structured markdown reports with executive summaries, chronological timelines, metrics analysis, and Mermaid diagrams. Triggers on Github repository URL or open source projects.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "image-generation",
+          "installUrl": "github:bytedance/deer-flow:skills/public/image-generation",
+          "description": "Use this skill when the user requests to generate, create, imagine, or visualize images including characters, scenes, products, or any visual content. Supports structured prompts and reference images for guided generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "newsletter-generation",
+          "installUrl": "github:bytedance/deer-flow:skills/public/newsletter-generation",
+          "description": "Use this skill when the user requests to generate, create, write, or draft a newsletter, email digest, weekly roundup, industry briefing, or curated content summary. Supports topic-based research, content curation from multiple sources, and professional formatting for email or web distribution. Trigger on requests like \"create a newsletter about X\", \"write a weekly digest\", \"generate a tech roundup\", or \"curate news about Y\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "skill-creator",
+          "installUrl": "github:bytedance/deer-flow:skills/public/skill-creator",
+          "description": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "smoke-test",
+          "installUrl": "github:bytedance/deer-flow:.agent/skills/smoke-test",
+          "description": "End-to-end smoke test skill for DeerFlow. Guides through: 1) Pulling latest code, 2) Docker OR Local installation and deployment (user preference, default to Local if Docker network issues), 3) Service availability verification, 4) Health check, 5) Final test report. Use when the user says \"run smoke test\", \"smoke test deployment\", \"verify installation\", \"test service availability\", \"end-to-end test\", or similar.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "vercel-deploy",
+          "installUrl": "github:bytedance/deer-flow:skills/public/vercel-deploy-claimable",
+          "description": "Deploy applications and websites to Vercel. Use this skill when the user requests deployment actions such as \"Deploy my app\", \"Deploy this to production\", \"Create a preview deployment\", \"Deploy and give me the link\", or \"Push this live\". No authentication required - returns preview URL and claimable deployment link.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "video-generation",
+          "installUrl": "github:bytedance/deer-flow:skills/public/video-generation",
+          "description": "Use this skill when the user requests to generate, create, or imagine videos. Supports structured prompts and reference image for guided generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "web-design-guidelines",
+          "installUrl": "github:bytedance/deer-flow:skills/public/web-design-guidelines",
+          "description": "Review UI code for Web Interface Guidelines compliance. Use when asked to \"review my UI\", \"check accessibility\", \"audit design\", \"review UX\", or \"check my site against best practices\".",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "bytedance",
+        "repo": "deer-flow",
+        "repoUrl": "https://github.com/bytedance/deer-flow.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "bytedance-deer-flow-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from bytedance/deer-flow.",
+      "author": "ASM (bytedance/deer-flow)",
+      "createdAt": "2026-05-09T08:10:49.340Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "bytedance",
+        "deer-flow"
+      ],
+      "skills": [
+        {
+          "name": "consulting-analysis",
+          "installUrl": "github:bytedance/deer-flow:skills/public/consulting-analysis",
+          "description": "Use this skill when the user requests to generate, create, or write professional research reports including but not limited to market analysis, consumer insights, brand analysis, financial analysis, industry research, competitive intelligence, investment due diligence, or any consulting-grade analytical report. This skill operates in two phases — (1) generating a structured analysis framework with chapter skeleton, data query requirements, and analysis logic, and (2) after data collection by other skills, producing the final consulting-grade report with structured narratives, embedded charts, and strategic insights.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "frontend-design",
+          "installUrl": "github:bytedance/deer-flow:skills/public/frontend-design",
+          "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "image-generation",
+          "installUrl": "github:bytedance/deer-flow:skills/public/image-generation",
+          "description": "Use this skill when the user requests to generate, create, imagine, or visualize images including characters, scenes, products, or any visual content. Supports structured prompts and reference images for guided generation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "vercel-deploy",
+          "installUrl": "github:bytedance/deer-flow:skills/public/vercel-deploy-claimable",
+          "description": "Deploy applications and websites to Vercel. Use this skill when the user requests deployment actions such as \"Deploy my app\", \"Deploy this to production\", \"Create a preview deployment\", \"Deploy and give me the link\", or \"Push this live\". No authentication required - returns preview URL and claimable deployment link.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "bytedance",
+        "repo": "deer-flow",
+        "repoUrl": "https://github.com/bytedance/deer-flow.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/coreyhaines31_marketingskills.json
+++ b/data/skill-index/coreyhaines31_marketingskills.json
@@ -5622,5 +5622,1411 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "coreyhaines31-marketingskills-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from coreyhaines31/marketingskills.",
+      "author": "ASM (coreyhaines31/marketingskills)",
+      "createdAt": "2026-05-09T08:10:39.133Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "coreyhaines31",
+        "marketingskills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-setup",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ab-test-setup",
+          "description": "When the user wants to plan, design, or implement an A/B test or experiment, or build a growth experimentation program. Also use when the user mentions \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"should I test this,\" \"which version is better,\" \"test two versions,\" \"statistical significance,\" \"how long should I run this test,\" \"growth experiments,\" \"experiment velocity,\" \"experiment backlog,\" \"ICE score,\" \"experimentation program,\" or \"experiment playbook.\" Use this whenever someone is comparing two approaches and wants to measure which performs better, or when they want to build a systematic experimentation practice. For tracking implementation, see analytics-tracking. For page-level conversion optimization, see page-cro.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "ad-creative",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ad-creative",
+          "description": "When the user wants to generate, iterate, or scale ad creative — headlines, descriptions, primary text, or full ad variations — for any paid advertising platform. Also use when the user mentions 'ad copy variations,' 'ad creative,' 'generate headlines,' 'RSA headlines,' 'bulk ad copy,' 'ad iterations,' 'creative testing,' 'ad performance optimization,' 'write me some ads,' 'Facebook ad copy,' 'Google ad headlines,' 'LinkedIn ad text,' or 'I need more ad variations.' Use this whenever someone needs to produce ad copy at scale or iterate on existing ads. For campaign strategy and targeting, see paid-ads. For landing page copy, see copywriting.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ai-seo",
+          "description": "When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' 'zero-click search,' 'how do I show up in AI answers,' 'LLM mentions,' or 'optimize for Claude/Gemini.' Use this whenever someone wants their content to be cited or surfaced by AI assistants and AI search engines. For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema-markup.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "analytics-tracking",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/analytics-tracking",
+          "description": "When the user wants to set up, improve, or audit analytics tracking and measurement. Also use when the user mentions \"set up tracking,\" \"GA4,\" \"Google Analytics,\" \"conversion tracking,\" \"event tracking,\" \"UTM parameters,\" \"tag manager,\" \"GTM,\" \"analytics implementation,\" \"tracking plan,\" \"how do I measure this,\" \"track conversions,\" \"attribution,\" \"Mixpanel,\" \"Segment,\" \"are my events firing,\" or \"analytics isn't working.\" Use this whenever someone asks how to know if something is working or wants to measure marketing results. For A/B test measurement, see ab-test-setup.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "aso-audit",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/aso-audit",
+          "description": "When the user wants to audit or optimize an App Store or Google Play listing. Also use when the user mentions 'ASO audit,' 'app store optimization,' 'optimize my app listing,' 'improve app visibility,' 'app store ranking,' 'audit my listing,' 'why aren't people downloading my app,' 'improve my app conversion,' 'keyword optimization for app,' or 'compare my app to competitors.' Use when the user shares an App Store or Google Play URL and wants to improve it.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "churn-prevention",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/churn-prevention",
+          "description": "When the user wants to reduce churn, build cancellation flows, set up save offers, recover failed payments, or implement retention strategies. Also use when the user mentions 'churn,' 'cancel flow,' 'offboarding,' 'save offer,' 'dunning,' 'failed payment recovery,' 'win-back,' 'retention,' 'exit survey,' 'pause subscription,' 'involuntary churn,' 'people keep canceling,' 'churn rate is too high,' 'how do I keep users,' or 'customers are leaving.' Use this whenever someone is losing subscribers or wants to build systems to prevent it. For post-cancel win-back email sequences, see email-sequence. For in-app upgrade paywalls, see paywall-upgrade-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "co-marketing",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/co-marketing",
+          "description": "When the user wants to find co-marketing partners, plan joint campaigns, or brainstorm partnership opportunities. Use when the user says 'co-marketing,' 'partner marketing,' 'joint campaign,' 'who should we partner with,' 'integration marketing,' 'cross-promotion,' 'collaborate with another company,' 'partnership ideas,' or 'co-brand.' For customer referral programs, see referral-program. For launch-specific partnerships, see launch-strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cold-email",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/cold-email",
+          "description": "Write B2B cold emails and follow-up sequences that get replies. Use when the user wants to write cold outreach emails, prospecting emails, cold email campaigns, sales development emails, or SDR emails. Also use when the user mentions \"cold outreach,\" \"prospecting email,\" \"outbound email,\" \"email to leads,\" \"reach out to prospects,\" \"sales email,\" \"follow-up email sequence,\" \"nobody's replying to my emails,\" or \"how do I write a cold email.\" Covers subject lines, opening lines, body copy, CTAs, personalization, and multi-touch follow-up sequences. For warm/lifecycle email sequences, see email-sequence. For sales collateral beyond emails, see sales-enablement.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "community-marketing",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/community-marketing",
+          "description": "Build and leverage online communities to drive product growth and brand loyalty. Use when the user wants to create a community strategy, grow a Discord or Slack community, manage a forum or subreddit, build brand advocates, increase word-of-mouth, drive community-led growth, engage users post-signup, or turn customers into evangelists. Trigger phrases: \\\"build a community,\\\" \\\"community strategy,\\\" \\\"Discord community,\\\" \\\"Slack community,\\\" \\\"community-led growth,\\\" \\\"brand advocates,\\\" \\\"user community,\\\" \\\"forum strategy,\\\" \\\"community engagement,\\\" \\\"grow our community,\\\" \\\"ambassador program,\\\" \\\"community flywheel.\\\"",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitor-alternatives",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/competitor-alternatives",
+          "description": "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'how do we compare to X,' 'battle card,' or 'competitor teardown.' Use this for any content that positions your product against competitors. Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. For sales-specific competitor docs, see sales-enablement.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "competitor-profiling",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/competitor-profiling",
+          "description": "When the user wants to research, profile, or analyze competitors from their URLs. Also use when the user mentions 'competitor profile,' 'competitor research,' 'competitor analysis,' 'profile this competitor,' 'analyze competitor,' 'competitive intelligence,' 'competitor deep dive,' 'who are my competitors,' 'competitor landscape,' 'competitor dossier,' 'competitive audit,' or 'research these competitors.' Input is a list of competitor URLs. Output is structured competitor profile markdown files. For creating comparison/alternative pages from profiles, see competitor-alternatives. For sales-specific battle cards, see sales-enablement.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/content-strategy",
+          "description": "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions \"content strategy,\" \"what should I write about,\" \"content ideas,\" \"blog strategy,\" \"topic clusters,\" \"content planning,\" \"editorial calendar,\" \"content marketing,\" \"content roadmap,\" \"what content should I create,\" \"blog topics,\" \"content pillars,\" or \"I don't know what to write.\" Use this whenever someone needs help deciding what content to produce, not just writing it. For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit. For social media content specifically, see social-content.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "copy-editing",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/copy-editing",
+          "description": "When the user wants to edit, review, or improve existing marketing copy, or refresh outdated content. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' 'copy sweep,' 'tighten this up,' 'this reads awkwardly,' 'clean up this text,' 'too wordy,' 'sharpen the messaging,' 'refresh this content,' 'update this page,' 'this content is outdated,' or 'content audit.' Use this when the user already has copy and wants it improved or refreshed rather than rewritten from scratch. For writing new copy, see copywriting.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "copywriting",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/copywriting",
+          "description": "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \"write copy for,\" \"improve this copy,\" \"rewrite this page,\" \"marketing copy,\" \"headline help,\" \"CTA copy,\" \"value proposition,\" \"tagline,\" \"subheadline,\" \"hero section copy,\" \"above the fold,\" \"this copy is weak,\" \"make this more compelling,\" or \"help me describe my product.\" Use this whenever someone is working on website text that needs to persuade or convert. For email copy, see email-sequence. For popup copy, see popup-cro. For editing existing copy, see copy-editing.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "customer-research",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/customer-research",
+          "description": "When the user wants to conduct, analyze, or synthesize customer research. Use when the user mentions \"customer research,\" \"ICP research,\" \"talk to customers,\" \"analyze transcripts,\" \"customer interviews,\" \"survey analysis,\" \"support ticket analysis,\" \"voice of customer,\" \"VOC,\" \"build personas,\" \"customer personas,\" \"jobs to be done,\" \"JTBD,\" \"what do customers say,\" \"what are customers struggling with,\" \"Reddit mining,\" \"G2 reviews,\" \"review mining,\" \"digital watering holes,\" \"community research,\" \"forum research,\" \"competitor reviews,\" \"customer sentiment,\" or \"find out why customers churn/convert/buy.\" Use for both analyzing existing research assets AND gathering new research from online sources. For writing copy informed by research, see copywriting. For acting on research to improve pages, see page-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "directory-submissions",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/directory-submissions",
+          "description": "When the user wants to submit their product to startup, SaaS, AI, agent, MCP, no-code, or review directories for backlinks, domain rating, and discovery. Also use when the user mentions \"directory submissions,\" \"submit to directories,\" \"backlinks from directories,\" \"list my product,\" \"submit to Product Hunt,\" \"BetaList,\" \"TAAFT,\" \"Futurepedia,\" \"G2 listing,\" \"Capterra listing,\" \"AlternativeTo,\" \"SaaSHub,\" \"AI directories,\" \"MCP registry,\" \"agent directory,\" \"dofollow backlinks,\" \"launch directories,\" or \"directory tracker.\" Use this whenever someone is planning the directory layer of a product launch or an ongoing backlink campaign. For the broader launch moment, see launch-strategy. For programmatic SEO pages that should live behind these backlinks, see programmatic-seo. For AI citation optimization, see ai-seo.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "email-sequence",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/email-sequence",
+          "description": "When the user wants to create or optimize an email sequence, drip campaign, automated email flow, or lifecycle email program. Also use when the user mentions \"email sequence,\" \"drip campaign,\" \"nurture sequence,\" \"onboarding emails,\" \"welcome sequence,\" \"re-engagement emails,\" \"email automation,\" \"lifecycle emails,\" \"trigger-based emails,\" \"email funnel,\" \"email workflow,\" \"what emails should I send,\" \"welcome series,\" or \"email cadence.\" Use this for any multi-email automated flow. For cold outreach emails, see cold-email. For in-app onboarding, see onboarding-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "form-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/form-cro",
+          "description": "When the user wants to optimize any form that is NOT signup/registration — including lead capture forms, contact forms, demo request forms, application forms, survey forms, or checkout forms. Also use when the user mentions \"form optimization,\" \"lead form conversions,\" \"form friction,\" \"form fields,\" \"form completion rate,\" \"contact form,\" \"nobody fills out our form,\" \"form abandonment,\" \"too many fields,\" \"demo request form,\" or \"lead form isn't converting.\" Use this for any non-signup form that captures information. For signup/registration forms, see signup-flow-cro. For popups containing forms, see popup-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "free-tool-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/free-tool-strategy",
+          "description": "When the user wants to plan, evaluate, or build a free tool for marketing purposes — lead generation, SEO value, or brand awareness. Also use when the user mentions \"engineering as marketing,\" \"free tool,\" \"marketing tool,\" \"calculator,\" \"generator,\" \"interactive tool,\" \"lead gen tool,\" \"build a tool for leads,\" \"free resource,\" \"ROI calculator,\" \"grader tool,\" \"audit tool,\" \"should I build a free tool,\" or \"tools for lead gen.\" Use this whenever someone wants to build something useful and give it away to attract leads or earn links. For downloadable content lead magnets (ebooks, checklists, templates), see lead-magnets.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "image",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/image",
+          "description": "When the user wants to create, generate, edit, or optimize images for marketing — blog heroes, social graphics, product mockups, profile banners, listing visuals, or brand assets. Also use when the user mentions 'AI image generation,' 'generate an image,' 'create a graphic,' 'product mockup,' 'hero image,' 'social media graphic,' 'banner image,' 'cover photo,' 'profile banner,' 'listing screenshot,' 'Flux,' 'Midjourney,' 'DALL-E,' 'GPT Image,' 'Ideogram,' 'Gemini image,' 'Canva,' 'Figma,' 'image optimization,' 'compress images,' 'WebP,' or 'OG image.' Use this for general-purpose marketing image creation and optimization. For paid ad image creative and platform-specific ad specs, see ad-creative. For video production, see video.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "launch-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/launch-strategy",
+          "description": "When the user wants to plan a product launch, feature announcement, or release strategy. Also use when the user mentions 'launch,' 'Product Hunt,' 'feature release,' 'announcement,' 'go-to-market,' 'beta launch,' 'early access,' 'waitlist,' 'product update,' 'how do I launch this,' 'launch checklist,' 'GTM plan,' or 'we're about to ship.' Use this whenever someone is preparing to release something publicly. For ongoing marketing after launch, see marketing-ideas.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "lead-magnets",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/lead-magnets",
+          "description": "When the user wants to create, plan, or optimize a lead magnet for email capture or lead generation. Also use when the user mentions \"lead magnet,\" \"gated content,\" \"content upgrade,\" \"downloadable,\" \"ebook,\" \"cheat sheet,\" \"checklist,\" \"template download,\" \"opt-in,\" \"freebie,\" \"PDF download,\" \"resource library,\" \"content offer,\" \"email capture content,\" \"Notion template,\" \"spreadsheet template,\" or \"what should I give away for emails.\" Use this for planning what to create and how to distribute it. For interactive tools as lead magnets, see free-tool-strategy. For writing the actual content, see copywriting. For the email sequence after capture, see email-sequence.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "marketing-ideas",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/marketing-ideas",
+          "description": "When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the user asks for 'marketing ideas,' 'growth ideas,' 'how to market,' 'marketing strategies,' 'marketing tactics,' 'ways to promote,' 'ideas to grow,' 'what else can I try,' 'I don't know how to market this,' 'brainstorm marketing,' or 'what marketing should I do.' Use this as a starting point whenever someone is stuck or looking for inspiration on how to grow. For specific channel execution, see the relevant skill (paid-ads, social-content, email-sequence, etc.).",
+          "version": "1.1.0"
+        },
+        {
+          "name": "marketing-psychology",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/marketing-psychology",
+          "description": "When the user wants to apply psychological principles, mental models, or behavioral science to marketing. Also use when the user mentions 'psychology,' 'mental models,' 'cognitive bias,' 'persuasion,' 'behavioral science,' 'why people buy,' 'decision-making,' 'consumer behavior,' 'anchoring,' 'social proof,' 'scarcity,' 'loss aversion,' 'framing,' or 'nudge.' Use this whenever someone wants to understand or leverage how people think and make decisions in a marketing context.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "onboarding-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/onboarding-cro",
+          "description": "When the user wants to optimize post-signup onboarding, user activation, first-run experience, or time-to-value. Also use when the user mentions \"onboarding flow,\" \"activation rate,\" \"user activation,\" \"first-run experience,\" \"empty states,\" \"onboarding checklist,\" \"aha moment,\" \"new user experience,\" \"users aren't activating,\" \"nobody completes setup,\" \"low activation rate,\" \"users sign up but don't use the product,\" \"time to value,\" or \"first session experience.\" Use this whenever users are signing up but not sticking around. For signup/registration optimization, see signup-flow-cro. For ongoing email sequences, see email-sequence.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "page-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/page-cro",
+          "description": "When the user wants to optimize, improve, or increase conversions on any marketing page — including homepage, landing pages, pricing pages, feature pages, or blog posts. Also use when the user says \"CRO,\" \"conversion rate optimization,\" \"this page isn't converting,\" \"improve conversions,\" \"why isn't this page working,\" \"my landing page sucks,\" \"nobody's converting,\" \"low conversion rate,\" \"bounce rate is too high,\" \"people leave without signing up,\" or \"this page needs work.\" Use this even if the user just shares a URL and asks for feedback — they probably want conversion help. For signup/registration flows, see signup-flow-cro. For post-signup activation, see onboarding-cro. For forms outside of signup, see form-cro. For popups/modals, see popup-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "paid-ads",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/paid-ads",
+          "description": "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions 'PPC,' 'paid media,' 'ROAS,' 'CPA,' 'ad campaign,' 'retargeting,' 'audience targeting,' 'Google Ads,' 'Facebook ads,' 'LinkedIn ads,' 'ad budget,' 'cost per click,' 'ad spend,' or 'should I run ads.' Use this for campaign strategy, audience targeting, bidding, and optimization. For bulk ad creative generation and iteration, see ad-creative. For landing page optimization, see page-cro.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "paywall-upgrade-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/paywall-upgrade-cro",
+          "description": "When the user wants to create or optimize in-app paywalls, upgrade screens, upsell modals, or feature gates. Also use when the user mentions \"paywall,\" \"upgrade screen,\" \"upgrade modal,\" \"upsell,\" \"feature gate,\" \"convert free to paid,\" \"freemium conversion,\" \"trial expiration screen,\" \"limit reached screen,\" \"plan upgrade prompt,\" \"in-app pricing,\" \"free users won't upgrade,\" \"trial to paid conversion,\" or \"how do I get users to pay.\" Use this for any in-product moment where you're asking users to upgrade. Distinct from public pricing pages (see page-cro) — this focuses on in-product upgrade moments where the user has already experienced value. For pricing decisions, see pricing-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "popup-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/popup-cro",
+          "description": "When the user wants to create or optimize popups, modals, overlays, slide-ins, or banners for conversion purposes. Also use when the user mentions \"exit intent,\" \"popup conversions,\" \"modal optimization,\" \"lead capture popup,\" \"email popup,\" \"announcement banner,\" \"overlay,\" \"collect emails with a popup,\" \"exit popup,\" \"scroll trigger,\" \"sticky bar,\" or \"notification bar.\" Use this for any overlay or interrupt-style conversion element. For forms outside of popups, see form-cro. For general page conversion optimization, see page-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "pricing-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/pricing-strategy",
+          "description": "When the user wants help with pricing decisions, packaging, or monetization strategy. Also use when the user mentions 'pricing,' 'pricing tiers,' 'freemium,' 'free trial,' 'packaging,' 'price increase,' 'value metric,' 'Van Westendorp,' 'willingness to pay,' 'monetization,' 'how much should I charge,' 'my pricing is wrong,' 'pricing page,' 'annual vs monthly,' 'per seat pricing,' or 'should I offer a free plan.' Use this whenever someone is figuring out what to charge or how to structure their plans. For in-app upgrade screens, see paywall-upgrade-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "product-marketing-context",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/product-marketing-context",
+          "description": "When the user wants to create or update their product marketing context document. Also use when the user mentions 'product context,' 'marketing context,' 'set up context,' 'positioning,' 'who is my target audience,' 'describe my product,' 'ICP,' 'ideal customer profile,' or wants to avoid repeating foundational information across marketing tasks. Use this at the start of any new project before using other marketing skills — it creates `.agents/product-marketing-context.md` that all other skills reference for product, audience, and positioning context.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "programmatic-seo",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/programmatic-seo",
+          "description": "When the user wants to create SEO-driven pages at scale using templates and data. Also use when the user mentions \"programmatic SEO,\" \"template pages,\" \"pages at scale,\" \"directory pages,\" \"location pages,\" \"[keyword] + [city] pages,\" \"comparison pages,\" \"integration pages,\" \"building many pages for SEO,\" \"pSEO,\" \"generate 100 pages,\" \"data-driven pages,\" or \"templated landing pages.\" Use this whenever someone wants to create many similar pages targeting different keywords or locations. For auditing existing SEO issues, see seo-audit. For content strategy planning, see content-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "referral-program",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/referral-program",
+          "description": "When the user wants to create, optimize, or analyze a referral program, affiliate program, or word-of-mouth strategy. Also use when the user mentions 'referral,' 'affiliate,' 'ambassador,' 'word of mouth,' 'viral loop,' 'refer a friend,' 'partner program,' 'referral incentive,' 'how to get referrals,' 'customers referring customers,' or 'affiliate payout.' Use this whenever someone wants existing users or partners to bring in new customers. For launch-specific virality, see launch-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "revops",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/revops",
+          "description": "When the user wants help with revenue operations, lead lifecycle management, or marketing-to-sales handoff processes. Also use when the user mentions 'RevOps,' 'revenue operations,' 'lead scoring,' 'lead routing,' 'MQL,' 'SQL,' 'pipeline stages,' 'deal desk,' 'CRM automation,' 'marketing-to-sales handoff,' 'data hygiene,' 'leads aren't getting to sales,' 'pipeline management,' 'lead qualification,' or 'when should marketing hand off to sales.' Use this for anything involving the systems and processes that connect marketing to revenue. For cold outreach emails, see cold-email. For email drip campaigns, see email-sequence. For pricing decisions, see pricing-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "sales-enablement",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/sales-enablement",
+          "description": "When the user wants to create sales collateral, pitch decks, one-pagers, objection handling docs, or demo scripts. Also use when the user mentions 'sales deck,' 'pitch deck,' 'one-pager,' 'leave-behind,' 'objection handling,' 'deal-specific ROI analysis,' 'demo script,' 'talk track,' 'sales playbook,' 'proposal template,' 'buyer persona card,' 'help my sales team,' 'sales materials,' or 'what should I give my sales reps.' Use this for any document or asset that helps a sales team close deals. For competitor comparison pages and battle cards, see competitor-alternatives. For marketing website copy, see copywriting. For cold outreach emails, see cold-email.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "schema-markup",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/schema-markup",
+          "description": "When the user wants to add, fix, or optimize schema markup and structured data on their site. Also use when the user mentions \"schema markup,\" \"structured data,\" \"JSON-LD,\" \"rich snippets,\" \"schema.org,\" \"FAQ schema,\" \"product schema,\" \"review schema,\" \"breadcrumb schema,\" \"Google rich results,\" \"knowledge panel,\" \"star ratings in search,\" or \"add structured data.\" Use this whenever someone wants their pages to show enhanced results in Google. For broader SEO issues, see seo-audit. For AI search optimization, see ai-seo.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "seo-audit",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/seo-audit",
+          "description": "When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions \"SEO audit,\" \"technical SEO,\" \"why am I not ranking,\" \"SEO issues,\" \"on-page SEO,\" \"meta tags review,\" \"SEO health check,\" \"my traffic dropped,\" \"lost rankings,\" \"not showing up in Google,\" \"site isn't ranking,\" \"Google update hit me,\" \"page speed,\" \"core web vitals,\" \"crawl errors,\" or \"indexing issues.\" Use this even if the user just says something vague like \"my SEO is bad\" or \"help with SEO\" — start with an audit. For building pages at scale to target keywords, see programmatic-seo. For adding structured data, see schema-markup. For AI search optimization, see ai-seo.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "signup-flow-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/signup-flow-cro",
+          "description": "When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the user mentions \"signup conversions,\" \"registration friction,\" \"signup form optimization,\" \"free trial signup,\" \"reduce signup dropoff,\" \"account creation flow,\" \"people aren't signing up,\" \"signup abandonment,\" \"trial conversion rate,\" \"nobody completes registration,\" \"too many steps to sign up,\" or \"simplify our signup.\" Use this whenever the user has a signup or registration flow that isn't performing. For post-signup onboarding, see onboarding-cro. For lead capture forms (not account creation), see form-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "site-architecture",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/site-architecture",
+          "description": "When the user wants to plan, map, or restructure their website's page hierarchy, navigation, URL structure, or internal linking. Also use when the user mentions \"sitemap,\" \"site map,\" \"visual sitemap,\" \"site structure,\" \"page hierarchy,\" \"information architecture,\" \"IA,\" \"navigation design,\" \"URL structure,\" \"breadcrumbs,\" \"internal linking strategy,\" \"website planning,\" \"what pages do I need,\" \"how should I organize my site,\" or \"site navigation.\" Use this whenever someone is planning what pages a website should have and how they connect. NOT for XML sitemaps (that's technical SEO — see seo-audit). For SEO audits, see seo-audit. For structured data, see schema-markup.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "social-content",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/social-content",
+          "description": "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, or other platforms. Also use when the user mentions 'LinkedIn post,' 'Twitter thread,' 'social media,' 'content calendar,' 'social scheduling,' 'engagement,' 'viral content,' 'what should I post,' 'repurpose this content,' 'tweet ideas,' 'LinkedIn carousel,' 'social media strategy,' 'grow my following,' 'TikTok video,' 'Reels,' 'Shorts,' 'video script,' 'video hook,' 'short-form video,' or 'create a reel.' Use this for social media content creation, repurposing, scheduling, and short-form video scripting. For broader content strategy, see content-strategy. For paid video ads, see ad-creative.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "video",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/video",
+          "description": "When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use when the user mentions 'video production,' 'AI video,' 'Remotion,' 'Hyperframes,' 'HeyGen,' 'Synthesia,' 'Veo,' 'Runway,' 'Kling,' 'Pika,' 'video generation,' 'AI avatar,' 'talking head video,' 'programmatic video,' 'video template,' 'explainer video,' 'product demo video,' 'video pipeline,' or 'make me a video.' Use this for video creation, generation, and production workflows. For video content strategy and what to post, see social-content. For paid video ad creative, see ad-creative.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "coreyhaines31",
+        "repo": "marketingskills",
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "coreyhaines31-marketingskills-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from coreyhaines31/marketingskills.",
+      "author": "ASM (coreyhaines31/marketingskills)",
+      "createdAt": "2026-05-09T08:10:39.133Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "coreyhaines31",
+        "marketingskills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-setup",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ab-test-setup",
+          "description": "When the user wants to plan, design, or implement an A/B test or experiment, or build a growth experimentation program. Also use when the user mentions \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"should I test this,\" \"which version is better,\" \"test two versions,\" \"statistical significance,\" \"how long should I run this test,\" \"growth experiments,\" \"experiment velocity,\" \"experiment backlog,\" \"ICE score,\" \"experimentation program,\" or \"experiment playbook.\" Use this whenever someone is comparing two approaches and wants to measure which performs better, or when they want to build a systematic experimentation practice. For tracking implementation, see analytics-tracking. For page-level conversion optimization, see page-cro.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "ad-creative",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ad-creative",
+          "description": "When the user wants to generate, iterate, or scale ad creative — headlines, descriptions, primary text, or full ad variations — for any paid advertising platform. Also use when the user mentions 'ad copy variations,' 'ad creative,' 'generate headlines,' 'RSA headlines,' 'bulk ad copy,' 'ad iterations,' 'creative testing,' 'ad performance optimization,' 'write me some ads,' 'Facebook ad copy,' 'Google ad headlines,' 'LinkedIn ad text,' or 'I need more ad variations.' Use this whenever someone needs to produce ad copy at scale or iterate on existing ads. For campaign strategy and targeting, see paid-ads. For landing page copy, see copywriting.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ai-seo",
+          "description": "When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' 'zero-click search,' 'how do I show up in AI answers,' 'LLM mentions,' or 'optimize for Claude/Gemini.' Use this whenever someone wants their content to be cited or surfaced by AI assistants and AI search engines. For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema-markup.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "cold-email",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/cold-email",
+          "description": "Write B2B cold emails and follow-up sequences that get replies. Use when the user wants to write cold outreach emails, prospecting emails, cold email campaigns, sales development emails, or SDR emails. Also use when the user mentions \"cold outreach,\" \"prospecting email,\" \"outbound email,\" \"email to leads,\" \"reach out to prospects,\" \"sales email,\" \"follow-up email sequence,\" \"nobody's replying to my emails,\" or \"how do I write a cold email.\" Covers subject lines, opening lines, body copy, CTAs, personalization, and multi-touch follow-up sequences. For warm/lifecycle email sequences, see email-sequence. For sales collateral beyond emails, see sales-enablement.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "competitor-alternatives",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/competitor-alternatives",
+          "description": "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'how do we compare to X,' 'battle card,' or 'competitor teardown.' Use this for any content that positions your product against competitors. Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. For sales-specific competitor docs, see sales-enablement.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "content-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/content-strategy",
+          "description": "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions \"content strategy,\" \"what should I write about,\" \"content ideas,\" \"blog strategy,\" \"topic clusters,\" \"content planning,\" \"editorial calendar,\" \"content marketing,\" \"content roadmap,\" \"what content should I create,\" \"blog topics,\" \"content pillars,\" or \"I don't know what to write.\" Use this whenever someone needs help deciding what content to produce, not just writing it. For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit. For social media content specifically, see social-content.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "copy-editing",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/copy-editing",
+          "description": "When the user wants to edit, review, or improve existing marketing copy, or refresh outdated content. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' 'copy sweep,' 'tighten this up,' 'this reads awkwardly,' 'clean up this text,' 'too wordy,' 'sharpen the messaging,' 'refresh this content,' 'update this page,' 'this content is outdated,' or 'content audit.' Use this when the user already has copy and wants it improved or refreshed rather than rewritten from scratch. For writing new copy, see copywriting.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "copywriting",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/copywriting",
+          "description": "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \"write copy for,\" \"improve this copy,\" \"rewrite this page,\" \"marketing copy,\" \"headline help,\" \"CTA copy,\" \"value proposition,\" \"tagline,\" \"subheadline,\" \"hero section copy,\" \"above the fold,\" \"this copy is weak,\" \"make this more compelling,\" or \"help me describe my product.\" Use this whenever someone is working on website text that needs to persuade or convert. For email copy, see email-sequence. For popup copy, see popup-cro. For editing existing copy, see copy-editing.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "customer-research",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/customer-research",
+          "description": "When the user wants to conduct, analyze, or synthesize customer research. Use when the user mentions \"customer research,\" \"ICP research,\" \"talk to customers,\" \"analyze transcripts,\" \"customer interviews,\" \"survey analysis,\" \"support ticket analysis,\" \"voice of customer,\" \"VOC,\" \"build personas,\" \"customer personas,\" \"jobs to be done,\" \"JTBD,\" \"what do customers say,\" \"what are customers struggling with,\" \"Reddit mining,\" \"G2 reviews,\" \"review mining,\" \"digital watering holes,\" \"community research,\" \"forum research,\" \"competitor reviews,\" \"customer sentiment,\" or \"find out why customers churn/convert/buy.\" Use for both analyzing existing research assets AND gathering new research from online sources. For writing copy informed by research, see copywriting. For acting on research to improve pages, see page-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "free-tool-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/free-tool-strategy",
+          "description": "When the user wants to plan, evaluate, or build a free tool for marketing purposes — lead generation, SEO value, or brand awareness. Also use when the user mentions \"engineering as marketing,\" \"free tool,\" \"marketing tool,\" \"calculator,\" \"generator,\" \"interactive tool,\" \"lead gen tool,\" \"build a tool for leads,\" \"free resource,\" \"ROI calculator,\" \"grader tool,\" \"audit tool,\" \"should I build a free tool,\" or \"tools for lead gen.\" Use this whenever someone wants to build something useful and give it away to attract leads or earn links. For downloadable content lead magnets (ebooks, checklists, templates), see lead-magnets.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "image",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/image",
+          "description": "When the user wants to create, generate, edit, or optimize images for marketing — blog heroes, social graphics, product mockups, profile banners, listing visuals, or brand assets. Also use when the user mentions 'AI image generation,' 'generate an image,' 'create a graphic,' 'product mockup,' 'hero image,' 'social media graphic,' 'banner image,' 'cover photo,' 'profile banner,' 'listing screenshot,' 'Flux,' 'Midjourney,' 'DALL-E,' 'GPT Image,' 'Ideogram,' 'Gemini image,' 'Canva,' 'Figma,' 'image optimization,' 'compress images,' 'WebP,' or 'OG image.' Use this for general-purpose marketing image creation and optimization. For paid ad image creative and platform-specific ad specs, see ad-creative. For video production, see video.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "lead-magnets",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/lead-magnets",
+          "description": "When the user wants to create, plan, or optimize a lead magnet for email capture or lead generation. Also use when the user mentions \"lead magnet,\" \"gated content,\" \"content upgrade,\" \"downloadable,\" \"ebook,\" \"cheat sheet,\" \"checklist,\" \"template download,\" \"opt-in,\" \"freebie,\" \"PDF download,\" \"resource library,\" \"content offer,\" \"email capture content,\" \"Notion template,\" \"spreadsheet template,\" or \"what should I give away for emails.\" Use this for planning what to create and how to distribute it. For interactive tools as lead magnets, see free-tool-strategy. For writing the actual content, see copywriting. For the email sequence after capture, see email-sequence.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "marketing-ideas",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/marketing-ideas",
+          "description": "When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the user asks for 'marketing ideas,' 'growth ideas,' 'how to market,' 'marketing strategies,' 'marketing tactics,' 'ways to promote,' 'ideas to grow,' 'what else can I try,' 'I don't know how to market this,' 'brainstorm marketing,' or 'what marketing should I do.' Use this as a starting point whenever someone is stuck or looking for inspiration on how to grow. For specific channel execution, see the relevant skill (paid-ads, social-content, email-sequence, etc.).",
+          "version": "1.1.0"
+        },
+        {
+          "name": "page-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/page-cro",
+          "description": "When the user wants to optimize, improve, or increase conversions on any marketing page — including homepage, landing pages, pricing pages, feature pages, or blog posts. Also use when the user says \"CRO,\" \"conversion rate optimization,\" \"this page isn't converting,\" \"improve conversions,\" \"why isn't this page working,\" \"my landing page sucks,\" \"nobody's converting,\" \"low conversion rate,\" \"bounce rate is too high,\" \"people leave without signing up,\" or \"this page needs work.\" Use this even if the user just shares a URL and asks for feedback — they probably want conversion help. For signup/registration flows, see signup-flow-cro. For post-signup activation, see onboarding-cro. For forms outside of signup, see form-cro. For popups/modals, see popup-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "programmatic-seo",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/programmatic-seo",
+          "description": "When the user wants to create SEO-driven pages at scale using templates and data. Also use when the user mentions \"programmatic SEO,\" \"template pages,\" \"pages at scale,\" \"directory pages,\" \"location pages,\" \"[keyword] + [city] pages,\" \"comparison pages,\" \"integration pages,\" \"building many pages for SEO,\" \"pSEO,\" \"generate 100 pages,\" \"data-driven pages,\" or \"templated landing pages.\" Use this whenever someone wants to create many similar pages targeting different keywords or locations. For auditing existing SEO issues, see seo-audit. For content strategy planning, see content-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "sales-enablement",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/sales-enablement",
+          "description": "When the user wants to create sales collateral, pitch decks, one-pagers, objection handling docs, or demo scripts. Also use when the user mentions 'sales deck,' 'pitch deck,' 'one-pager,' 'leave-behind,' 'objection handling,' 'deal-specific ROI analysis,' 'demo script,' 'talk track,' 'sales playbook,' 'proposal template,' 'buyer persona card,' 'help my sales team,' 'sales materials,' or 'what should I give my sales reps.' Use this for any document or asset that helps a sales team close deals. For competitor comparison pages and battle cards, see competitor-alternatives. For marketing website copy, see copywriting. For cold outreach emails, see cold-email.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "social-content",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/social-content",
+          "description": "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, or other platforms. Also use when the user mentions 'LinkedIn post,' 'Twitter thread,' 'social media,' 'content calendar,' 'social scheduling,' 'engagement,' 'viral content,' 'what should I post,' 'repurpose this content,' 'tweet ideas,' 'LinkedIn carousel,' 'social media strategy,' 'grow my following,' 'TikTok video,' 'Reels,' 'Shorts,' 'video script,' 'video hook,' 'short-form video,' or 'create a reel.' Use this for social media content creation, repurposing, scheduling, and short-form video scripting. For broader content strategy, see content-strategy. For paid video ads, see ad-creative.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "video",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/video",
+          "description": "When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use when the user mentions 'video production,' 'AI video,' 'Remotion,' 'Hyperframes,' 'HeyGen,' 'Synthesia,' 'Veo,' 'Runway,' 'Kling,' 'Pika,' 'video generation,' 'AI avatar,' 'talking head video,' 'programmatic video,' 'video template,' 'explainer video,' 'product demo video,' 'video pipeline,' or 'make me a video.' Use this for video creation, generation, and production workflows. For video content strategy and what to post, see social-content. For paid video ad creative, see ad-creative.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "coreyhaines31",
+        "repo": "marketingskills",
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "coreyhaines31-marketingskills-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from coreyhaines31/marketingskills.",
+      "author": "ASM (coreyhaines31/marketingskills)",
+      "createdAt": "2026-05-09T08:10:39.133Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "coreyhaines31",
+        "marketingskills"
+      ],
+      "skills": [
+        {
+          "name": "ai-seo",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ai-seo",
+          "description": "When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' 'zero-click search,' 'how do I show up in AI answers,' 'LLM mentions,' or 'optimize for Claude/Gemini.' Use this whenever someone wants their content to be cited or surfaced by AI assistants and AI search engines. For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema-markup.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "competitor-profiling",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/competitor-profiling",
+          "description": "When the user wants to research, profile, or analyze competitors from their URLs. Also use when the user mentions 'competitor profile,' 'competitor research,' 'competitor analysis,' 'profile this competitor,' 'analyze competitor,' 'competitive intelligence,' 'competitor deep dive,' 'who are my competitors,' 'competitor landscape,' 'competitor dossier,' 'competitive audit,' or 'research these competitors.' Input is a list of competitor URLs. Output is structured competitor profile markdown files. For creating comparison/alternative pages from profiles, see competitor-alternatives. For sales-specific battle cards, see sales-enablement.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "copy-editing",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/copy-editing",
+          "description": "When the user wants to edit, review, or improve existing marketing copy, or refresh outdated content. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' 'copy sweep,' 'tighten this up,' 'this reads awkwardly,' 'clean up this text,' 'too wordy,' 'sharpen the messaging,' 'refresh this content,' 'update this page,' 'this content is outdated,' or 'content audit.' Use this when the user already has copy and wants it improved or refreshed rather than rewritten from scratch. For writing new copy, see copywriting.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "customer-research",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/customer-research",
+          "description": "When the user wants to conduct, analyze, or synthesize customer research. Use when the user mentions \"customer research,\" \"ICP research,\" \"talk to customers,\" \"analyze transcripts,\" \"customer interviews,\" \"survey analysis,\" \"support ticket analysis,\" \"voice of customer,\" \"VOC,\" \"build personas,\" \"customer personas,\" \"jobs to be done,\" \"JTBD,\" \"what do customers say,\" \"what are customers struggling with,\" \"Reddit mining,\" \"G2 reviews,\" \"review mining,\" \"digital watering holes,\" \"community research,\" \"forum research,\" \"competitor reviews,\" \"customer sentiment,\" or \"find out why customers churn/convert/buy.\" Use for both analyzing existing research assets AND gathering new research from online sources. For writing copy informed by research, see copywriting. For acting on research to improve pages, see page-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "directory-submissions",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/directory-submissions",
+          "description": "When the user wants to submit their product to startup, SaaS, AI, agent, MCP, no-code, or review directories for backlinks, domain rating, and discovery. Also use when the user mentions \"directory submissions,\" \"submit to directories,\" \"backlinks from directories,\" \"list my product,\" \"submit to Product Hunt,\" \"BetaList,\" \"TAAFT,\" \"Futurepedia,\" \"G2 listing,\" \"Capterra listing,\" \"AlternativeTo,\" \"SaaSHub,\" \"AI directories,\" \"MCP registry,\" \"agent directory,\" \"dofollow backlinks,\" \"launch directories,\" or \"directory tracker.\" Use this whenever someone is planning the directory layer of a product launch or an ongoing backlink campaign. For the broader launch moment, see launch-strategy. For programmatic SEO pages that should live behind these backlinks, see programmatic-seo. For AI citation optimization, see ai-seo.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "free-tool-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/free-tool-strategy",
+          "description": "When the user wants to plan, evaluate, or build a free tool for marketing purposes — lead generation, SEO value, or brand awareness. Also use when the user mentions \"engineering as marketing,\" \"free tool,\" \"marketing tool,\" \"calculator,\" \"generator,\" \"interactive tool,\" \"lead gen tool,\" \"build a tool for leads,\" \"free resource,\" \"ROI calculator,\" \"grader tool,\" \"audit tool,\" \"should I build a free tool,\" or \"tools for lead gen.\" Use this whenever someone wants to build something useful and give it away to attract leads or earn links. For downloadable content lead magnets (ebooks, checklists, templates), see lead-magnets.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "sales-enablement",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/sales-enablement",
+          "description": "When the user wants to create sales collateral, pitch decks, one-pagers, objection handling docs, or demo scripts. Also use when the user mentions 'sales deck,' 'pitch deck,' 'one-pager,' 'leave-behind,' 'objection handling,' 'deal-specific ROI analysis,' 'demo script,' 'talk track,' 'sales playbook,' 'proposal template,' 'buyer persona card,' 'help my sales team,' 'sales materials,' or 'what should I give my sales reps.' Use this for any document or asset that helps a sales team close deals. For competitor comparison pages and battle cards, see competitor-alternatives. For marketing website copy, see copywriting. For cold outreach emails, see cold-email.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "schema-markup",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/schema-markup",
+          "description": "When the user wants to add, fix, or optimize schema markup and structured data on their site. Also use when the user mentions \"schema markup,\" \"structured data,\" \"JSON-LD,\" \"rich snippets,\" \"schema.org,\" \"FAQ schema,\" \"product schema,\" \"review schema,\" \"breadcrumb schema,\" \"Google rich results,\" \"knowledge panel,\" \"star ratings in search,\" or \"add structured data.\" Use this whenever someone wants their pages to show enhanced results in Google. For broader SEO issues, see seo-audit. For AI search optimization, see ai-seo.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "seo-audit",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/seo-audit",
+          "description": "When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions \"SEO audit,\" \"technical SEO,\" \"why am I not ranking,\" \"SEO issues,\" \"on-page SEO,\" \"meta tags review,\" \"SEO health check,\" \"my traffic dropped,\" \"lost rankings,\" \"not showing up in Google,\" \"site isn't ranking,\" \"Google update hit me,\" \"page speed,\" \"core web vitals,\" \"crawl errors,\" or \"indexing issues.\" Use this even if the user just says something vague like \"my SEO is bad\" or \"help with SEO\" — start with an audit. For building pages at scale to target keywords, see programmatic-seo. For adding structured data, see schema-markup. For AI search optimization, see ai-seo.",
+          "version": "1.2.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "coreyhaines31",
+        "repo": "marketingskills",
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "coreyhaines31-marketingskills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from coreyhaines31/marketingskills.",
+      "author": "ASM (coreyhaines31/marketingskills)",
+      "createdAt": "2026-05-09T08:10:39.133Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "coreyhaines31",
+        "marketingskills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-setup",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ab-test-setup",
+          "description": "When the user wants to plan, design, or implement an A/B test or experiment, or build a growth experimentation program. Also use when the user mentions \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"should I test this,\" \"which version is better,\" \"test two versions,\" \"statistical significance,\" \"how long should I run this test,\" \"growth experiments,\" \"experiment velocity,\" \"experiment backlog,\" \"ICE score,\" \"experimentation program,\" or \"experiment playbook.\" Use this whenever someone is comparing two approaches and wants to measure which performs better, or when they want to build a systematic experimentation practice. For tracking implementation, see analytics-tracking. For page-level conversion optimization, see page-cro.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "ad-creative",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ad-creative",
+          "description": "When the user wants to generate, iterate, or scale ad creative — headlines, descriptions, primary text, or full ad variations — for any paid advertising platform. Also use when the user mentions 'ad copy variations,' 'ad creative,' 'generate headlines,' 'RSA headlines,' 'bulk ad copy,' 'ad iterations,' 'creative testing,' 'ad performance optimization,' 'write me some ads,' 'Facebook ad copy,' 'Google ad headlines,' 'LinkedIn ad text,' or 'I need more ad variations.' Use this whenever someone needs to produce ad copy at scale or iterate on existing ads. For campaign strategy and targeting, see paid-ads. For landing page copy, see copywriting.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ai-seo",
+          "description": "When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' 'zero-click search,' 'how do I show up in AI answers,' 'LLM mentions,' or 'optimize for Claude/Gemini.' Use this whenever someone wants their content to be cited or surfaced by AI assistants and AI search engines. For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema-markup.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "analytics-tracking",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/analytics-tracking",
+          "description": "When the user wants to set up, improve, or audit analytics tracking and measurement. Also use when the user mentions \"set up tracking,\" \"GA4,\" \"Google Analytics,\" \"conversion tracking,\" \"event tracking,\" \"UTM parameters,\" \"tag manager,\" \"GTM,\" \"analytics implementation,\" \"tracking plan,\" \"how do I measure this,\" \"track conversions,\" \"attribution,\" \"Mixpanel,\" \"Segment,\" \"are my events firing,\" or \"analytics isn't working.\" Use this whenever someone asks how to know if something is working or wants to measure marketing results. For A/B test measurement, see ab-test-setup.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "churn-prevention",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/churn-prevention",
+          "description": "When the user wants to reduce churn, build cancellation flows, set up save offers, recover failed payments, or implement retention strategies. Also use when the user mentions 'churn,' 'cancel flow,' 'offboarding,' 'save offer,' 'dunning,' 'failed payment recovery,' 'win-back,' 'retention,' 'exit survey,' 'pause subscription,' 'involuntary churn,' 'people keep canceling,' 'churn rate is too high,' 'how do I keep users,' or 'customers are leaving.' Use this whenever someone is losing subscribers or wants to build systems to prevent it. For post-cancel win-back email sequences, see email-sequence. For in-app upgrade paywalls, see paywall-upgrade-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "community-marketing",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/community-marketing",
+          "description": "Build and leverage online communities to drive product growth and brand loyalty. Use when the user wants to create a community strategy, grow a Discord or Slack community, manage a forum or subreddit, build brand advocates, increase word-of-mouth, drive community-led growth, engage users post-signup, or turn customers into evangelists. Trigger phrases: \\\"build a community,\\\" \\\"community strategy,\\\" \\\"Discord community,\\\" \\\"Slack community,\\\" \\\"community-led growth,\\\" \\\"brand advocates,\\\" \\\"user community,\\\" \\\"forum strategy,\\\" \\\"community engagement,\\\" \\\"grow our community,\\\" \\\"ambassador program,\\\" \\\"community flywheel.\\\"",
+          "version": "1.0.0"
+        },
+        {
+          "name": "copy-editing",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/copy-editing",
+          "description": "When the user wants to edit, review, or improve existing marketing copy, or refresh outdated content. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' 'copy sweep,' 'tighten this up,' 'this reads awkwardly,' 'clean up this text,' 'too wordy,' 'sharpen the messaging,' 'refresh this content,' 'update this page,' 'this content is outdated,' or 'content audit.' Use this when the user already has copy and wants it improved or refreshed rather than rewritten from scratch. For writing new copy, see copywriting.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "customer-research",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/customer-research",
+          "description": "When the user wants to conduct, analyze, or synthesize customer research. Use when the user mentions \"customer research,\" \"ICP research,\" \"talk to customers,\" \"analyze transcripts,\" \"customer interviews,\" \"survey analysis,\" \"support ticket analysis,\" \"voice of customer,\" \"VOC,\" \"build personas,\" \"customer personas,\" \"jobs to be done,\" \"JTBD,\" \"what do customers say,\" \"what are customers struggling with,\" \"Reddit mining,\" \"G2 reviews,\" \"review mining,\" \"digital watering holes,\" \"community research,\" \"forum research,\" \"competitor reviews,\" \"customer sentiment,\" or \"find out why customers churn/convert/buy.\" Use for both analyzing existing research assets AND gathering new research from online sources. For writing copy informed by research, see copywriting. For acting on research to improve pages, see page-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "directory-submissions",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/directory-submissions",
+          "description": "When the user wants to submit their product to startup, SaaS, AI, agent, MCP, no-code, or review directories for backlinks, domain rating, and discovery. Also use when the user mentions \"directory submissions,\" \"submit to directories,\" \"backlinks from directories,\" \"list my product,\" \"submit to Product Hunt,\" \"BetaList,\" \"TAAFT,\" \"Futurepedia,\" \"G2 listing,\" \"Capterra listing,\" \"AlternativeTo,\" \"SaaSHub,\" \"AI directories,\" \"MCP registry,\" \"agent directory,\" \"dofollow backlinks,\" \"launch directories,\" or \"directory tracker.\" Use this whenever someone is planning the directory layer of a product launch or an ongoing backlink campaign. For the broader launch moment, see launch-strategy. For programmatic SEO pages that should live behind these backlinks, see programmatic-seo. For AI citation optimization, see ai-seo.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "free-tool-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/free-tool-strategy",
+          "description": "When the user wants to plan, evaluate, or build a free tool for marketing purposes — lead generation, SEO value, or brand awareness. Also use when the user mentions \"engineering as marketing,\" \"free tool,\" \"marketing tool,\" \"calculator,\" \"generator,\" \"interactive tool,\" \"lead gen tool,\" \"build a tool for leads,\" \"free resource,\" \"ROI calculator,\" \"grader tool,\" \"audit tool,\" \"should I build a free tool,\" or \"tools for lead gen.\" Use this whenever someone wants to build something useful and give it away to attract leads or earn links. For downloadable content lead magnets (ebooks, checklists, templates), see lead-magnets.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "paid-ads",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/paid-ads",
+          "description": "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions 'PPC,' 'paid media,' 'ROAS,' 'CPA,' 'ad campaign,' 'retargeting,' 'audience targeting,' 'Google Ads,' 'Facebook ads,' 'LinkedIn ads,' 'ad budget,' 'cost per click,' 'ad spend,' or 'should I run ads.' Use this for campaign strategy, audience targeting, bidding, and optimization. For bulk ad creative generation and iteration, see ad-creative. For landing page optimization, see page-cro.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "programmatic-seo",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/programmatic-seo",
+          "description": "When the user wants to create SEO-driven pages at scale using templates and data. Also use when the user mentions \"programmatic SEO,\" \"template pages,\" \"pages at scale,\" \"directory pages,\" \"location pages,\" \"[keyword] + [city] pages,\" \"comparison pages,\" \"integration pages,\" \"building many pages for SEO,\" \"pSEO,\" \"generate 100 pages,\" \"data-driven pages,\" or \"templated landing pages.\" Use this whenever someone wants to create many similar pages targeting different keywords or locations. For auditing existing SEO issues, see seo-audit. For content strategy planning, see content-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "schema-markup",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/schema-markup",
+          "description": "When the user wants to add, fix, or optimize schema markup and structured data on their site. Also use when the user mentions \"schema markup,\" \"structured data,\" \"JSON-LD,\" \"rich snippets,\" \"schema.org,\" \"FAQ schema,\" \"product schema,\" \"review schema,\" \"breadcrumb schema,\" \"Google rich results,\" \"knowledge panel,\" \"star ratings in search,\" or \"add structured data.\" Use this whenever someone wants their pages to show enhanced results in Google. For broader SEO issues, see seo-audit. For AI search optimization, see ai-seo.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "seo-audit",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/seo-audit",
+          "description": "When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions \"SEO audit,\" \"technical SEO,\" \"why am I not ranking,\" \"SEO issues,\" \"on-page SEO,\" \"meta tags review,\" \"SEO health check,\" \"my traffic dropped,\" \"lost rankings,\" \"not showing up in Google,\" \"site isn't ranking,\" \"Google update hit me,\" \"page speed,\" \"core web vitals,\" \"crawl errors,\" or \"indexing issues.\" Use this even if the user just says something vague like \"my SEO is bad\" or \"help with SEO\" — start with an audit. For building pages at scale to target keywords, see programmatic-seo. For adding structured data, see schema-markup. For AI search optimization, see ai-seo.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "site-architecture",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/site-architecture",
+          "description": "When the user wants to plan, map, or restructure their website's page hierarchy, navigation, URL structure, or internal linking. Also use when the user mentions \"sitemap,\" \"site map,\" \"visual sitemap,\" \"site structure,\" \"page hierarchy,\" \"information architecture,\" \"IA,\" \"navigation design,\" \"URL structure,\" \"breadcrumbs,\" \"internal linking strategy,\" \"website planning,\" \"what pages do I need,\" \"how should I organize my site,\" or \"site navigation.\" Use this whenever someone is planning what pages a website should have and how they connect. NOT for XML sitemaps (that's technical SEO — see seo-audit). For SEO audits, see seo-audit. For structured data, see schema-markup.",
+          "version": "1.1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "coreyhaines31",
+        "repo": "marketingskills",
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "coreyhaines31-marketingskills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from coreyhaines31/marketingskills.",
+      "author": "ASM (coreyhaines31/marketingskills)",
+      "createdAt": "2026-05-09T08:10:39.133Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "coreyhaines31",
+        "marketingskills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-setup",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ab-test-setup",
+          "description": "When the user wants to plan, design, or implement an A/B test or experiment, or build a growth experimentation program. Also use when the user mentions \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"should I test this,\" \"which version is better,\" \"test two versions,\" \"statistical significance,\" \"how long should I run this test,\" \"growth experiments,\" \"experiment velocity,\" \"experiment backlog,\" \"ICE score,\" \"experimentation program,\" or \"experiment playbook.\" Use this whenever someone is comparing two approaches and wants to measure which performs better, or when they want to build a systematic experimentation practice. For tracking implementation, see analytics-tracking. For page-level conversion optimization, see page-cro.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "ad-creative",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ad-creative",
+          "description": "When the user wants to generate, iterate, or scale ad creative — headlines, descriptions, primary text, or full ad variations — for any paid advertising platform. Also use when the user mentions 'ad copy variations,' 'ad creative,' 'generate headlines,' 'RSA headlines,' 'bulk ad copy,' 'ad iterations,' 'creative testing,' 'ad performance optimization,' 'write me some ads,' 'Facebook ad copy,' 'Google ad headlines,' 'LinkedIn ad text,' or 'I need more ad variations.' Use this whenever someone needs to produce ad copy at scale or iterate on existing ads. For campaign strategy and targeting, see paid-ads. For landing page copy, see copywriting.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "churn-prevention",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/churn-prevention",
+          "description": "When the user wants to reduce churn, build cancellation flows, set up save offers, recover failed payments, or implement retention strategies. Also use when the user mentions 'churn,' 'cancel flow,' 'offboarding,' 'save offer,' 'dunning,' 'failed payment recovery,' 'win-back,' 'retention,' 'exit survey,' 'pause subscription,' 'involuntary churn,' 'people keep canceling,' 'churn rate is too high,' 'how do I keep users,' or 'customers are leaving.' Use this whenever someone is losing subscribers or wants to build systems to prevent it. For post-cancel win-back email sequences, see email-sequence. For in-app upgrade paywalls, see paywall-upgrade-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "co-marketing",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/co-marketing",
+          "description": "When the user wants to find co-marketing partners, plan joint campaigns, or brainstorm partnership opportunities. Use when the user says 'co-marketing,' 'partner marketing,' 'joint campaign,' 'who should we partner with,' 'integration marketing,' 'cross-promotion,' 'collaborate with another company,' 'partnership ideas,' or 'co-brand.' For customer referral programs, see referral-program. For launch-specific partnerships, see launch-strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "community-marketing",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/community-marketing",
+          "description": "Build and leverage online communities to drive product growth and brand loyalty. Use when the user wants to create a community strategy, grow a Discord or Slack community, manage a forum or subreddit, build brand advocates, increase word-of-mouth, drive community-led growth, engage users post-signup, or turn customers into evangelists. Trigger phrases: \\\"build a community,\\\" \\\"community strategy,\\\" \\\"Discord community,\\\" \\\"Slack community,\\\" \\\"community-led growth,\\\" \\\"brand advocates,\\\" \\\"user community,\\\" \\\"forum strategy,\\\" \\\"community engagement,\\\" \\\"grow our community,\\\" \\\"ambassador program,\\\" \\\"community flywheel.\\\"",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitor-alternatives",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/competitor-alternatives",
+          "description": "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'how do we compare to X,' 'battle card,' or 'competitor teardown.' Use this for any content that positions your product against competitors. Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. For sales-specific competitor docs, see sales-enablement.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "copywriting",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/copywriting",
+          "description": "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \"write copy for,\" \"improve this copy,\" \"rewrite this page,\" \"marketing copy,\" \"headline help,\" \"CTA copy,\" \"value proposition,\" \"tagline,\" \"subheadline,\" \"hero section copy,\" \"above the fold,\" \"this copy is weak,\" \"make this more compelling,\" or \"help me describe my product.\" Use this whenever someone is working on website text that needs to persuade or convert. For email copy, see email-sequence. For popup copy, see popup-cro. For editing existing copy, see copy-editing.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "customer-research",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/customer-research",
+          "description": "When the user wants to conduct, analyze, or synthesize customer research. Use when the user mentions \"customer research,\" \"ICP research,\" \"talk to customers,\" \"analyze transcripts,\" \"customer interviews,\" \"survey analysis,\" \"support ticket analysis,\" \"voice of customer,\" \"VOC,\" \"build personas,\" \"customer personas,\" \"jobs to be done,\" \"JTBD,\" \"what do customers say,\" \"what are customers struggling with,\" \"Reddit mining,\" \"G2 reviews,\" \"review mining,\" \"digital watering holes,\" \"community research,\" \"forum research,\" \"competitor reviews,\" \"customer sentiment,\" or \"find out why customers churn/convert/buy.\" Use for both analyzing existing research assets AND gathering new research from online sources. For writing copy informed by research, see copywriting. For acting on research to improve pages, see page-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "free-tool-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/free-tool-strategy",
+          "description": "When the user wants to plan, evaluate, or build a free tool for marketing purposes — lead generation, SEO value, or brand awareness. Also use when the user mentions \"engineering as marketing,\" \"free tool,\" \"marketing tool,\" \"calculator,\" \"generator,\" \"interactive tool,\" \"lead gen tool,\" \"build a tool for leads,\" \"free resource,\" \"ROI calculator,\" \"grader tool,\" \"audit tool,\" \"should I build a free tool,\" or \"tools for lead gen.\" Use this whenever someone wants to build something useful and give it away to attract leads or earn links. For downloadable content lead magnets (ebooks, checklists, templates), see lead-magnets.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "image",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/image",
+          "description": "When the user wants to create, generate, edit, or optimize images for marketing — blog heroes, social graphics, product mockups, profile banners, listing visuals, or brand assets. Also use when the user mentions 'AI image generation,' 'generate an image,' 'create a graphic,' 'product mockup,' 'hero image,' 'social media graphic,' 'banner image,' 'cover photo,' 'profile banner,' 'listing screenshot,' 'Flux,' 'Midjourney,' 'DALL-E,' 'GPT Image,' 'Ideogram,' 'Gemini image,' 'Canva,' 'Figma,' 'image optimization,' 'compress images,' 'WebP,' or 'OG image.' Use this for general-purpose marketing image creation and optimization. For paid ad image creative and platform-specific ad specs, see ad-creative. For video production, see video.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "page-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/page-cro",
+          "description": "When the user wants to optimize, improve, or increase conversions on any marketing page — including homepage, landing pages, pricing pages, feature pages, or blog posts. Also use when the user says \"CRO,\" \"conversion rate optimization,\" \"this page isn't converting,\" \"improve conversions,\" \"why isn't this page working,\" \"my landing page sucks,\" \"nobody's converting,\" \"low conversion rate,\" \"bounce rate is too high,\" \"people leave without signing up,\" or \"this page needs work.\" Use this even if the user just shares a URL and asks for feedback — they probably want conversion help. For signup/registration flows, see signup-flow-cro. For post-signup activation, see onboarding-cro. For forms outside of signup, see form-cro. For popups/modals, see popup-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "paid-ads",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/paid-ads",
+          "description": "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions 'PPC,' 'paid media,' 'ROAS,' 'CPA,' 'ad campaign,' 'retargeting,' 'audience targeting,' 'Google Ads,' 'Facebook ads,' 'LinkedIn ads,' 'ad budget,' 'cost per click,' 'ad spend,' or 'should I run ads.' Use this for campaign strategy, audience targeting, bidding, and optimization. For bulk ad creative generation and iteration, see ad-creative. For landing page optimization, see page-cro.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "programmatic-seo",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/programmatic-seo",
+          "description": "When the user wants to create SEO-driven pages at scale using templates and data. Also use when the user mentions \"programmatic SEO,\" \"template pages,\" \"pages at scale,\" \"directory pages,\" \"location pages,\" \"[keyword] + [city] pages,\" \"comparison pages,\" \"integration pages,\" \"building many pages for SEO,\" \"pSEO,\" \"generate 100 pages,\" \"data-driven pages,\" or \"templated landing pages.\" Use this whenever someone wants to create many similar pages targeting different keywords or locations. For auditing existing SEO issues, see seo-audit. For content strategy planning, see content-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "seo-audit",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/seo-audit",
+          "description": "When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions \"SEO audit,\" \"technical SEO,\" \"why am I not ranking,\" \"SEO issues,\" \"on-page SEO,\" \"meta tags review,\" \"SEO health check,\" \"my traffic dropped,\" \"lost rankings,\" \"not showing up in Google,\" \"site isn't ranking,\" \"Google update hit me,\" \"page speed,\" \"core web vitals,\" \"crawl errors,\" or \"indexing issues.\" Use this even if the user just says something vague like \"my SEO is bad\" or \"help with SEO\" — start with an audit. For building pages at scale to target keywords, see programmatic-seo. For adding structured data, see schema-markup. For AI search optimization, see ai-seo.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "site-architecture",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/site-architecture",
+          "description": "When the user wants to plan, map, or restructure their website's page hierarchy, navigation, URL structure, or internal linking. Also use when the user mentions \"sitemap,\" \"site map,\" \"visual sitemap,\" \"site structure,\" \"page hierarchy,\" \"information architecture,\" \"IA,\" \"navigation design,\" \"URL structure,\" \"breadcrumbs,\" \"internal linking strategy,\" \"website planning,\" \"what pages do I need,\" \"how should I organize my site,\" or \"site navigation.\" Use this whenever someone is planning what pages a website should have and how they connect. NOT for XML sitemaps (that's technical SEO — see seo-audit). For SEO audits, see seo-audit. For structured data, see schema-markup.",
+          "version": "1.1.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "coreyhaines31",
+        "repo": "marketingskills",
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "coreyhaines31-marketingskills-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from coreyhaines31/marketingskills.",
+      "author": "ASM (coreyhaines31/marketingskills)",
+      "createdAt": "2026-05-09T08:10:39.133Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "coreyhaines31",
+        "marketingskills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-setup",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ab-test-setup",
+          "description": "When the user wants to plan, design, or implement an A/B test or experiment, or build a growth experimentation program. Also use when the user mentions \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"should I test this,\" \"which version is better,\" \"test two versions,\" \"statistical significance,\" \"how long should I run this test,\" \"growth experiments,\" \"experiment velocity,\" \"experiment backlog,\" \"ICE score,\" \"experimentation program,\" or \"experiment playbook.\" Use this whenever someone is comparing two approaches and wants to measure which performs better, or when they want to build a systematic experimentation practice. For tracking implementation, see analytics-tracking. For page-level conversion optimization, see page-cro.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ai-seo",
+          "description": "When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' 'zero-click search,' 'how do I show up in AI answers,' 'LLM mentions,' or 'optimize for Claude/Gemini.' Use this whenever someone wants their content to be cited or surfaced by AI assistants and AI search engines. For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema-markup.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "co-marketing",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/co-marketing",
+          "description": "When the user wants to find co-marketing partners, plan joint campaigns, or brainstorm partnership opportunities. Use when the user says 'co-marketing,' 'partner marketing,' 'joint campaign,' 'who should we partner with,' 'integration marketing,' 'cross-promotion,' 'collaborate with another company,' 'partnership ideas,' or 'co-brand.' For customer referral programs, see referral-program. For launch-specific partnerships, see launch-strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitor-alternatives",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/competitor-alternatives",
+          "description": "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'how do we compare to X,' 'battle card,' or 'competitor teardown.' Use this for any content that positions your product against competitors. Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. For sales-specific competitor docs, see sales-enablement.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "competitor-profiling",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/competitor-profiling",
+          "description": "When the user wants to research, profile, or analyze competitors from their URLs. Also use when the user mentions 'competitor profile,' 'competitor research,' 'competitor analysis,' 'profile this competitor,' 'analyze competitor,' 'competitive intelligence,' 'competitor deep dive,' 'who are my competitors,' 'competitor landscape,' 'competitor dossier,' 'competitive audit,' or 'research these competitors.' Input is a list of competitor URLs. Output is structured competitor profile markdown files. For creating comparison/alternative pages from profiles, see competitor-alternatives. For sales-specific battle cards, see sales-enablement.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/content-strategy",
+          "description": "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions \"content strategy,\" \"what should I write about,\" \"content ideas,\" \"blog strategy,\" \"topic clusters,\" \"content planning,\" \"editorial calendar,\" \"content marketing,\" \"content roadmap,\" \"what content should I create,\" \"blog topics,\" \"content pillars,\" or \"I don't know what to write.\" Use this whenever someone needs help deciding what content to produce, not just writing it. For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit. For social media content specifically, see social-content.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "copywriting",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/copywriting",
+          "description": "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \"write copy for,\" \"improve this copy,\" \"rewrite this page,\" \"marketing copy,\" \"headline help,\" \"CTA copy,\" \"value proposition,\" \"tagline,\" \"subheadline,\" \"hero section copy,\" \"above the fold,\" \"this copy is weak,\" \"make this more compelling,\" or \"help me describe my product.\" Use this whenever someone is working on website text that needs to persuade or convert. For email copy, see email-sequence. For popup copy, see popup-cro. For editing existing copy, see copy-editing.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "directory-submissions",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/directory-submissions",
+          "description": "When the user wants to submit their product to startup, SaaS, AI, agent, MCP, no-code, or review directories for backlinks, domain rating, and discovery. Also use when the user mentions \"directory submissions,\" \"submit to directories,\" \"backlinks from directories,\" \"list my product,\" \"submit to Product Hunt,\" \"BetaList,\" \"TAAFT,\" \"Futurepedia,\" \"G2 listing,\" \"Capterra listing,\" \"AlternativeTo,\" \"SaaSHub,\" \"AI directories,\" \"MCP registry,\" \"agent directory,\" \"dofollow backlinks,\" \"launch directories,\" or \"directory tracker.\" Use this whenever someone is planning the directory layer of a product launch or an ongoing backlink campaign. For the broader launch moment, see launch-strategy. For programmatic SEO pages that should live behind these backlinks, see programmatic-seo. For AI citation optimization, see ai-seo.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "email-sequence",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/email-sequence",
+          "description": "When the user wants to create or optimize an email sequence, drip campaign, automated email flow, or lifecycle email program. Also use when the user mentions \"email sequence,\" \"drip campaign,\" \"nurture sequence,\" \"onboarding emails,\" \"welcome sequence,\" \"re-engagement emails,\" \"email automation,\" \"lifecycle emails,\" \"trigger-based emails,\" \"email funnel,\" \"email workflow,\" \"what emails should I send,\" \"welcome series,\" or \"email cadence.\" Use this for any multi-email automated flow. For cold outreach emails, see cold-email. For in-app onboarding, see onboarding-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "image",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/image",
+          "description": "When the user wants to create, generate, edit, or optimize images for marketing — blog heroes, social graphics, product mockups, profile banners, listing visuals, or brand assets. Also use when the user mentions 'AI image generation,' 'generate an image,' 'create a graphic,' 'product mockup,' 'hero image,' 'social media graphic,' 'banner image,' 'cover photo,' 'profile banner,' 'listing screenshot,' 'Flux,' 'Midjourney,' 'DALL-E,' 'GPT Image,' 'Ideogram,' 'Gemini image,' 'Canva,' 'Figma,' 'image optimization,' 'compress images,' 'WebP,' or 'OG image.' Use this for general-purpose marketing image creation and optimization. For paid ad image creative and platform-specific ad specs, see ad-creative. For video production, see video.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "launch-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/launch-strategy",
+          "description": "When the user wants to plan a product launch, feature announcement, or release strategy. Also use when the user mentions 'launch,' 'Product Hunt,' 'feature release,' 'announcement,' 'go-to-market,' 'beta launch,' 'early access,' 'waitlist,' 'product update,' 'how do I launch this,' 'launch checklist,' 'GTM plan,' or 'we're about to ship.' Use this whenever someone is preparing to release something publicly. For ongoing marketing after launch, see marketing-ideas.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "marketing-ideas",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/marketing-ideas",
+          "description": "When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the user asks for 'marketing ideas,' 'growth ideas,' 'how to market,' 'marketing strategies,' 'marketing tactics,' 'ways to promote,' 'ideas to grow,' 'what else can I try,' 'I don't know how to market this,' 'brainstorm marketing,' or 'what marketing should I do.' Use this as a starting point whenever someone is stuck or looking for inspiration on how to grow. For specific channel execution, see the relevant skill (paid-ads, social-content, email-sequence, etc.).",
+          "version": "1.1.0"
+        },
+        {
+          "name": "marketing-psychology",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/marketing-psychology",
+          "description": "When the user wants to apply psychological principles, mental models, or behavioral science to marketing. Also use when the user mentions 'psychology,' 'mental models,' 'cognitive bias,' 'persuasion,' 'behavioral science,' 'why people buy,' 'decision-making,' 'consumer behavior,' 'anchoring,' 'social proof,' 'scarcity,' 'loss aversion,' 'framing,' or 'nudge.' Use this whenever someone wants to understand or leverage how people think and make decisions in a marketing context.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "page-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/page-cro",
+          "description": "When the user wants to optimize, improve, or increase conversions on any marketing page — including homepage, landing pages, pricing pages, feature pages, or blog posts. Also use when the user says \"CRO,\" \"conversion rate optimization,\" \"this page isn't converting,\" \"improve conversions,\" \"why isn't this page working,\" \"my landing page sucks,\" \"nobody's converting,\" \"low conversion rate,\" \"bounce rate is too high,\" \"people leave without signing up,\" or \"this page needs work.\" Use this even if the user just shares a URL and asks for feedback — they probably want conversion help. For signup/registration flows, see signup-flow-cro. For post-signup activation, see onboarding-cro. For forms outside of signup, see form-cro. For popups/modals, see popup-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "paywall-upgrade-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/paywall-upgrade-cro",
+          "description": "When the user wants to create or optimize in-app paywalls, upgrade screens, upsell modals, or feature gates. Also use when the user mentions \"paywall,\" \"upgrade screen,\" \"upgrade modal,\" \"upsell,\" \"feature gate,\" \"convert free to paid,\" \"freemium conversion,\" \"trial expiration screen,\" \"limit reached screen,\" \"plan upgrade prompt,\" \"in-app pricing,\" \"free users won't upgrade,\" \"trial to paid conversion,\" or \"how do I get users to pay.\" Use this for any in-product moment where you're asking users to upgrade. Distinct from public pricing pages (see page-cro) — this focuses on in-product upgrade moments where the user has already experienced value. For pricing decisions, see pricing-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "pricing-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/pricing-strategy",
+          "description": "When the user wants help with pricing decisions, packaging, or monetization strategy. Also use when the user mentions 'pricing,' 'pricing tiers,' 'freemium,' 'free trial,' 'packaging,' 'price increase,' 'value metric,' 'Van Westendorp,' 'willingness to pay,' 'monetization,' 'how much should I charge,' 'my pricing is wrong,' 'pricing page,' 'annual vs monthly,' 'per seat pricing,' or 'should I offer a free plan.' Use this whenever someone is figuring out what to charge or how to structure their plans. For in-app upgrade screens, see paywall-upgrade-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "programmatic-seo",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/programmatic-seo",
+          "description": "When the user wants to create SEO-driven pages at scale using templates and data. Also use when the user mentions \"programmatic SEO,\" \"template pages,\" \"pages at scale,\" \"directory pages,\" \"location pages,\" \"[keyword] + [city] pages,\" \"comparison pages,\" \"integration pages,\" \"building many pages for SEO,\" \"pSEO,\" \"generate 100 pages,\" \"data-driven pages,\" or \"templated landing pages.\" Use this whenever someone wants to create many similar pages targeting different keywords or locations. For auditing existing SEO issues, see seo-audit. For content strategy planning, see content-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "referral-program",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/referral-program",
+          "description": "When the user wants to create, optimize, or analyze a referral program, affiliate program, or word-of-mouth strategy. Also use when the user mentions 'referral,' 'affiliate,' 'ambassador,' 'word of mouth,' 'viral loop,' 'refer a friend,' 'partner program,' 'referral incentive,' 'how to get referrals,' 'customers referring customers,' or 'affiliate payout.' Use this whenever someone wants existing users or partners to bring in new customers. For launch-specific virality, see launch-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "revops",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/revops",
+          "description": "When the user wants help with revenue operations, lead lifecycle management, or marketing-to-sales handoff processes. Also use when the user mentions 'RevOps,' 'revenue operations,' 'lead scoring,' 'lead routing,' 'MQL,' 'SQL,' 'pipeline stages,' 'deal desk,' 'CRM automation,' 'marketing-to-sales handoff,' 'data hygiene,' 'leads aren't getting to sales,' 'pipeline management,' 'lead qualification,' or 'when should marketing hand off to sales.' Use this for anything involving the systems and processes that connect marketing to revenue. For cold outreach emails, see cold-email. For email drip campaigns, see email-sequence. For pricing decisions, see pricing-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "sales-enablement",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/sales-enablement",
+          "description": "When the user wants to create sales collateral, pitch decks, one-pagers, objection handling docs, or demo scripts. Also use when the user mentions 'sales deck,' 'pitch deck,' 'one-pager,' 'leave-behind,' 'objection handling,' 'deal-specific ROI analysis,' 'demo script,' 'talk track,' 'sales playbook,' 'proposal template,' 'buyer persona card,' 'help my sales team,' 'sales materials,' or 'what should I give my sales reps.' Use this for any document or asset that helps a sales team close deals. For competitor comparison pages and battle cards, see competitor-alternatives. For marketing website copy, see copywriting. For cold outreach emails, see cold-email.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "social-content",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/social-content",
+          "description": "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, or other platforms. Also use when the user mentions 'LinkedIn post,' 'Twitter thread,' 'social media,' 'content calendar,' 'social scheduling,' 'engagement,' 'viral content,' 'what should I post,' 'repurpose this content,' 'tweet ideas,' 'LinkedIn carousel,' 'social media strategy,' 'grow my following,' 'TikTok video,' 'Reels,' 'Shorts,' 'video script,' 'video hook,' 'short-form video,' or 'create a reel.' Use this for social media content creation, repurposing, scheduling, and short-form video scripting. For broader content strategy, see content-strategy. For paid video ads, see ad-creative.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "video",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/video",
+          "description": "When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use when the user mentions 'video production,' 'AI video,' 'Remotion,' 'Hyperframes,' 'HeyGen,' 'Synthesia,' 'Veo,' 'Runway,' 'Kling,' 'Pika,' 'video generation,' 'AI avatar,' 'talking head video,' 'programmatic video,' 'video template,' 'explainer video,' 'product demo video,' 'video pipeline,' or 'make me a video.' Use this for video creation, generation, and production workflows. For video content strategy and what to post, see social-content. For paid video ad creative, see ad-creative.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "coreyhaines31",
+        "repo": "marketingskills",
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "coreyhaines31-marketingskills-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from coreyhaines31/marketingskills.",
+      "author": "ASM (coreyhaines31/marketingskills)",
+      "createdAt": "2026-05-09T08:10:39.133Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "coreyhaines31",
+        "marketingskills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-setup",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ab-test-setup",
+          "description": "When the user wants to plan, design, or implement an A/B test or experiment, or build a growth experimentation program. Also use when the user mentions \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"should I test this,\" \"which version is better,\" \"test two versions,\" \"statistical significance,\" \"how long should I run this test,\" \"growth experiments,\" \"experiment velocity,\" \"experiment backlog,\" \"ICE score,\" \"experimentation program,\" or \"experiment playbook.\" Use this whenever someone is comparing two approaches and wants to measure which performs better, or when they want to build a systematic experimentation practice. For tracking implementation, see analytics-tracking. For page-level conversion optimization, see page-cro.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "ad-creative",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ad-creative",
+          "description": "When the user wants to generate, iterate, or scale ad creative — headlines, descriptions, primary text, or full ad variations — for any paid advertising platform. Also use when the user mentions 'ad copy variations,' 'ad creative,' 'generate headlines,' 'RSA headlines,' 'bulk ad copy,' 'ad iterations,' 'creative testing,' 'ad performance optimization,' 'write me some ads,' 'Facebook ad copy,' 'Google ad headlines,' 'LinkedIn ad text,' or 'I need more ad variations.' Use this whenever someone needs to produce ad copy at scale or iterate on existing ads. For campaign strategy and targeting, see paid-ads. For landing page copy, see copywriting.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ai-seo",
+          "description": "When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' 'zero-click search,' 'how do I show up in AI answers,' 'LLM mentions,' or 'optimize for Claude/Gemini.' Use this whenever someone wants their content to be cited or surfaced by AI assistants and AI search engines. For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema-markup.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "analytics-tracking",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/analytics-tracking",
+          "description": "When the user wants to set up, improve, or audit analytics tracking and measurement. Also use when the user mentions \"set up tracking,\" \"GA4,\" \"Google Analytics,\" \"conversion tracking,\" \"event tracking,\" \"UTM parameters,\" \"tag manager,\" \"GTM,\" \"analytics implementation,\" \"tracking plan,\" \"how do I measure this,\" \"track conversions,\" \"attribution,\" \"Mixpanel,\" \"Segment,\" \"are my events firing,\" or \"analytics isn't working.\" Use this whenever someone asks how to know if something is working or wants to measure marketing results. For A/B test measurement, see ab-test-setup.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "aso-audit",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/aso-audit",
+          "description": "When the user wants to audit or optimize an App Store or Google Play listing. Also use when the user mentions 'ASO audit,' 'app store optimization,' 'optimize my app listing,' 'improve app visibility,' 'app store ranking,' 'audit my listing,' 'why aren't people downloading my app,' 'improve my app conversion,' 'keyword optimization for app,' or 'compare my app to competitors.' Use when the user shares an App Store or Google Play URL and wants to improve it.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "churn-prevention",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/churn-prevention",
+          "description": "When the user wants to reduce churn, build cancellation flows, set up save offers, recover failed payments, or implement retention strategies. Also use when the user mentions 'churn,' 'cancel flow,' 'offboarding,' 'save offer,' 'dunning,' 'failed payment recovery,' 'win-back,' 'retention,' 'exit survey,' 'pause subscription,' 'involuntary churn,' 'people keep canceling,' 'churn rate is too high,' 'how do I keep users,' or 'customers are leaving.' Use this whenever someone is losing subscribers or wants to build systems to prevent it. For post-cancel win-back email sequences, see email-sequence. For in-app upgrade paywalls, see paywall-upgrade-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "co-marketing",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/co-marketing",
+          "description": "When the user wants to find co-marketing partners, plan joint campaigns, or brainstorm partnership opportunities. Use when the user says 'co-marketing,' 'partner marketing,' 'joint campaign,' 'who should we partner with,' 'integration marketing,' 'cross-promotion,' 'collaborate with another company,' 'partnership ideas,' or 'co-brand.' For customer referral programs, see referral-program. For launch-specific partnerships, see launch-strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cold-email",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/cold-email",
+          "description": "Write B2B cold emails and follow-up sequences that get replies. Use when the user wants to write cold outreach emails, prospecting emails, cold email campaigns, sales development emails, or SDR emails. Also use when the user mentions \"cold outreach,\" \"prospecting email,\" \"outbound email,\" \"email to leads,\" \"reach out to prospects,\" \"sales email,\" \"follow-up email sequence,\" \"nobody's replying to my emails,\" or \"how do I write a cold email.\" Covers subject lines, opening lines, body copy, CTAs, personalization, and multi-touch follow-up sequences. For warm/lifecycle email sequences, see email-sequence. For sales collateral beyond emails, see sales-enablement.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "community-marketing",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/community-marketing",
+          "description": "Build and leverage online communities to drive product growth and brand loyalty. Use when the user wants to create a community strategy, grow a Discord or Slack community, manage a forum or subreddit, build brand advocates, increase word-of-mouth, drive community-led growth, engage users post-signup, or turn customers into evangelists. Trigger phrases: \\\"build a community,\\\" \\\"community strategy,\\\" \\\"Discord community,\\\" \\\"Slack community,\\\" \\\"community-led growth,\\\" \\\"brand advocates,\\\" \\\"user community,\\\" \\\"forum strategy,\\\" \\\"community engagement,\\\" \\\"grow our community,\\\" \\\"ambassador program,\\\" \\\"community flywheel.\\\"",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitor-alternatives",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/competitor-alternatives",
+          "description": "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'how do we compare to X,' 'battle card,' or 'competitor teardown.' Use this for any content that positions your product against competitors. Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. For sales-specific competitor docs, see sales-enablement.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "competitor-profiling",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/competitor-profiling",
+          "description": "When the user wants to research, profile, or analyze competitors from their URLs. Also use when the user mentions 'competitor profile,' 'competitor research,' 'competitor analysis,' 'profile this competitor,' 'analyze competitor,' 'competitive intelligence,' 'competitor deep dive,' 'who are my competitors,' 'competitor landscape,' 'competitor dossier,' 'competitive audit,' or 'research these competitors.' Input is a list of competitor URLs. Output is structured competitor profile markdown files. For creating comparison/alternative pages from profiles, see competitor-alternatives. For sales-specific battle cards, see sales-enablement.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/content-strategy",
+          "description": "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions \"content strategy,\" \"what should I write about,\" \"content ideas,\" \"blog strategy,\" \"topic clusters,\" \"content planning,\" \"editorial calendar,\" \"content marketing,\" \"content roadmap,\" \"what content should I create,\" \"blog topics,\" \"content pillars,\" or \"I don't know what to write.\" Use this whenever someone needs help deciding what content to produce, not just writing it. For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit. For social media content specifically, see social-content.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "copy-editing",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/copy-editing",
+          "description": "When the user wants to edit, review, or improve existing marketing copy, or refresh outdated content. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' 'copy sweep,' 'tighten this up,' 'this reads awkwardly,' 'clean up this text,' 'too wordy,' 'sharpen the messaging,' 'refresh this content,' 'update this page,' 'this content is outdated,' or 'content audit.' Use this when the user already has copy and wants it improved or refreshed rather than rewritten from scratch. For writing new copy, see copywriting.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "copywriting",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/copywriting",
+          "description": "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \"write copy for,\" \"improve this copy,\" \"rewrite this page,\" \"marketing copy,\" \"headline help,\" \"CTA copy,\" \"value proposition,\" \"tagline,\" \"subheadline,\" \"hero section copy,\" \"above the fold,\" \"this copy is weak,\" \"make this more compelling,\" or \"help me describe my product.\" Use this whenever someone is working on website text that needs to persuade or convert. For email copy, see email-sequence. For popup copy, see popup-cro. For editing existing copy, see copy-editing.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "customer-research",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/customer-research",
+          "description": "When the user wants to conduct, analyze, or synthesize customer research. Use when the user mentions \"customer research,\" \"ICP research,\" \"talk to customers,\" \"analyze transcripts,\" \"customer interviews,\" \"survey analysis,\" \"support ticket analysis,\" \"voice of customer,\" \"VOC,\" \"build personas,\" \"customer personas,\" \"jobs to be done,\" \"JTBD,\" \"what do customers say,\" \"what are customers struggling with,\" \"Reddit mining,\" \"G2 reviews,\" \"review mining,\" \"digital watering holes,\" \"community research,\" \"forum research,\" \"competitor reviews,\" \"customer sentiment,\" or \"find out why customers churn/convert/buy.\" Use for both analyzing existing research assets AND gathering new research from online sources. For writing copy informed by research, see copywriting. For acting on research to improve pages, see page-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "directory-submissions",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/directory-submissions",
+          "description": "When the user wants to submit their product to startup, SaaS, AI, agent, MCP, no-code, or review directories for backlinks, domain rating, and discovery. Also use when the user mentions \"directory submissions,\" \"submit to directories,\" \"backlinks from directories,\" \"list my product,\" \"submit to Product Hunt,\" \"BetaList,\" \"TAAFT,\" \"Futurepedia,\" \"G2 listing,\" \"Capterra listing,\" \"AlternativeTo,\" \"SaaSHub,\" \"AI directories,\" \"MCP registry,\" \"agent directory,\" \"dofollow backlinks,\" \"launch directories,\" or \"directory tracker.\" Use this whenever someone is planning the directory layer of a product launch or an ongoing backlink campaign. For the broader launch moment, see launch-strategy. For programmatic SEO pages that should live behind these backlinks, see programmatic-seo. For AI citation optimization, see ai-seo.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "email-sequence",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/email-sequence",
+          "description": "When the user wants to create or optimize an email sequence, drip campaign, automated email flow, or lifecycle email program. Also use when the user mentions \"email sequence,\" \"drip campaign,\" \"nurture sequence,\" \"onboarding emails,\" \"welcome sequence,\" \"re-engagement emails,\" \"email automation,\" \"lifecycle emails,\" \"trigger-based emails,\" \"email funnel,\" \"email workflow,\" \"what emails should I send,\" \"welcome series,\" or \"email cadence.\" Use this for any multi-email automated flow. For cold outreach emails, see cold-email. For in-app onboarding, see onboarding-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "form-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/form-cro",
+          "description": "When the user wants to optimize any form that is NOT signup/registration — including lead capture forms, contact forms, demo request forms, application forms, survey forms, or checkout forms. Also use when the user mentions \"form optimization,\" \"lead form conversions,\" \"form friction,\" \"form fields,\" \"form completion rate,\" \"contact form,\" \"nobody fills out our form,\" \"form abandonment,\" \"too many fields,\" \"demo request form,\" or \"lead form isn't converting.\" Use this for any non-signup form that captures information. For signup/registration forms, see signup-flow-cro. For popups containing forms, see popup-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "free-tool-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/free-tool-strategy",
+          "description": "When the user wants to plan, evaluate, or build a free tool for marketing purposes — lead generation, SEO value, or brand awareness. Also use when the user mentions \"engineering as marketing,\" \"free tool,\" \"marketing tool,\" \"calculator,\" \"generator,\" \"interactive tool,\" \"lead gen tool,\" \"build a tool for leads,\" \"free resource,\" \"ROI calculator,\" \"grader tool,\" \"audit tool,\" \"should I build a free tool,\" or \"tools for lead gen.\" Use this whenever someone wants to build something useful and give it away to attract leads or earn links. For downloadable content lead magnets (ebooks, checklists, templates), see lead-magnets.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "image",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/image",
+          "description": "When the user wants to create, generate, edit, or optimize images for marketing — blog heroes, social graphics, product mockups, profile banners, listing visuals, or brand assets. Also use when the user mentions 'AI image generation,' 'generate an image,' 'create a graphic,' 'product mockup,' 'hero image,' 'social media graphic,' 'banner image,' 'cover photo,' 'profile banner,' 'listing screenshot,' 'Flux,' 'Midjourney,' 'DALL-E,' 'GPT Image,' 'Ideogram,' 'Gemini image,' 'Canva,' 'Figma,' 'image optimization,' 'compress images,' 'WebP,' or 'OG image.' Use this for general-purpose marketing image creation and optimization. For paid ad image creative and platform-specific ad specs, see ad-creative. For video production, see video.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "launch-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/launch-strategy",
+          "description": "When the user wants to plan a product launch, feature announcement, or release strategy. Also use when the user mentions 'launch,' 'Product Hunt,' 'feature release,' 'announcement,' 'go-to-market,' 'beta launch,' 'early access,' 'waitlist,' 'product update,' 'how do I launch this,' 'launch checklist,' 'GTM plan,' or 'we're about to ship.' Use this whenever someone is preparing to release something publicly. For ongoing marketing after launch, see marketing-ideas.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "lead-magnets",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/lead-magnets",
+          "description": "When the user wants to create, plan, or optimize a lead magnet for email capture or lead generation. Also use when the user mentions \"lead magnet,\" \"gated content,\" \"content upgrade,\" \"downloadable,\" \"ebook,\" \"cheat sheet,\" \"checklist,\" \"template download,\" \"opt-in,\" \"freebie,\" \"PDF download,\" \"resource library,\" \"content offer,\" \"email capture content,\" \"Notion template,\" \"spreadsheet template,\" or \"what should I give away for emails.\" Use this for planning what to create and how to distribute it. For interactive tools as lead magnets, see free-tool-strategy. For writing the actual content, see copywriting. For the email sequence after capture, see email-sequence.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "marketing-ideas",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/marketing-ideas",
+          "description": "When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the user asks for 'marketing ideas,' 'growth ideas,' 'how to market,' 'marketing strategies,' 'marketing tactics,' 'ways to promote,' 'ideas to grow,' 'what else can I try,' 'I don't know how to market this,' 'brainstorm marketing,' or 'what marketing should I do.' Use this as a starting point whenever someone is stuck or looking for inspiration on how to grow. For specific channel execution, see the relevant skill (paid-ads, social-content, email-sequence, etc.).",
+          "version": "1.1.0"
+        },
+        {
+          "name": "marketing-psychology",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/marketing-psychology",
+          "description": "When the user wants to apply psychological principles, mental models, or behavioral science to marketing. Also use when the user mentions 'psychology,' 'mental models,' 'cognitive bias,' 'persuasion,' 'behavioral science,' 'why people buy,' 'decision-making,' 'consumer behavior,' 'anchoring,' 'social proof,' 'scarcity,' 'loss aversion,' 'framing,' or 'nudge.' Use this whenever someone wants to understand or leverage how people think and make decisions in a marketing context.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "onboarding-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/onboarding-cro",
+          "description": "When the user wants to optimize post-signup onboarding, user activation, first-run experience, or time-to-value. Also use when the user mentions \"onboarding flow,\" \"activation rate,\" \"user activation,\" \"first-run experience,\" \"empty states,\" \"onboarding checklist,\" \"aha moment,\" \"new user experience,\" \"users aren't activating,\" \"nobody completes setup,\" \"low activation rate,\" \"users sign up but don't use the product,\" \"time to value,\" or \"first session experience.\" Use this whenever users are signing up but not sticking around. For signup/registration optimization, see signup-flow-cro. For ongoing email sequences, see email-sequence.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "page-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/page-cro",
+          "description": "When the user wants to optimize, improve, or increase conversions on any marketing page — including homepage, landing pages, pricing pages, feature pages, or blog posts. Also use when the user says \"CRO,\" \"conversion rate optimization,\" \"this page isn't converting,\" \"improve conversions,\" \"why isn't this page working,\" \"my landing page sucks,\" \"nobody's converting,\" \"low conversion rate,\" \"bounce rate is too high,\" \"people leave without signing up,\" or \"this page needs work.\" Use this even if the user just shares a URL and asks for feedback — they probably want conversion help. For signup/registration flows, see signup-flow-cro. For post-signup activation, see onboarding-cro. For forms outside of signup, see form-cro. For popups/modals, see popup-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "paid-ads",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/paid-ads",
+          "description": "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions 'PPC,' 'paid media,' 'ROAS,' 'CPA,' 'ad campaign,' 'retargeting,' 'audience targeting,' 'Google Ads,' 'Facebook ads,' 'LinkedIn ads,' 'ad budget,' 'cost per click,' 'ad spend,' or 'should I run ads.' Use this for campaign strategy, audience targeting, bidding, and optimization. For bulk ad creative generation and iteration, see ad-creative. For landing page optimization, see page-cro.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "paywall-upgrade-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/paywall-upgrade-cro",
+          "description": "When the user wants to create or optimize in-app paywalls, upgrade screens, upsell modals, or feature gates. Also use when the user mentions \"paywall,\" \"upgrade screen,\" \"upgrade modal,\" \"upsell,\" \"feature gate,\" \"convert free to paid,\" \"freemium conversion,\" \"trial expiration screen,\" \"limit reached screen,\" \"plan upgrade prompt,\" \"in-app pricing,\" \"free users won't upgrade,\" \"trial to paid conversion,\" or \"how do I get users to pay.\" Use this for any in-product moment where you're asking users to upgrade. Distinct from public pricing pages (see page-cro) — this focuses on in-product upgrade moments where the user has already experienced value. For pricing decisions, see pricing-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "popup-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/popup-cro",
+          "description": "When the user wants to create or optimize popups, modals, overlays, slide-ins, or banners for conversion purposes. Also use when the user mentions \"exit intent,\" \"popup conversions,\" \"modal optimization,\" \"lead capture popup,\" \"email popup,\" \"announcement banner,\" \"overlay,\" \"collect emails with a popup,\" \"exit popup,\" \"scroll trigger,\" \"sticky bar,\" or \"notification bar.\" Use this for any overlay or interrupt-style conversion element. For forms outside of popups, see form-cro. For general page conversion optimization, see page-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "pricing-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/pricing-strategy",
+          "description": "When the user wants help with pricing decisions, packaging, or monetization strategy. Also use when the user mentions 'pricing,' 'pricing tiers,' 'freemium,' 'free trial,' 'packaging,' 'price increase,' 'value metric,' 'Van Westendorp,' 'willingness to pay,' 'monetization,' 'how much should I charge,' 'my pricing is wrong,' 'pricing page,' 'annual vs monthly,' 'per seat pricing,' or 'should I offer a free plan.' Use this whenever someone is figuring out what to charge or how to structure their plans. For in-app upgrade screens, see paywall-upgrade-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "product-marketing-context",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/product-marketing-context",
+          "description": "When the user wants to create or update their product marketing context document. Also use when the user mentions 'product context,' 'marketing context,' 'set up context,' 'positioning,' 'who is my target audience,' 'describe my product,' 'ICP,' 'ideal customer profile,' or wants to avoid repeating foundational information across marketing tasks. Use this at the start of any new project before using other marketing skills — it creates `.agents/product-marketing-context.md` that all other skills reference for product, audience, and positioning context.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "programmatic-seo",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/programmatic-seo",
+          "description": "When the user wants to create SEO-driven pages at scale using templates and data. Also use when the user mentions \"programmatic SEO,\" \"template pages,\" \"pages at scale,\" \"directory pages,\" \"location pages,\" \"[keyword] + [city] pages,\" \"comparison pages,\" \"integration pages,\" \"building many pages for SEO,\" \"pSEO,\" \"generate 100 pages,\" \"data-driven pages,\" or \"templated landing pages.\" Use this whenever someone wants to create many similar pages targeting different keywords or locations. For auditing existing SEO issues, see seo-audit. For content strategy planning, see content-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "referral-program",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/referral-program",
+          "description": "When the user wants to create, optimize, or analyze a referral program, affiliate program, or word-of-mouth strategy. Also use when the user mentions 'referral,' 'affiliate,' 'ambassador,' 'word of mouth,' 'viral loop,' 'refer a friend,' 'partner program,' 'referral incentive,' 'how to get referrals,' 'customers referring customers,' or 'affiliate payout.' Use this whenever someone wants existing users or partners to bring in new customers. For launch-specific virality, see launch-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "revops",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/revops",
+          "description": "When the user wants help with revenue operations, lead lifecycle management, or marketing-to-sales handoff processes. Also use when the user mentions 'RevOps,' 'revenue operations,' 'lead scoring,' 'lead routing,' 'MQL,' 'SQL,' 'pipeline stages,' 'deal desk,' 'CRM automation,' 'marketing-to-sales handoff,' 'data hygiene,' 'leads aren't getting to sales,' 'pipeline management,' 'lead qualification,' or 'when should marketing hand off to sales.' Use this for anything involving the systems and processes that connect marketing to revenue. For cold outreach emails, see cold-email. For email drip campaigns, see email-sequence. For pricing decisions, see pricing-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "sales-enablement",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/sales-enablement",
+          "description": "When the user wants to create sales collateral, pitch decks, one-pagers, objection handling docs, or demo scripts. Also use when the user mentions 'sales deck,' 'pitch deck,' 'one-pager,' 'leave-behind,' 'objection handling,' 'deal-specific ROI analysis,' 'demo script,' 'talk track,' 'sales playbook,' 'proposal template,' 'buyer persona card,' 'help my sales team,' 'sales materials,' or 'what should I give my sales reps.' Use this for any document or asset that helps a sales team close deals. For competitor comparison pages and battle cards, see competitor-alternatives. For marketing website copy, see copywriting. For cold outreach emails, see cold-email.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "schema-markup",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/schema-markup",
+          "description": "When the user wants to add, fix, or optimize schema markup and structured data on their site. Also use when the user mentions \"schema markup,\" \"structured data,\" \"JSON-LD,\" \"rich snippets,\" \"schema.org,\" \"FAQ schema,\" \"product schema,\" \"review schema,\" \"breadcrumb schema,\" \"Google rich results,\" \"knowledge panel,\" \"star ratings in search,\" or \"add structured data.\" Use this whenever someone wants their pages to show enhanced results in Google. For broader SEO issues, see seo-audit. For AI search optimization, see ai-seo.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "seo-audit",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/seo-audit",
+          "description": "When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions \"SEO audit,\" \"technical SEO,\" \"why am I not ranking,\" \"SEO issues,\" \"on-page SEO,\" \"meta tags review,\" \"SEO health check,\" \"my traffic dropped,\" \"lost rankings,\" \"not showing up in Google,\" \"site isn't ranking,\" \"Google update hit me,\" \"page speed,\" \"core web vitals,\" \"crawl errors,\" or \"indexing issues.\" Use this even if the user just says something vague like \"my SEO is bad\" or \"help with SEO\" — start with an audit. For building pages at scale to target keywords, see programmatic-seo. For adding structured data, see schema-markup. For AI search optimization, see ai-seo.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "signup-flow-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/signup-flow-cro",
+          "description": "When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the user mentions \"signup conversions,\" \"registration friction,\" \"signup form optimization,\" \"free trial signup,\" \"reduce signup dropoff,\" \"account creation flow,\" \"people aren't signing up,\" \"signup abandonment,\" \"trial conversion rate,\" \"nobody completes registration,\" \"too many steps to sign up,\" or \"simplify our signup.\" Use this whenever the user has a signup or registration flow that isn't performing. For post-signup onboarding, see onboarding-cro. For lead capture forms (not account creation), see form-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "site-architecture",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/site-architecture",
+          "description": "When the user wants to plan, map, or restructure their website's page hierarchy, navigation, URL structure, or internal linking. Also use when the user mentions \"sitemap,\" \"site map,\" \"visual sitemap,\" \"site structure,\" \"page hierarchy,\" \"information architecture,\" \"IA,\" \"navigation design,\" \"URL structure,\" \"breadcrumbs,\" \"internal linking strategy,\" \"website planning,\" \"what pages do I need,\" \"how should I organize my site,\" or \"site navigation.\" Use this whenever someone is planning what pages a website should have and how they connect. NOT for XML sitemaps (that's technical SEO — see seo-audit). For SEO audits, see seo-audit. For structured data, see schema-markup.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "social-content",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/social-content",
+          "description": "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, or other platforms. Also use when the user mentions 'LinkedIn post,' 'Twitter thread,' 'social media,' 'content calendar,' 'social scheduling,' 'engagement,' 'viral content,' 'what should I post,' 'repurpose this content,' 'tweet ideas,' 'LinkedIn carousel,' 'social media strategy,' 'grow my following,' 'TikTok video,' 'Reels,' 'Shorts,' 'video script,' 'video hook,' 'short-form video,' or 'create a reel.' Use this for social media content creation, repurposing, scheduling, and short-form video scripting. For broader content strategy, see content-strategy. For paid video ads, see ad-creative.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "video",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/video",
+          "description": "When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use when the user mentions 'video production,' 'AI video,' 'Remotion,' 'Hyperframes,' 'HeyGen,' 'Synthesia,' 'Veo,' 'Runway,' 'Kling,' 'Pika,' 'video generation,' 'AI avatar,' 'talking head video,' 'programmatic video,' 'video template,' 'explainer video,' 'product demo video,' 'video pipeline,' or 'make me a video.' Use this for video creation, generation, and production workflows. For video content strategy and what to post, see social-content. For paid video ad creative, see ad-creative.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "coreyhaines31",
+        "repo": "marketingskills",
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "coreyhaines31-marketingskills-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from coreyhaines31/marketingskills.",
+      "author": "ASM (coreyhaines31/marketingskills)",
+      "createdAt": "2026-05-09T08:10:39.133Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "coreyhaines31",
+        "marketingskills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-setup",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ab-test-setup",
+          "description": "When the user wants to plan, design, or implement an A/B test or experiment, or build a growth experimentation program. Also use when the user mentions \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"should I test this,\" \"which version is better,\" \"test two versions,\" \"statistical significance,\" \"how long should I run this test,\" \"growth experiments,\" \"experiment velocity,\" \"experiment backlog,\" \"ICE score,\" \"experimentation program,\" or \"experiment playbook.\" Use this whenever someone is comparing two approaches and wants to measure which performs better, or when they want to build a systematic experimentation practice. For tracking implementation, see analytics-tracking. For page-level conversion optimization, see page-cro.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "ad-creative",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ad-creative",
+          "description": "When the user wants to generate, iterate, or scale ad creative — headlines, descriptions, primary text, or full ad variations — for any paid advertising platform. Also use when the user mentions 'ad copy variations,' 'ad creative,' 'generate headlines,' 'RSA headlines,' 'bulk ad copy,' 'ad iterations,' 'creative testing,' 'ad performance optimization,' 'write me some ads,' 'Facebook ad copy,' 'Google ad headlines,' 'LinkedIn ad text,' or 'I need more ad variations.' Use this whenever someone needs to produce ad copy at scale or iterate on existing ads. For campaign strategy and targeting, see paid-ads. For landing page copy, see copywriting.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/ai-seo",
+          "description": "When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' 'zero-click search,' 'how do I show up in AI answers,' 'LLM mentions,' or 'optimize for Claude/Gemini.' Use this whenever someone wants their content to be cited or surfaced by AI assistants and AI search engines. For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema-markup.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "analytics-tracking",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/analytics-tracking",
+          "description": "When the user wants to set up, improve, or audit analytics tracking and measurement. Also use when the user mentions \"set up tracking,\" \"GA4,\" \"Google Analytics,\" \"conversion tracking,\" \"event tracking,\" \"UTM parameters,\" \"tag manager,\" \"GTM,\" \"analytics implementation,\" \"tracking plan,\" \"how do I measure this,\" \"track conversions,\" \"attribution,\" \"Mixpanel,\" \"Segment,\" \"are my events firing,\" or \"analytics isn't working.\" Use this whenever someone asks how to know if something is working or wants to measure marketing results. For A/B test measurement, see ab-test-setup.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "aso-audit",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/aso-audit",
+          "description": "When the user wants to audit or optimize an App Store or Google Play listing. Also use when the user mentions 'ASO audit,' 'app store optimization,' 'optimize my app listing,' 'improve app visibility,' 'app store ranking,' 'audit my listing,' 'why aren't people downloading my app,' 'improve my app conversion,' 'keyword optimization for app,' or 'compare my app to competitors.' Use when the user shares an App Store or Google Play URL and wants to improve it.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "churn-prevention",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/churn-prevention",
+          "description": "When the user wants to reduce churn, build cancellation flows, set up save offers, recover failed payments, or implement retention strategies. Also use when the user mentions 'churn,' 'cancel flow,' 'offboarding,' 'save offer,' 'dunning,' 'failed payment recovery,' 'win-back,' 'retention,' 'exit survey,' 'pause subscription,' 'involuntary churn,' 'people keep canceling,' 'churn rate is too high,' 'how do I keep users,' or 'customers are leaving.' Use this whenever someone is losing subscribers or wants to build systems to prevent it. For post-cancel win-back email sequences, see email-sequence. For in-app upgrade paywalls, see paywall-upgrade-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "co-marketing",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/co-marketing",
+          "description": "When the user wants to find co-marketing partners, plan joint campaigns, or brainstorm partnership opportunities. Use when the user says 'co-marketing,' 'partner marketing,' 'joint campaign,' 'who should we partner with,' 'integration marketing,' 'cross-promotion,' 'collaborate with another company,' 'partnership ideas,' or 'co-brand.' For customer referral programs, see referral-program. For launch-specific partnerships, see launch-strategy.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "cold-email",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/cold-email",
+          "description": "Write B2B cold emails and follow-up sequences that get replies. Use when the user wants to write cold outreach emails, prospecting emails, cold email campaigns, sales development emails, or SDR emails. Also use when the user mentions \"cold outreach,\" \"prospecting email,\" \"outbound email,\" \"email to leads,\" \"reach out to prospects,\" \"sales email,\" \"follow-up email sequence,\" \"nobody's replying to my emails,\" or \"how do I write a cold email.\" Covers subject lines, opening lines, body copy, CTAs, personalization, and multi-touch follow-up sequences. For warm/lifecycle email sequences, see email-sequence. For sales collateral beyond emails, see sales-enablement.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "community-marketing",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/community-marketing",
+          "description": "Build and leverage online communities to drive product growth and brand loyalty. Use when the user wants to create a community strategy, grow a Discord or Slack community, manage a forum or subreddit, build brand advocates, increase word-of-mouth, drive community-led growth, engage users post-signup, or turn customers into evangelists. Trigger phrases: \\\"build a community,\\\" \\\"community strategy,\\\" \\\"Discord community,\\\" \\\"Slack community,\\\" \\\"community-led growth,\\\" \\\"brand advocates,\\\" \\\"user community,\\\" \\\"forum strategy,\\\" \\\"community engagement,\\\" \\\"grow our community,\\\" \\\"ambassador program,\\\" \\\"community flywheel.\\\"",
+          "version": "1.0.0"
+        },
+        {
+          "name": "competitor-alternatives",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/competitor-alternatives",
+          "description": "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'how do we compare to X,' 'battle card,' or 'competitor teardown.' Use this for any content that positions your product against competitors. Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. For sales-specific competitor docs, see sales-enablement.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "competitor-profiling",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/competitor-profiling",
+          "description": "When the user wants to research, profile, or analyze competitors from their URLs. Also use when the user mentions 'competitor profile,' 'competitor research,' 'competitor analysis,' 'profile this competitor,' 'analyze competitor,' 'competitive intelligence,' 'competitor deep dive,' 'who are my competitors,' 'competitor landscape,' 'competitor dossier,' 'competitive audit,' or 'research these competitors.' Input is a list of competitor URLs. Output is structured competitor profile markdown files. For creating comparison/alternative pages from profiles, see competitor-alternatives. For sales-specific battle cards, see sales-enablement.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "content-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/content-strategy",
+          "description": "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions \"content strategy,\" \"what should I write about,\" \"content ideas,\" \"blog strategy,\" \"topic clusters,\" \"content planning,\" \"editorial calendar,\" \"content marketing,\" \"content roadmap,\" \"what content should I create,\" \"blog topics,\" \"content pillars,\" or \"I don't know what to write.\" Use this whenever someone needs help deciding what content to produce, not just writing it. For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit. For social media content specifically, see social-content.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "copy-editing",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/copy-editing",
+          "description": "When the user wants to edit, review, or improve existing marketing copy, or refresh outdated content. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' 'copy sweep,' 'tighten this up,' 'this reads awkwardly,' 'clean up this text,' 'too wordy,' 'sharpen the messaging,' 'refresh this content,' 'update this page,' 'this content is outdated,' or 'content audit.' Use this when the user already has copy and wants it improved or refreshed rather than rewritten from scratch. For writing new copy, see copywriting.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "copywriting",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/copywriting",
+          "description": "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \"write copy for,\" \"improve this copy,\" \"rewrite this page,\" \"marketing copy,\" \"headline help,\" \"CTA copy,\" \"value proposition,\" \"tagline,\" \"subheadline,\" \"hero section copy,\" \"above the fold,\" \"this copy is weak,\" \"make this more compelling,\" or \"help me describe my product.\" Use this whenever someone is working on website text that needs to persuade or convert. For email copy, see email-sequence. For popup copy, see popup-cro. For editing existing copy, see copy-editing.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "customer-research",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/customer-research",
+          "description": "When the user wants to conduct, analyze, or synthesize customer research. Use when the user mentions \"customer research,\" \"ICP research,\" \"talk to customers,\" \"analyze transcripts,\" \"customer interviews,\" \"survey analysis,\" \"support ticket analysis,\" \"voice of customer,\" \"VOC,\" \"build personas,\" \"customer personas,\" \"jobs to be done,\" \"JTBD,\" \"what do customers say,\" \"what are customers struggling with,\" \"Reddit mining,\" \"G2 reviews,\" \"review mining,\" \"digital watering holes,\" \"community research,\" \"forum research,\" \"competitor reviews,\" \"customer sentiment,\" or \"find out why customers churn/convert/buy.\" Use for both analyzing existing research assets AND gathering new research from online sources. For writing copy informed by research, see copywriting. For acting on research to improve pages, see page-cro.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "directory-submissions",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/directory-submissions",
+          "description": "When the user wants to submit their product to startup, SaaS, AI, agent, MCP, no-code, or review directories for backlinks, domain rating, and discovery. Also use when the user mentions \"directory submissions,\" \"submit to directories,\" \"backlinks from directories,\" \"list my product,\" \"submit to Product Hunt,\" \"BetaList,\" \"TAAFT,\" \"Futurepedia,\" \"G2 listing,\" \"Capterra listing,\" \"AlternativeTo,\" \"SaaSHub,\" \"AI directories,\" \"MCP registry,\" \"agent directory,\" \"dofollow backlinks,\" \"launch directories,\" or \"directory tracker.\" Use this whenever someone is planning the directory layer of a product launch or an ongoing backlink campaign. For the broader launch moment, see launch-strategy. For programmatic SEO pages that should live behind these backlinks, see programmatic-seo. For AI citation optimization, see ai-seo.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "email-sequence",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/email-sequence",
+          "description": "When the user wants to create or optimize an email sequence, drip campaign, automated email flow, or lifecycle email program. Also use when the user mentions \"email sequence,\" \"drip campaign,\" \"nurture sequence,\" \"onboarding emails,\" \"welcome sequence,\" \"re-engagement emails,\" \"email automation,\" \"lifecycle emails,\" \"trigger-based emails,\" \"email funnel,\" \"email workflow,\" \"what emails should I send,\" \"welcome series,\" or \"email cadence.\" Use this for any multi-email automated flow. For cold outreach emails, see cold-email. For in-app onboarding, see onboarding-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "form-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/form-cro",
+          "description": "When the user wants to optimize any form that is NOT signup/registration — including lead capture forms, contact forms, demo request forms, application forms, survey forms, or checkout forms. Also use when the user mentions \"form optimization,\" \"lead form conversions,\" \"form friction,\" \"form fields,\" \"form completion rate,\" \"contact form,\" \"nobody fills out our form,\" \"form abandonment,\" \"too many fields,\" \"demo request form,\" or \"lead form isn't converting.\" Use this for any non-signup form that captures information. For signup/registration forms, see signup-flow-cro. For popups containing forms, see popup-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "free-tool-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/free-tool-strategy",
+          "description": "When the user wants to plan, evaluate, or build a free tool for marketing purposes — lead generation, SEO value, or brand awareness. Also use when the user mentions \"engineering as marketing,\" \"free tool,\" \"marketing tool,\" \"calculator,\" \"generator,\" \"interactive tool,\" \"lead gen tool,\" \"build a tool for leads,\" \"free resource,\" \"ROI calculator,\" \"grader tool,\" \"audit tool,\" \"should I build a free tool,\" or \"tools for lead gen.\" Use this whenever someone wants to build something useful and give it away to attract leads or earn links. For downloadable content lead magnets (ebooks, checklists, templates), see lead-magnets.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "image",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/image",
+          "description": "When the user wants to create, generate, edit, or optimize images for marketing — blog heroes, social graphics, product mockups, profile banners, listing visuals, or brand assets. Also use when the user mentions 'AI image generation,' 'generate an image,' 'create a graphic,' 'product mockup,' 'hero image,' 'social media graphic,' 'banner image,' 'cover photo,' 'profile banner,' 'listing screenshot,' 'Flux,' 'Midjourney,' 'DALL-E,' 'GPT Image,' 'Ideogram,' 'Gemini image,' 'Canva,' 'Figma,' 'image optimization,' 'compress images,' 'WebP,' or 'OG image.' Use this for general-purpose marketing image creation and optimization. For paid ad image creative and platform-specific ad specs, see ad-creative. For video production, see video.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "launch-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/launch-strategy",
+          "description": "When the user wants to plan a product launch, feature announcement, or release strategy. Also use when the user mentions 'launch,' 'Product Hunt,' 'feature release,' 'announcement,' 'go-to-market,' 'beta launch,' 'early access,' 'waitlist,' 'product update,' 'how do I launch this,' 'launch checklist,' 'GTM plan,' or 'we're about to ship.' Use this whenever someone is preparing to release something publicly. For ongoing marketing after launch, see marketing-ideas.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "lead-magnets",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/lead-magnets",
+          "description": "When the user wants to create, plan, or optimize a lead magnet for email capture or lead generation. Also use when the user mentions \"lead magnet,\" \"gated content,\" \"content upgrade,\" \"downloadable,\" \"ebook,\" \"cheat sheet,\" \"checklist,\" \"template download,\" \"opt-in,\" \"freebie,\" \"PDF download,\" \"resource library,\" \"content offer,\" \"email capture content,\" \"Notion template,\" \"spreadsheet template,\" or \"what should I give away for emails.\" Use this for planning what to create and how to distribute it. For interactive tools as lead magnets, see free-tool-strategy. For writing the actual content, see copywriting. For the email sequence after capture, see email-sequence.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "marketing-ideas",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/marketing-ideas",
+          "description": "When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the user asks for 'marketing ideas,' 'growth ideas,' 'how to market,' 'marketing strategies,' 'marketing tactics,' 'ways to promote,' 'ideas to grow,' 'what else can I try,' 'I don't know how to market this,' 'brainstorm marketing,' or 'what marketing should I do.' Use this as a starting point whenever someone is stuck or looking for inspiration on how to grow. For specific channel execution, see the relevant skill (paid-ads, social-content, email-sequence, etc.).",
+          "version": "1.1.0"
+        },
+        {
+          "name": "marketing-psychology",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/marketing-psychology",
+          "description": "When the user wants to apply psychological principles, mental models, or behavioral science to marketing. Also use when the user mentions 'psychology,' 'mental models,' 'cognitive bias,' 'persuasion,' 'behavioral science,' 'why people buy,' 'decision-making,' 'consumer behavior,' 'anchoring,' 'social proof,' 'scarcity,' 'loss aversion,' 'framing,' or 'nudge.' Use this whenever someone wants to understand or leverage how people think and make decisions in a marketing context.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "onboarding-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/onboarding-cro",
+          "description": "When the user wants to optimize post-signup onboarding, user activation, first-run experience, or time-to-value. Also use when the user mentions \"onboarding flow,\" \"activation rate,\" \"user activation,\" \"first-run experience,\" \"empty states,\" \"onboarding checklist,\" \"aha moment,\" \"new user experience,\" \"users aren't activating,\" \"nobody completes setup,\" \"low activation rate,\" \"users sign up but don't use the product,\" \"time to value,\" or \"first session experience.\" Use this whenever users are signing up but not sticking around. For signup/registration optimization, see signup-flow-cro. For ongoing email sequences, see email-sequence.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "page-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/page-cro",
+          "description": "When the user wants to optimize, improve, or increase conversions on any marketing page — including homepage, landing pages, pricing pages, feature pages, or blog posts. Also use when the user says \"CRO,\" \"conversion rate optimization,\" \"this page isn't converting,\" \"improve conversions,\" \"why isn't this page working,\" \"my landing page sucks,\" \"nobody's converting,\" \"low conversion rate,\" \"bounce rate is too high,\" \"people leave without signing up,\" or \"this page needs work.\" Use this even if the user just shares a URL and asks for feedback — they probably want conversion help. For signup/registration flows, see signup-flow-cro. For post-signup activation, see onboarding-cro. For forms outside of signup, see form-cro. For popups/modals, see popup-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "paid-ads",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/paid-ads",
+          "description": "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions 'PPC,' 'paid media,' 'ROAS,' 'CPA,' 'ad campaign,' 'retargeting,' 'audience targeting,' 'Google Ads,' 'Facebook ads,' 'LinkedIn ads,' 'ad budget,' 'cost per click,' 'ad spend,' or 'should I run ads.' Use this for campaign strategy, audience targeting, bidding, and optimization. For bulk ad creative generation and iteration, see ad-creative. For landing page optimization, see page-cro.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "paywall-upgrade-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/paywall-upgrade-cro",
+          "description": "When the user wants to create or optimize in-app paywalls, upgrade screens, upsell modals, or feature gates. Also use when the user mentions \"paywall,\" \"upgrade screen,\" \"upgrade modal,\" \"upsell,\" \"feature gate,\" \"convert free to paid,\" \"freemium conversion,\" \"trial expiration screen,\" \"limit reached screen,\" \"plan upgrade prompt,\" \"in-app pricing,\" \"free users won't upgrade,\" \"trial to paid conversion,\" or \"how do I get users to pay.\" Use this for any in-product moment where you're asking users to upgrade. Distinct from public pricing pages (see page-cro) — this focuses on in-product upgrade moments where the user has already experienced value. For pricing decisions, see pricing-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "popup-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/popup-cro",
+          "description": "When the user wants to create or optimize popups, modals, overlays, slide-ins, or banners for conversion purposes. Also use when the user mentions \"exit intent,\" \"popup conversions,\" \"modal optimization,\" \"lead capture popup,\" \"email popup,\" \"announcement banner,\" \"overlay,\" \"collect emails with a popup,\" \"exit popup,\" \"scroll trigger,\" \"sticky bar,\" or \"notification bar.\" Use this for any overlay or interrupt-style conversion element. For forms outside of popups, see form-cro. For general page conversion optimization, see page-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "pricing-strategy",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/pricing-strategy",
+          "description": "When the user wants help with pricing decisions, packaging, or monetization strategy. Also use when the user mentions 'pricing,' 'pricing tiers,' 'freemium,' 'free trial,' 'packaging,' 'price increase,' 'value metric,' 'Van Westendorp,' 'willingness to pay,' 'monetization,' 'how much should I charge,' 'my pricing is wrong,' 'pricing page,' 'annual vs monthly,' 'per seat pricing,' or 'should I offer a free plan.' Use this whenever someone is figuring out what to charge or how to structure their plans. For in-app upgrade screens, see paywall-upgrade-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "product-marketing-context",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/product-marketing-context",
+          "description": "When the user wants to create or update their product marketing context document. Also use when the user mentions 'product context,' 'marketing context,' 'set up context,' 'positioning,' 'who is my target audience,' 'describe my product,' 'ICP,' 'ideal customer profile,' or wants to avoid repeating foundational information across marketing tasks. Use this at the start of any new project before using other marketing skills — it creates `.agents/product-marketing-context.md` that all other skills reference for product, audience, and positioning context.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "programmatic-seo",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/programmatic-seo",
+          "description": "When the user wants to create SEO-driven pages at scale using templates and data. Also use when the user mentions \"programmatic SEO,\" \"template pages,\" \"pages at scale,\" \"directory pages,\" \"location pages,\" \"[keyword] + [city] pages,\" \"comparison pages,\" \"integration pages,\" \"building many pages for SEO,\" \"pSEO,\" \"generate 100 pages,\" \"data-driven pages,\" or \"templated landing pages.\" Use this whenever someone wants to create many similar pages targeting different keywords or locations. For auditing existing SEO issues, see seo-audit. For content strategy planning, see content-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "referral-program",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/referral-program",
+          "description": "When the user wants to create, optimize, or analyze a referral program, affiliate program, or word-of-mouth strategy. Also use when the user mentions 'referral,' 'affiliate,' 'ambassador,' 'word of mouth,' 'viral loop,' 'refer a friend,' 'partner program,' 'referral incentive,' 'how to get referrals,' 'customers referring customers,' or 'affiliate payout.' Use this whenever someone wants existing users or partners to bring in new customers. For launch-specific virality, see launch-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "revops",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/revops",
+          "description": "When the user wants help with revenue operations, lead lifecycle management, or marketing-to-sales handoff processes. Also use when the user mentions 'RevOps,' 'revenue operations,' 'lead scoring,' 'lead routing,' 'MQL,' 'SQL,' 'pipeline stages,' 'deal desk,' 'CRM automation,' 'marketing-to-sales handoff,' 'data hygiene,' 'leads aren't getting to sales,' 'pipeline management,' 'lead qualification,' or 'when should marketing hand off to sales.' Use this for anything involving the systems and processes that connect marketing to revenue. For cold outreach emails, see cold-email. For email drip campaigns, see email-sequence. For pricing decisions, see pricing-strategy.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "sales-enablement",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/sales-enablement",
+          "description": "When the user wants to create sales collateral, pitch decks, one-pagers, objection handling docs, or demo scripts. Also use when the user mentions 'sales deck,' 'pitch deck,' 'one-pager,' 'leave-behind,' 'objection handling,' 'deal-specific ROI analysis,' 'demo script,' 'talk track,' 'sales playbook,' 'proposal template,' 'buyer persona card,' 'help my sales team,' 'sales materials,' or 'what should I give my sales reps.' Use this for any document or asset that helps a sales team close deals. For competitor comparison pages and battle cards, see competitor-alternatives. For marketing website copy, see copywriting. For cold outreach emails, see cold-email.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "schema-markup",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/schema-markup",
+          "description": "When the user wants to add, fix, or optimize schema markup and structured data on their site. Also use when the user mentions \"schema markup,\" \"structured data,\" \"JSON-LD,\" \"rich snippets,\" \"schema.org,\" \"FAQ schema,\" \"product schema,\" \"review schema,\" \"breadcrumb schema,\" \"Google rich results,\" \"knowledge panel,\" \"star ratings in search,\" or \"add structured data.\" Use this whenever someone wants their pages to show enhanced results in Google. For broader SEO issues, see seo-audit. For AI search optimization, see ai-seo.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "seo-audit",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/seo-audit",
+          "description": "When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions \"SEO audit,\" \"technical SEO,\" \"why am I not ranking,\" \"SEO issues,\" \"on-page SEO,\" \"meta tags review,\" \"SEO health check,\" \"my traffic dropped,\" \"lost rankings,\" \"not showing up in Google,\" \"site isn't ranking,\" \"Google update hit me,\" \"page speed,\" \"core web vitals,\" \"crawl errors,\" or \"indexing issues.\" Use this even if the user just says something vague like \"my SEO is bad\" or \"help with SEO\" — start with an audit. For building pages at scale to target keywords, see programmatic-seo. For adding structured data, see schema-markup. For AI search optimization, see ai-seo.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "signup-flow-cro",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/signup-flow-cro",
+          "description": "When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the user mentions \"signup conversions,\" \"registration friction,\" \"signup form optimization,\" \"free trial signup,\" \"reduce signup dropoff,\" \"account creation flow,\" \"people aren't signing up,\" \"signup abandonment,\" \"trial conversion rate,\" \"nobody completes registration,\" \"too many steps to sign up,\" or \"simplify our signup.\" Use this whenever the user has a signup or registration flow that isn't performing. For post-signup onboarding, see onboarding-cro. For lead capture forms (not account creation), see form-cro.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "site-architecture",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/site-architecture",
+          "description": "When the user wants to plan, map, or restructure their website's page hierarchy, navigation, URL structure, or internal linking. Also use when the user mentions \"sitemap,\" \"site map,\" \"visual sitemap,\" \"site structure,\" \"page hierarchy,\" \"information architecture,\" \"IA,\" \"navigation design,\" \"URL structure,\" \"breadcrumbs,\" \"internal linking strategy,\" \"website planning,\" \"what pages do I need,\" \"how should I organize my site,\" or \"site navigation.\" Use this whenever someone is planning what pages a website should have and how they connect. NOT for XML sitemaps (that's technical SEO — see seo-audit). For SEO audits, see seo-audit. For structured data, see schema-markup.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "social-content",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/social-content",
+          "description": "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, or other platforms. Also use when the user mentions 'LinkedIn post,' 'Twitter thread,' 'social media,' 'content calendar,' 'social scheduling,' 'engagement,' 'viral content,' 'what should I post,' 'repurpose this content,' 'tweet ideas,' 'LinkedIn carousel,' 'social media strategy,' 'grow my following,' 'TikTok video,' 'Reels,' 'Shorts,' 'video script,' 'video hook,' 'short-form video,' or 'create a reel.' Use this for social media content creation, repurposing, scheduling, and short-form video scripting. For broader content strategy, see content-strategy. For paid video ads, see ad-creative.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "video",
+          "installUrl": "github:coreyhaines31/marketingskills:skills/video",
+          "description": "When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use when the user mentions 'video production,' 'AI video,' 'Remotion,' 'Hyperframes,' 'HeyGen,' 'Synthesia,' 'Veo,' 'Runway,' 'Kling,' 'Pika,' 'video generation,' 'AI avatar,' 'talking head video,' 'programmatic video,' 'video template,' 'explainer video,' 'product demo video,' 'video pipeline,' or 'make me a video.' Use this for video creation, generation, and production workflows. For video content strategy and what to post, see social-content. For paid video ad creative, see ad-creative.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "coreyhaines31",
+        "repo": "marketingskills",
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/entireio_skills.json
+++ b/data/skill-index/entireio_skills.json
@@ -690,5 +690,133 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "entireio-skills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from entireio/skills.",
+      "author": "ASM (entireio/skills)",
+      "createdAt": "2026-05-09T08:11:13.670Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "entireio",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "explain",
+          "installUrl": "github:entireio/skills:skills/explain",
+          "description": "Explains the intent behind source code by finding original session transcripts. Use explain with a function, file, or line of code to understand why it exists.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "what-happened",
+          "installUrl": "github:entireio/skills:skills/what-happened",
+          "description": "Explain why code looks the way it does by tracing the latest change for a file range or pasted snippet through `git blame` and deduplicated `entire explain` lookups. Use when the user asks what happened, says \"tell me why\" about a code block, is confused about a section of code, asks \"wtf is going on\", \"why is this like this\", \"why was this changed\", or wants provenance for a specific file block.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "entireio",
+        "repo": "skills",
+        "repoUrl": "https://github.com/entireio/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "entireio-skills-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from entireio/skills.",
+      "author": "ASM (entireio/skills)",
+      "createdAt": "2026-05-09T08:11:13.670Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "entireio",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "session-to-skill",
+          "installUrl": "github:entireio/skills:skills/session-to-skill",
+          "description": "Use when the user wants to turn one or more Entire-tracked sessions, checkpoints, or repeated agent workflows into a reusable agent skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "what-happened",
+          "installUrl": "github:entireio/skills:skills/what-happened",
+          "description": "Explain why code looks the way it does by tracing the latest change for a file range or pasted snippet through `git blame` and deduplicated `entire explain` lookups. Use when the user asks what happened, says \"tell me why\" about a code block, is confused about a section of code, asks \"wtf is going on\", \"why is this like this\", \"why was this changed\", or wants provenance for a specific file block.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "entireio",
+        "repo": "skills",
+        "repoUrl": "https://github.com/entireio/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "entireio-skills-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from entireio/skills.",
+      "author": "ASM (entireio/skills)",
+      "createdAt": "2026-05-09T08:11:13.670Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "entireio",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "explain",
+          "installUrl": "github:entireio/skills:skills/explain",
+          "description": "Explains the intent behind source code by finding original session transcripts. Use explain with a function, file, or line of code to understand why it exists.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "search",
+          "installUrl": "github:entireio/skills:skills/search",
+          "description": "Use when the user wants to find prior work, checkpoints, or agent conversations by topic, repo, branch, author, or recent time window",
+          "version": "0.0.0"
+        },
+        {
+          "name": "session-handoff",
+          "installUrl": "github:entireio/skills:skills/session-handoff",
+          "description": "Use when the user wants to continue work from one agent in another agent, inspect recent sessions, or summarize a saved session or checkpoint for handoff",
+          "version": "0.0.0"
+        },
+        {
+          "name": "session-to-skill",
+          "installUrl": "github:entireio/skills:skills/session-to-skill",
+          "description": "Use when the user wants to turn one or more Entire-tracked sessions, checkpoints, or repeated agent workflows into a reusable agent skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "what-happened",
+          "installUrl": "github:entireio/skills:skills/what-happened",
+          "description": "Explain why code looks the way it does by tracing the latest change for a file range or pasted snippet through `git blame` and deduplicated `entire explain` lookups. Use when the user asks what happened, says \"tell me why\" about a code block, is confused about a section of code, asks \"wtf is going on\", \"why is this like this\", \"why was this changed\", or wants provenance for a specific file block.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "entireio",
+        "repo": "skills",
+        "repoUrl": "https://github.com/entireio/skills.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/github_awesome-copilot.json
+++ b/data/skill-index/github_awesome-copilot.json
@@ -9337,7 +9337,11 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["ask_user", "sql", "fetch_copilot_cli_documentation"],
+      "allowedTools": [
+        "ask_user",
+        "sql",
+        "fetch_copilot_cli_documentation"
+      ],
       "installUrl": "github:github/awesome-copilot:skills/copilot-cli-quickstart",
       "relPath": "skills/copilot-cli-quickstart",
       "verified": true,
@@ -20297,7 +20301,9 @@
       "license": "MIT",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Bash"],
+      "allowedTools": [
+        "Bash"
+      ],
       "installUrl": "github:github/awesome-copilot:skills/git-commit",
       "relPath": "skills/git-commit",
       "verified": true,
@@ -31128,7 +31134,11 @@
       "license": "MIT",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Bash", "Write", "Read"],
+      "allowedTools": [
+        "Bash",
+        "Write",
+        "Read"
+      ],
       "installUrl": "github:github/awesome-copilot:skills/plantuml-ascii",
       "relPath": "skills/plantuml-ascii",
       "verified": true,
@@ -46053,6 +46063,3542 @@
           "evaluatedVersion": "0.0.0"
         }
       }
+    }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "github-awesome-copilot-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from github/awesome-copilot.",
+      "author": "ASM (github/awesome-copilot)",
+      "createdAt": "2026-05-09T08:10:57.006Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "github",
+        "awesome-copilot"
+      ],
+      "skills": [
+        {
+          "name": "acreadiness-assess",
+          "installUrl": "github:github/awesome-copilot:skills/acreadiness-assess",
+          "description": "Run the AgentRC readiness assessment on the current repository and produce a static HTML dashboard at reports/index.html. Wraps `npx github:microsoft/agentrc readiness` and hands off rendering to the @ai-readiness-reporter custom agent. Supports policies (--policy) for org-specific scoring. Use when asked to assess, audit, or score the AI readiness of a repo.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apple-appstore-reviewer",
+          "installUrl": "github:github/awesome-copilot:skills/apple-appstore-reviewer",
+          "description": "Serves as a reviewer of the codebase with instructions on looking for Apple App Store optimizations or rejection reasons.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-architecture-autopilot",
+          "installUrl": "github:github/awesome-copilot:skills/azure-architecture-autopilot",
+          "description": "Design Azure infrastructure using natural language, or analyze existing Azure resources to auto-generate architecture diagrams, refine them through conversation, and deploy with Bicep. When to use this skill: - \"Create X on Azure\", \"Set up a RAG architecture\" (new design) - \"Analyze my current Azure infrastructure\", \"Draw a diagram for rg-xxx\" (existing analysis) - \"Foundry is slow\", \"I want to reduce costs\", \"Strengthen security\" (natural language modification) - Azure resource deployment, Bicep template generation, IaC code generation - Microsoft Foundry, AI Search, OpenAI, Fabric, ADLS Gen2, Databricks, and all Azure services",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brag-sheet",
+          "installUrl": "github:github/awesome-copilot:skills/brag-sheet",
+          "description": "Turn vague \"what did I do?\" into evidence-backed impact statements for performance reviews, self-reviews, promotion packets, and weekly updates. Uniquely mines Copilot CLI session logs to reconstruct forgotten work, plus git commits and GitHub PRs. Enforces a 3-part impact contract (action → result → evidence). Works standalone with zero dependencies. Trigger for: \"brag\", \"log work\", \"what did I do\", \"backfill my work history\", \"performance review\", \"self-review\", \"self assessment\", \"write impact statement\", \"review prep\", \"promo packet\", \"promotion case\", \"weekly update\", \"status report\", \"accomplishments\", \"what did I ship\", \"I forgot to log my work\", \"summarize my work\", \"track my wins\", \"what should I highlight\", \"end of half\", \"career growth\", \"work journal\", or any request to document, summarize, or organize work accomplishments.",
+          "version": "1.1"
+        },
+        {
+          "name": "cloud-design-patterns",
+          "installUrl": "github:github/awesome-copilot:skills/cloud-design-patterns",
+          "description": "Cloud design patterns for distributed systems architecture covering 42 industry-standard patterns across reliability, performance, messaging, security, and deployment categories. Use when designing, reviewing, or implementing distributed system architectures.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-exemplars-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/code-exemplars-blueprint-generator",
+          "description": "Technology-agnostic prompt generator that creates customizable AI prompts for scanning codebases and identifying high-quality code exemplars. Supports multiple programming languages (.NET, Java, JavaScript, TypeScript, React, Angular, Python) with configurable analysis depth, categorization methods, and documentation formats to establish coding standards and maintain consistency across development teams.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-management-systems",
+          "installUrl": "github:github/awesome-copilot:skills/content-management-systems",
+          "description": "Workflow for building and modifying content management systems across WordPress, Shopify, Wix, Squarespace, Drupal, WooCommerce, Joomla, HubSpot CMS Hub, Webflow, Adobe Experience Manager, and similar platforms. Use when working on CMS themes, plugins, apps, modules, admin panels, media uploads, content models, editors, markdown pipelines, or static export workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "creating-oracle-to-postgres-migration-integration-tests",
+          "installUrl": "github:github/awesome-copilot:skills/creating-oracle-to-postgres-migration-integration-tests",
+          "description": "Creates integration test cases for .NET data access artifacts during Oracle-to-PostgreSQL database migrations. Generates DB-agnostic xUnit tests with deterministic seed data that validate behavior consistency across both database systems. Use when creating integration tests for a migrated project, generating test coverage for data access layers, or writing Oracle-to-PostgreSQL migration validation tests.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "daily-prep",
+          "installUrl": "github:github/awesome-copilot:skills/daily-prep",
+          "description": "Prepare for tomorrow''s meetings and tasks. Pulls calendar from Outlook via WorkIQ, cross-references open tasks and workspace context, classifies meetings, detects conflicts and day-fit issues, finds learning and deep-work slots, and generates a structured HTML prep file with productivity recommendations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "declarative-agents",
+          "installUrl": "github:github/awesome-copilot:skills/declarative-agents",
+          "description": "Complete development kit for Microsoft 365 Copilot declarative agents with three comprehensive workflows (basic, advanced, validation), TypeSpec support, and Microsoft 365 Agents Toolkit integration",
+          "version": "0.0.0"
+        },
+        {
+          "name": "diagnose",
+          "installUrl": "github:github/awesome-copilot:skills/diagnose",
+          "description": "Perform a systematic diagnostic scan of an AI workflow across 5 quality dimensions — prompt quality, context efficiency, tool health, architecture fitness, and safety — producing a scored report with prioritized remediation actions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dotnet-timezone",
+          "installUrl": "github:github/awesome-copilot:skills/dotnet-timezone",
+          "description": ".NET timezone handling guidance for C# applications. Use when working with TimeZoneInfo, DateTimeOffset, NodaTime, UTC conversion, daylight saving time, scheduling across timezones, cross-platform Windows/IANA timezone IDs, or when a .NET user needs the timezone for a city, address, region, or country and copy-paste-ready C# code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "entra-agent-user",
+          "installUrl": "github:github/awesome-copilot:skills/entra-agent-user",
+          "description": "Create Agent Users in Microsoft Entra ID from Agent Identities, enabling AI agents to act as digital workers with user identity capabilities in Microsoft 365 and Azure environments.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-monitoring",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-monitoring",
+          "description": "**Pro+ subscription required.** Tenant-wide Power Automate flow health monitoring, failure rate analytics, and asset inventory using the FlowStudio MCP cached store. Load this skill ONLY for tenant-wide aggregated views — not for listing flows in a single environment or debugging a specific run (use power-automate-mcp or power-automate-debug for those). Not the same as the server's `monitor-flow` tool bundle (`tool_search query: \"skill:monitor-flow\"`) — that bundle is for runtime control of a single flow (start/stop/trigger/ cancel/resubmit); this skill is for tenant-wide health analytics over the cached store. Load when asked to: monitor tenant health, get aggregated failure rates over a time window, review tenant-wide error trends, find inactive makers across the tenant, inventory all Power Apps in the tenant, compute governance scores, generate a compliance report, or run a tenant-wide health overview. Requires a FlowStudio for Teams or MCP Pro+ subscription — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fluentui-blazor",
+          "installUrl": "github:github/awesome-copilot:skills/fluentui-blazor",
+          "description": "Guide for using the Microsoft Fluent UI Blazor component library (Microsoft.FluentUI.AspNetCore.Components NuGet package) in Blazor applications. Use this when the user is building a Blazor app with Fluent UI components, setting up the library, using FluentUI components like FluentButton, FluentDataGrid, FluentDialog, FluentToast, FluentNavMenu, FluentTextField, FluentSelect, FluentAutocomplete, FluentDesignTheme, or any component prefixed with \"Fluent\". Also use when troubleshooting missing providers, JS interop issues, or theming.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "folder-structure-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/folder-structure-blueprint-generator",
+          "description": "Comprehensive technology-agnostic prompt for analyzing and documenting project folder structures. Auto-detects project types (.NET, Java, React, Angular, Python, Node.js, Flutter), generates detailed blueprints with visualization options, naming conventions, file placement patterns, and extension templates for maintaining consistent code organization across diverse technology stacks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "freecad-scripts",
+          "installUrl": "github:github/awesome-copilot:skills/freecad-scripts",
+          "description": "Expert skill for writing FreeCAD Python scripts, macros, and automation. Use when asked to create FreeCAD models, parametric objects, Part/Mesh/Sketcher scripts, workbench tools, GUI dialogs with PySide, Coin3D scenegraph manipulation, or any FreeCAD Python API task. Covers FreeCAD scripting basics, geometry creation, FeaturePython objects, interface tools, and macro development.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gdpr-compliant",
+          "installUrl": "github:github/awesome-copilot:skills/gdpr-compliant",
+          "description": "Apply GDPR-compliant engineering practices across your codebase. Use this skill whenever you are designing APIs, writing data models, building authentication flows, implementing logging, handling user data, writing retention/deletion jobs, designing cloud infrastructure, or reviewing pull requests for privacy compliance. Trigger this skill for any task involving personal data, user accounts, cookies, analytics, emails, audit logs, encryption, pseudonymization, anonymization, data exports, breach response, CI/CD pipelines that process real data, or any question framed as \"is this GDPR-compliant?\". Inspired by CNIL developer guidance and GDPR Articles 5, 25, 32, 33, 35.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gsap-framer-scroll-animation",
+          "installUrl": "github:github/awesome-copilot:skills/gsap-framer-scroll-animation",
+          "description": "Use this skill whenever the user wants to build scroll animations, scroll effects, parallax, scroll-triggered reveals, pinned sections, horizontal scroll, text animations, or any motion tied to scroll position — in vanilla JS, React, or Next.js. Covers GSAP ScrollTrigger (pinning, scrubbing, snapping, timelines, horizontal scroll, ScrollSmoother, matchMedia) and Framer Motion / Motion v12 (useScroll, useTransform, useSpring, whileInView, variants). Use this skill even if the user just says \"animate on scroll\", \"fade in as I scroll\", \"make it scroll like Apple\", \"parallax effect\", \"sticky section\", \"scroll progress bar\", or \"entrance animation\". Also triggers for Copilot prompt patterns for GSAP or Framer Motion code generation. Pairs with the premium-frontend-ui skill for creative philosophy and design-level polish.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-0-to-1-launch",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-0-to-1-launch",
+          "description": "Launch new products from idea to first customers. Use when launching products, finding early adopters, building launch week playbooks, diagnosing why adoption stalls, or learning that press coverage does not equal growth. Includes the three-layer diagnosis, the 2-week experiment cycle, and the launch that got 50K impressions and 12 signups.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-enterprise-account-planning",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-enterprise-account-planning",
+          "description": "Strategic account planning and execution for enterprise deals. Use when planning complex sales cycles, managing multiple stakeholders, applying MEDDICC qualification, tracking deal health, or building mutual action plans. Includes the \"stale MAP equals dead deal\" pattern.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-partnership-architecture",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-partnership-architecture",
+          "description": "Build and scale partner ecosystems that drive revenue and platform adoption. Use when building partner programs from scratch, tiering partnerships, managing co-marketing, making build-vs-partner decisions, or structuring crawl-walk-run partner deployment.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-positioning-strategy",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-positioning-strategy",
+          "description": "Find and own a defensible market position. Use when messaging sounds like competitors, conversion is weak despite awareness, repositioning a product, or testing positioning claims. Includes Crawl-Walk-Run rollout methodology and the word change that improved enterprise deal progression.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-product-led-growth",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-product-led-growth",
+          "description": "Build self-serve acquisition and expansion motions. Use when deciding PLG vs sales-led, optimizing activation, driving freemium conversion, building growth equations, or recognizing when product complexity demands human touch. Includes the parallel test where sales-led won 10x on revenue.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "image-manipulation-image-magick",
+          "installUrl": "github:github/awesome-copilot:skills/image-manipulation-image-magick",
+          "description": "Process and manipulate images using ImageMagick. Supports resizing, format conversion, batch processing, and retrieving image metadata. Use when working with images, creating thumbnails, resizing wallpapers, or performing batch image operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "import-infrastructure-as-code",
+          "installUrl": "github:github/awesome-copilot:skills/import-infrastructure-as-code",
+          "description": "Import existing Azure resources into Terraform using Azure CLI discovery and Azure Verified Modules (AVM). Use when asked to reverse-engineer live Azure infrastructure, generate Infrastructure as Code from existing subscriptions/resource groups/resource IDs, map dependencies, derive exact import addresses from downloaded module source, prevent configuration drift, and produce AVM-based Terraform files ready for validation and planning across any Azure resource type.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "issue-fields-migration",
+          "installUrl": "github:github/awesome-copilot:skills/issue-fields-migration",
+          "description": "Bulk-migrate metadata to GitHub issue fields from two sources: repo labels (e.g. priority labels to a Priority field) and Project V2 fields. Use when users say \"migrate my labels to issue fields\", \"migrate project fields to issue fields\", \"convert labels to issue fields\", \"copy project field values to issue fields\", or ask about adopting issue fields. Issue fields are org-level typed metadata (single select, text, number, date) that replace label-based workarounds with structured, searchable, cross-repo fields.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "legacy-circuit-mockups",
+          "installUrl": "github:github/awesome-copilot:skills/legacy-circuit-mockups",
+          "description": "Generate breadboard circuit mockups and visual diagrams using HTML5 Canvas drawing techniques. Use when asked to create circuit layouts, visualize electronic component placements, draw breadboard diagrams, mockup 6502 builds, generate retro computer schematics, or design vintage electronics projects. Supports 555 timers, W65C02S microprocessors, 28C256 EEPROMs, W65C22 VIA chips, 7400-series logic gates, LEDs, resistors, capacitors, switches, buttons, crystals, and wires.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "linkedin-post-formatter",
+          "installUrl": "github:github/awesome-copilot:skills/linkedin-post-formatter",
+          "description": "Format and draft compelling LinkedIn posts using Unicode bold/italic styling, visual separators, structured sections, and engagement-optimized patterns. USE FOR: draft LinkedIn post, format text for LinkedIn, create social media post, write thought leadership post, convert content to LinkedIn format, LinkedIn carousel text, Unicode bold italic formatting.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "microsoft-agent-framework",
+          "installUrl": "github:github/awesome-copilot:skills/microsoft-agent-framework",
+          "description": "Create, update, refactor, explain, or review Microsoft Agent Framework solutions using shared guidance plus language-specific references for .NET and Python.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "microsoft-code-reference",
+          "installUrl": "github:github/awesome-copilot:skills/microsoft-code-reference",
+          "description": "Look up Microsoft API references, find working code samples, and verify SDK code is correct. Use when working with Azure SDKs, .NET libraries, or Microsoft APIs—to find the right method, check parameters, get working examples, or troubleshoot errors. Catches hallucinated methods, wrong signatures, and deprecated patterns by querying official docs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "microsoft-docs",
+          "installUrl": "github:github/awesome-copilot:skills/microsoft-docs",
+          "description": "Query official Microsoft documentation to find concepts, tutorials, and code examples across Azure, .NET, Agent Framework, Aspire, VS Code, GitHub, and more. Uses Microsoft Learn MCP as the default, with Context7 and Aspire MCP for content that lives outside learn.microsoft.com.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "microsoft-skill-creator",
+          "installUrl": "github:github/awesome-copilot:skills/microsoft-skill-creator",
+          "description": "Create agent skills for Microsoft technologies using Learn MCP tools. Use when users want to create a skill that teaches agents about any Microsoft technology, library, framework, or service (Azure, .NET, M365, VS Code, Bicep, etc.). Investigates topics deeply, then generates a hybrid skill storing essential knowledge locally while enabling dynamic deeper investigation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "mini-context-graph",
+          "installUrl": "github:github/awesome-copilot:skills/mini-context-graph",
+          "description": "A persistent, compounding knowledge base combining Karpathy's LLM Wiki pattern with a structured knowledge graph. Ingest documents once — the LLM writes wiki pages, extracts entities/relations into the graph, and stores raw content for evidence retrieval. Knowledge accumulates and cross-references; it is never re-derived from scratch.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "msstore-cli",
+          "installUrl": "github:github/awesome-copilot:skills/msstore-cli",
+          "description": "Microsoft Store Developer CLI (msstore) for publishing Windows applications to the Microsoft Store. Use when asked to configure Store credentials, list Store apps, check submission status, publish submissions, manage package flights, set up CI/CD for Store publishing, or integrate with Partner Center. Supports Windows App SDK/WinUI, UWP, .NET MAUI, Flutter, Electron, React Native, and PWA applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "powerbi-modeling",
+          "installUrl": "github:github/awesome-copilot:skills/powerbi-modeling",
+          "description": "Power BI semantic modeling assistant for building optimized data models. Use when working with Power BI semantic models, creating measures, designing star schemas, configuring relationships, implementing RLS, or optimizing model performance. Triggers on queries about DAX calculations, table relationships, dimension/fact table design, naming conventions, model documentation, cardinality, cross-filter direction, calculation groups, and data model best practices. Always connects to the active model first using power-bi-modeling MCP tools to understand the data structure before providing guidance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "project-workflow-analysis-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/project-workflow-analysis-blueprint-generator",
+          "description": "Comprehensive technology-agnostic prompt generator for documenting end-to-end application workflows. Automatically detects project architecture patterns, technology stacks, and data flow patterns to generate detailed implementation blueprints covering entry points, service layers, data access, error handling, and testing approaches across multiple technologies including .NET, Java/Spring, React, and microservices architectures.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "publish-to-pages",
+          "installUrl": "github:github/awesome-copilot:skills/publish-to-pages",
+          "description": "Publish presentations and web content to GitHub Pages. Converts PPTX, PDF, HTML, or Google Slides to a live GitHub Pages URL. Handles repo creation, file conversion, Pages enablement, and returns the live URL. Use when the user wants to publish, deploy, or share a presentation or HTML file via GitHub Pages.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "qdrant-search-quality",
+          "installUrl": "github:github/awesome-copilot:skills/qdrant-search-quality",
+          "description": "Diagnoses and improves Qdrant search relevance. Use when someone reports 'search results are bad', 'wrong results', 'low precision', 'low recall', 'irrelevant matches', 'missing expected results', or asks 'how to improve search quality?', 'which embedding model?', 'should I use hybrid search?', 'should I use reranking?'. Also use when search quality degrades after quantization, model change, or data growth.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "react18-legacy-context",
+          "installUrl": "github:github/awesome-copilot:skills/react18-legacy-context",
+          "description": "Provides the complete migration pattern for React legacy context API (contextTypes, childContextTypes, getChildContext) to the modern createContext API. Use this skill whenever migrating legacy context in class components - this is always a cross-file migration requiring the provider AND all consumers to be updated together. Use it before touching any contextTypes or childContextTypes code, because migrating only the provider without the consumers (or vice versa) will cause a runtime failure. Always read this skill before writing any context migration - the cross-file coordination steps here prevent the most common context migration bugs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "react19-concurrent-patterns",
+          "installUrl": "github:github/awesome-copilot:skills/react19-concurrent-patterns",
+          "description": "Preserve React 18 concurrent patterns and adopt React 19 APIs (useTransition, useDeferredValue, Suspense, use(), useOptimistic, Actions) during migration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "readme-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/readme-blueprint-generator",
+          "description": "Intelligent README.md generation prompt that analyzes project documentation structure and creates comprehensive repository documentation. Scans .github/copilot directory files and copilot-instructions.md to extract project information, technology stack, architecture, development workflow, coding standards, and testing approaches while generating well-structured markdown documentation with proper formatting, cross-references, and developer-focused content.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "remember-interactive-programming",
+          "installUrl": "github:github/awesome-copilot:skills/remember-interactive-programming",
+          "description": "A micro-prompt that reminds the agent that it is an interactive programmer. Works great in Clojure when Copilot has access to the REPL (probably via Backseat Driver). Will work with any system that has a live REPL that the agent can use. Adapt the prompt with any specific reminders in your workflow and/or workspace.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "reviewing-oracle-to-postgres-migration",
+          "installUrl": "github:github/awesome-copilot:skills/reviewing-oracle-to-postgres-migration",
+          "description": "Identifies Oracle-to-PostgreSQL migration risks by cross-referencing code against known behavioral differences (empty strings, refcursors, type coercion, sorting, timestamps, concurrent transactions, etc.). Use when planning a database migration, reviewing migration artifacts, or validating that integration tests cover Oracle/PostgreSQL differences.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "roundup",
+          "installUrl": "github:github/awesome-copilot:skills/roundup",
+          "description": "Generate personalized status briefings on demand. Pulls from your configured data sources (GitHub, email, Teams, Slack, and more), synthesizes across them, and drafts updates in your own communication style for any audience you define.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "salesforce-apex-quality",
+          "installUrl": "github:github/awesome-copilot:skills/salesforce-apex-quality",
+          "description": "Apex code quality guardrails for Salesforce development. Enforces bulk-safety rules (no SOQL/DML in loops), sharing model requirements, CRUD/FLS security, SOQL injection prevention, PNB test coverage (Positive / Negative / Bulk), and modern Apex idioms. Use this skill when reviewing or generating Apex classes, trigger handlers, batch jobs, or test classes to catch governor limit risks, security gaps, and quality issues before deployment.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "salesforce-component-standards",
+          "installUrl": "github:github/awesome-copilot:skills/salesforce-component-standards",
+          "description": "Quality standards for Salesforce Lightning Web Components (LWC), Aura components, and Visualforce pages. Covers SLDS 2 compliance, accessibility (WCAG 2.1 AA), data access pattern selection, component communication rules, XSS prevention, CSRF enforcement, FLS/CRUD in AuraEnabled methods, view state management, and Jest test requirements. Use this skill when building or reviewing any Salesforce UI component to enforce platform-specific security and quality standards.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "salesforce-flow-design",
+          "installUrl": "github:github/awesome-copilot:skills/salesforce-flow-design",
+          "description": "Salesforce Flow architecture decisions, flow type selection, bulk safety validation, and fault handling standards. Use this skill when designing or reviewing Record-Triggered, Screen, Autolaunched, Scheduled, or Platform Event flows to ensure correct type selection, no DML/Get Records in loops, proper fault connectors on all data-changing elements, and appropriate automation density checks before deployment.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "security-review",
+          "installUrl": "github:github/awesome-copilot:skills/security-review",
+          "description": "AI-powered codebase security scanner that reasons about code like a security researcher — tracing data flows, understanding component interactions, and catching vulnerabilities that pattern-matching tools miss. Use this skill when asked to scan code for security vulnerabilities, find bugs, check for SQL injection, XSS, command injection, exposed API keys, hardcoded secrets, insecure dependencies, access control issues, or any request like \"is my code secure?\", \"review for security issues\", \"audit this codebase\", or \"check for vulnerabilities\". Covers injection flaws, authentication and access control bugs, secrets exposure, weak cryptography, insecure dependencies, and business logic issues across JavaScript, TypeScript, Python, Java, PHP, Go, Ruby, and Rust.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "sponsor-finder",
+          "installUrl": "github:github/awesome-copilot:skills/sponsor-finder",
+          "description": "Find which of a GitHub repository's dependencies are sponsorable via GitHub Sponsors. Uses deps.dev API for dependency resolution across npm, PyPI, Cargo, Go, RubyGems, Maven, and NuGet. Checks npm funding metadata, FUNDING.yml files, and web search. Verifies every link. Shows direct and transitive dependencies with OSSF Scorecard health data. Invoke with /sponsor followed by a GitHub owner/repo (e.g. \"/sponsor expressjs/express\").",
+          "version": "0.0.0"
+        },
+        {
+          "name": "sql-code-review",
+          "installUrl": "github:github/awesome-copilot:skills/sql-code-review",
+          "description": "Universal SQL code review assistant that performs comprehensive security, maintainability, and code quality analysis across all SQL databases (MySQL, PostgreSQL, SQL Server, Oracle). Focuses on SQL injection prevention, access control, code standards, and anti-pattern detection. Complements SQL optimization prompt for complete development coverage.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "sql-optimization",
+          "installUrl": "github:github/awesome-copilot:skills/sql-optimization",
+          "description": "Universal SQL performance optimization assistant for comprehensive query tuning, indexing strategies, and database performance analysis across all SQL databases (MySQL, PostgreSQL, SQL Server, Oracle). Provides execution plan analysis, pagination optimization, batch operations, and performance monitoring guidance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "technology-stack-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/technology-stack-blueprint-generator",
+          "description": "Comprehensive technology stack blueprint generator that analyzes codebases to create detailed architectural documentation. Automatically detects technology stacks, programming languages, and implementation patterns across multiple platforms (.NET, Java, JavaScript, React, Python). Generates configurable blueprints with version information, licensing details, usage patterns, coding conventions, and visual diagrams. Provides implementation-ready templates and maintains architectural consistency for guided development.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "typespec-create-agent",
+          "installUrl": "github:github/awesome-copilot:skills/typespec-create-agent",
+          "description": "Generate a complete TypeSpec declarative agent with instructions, capabilities, and conversation starters for Microsoft 365 Copilot",
+          "version": "0.0.0"
+        },
+        {
+          "name": "typespec-create-api-plugin",
+          "installUrl": "github:github/awesome-copilot:skills/typespec-create-api-plugin",
+          "description": "Generate a TypeSpec API plugin with REST operations, authentication, and Adaptive Cards for Microsoft 365 Copilot",
+          "version": "0.0.0"
+        },
+        {
+          "name": "web-coder",
+          "installUrl": "github:github/awesome-copilot:skills/web-coder",
+          "description": "Expert 10x engineer with comprehensive knowledge of web development, internet protocols, and web standards. Use when working with HTML, CSS, JavaScript, web APIs, HTTP/HTTPS, web security, performance optimization, accessibility, or any web/internet concepts. Specializes in translating web terminology accurately and implementing modern web standards across frontend and backend development.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "winapp-cli",
+          "installUrl": "github:github/awesome-copilot:skills/winapp-cli",
+          "description": "Windows App Development CLI (winapp) for building, packaging, signing, debugging, and UI-automating Windows applications. Use when asked to initialize Windows app projects, create MSIX packages, manage AppxManifest.xml or development certificates, run an app as packaged for debugging, automate Windows UI via Microsoft UI Automation, publish to the Microsoft Store, or access Windows SDK build tools. Covers commands like init, pack, run, unregister, manifest, cert, sign, store, ui, and tool. Supports .NET (csproj), C++, Electron, Rust, Tauri, Flutter, and other Windows frameworks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "workiq-copilot",
+          "installUrl": "github:github/awesome-copilot:skills/workiq-copilot",
+          "description": "Guides the Copilot CLI on how to use the WorkIQ CLI/MCP server to query Microsoft 365 Copilot data (emails, meetings, docs, Teams, people) for live context, summaries, and recommendations.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "github",
+        "repo": "awesome-copilot",
+        "repoUrl": "https://github.com/github/awesome-copilot.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "github-awesome-copilot-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from github/awesome-copilot.",
+      "author": "ASM (github/awesome-copilot)",
+      "createdAt": "2026-05-09T08:10:57.006Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "github",
+        "awesome-copilot"
+      ],
+      "skills": [
+        {
+          "name": "acquire-codebase-knowledge",
+          "installUrl": "github:github/awesome-copilot:skills/acquire-codebase-knowledge",
+          "description": "Use this skill when the user explicitly asks to map, document, or onboard into an existing codebase. Trigger for prompts like \"map this codebase\", \"document this architecture\", \"onboard me to this repo\", or \"create codebase docs\". Do not trigger for routine feature implementation, bug fixes, or narrow code edits unless the user asks for repository-level discovery.",
+          "version": "1.3"
+        },
+        {
+          "name": "acreadiness-policy",
+          "installUrl": "github:github/awesome-copilot:skills/acreadiness-policy",
+          "description": "Help the user pick, write, or apply an AgentRC policy. Policies customise readiness scoring by disabling irrelevant checks, overriding impact/level, setting pass-rate thresholds, or chaining org baselines with team overrides. Use when the user asks about strict mode, AI-only scoring, custom weights, CI gating, or wants org-wide standardisation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "adobe-illustrator-scripting",
+          "installUrl": "github:github/awesome-copilot:skills/adobe-illustrator-scripting",
+          "description": "Write, debug, and optimize Adobe Illustrator automation scripts using ExtendScript (JavaScript/JSX). Use when creating or modifying scripts that manipulate documents, layers, paths, text frames, colors, symbols, artboards, or any Illustrator DOM objects. Covers the complete JavaScript object model, coordinate system, measurement units, export workflows, and scripting best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-governance",
+          "installUrl": "github:github/awesome-copilot:skills/agent-governance",
+          "description": "Patterns and techniques for adding governance, safety, and trust controls to AI agent systems. Use this skill when: - Building AI agents that call external tools (APIs, databases, file systems) - Implementing policy-based access controls for agent tool usage - Adding semantic intent classification to detect dangerous prompts - Creating trust scoring systems for multi-agent workflows - Building audit trails for agent actions and decisions - Enforcing rate limits, content filters, or tool restrictions on agents - Working with any agent framework (PydanticAI, CrewAI, OpenAI Agents, LangChain, AutoGen)",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-prompt-engineering-safety-review",
+          "installUrl": "github:github/awesome-copilot:skills/ai-prompt-engineering-safety-review",
+          "description": "Comprehensive AI prompt engineering safety review and improvement prompt. Analyzes prompts for safety, bias, security vulnerabilities, and effectiveness while providing detailed improvement recommendations with extensive frameworks, testing methodologies, and educational content.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-team-orchestration",
+          "installUrl": "github:github/awesome-copilot:skills/ai-team-orchestration",
+          "description": "Bootstrap and run a multi-agent AI development team. Use when: starting a new software project with AI agents, setting up parallel dev/QA teams, creating sprint plans, writing brainstorm prompts with distinct agent voices, recovering a project workflow, or planning sprints.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/architecture-blueprint-generator",
+          "description": "Comprehensive project architecture blueprint generator that analyzes codebases to create detailed architectural documentation. Automatically detects technology stacks and architectural patterns, generates visual diagrams, documents implementation patterns, and provides extensible blueprints for maintaining architectural consistency and guiding new development.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-instrumentation",
+          "installUrl": "github:github/awesome-copilot:skills/arize-instrumentation",
+          "description": "INVOKE THIS SKILL when adding Arize AX tracing or observability to an app for the first time, or when the user wants to instrument their LLM app or get started with LLM observability. Follow the Agent-Assisted Tracing two-phase flow: analyze the codebase (read-only), then implement after user confirmation. When the app uses LLM tool/function calling, add manual CHAIN + TOOL spans. Leverages https://arize.com/docs/ax/alyx/tracing-assistant and https://arize.com/docs/PROMPT.md.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aspnet-minimal-api-openapi",
+          "installUrl": "github:github/awesome-copilot:skills/aspnet-minimal-api-openapi",
+          "description": "Create ASP.NET Minimal API endpoints with proper OpenAPI documentation",
+          "version": "0.0.0"
+        },
+        {
+          "name": "batch-files",
+          "installUrl": "github:github/awesome-copilot:skills/batch-files",
+          "description": "Expert-level Windows batch file (.bat/.cmd) skill for writing, debugging, and maintaining CMD scripts. Use when asked to \"create a batch file\", \"write a .bat script\", \"automate a Windows task\", \"CMD scripting\", \"batch automation\", \"scheduled task script\", \"Windows shell script\", or when working with .bat/.cmd files in the workspace. Covers cmd.exe syntax, environment variables, control flow, string processing, error handling, and integration with system tools.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "boost-prompt",
+          "installUrl": "github:github/awesome-copilot:skills/boost-prompt",
+          "description": "Interactive prompt refinement workflow: interrogates scope, deliverables, constraints; copies final markdown to clipboard; never writes code. Requires the Joyride extension.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brag-sheet",
+          "installUrl": "github:github/awesome-copilot:skills/brag-sheet",
+          "description": "Turn vague \"what did I do?\" into evidence-backed impact statements for performance reviews, self-reviews, promotion packets, and weekly updates. Uniquely mines Copilot CLI session logs to reconstruct forgotten work, plus git commits and GitHub PRs. Enforces a 3-part impact contract (action → result → evidence). Works standalone with zero dependencies. Trigger for: \"brag\", \"log work\", \"what did I do\", \"backfill my work history\", \"performance review\", \"self-review\", \"self assessment\", \"write impact statement\", \"review prep\", \"promo packet\", \"promotion case\", \"weekly update\", \"status report\", \"accomplishments\", \"what did I ship\", \"I forgot to log my work\", \"summarize my work\", \"track my wins\", \"what should I highlight\", \"end of half\", \"career growth\", \"work journal\", or any request to document, summarize, or organize work accomplishments.",
+          "version": "1.1"
+        },
+        {
+          "name": "code-exemplars-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/code-exemplars-blueprint-generator",
+          "description": "Technology-agnostic prompt generator that creates customizable AI prompts for scanning codebases and identifying high-quality code exemplars. Supports multiple programming languages (.NET, Java, JavaScript, TypeScript, React, Angular, Python) with configurable analysis depth, categorization methods, and documentation formats to establish coding standards and maintain consistency across development teams.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "commit-message-storyteller",
+          "installUrl": "github:github/awesome-copilot:skills/commit-message-storyteller",
+          "description": "Analyzes git diffs or staged changes and generates narrative commit messages that explain WHY a change was made, not just what changed — following Conventional Commits format. Use when asked to \"write a commit message\", \"generate a commit\", \"describe my changes\", \"what should I commit this as\", \"commit this\", \"summarize my diff\", or \"help me commit\". Works with git diff output, staged files, or plain descriptions of changes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-management-systems",
+          "installUrl": "github:github/awesome-copilot:skills/content-management-systems",
+          "description": "Workflow for building and modifying content management systems across WordPress, Shopify, Wix, Squarespace, Drupal, WooCommerce, Joomla, HubSpot CMS Hub, Webflow, Adobe Experience Manager, and similar platforms. Use when working on CMS themes, plugins, apps, modules, admin panels, media uploads, content models, editors, markdown pipelines, or static export workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copilot-cli-quickstart",
+          "installUrl": "github:github/awesome-copilot:skills/copilot-cli-quickstart",
+          "description": "Use this skill when someone wants to learn GitHub Copilot CLI from scratch. Offers interactive step-by-step tutorials with separate Developer and Non-Developer tracks, plus on-demand Q&A. Just say \"start tutorial\" or ask a question! Note: This skill targets GitHub Copilot CLI specifically and uses CLI-specific tools (ask_user, sql, fetch_copilot_cli_documentation).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copilot-spaces",
+          "installUrl": "github:github/awesome-copilot:skills/copilot-spaces",
+          "description": "Use Copilot Spaces to provide project-specific context to conversations. Use this skill when users mention a \"Copilot space\", want to load context from a shared knowledge base, discover available spaces, or ask questions grounded in curated project documentation, code, and instructions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-architectural-decision-record",
+          "installUrl": "github:github/awesome-copilot:skills/create-architectural-decision-record",
+          "description": "Create an Architectural Decision Record (ADR) document for AI-optimized decision documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-readme",
+          "installUrl": "github:github/awesome-copilot:skills/create-readme",
+          "description": "Create a README.md file for the project",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-tldr-page",
+          "installUrl": "github:github/awesome-copilot:skills/create-tldr-page",
+          "description": "Create a tldr page from documentation URLs and command examples, requiring both URL and command name.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "creating-oracle-to-postgres-migration-integration-tests",
+          "installUrl": "github:github/awesome-copilot:skills/creating-oracle-to-postgres-migration-integration-tests",
+          "description": "Creates integration test cases for .NET data access artifacts during Oracle-to-PostgreSQL database migrations. Generates DB-agnostic xUnit tests with deterministic seed data that validate behavior consistency across both database systems. Use when creating integration tests for a migrated project, generating test coverage for data access layers, or writing Oracle-to-PostgreSQL migration validation tests.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "csharp-docs",
+          "installUrl": "github:github/awesome-copilot:skills/csharp-docs",
+          "description": "Ensure that C# types are documented with XML comments and follow best practices for documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "documentation-writer",
+          "installUrl": "github:github/awesome-copilot:skills/documentation-writer",
+          "description": "Diátaxis Documentation Expert. An expert technical writer specializing in creating high-quality software documentation, guided by the principles and structure of the Diátaxis technical documentation authoring framework.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dotnet-timezone",
+          "installUrl": "github:github/awesome-copilot:skills/dotnet-timezone",
+          "description": ".NET timezone handling guidance for C# applications. Use when working with TimeZoneInfo, DateTimeOffset, NodaTime, UTC conversion, daylight saving time, scheduling across timezones, cross-platform Windows/IANA timezone IDs, or when a .NET user needs the timezone for a city, address, region, or country and copy-paste-ready C# code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "email-drafter",
+          "installUrl": "github:github/awesome-copilot:skills/email-drafter",
+          "description": "Draft and review professional emails that match your personal writing style. Analyzes your sent emails for tone, greeting, structure, and sign-off patterns via WorkIQ, then generates context-aware drafts for any recipient. USE FOR: draft email, write email, compose email, reply email, follow-up email, analyze email tone, email style.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "finnish-humanizer",
+          "installUrl": "github:github/awesome-copilot:skills/finnish-humanizer",
+          "description": "Detect and remove AI-generated markers from Finnish text, making it sound like a native Finnish speaker wrote it. Use when asked to \"humanize\", \"naturalize\", or \"remove AI feel\" from Finnish text, or when editing .md/.txt files containing Finnish content. Identifies 26 patterns (12 Finnish-specific + 14 universal) and 4 style markers.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-governance",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-governance",
+          "description": "Govern Power Automate flows and Power Apps at scale using the FlowStudio MCP cached store. Classify flows by business impact, detect orphaned resources, audit connector usage, enforce compliance standards, manage notification rules, and compute governance scores — all without Dataverse or the CoE Starter Kit. Load this skill when asked to: tag or classify flows, set business impact, assign ownership, detect orphans, audit connectors, check compliance, compute archive scores, manage notification rules, run a governance review, generate a compliance report, offboard a maker, or any task that involves writing governance metadata to flows. Requires a FlowStudio for Teams or MCP Pro+ subscription — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "freecad-scripts",
+          "installUrl": "github:github/awesome-copilot:skills/freecad-scripts",
+          "description": "Expert skill for writing FreeCAD Python scripts, macros, and automation. Use when asked to create FreeCAD models, parametric objects, Part/Mesh/Sketcher scripts, workbench tools, GUI dialogs with PySide, Coin3D scenegraph manipulation, or any FreeCAD Python API task. Covers FreeCAD scripting basics, geometry creation, FeaturePython objects, interface tools, and macro development.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gdpr-compliant",
+          "installUrl": "github:github/awesome-copilot:skills/gdpr-compliant",
+          "description": "Apply GDPR-compliant engineering practices across your codebase. Use this skill whenever you are designing APIs, writing data models, building authentication flows, implementing logging, handling user data, writing retention/deletion jobs, designing cloud infrastructure, or reviewing pull requests for privacy compliance. Trigger this skill for any task involving personal data, user accounts, cookies, analytics, emails, audit logs, encryption, pseudonymization, anonymization, data exports, breach response, CI/CD pipelines that process real data, or any question framed as \"is this GDPR-compliant?\". Inspired by CNIL developer guidance and GDPR Articles 5, 25, 32, 33, 35.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-board-and-investor-communication",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-board-and-investor-communication",
+          "description": "Board meeting preparation, investor updates, and executive communication. Use when preparing board decks, writing investor updates, handling bad news with the board, structuring QBRs, or building board-level metric discipline. Includes the \"Three Things\" narrative model, the 4-tier metric hierarchy, and the pre-brief pattern that prevents board surprises.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "image-manipulation-image-magick",
+          "installUrl": "github:github/awesome-copilot:skills/image-manipulation-image-magick",
+          "description": "Process and manipulate images using ImageMagick. Supports resizing, format conversion, batch processing, and retrieving image metadata. Use when working with images, creating thumbnails, resizing wallpapers, or performing batch image operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "issue-fields-migration",
+          "installUrl": "github:github/awesome-copilot:skills/issue-fields-migration",
+          "description": "Bulk-migrate metadata to GitHub issue fields from two sources: repo labels (e.g. priority labels to a Priority field) and Project V2 fields. Use when users say \"migrate my labels to issue fields\", \"migrate project fields to issue fields\", \"convert labels to issue fields\", \"copy project field values to issue fields\", or ask about adopting issue fields. Issue fields are org-level typed metadata (single select, text, number, date) that replace label-based workarounds with structured, searchable, cross-repo fields.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "java-docs",
+          "installUrl": "github:github/awesome-copilot:skills/java-docs",
+          "description": "Ensure that Java types are documented with Javadoc comments and follow best practices for documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "javascript-typescript-jest",
+          "installUrl": "github:github/awesome-copilot:skills/javascript-typescript-jest",
+          "description": "Best practices for writing JavaScript/TypeScript tests using Jest, including mocking strategies, test structure, and common patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "linkedin-post-formatter",
+          "installUrl": "github:github/awesome-copilot:skills/linkedin-post-formatter",
+          "description": "Format and draft compelling LinkedIn posts using Unicode bold/italic styling, visual separators, structured sections, and engagement-optimized patterns. USE FOR: draft LinkedIn post, format text for LinkedIn, create social media post, write thought leadership post, convert content to LinkedIn format, LinkedIn carousel text, Unicode bold italic formatting.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "markdown-to-html",
+          "installUrl": "github:github/awesome-copilot:skills/markdown-to-html",
+          "description": "Convert Markdown files to HTML similar to `marked.js`, `pandoc`, `gomarkdown/markdown`, or similar tools; or writing custom script to convert markdown to html and/or working on web template systems like `jekyll/jekyll`, `gohugoio/hugo`, or similar web templating systems that utilize markdown documents, converting them to html. Use when asked to \"convert markdown to html\", \"transform md to html\", \"render markdown\", \"generate html from markdown\", or when working with .md files and/or web a templating system that converts markdown to HTML output. Supports CLI and Node.js workflows with GFM, CommonMark, and standard Markdown flavors.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "microsoft-code-reference",
+          "installUrl": "github:github/awesome-copilot:skills/microsoft-code-reference",
+          "description": "Look up Microsoft API references, find working code samples, and verify SDK code is correct. Use when working with Azure SDKs, .NET libraries, or Microsoft APIs—to find the right method, check parameters, get working examples, or troubleshoot errors. Catches hallucinated methods, wrong signatures, and deprecated patterns by querying official docs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "microsoft-docs",
+          "installUrl": "github:github/awesome-copilot:skills/microsoft-docs",
+          "description": "Query official Microsoft documentation to find concepts, tutorials, and code examples across Azure, .NET, Agent Framework, Aspire, VS Code, GitHub, and more. Uses Microsoft Learn MCP as the default, with Context7 and Aspire MCP for content that lives outside learn.microsoft.com.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "minecraft-plugin-development",
+          "installUrl": "github:github/awesome-copilot:skills/minecraft-plugin-development",
+          "description": "Use this skill when building or modifying Minecraft server plugins for Paper, Spigot, or Bukkit, including plugin.yml setup, commands, listeners, schedulers, player state, team or arena systems, persistent progression, economy or profile data, configuration files, Adventure text, and version-safe API usage. Trigger for requests like \"build a Minecraft plugin\", \"add a Paper command\", \"fix a Bukkit listener\", \"create plugin.yml\", \"implement a minigame mechanic\", \"add a perk or quest system\", or \"debug server plugin behavior\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "mini-context-graph",
+          "installUrl": "github:github/awesome-copilot:skills/mini-context-graph",
+          "description": "A persistent, compounding knowledge base combining Karpathy's LLM Wiki pattern with a structured knowledge graph. Ingest documents once — the LLM writes wiki pages, extracts entities/relations into the graph, and stores raw content for evidence retrieval. Knowledge accumulates and cross-references; it is never re-derived from scratch.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "mkdocs-translations",
+          "installUrl": "github:github/awesome-copilot:skills/mkdocs-translations",
+          "description": "Generate a language translation for a mkdocs documentation stack.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "oo-component-documentation",
+          "installUrl": "github:github/awesome-copilot:skills/oo-component-documentation",
+          "description": "Create or update standardized object-oriented component documentation using a shared template plus mode-specific guidance for new and existing docs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "performance-review-writer",
+          "installUrl": "github:github/awesome-copilot:skills/performance-review-writer",
+          "description": "Draft performance reviews, self-assessments, peer reviews, and upward feedback in your own voice. Analyzes your contributions, emails, and meeting history via WorkIQ, then produces honest, impact-focused drafts using the STAR format. USE FOR: write my performance review, draft self-assessment, peer review, 360 feedback, annual review, mid-year review, upward feedback, write review for colleague, performance appraisal.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "phoenix-cli",
+          "installUrl": "github:github/awesome-copilot:skills/phoenix-cli",
+          "description": "Debug LLM applications using the Phoenix CLI. Fetch traces, analyze errors, structure trace review with open coding and axial coding, inspect datasets, review experiments, query annotation configs, and use the GraphQL API. Use whenever the user is analyzing traces or spans, investigating LLM/agent failures, deciding what to do after instrumenting an app, building failure taxonomies, choosing what evals to write, or asking \"what's going wrong\", \"what kinds of mistakes\", or \"where do I focus\" — even without naming a technique.",
+          "version": "3.3.0"
+        },
+        {
+          "name": "polyglot-test-agent",
+          "installUrl": "github:github/awesome-copilot:skills/polyglot-test-agent",
+          "description": "Generates comprehensive, workable unit tests for any programming language using a multi-agent pipeline. Use when asked to generate tests, write unit tests, improve test coverage, add test coverage, create test files, or test a codebase. Supports C#, TypeScript, JavaScript, Python, Go, Rust, Java, and more. Orchestrates research, planning, and implementation phases to produce tests that compile, pass, and follow project conventions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "powerbi-modeling",
+          "installUrl": "github:github/awesome-copilot:skills/powerbi-modeling",
+          "description": "Power BI semantic modeling assistant for building optimized data models. Use when working with Power BI semantic models, creating measures, designing star schemas, configuring relationships, implementing RLS, or optimizing model performance. Triggers on queries about DAX calculations, table relationships, dimension/fact table design, naming conventions, model documentation, cardinality, cross-filter direction, calculation groups, and data model best practices. Always connects to the active model first using power-bi-modeling MCP tools to understand the data structure before providing guidance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "publish-to-pages",
+          "installUrl": "github:github/awesome-copilot:skills/publish-to-pages",
+          "description": "Publish presentations and web content to GitHub Pages. Converts PPTX, PDF, HTML, or Google Slides to a live GitHub Pages URL. Handles repo creation, file conversion, Pages enablement, and returns the live URL. Use when the user wants to publish, deploy, or share a presentation or HTML file via GitHub Pages.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "react-audit-grep-patterns",
+          "installUrl": "github:github/awesome-copilot:skills/react-audit-grep-patterns",
+          "description": "Provides the complete, verified grep scan command library for auditing React codebases before a React 18.3.1 or React 19 upgrade. Use this skill whenever running a migration audit - for both the react18-auditor and react19-auditor agents. Contains every grep pattern needed to find deprecated APIs, removed APIs, unsafe lifecycle methods, batching vulnerabilities, test file issues, dependency conflicts, and React 19 specific removals. Always use this skill when writing audit scan commands - do not rely on memory for grep syntax, especially for the multi-line async setState patterns which require context flags.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "react18-batching-patterns",
+          "installUrl": "github:github/awesome-copilot:skills/react18-batching-patterns",
+          "description": "Provides exact patterns for diagnosing and fixing automatic batching regressions in React 18 class components. Use this skill whenever a class component has multiple setState calls in an async method, inside setTimeout, inside a Promise .then() or .catch(), or in a native event handler. Use it before writing any flushSync call - the decision tree here prevents unnecessary flushSync overuse. Also use this skill when fixing test failures caused by intermediate state assertions that break after React 18 upgrade.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "react18-enzyme-to-rtl",
+          "installUrl": "github:github/awesome-copilot:skills/react18-enzyme-to-rtl",
+          "description": "Provides exact Enzyme → React Testing Library migration patterns for React 18 upgrades. Use this skill whenever Enzyme tests need to be rewritten - shallow, mount, wrapper.find(), wrapper.simulate(), wrapper.prop(), wrapper.state(), wrapper.instance(), Enzyme configure/Adapter calls, or any test file that imports from enzyme. This skill covers the full API mapping and the philosophy shift from implementation testing to behavior testing. Always read this skill before rewriting Enzyme tests - do not translate Enzyme APIs 1:1, that produces brittle RTL tests.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "react18-legacy-context",
+          "installUrl": "github:github/awesome-copilot:skills/react18-legacy-context",
+          "description": "Provides the complete migration pattern for React legacy context API (contextTypes, childContextTypes, getChildContext) to the modern createContext API. Use this skill whenever migrating legacy context in class components - this is always a cross-file migration requiring the provider AND all consumers to be updated together. Use it before touching any contextTypes or childContextTypes code, because migrating only the provider without the consumers (or vice versa) will cause a runtime failure. Always read this skill before writing any context migration - the cross-file coordination steps here prevent the most common context migration bugs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "react18-lifecycle-patterns",
+          "installUrl": "github:github/awesome-copilot:skills/react18-lifecycle-patterns",
+          "description": "Provides exact before/after migration patterns for the three unsafe class component lifecycle methods - componentWillMount, componentWillReceiveProps, and componentWillUpdate - targeting React 18.3.1. Use this skill whenever a class component needs its lifecycle methods migrated, when deciding between getDerivedStateFromProps vs componentDidUpdate, when adding getSnapshotBeforeUpdate, or when fixing React 18 UNSAFE_ lifecycle warnings. Always use this skill before writing any lifecycle migration code - do not guess the pattern from memory, the decision trees here prevent the most common migration mistakes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "react18-string-refs",
+          "installUrl": "github:github/awesome-copilot:skills/react18-string-refs",
+          "description": "Provides exact migration patterns for React string refs (ref=\"name\" + this.refs.name) to React.createRef() in class components. Use this skill whenever migrating string ref usage - including single element refs, multiple refs in a component, refs in lists, callback refs, and refs passed to child components. Always use this skill before writing any ref migration code - the multiple-refs-in-list pattern is particularly tricky and this skill prevents the most common mistakes. Use it for React 18.3.1 migration (string refs warn) and React 19 migration (string refs removed).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "readme-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/readme-blueprint-generator",
+          "description": "Intelligent README.md generation prompt that analyzes project documentation structure and creates comprehensive repository documentation. Scans .github/copilot directory files and copilot-instructions.md to extract project information, technology stack, architecture, development workflow, coding standards, and testing approaches while generating well-structured markdown documentation with proper formatting, cross-references, and developer-focused content.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "resemble-detect",
+          "installUrl": "github:github/awesome-copilot:skills/resemble-detect",
+          "description": "Deepfake detection and media safety — detect AI-generated audio, images, video, and text, trace synthesis sources, apply watermarks, verify speaker identity, and analyze media intelligence using Resemble AI",
+          "version": "0.0.0"
+        },
+        {
+          "name": "roundup",
+          "installUrl": "github:github/awesome-copilot:skills/roundup",
+          "description": "Generate personalized status briefings on demand. Pulls from your configured data sources (GitHub, email, Teams, Slack, and more), synthesizes across them, and drafts updates in your own communication style for any audience you define.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "roundup-setup",
+          "installUrl": "github:github/awesome-copilot:skills/roundup-setup",
+          "description": "Interactive onboarding that learns your communication style, audiences, and data sources to configure personalized status briefings. Paste in examples of updates you already write, answer a few questions, and roundup calibrates itself to your workflow.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scaffolding-oracle-to-postgres-migration-test-project",
+          "installUrl": "github:github/awesome-copilot:skills/scaffolding-oracle-to-postgres-migration-test-project",
+          "description": "Scaffolds an xUnit integration test project for validating Oracle-to-PostgreSQL database migration behavior in .NET solutions. Creates the test project, transaction-rollback base class, and seed data manager. Use when setting up test infrastructure before writing migration integration tests, or when a test project is needed for Oracle-to-PostgreSQL validation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "technology-stack-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/technology-stack-blueprint-generator",
+          "description": "Comprehensive technology stack blueprint generator that analyzes codebases to create detailed architectural documentation. Automatically detects technology stacks, programming languages, and implementation patterns across multiple platforms (.NET, Java, JavaScript, React, Python). Generates configurable blueprints with version information, licensing details, usage patterns, coding conventions, and visual diagrams. Provides implementation-ready templates and maintains architectural consistency for guided development.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "tldr-prompt",
+          "installUrl": "github:github/awesome-copilot:skills/tldr-prompt",
+          "description": "Create tldr summaries for GitHub Copilot files (prompts, agents, instructions, collections), MCP servers, or documentation from URLs and queries.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "unit-test-vue-pinia",
+          "installUrl": "github:github/awesome-copilot:skills/unit-test-vue-pinia",
+          "description": "Write and review unit tests for Vue 3 + TypeScript + Vitest + Pinia codebases. Use when creating or updating tests for components, composables, and stores; mocking Pinia with createTestingPinia; applying Vue Test Utils patterns; and enforcing black-box assertions over implementation details.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "update-llms",
+          "installUrl": "github:github/awesome-copilot:skills/update-llms",
+          "description": "Update the llms.txt file in the root folder to reflect changes in documentation or specifications following the llms.txt specification at https://llmstxt.org/",
+          "version": "0.0.0"
+        },
+        {
+          "name": "vardoger-analyze",
+          "installUrl": "github:github/awesome-copilot:skills/vardoger-analyze",
+          "description": "Use when the user asks to personalize the GitHub Copilot CLI assistant, adapt Copilot to their style, use vardoger, or analyze their Copilot CLI conversation history. Reads the local session directory at `~/.copilot/session-state/`, extracts recurring preferences and conventions, and writes a fenced personalization block into `~/.copilot/copilot-instructions.md`. Runs entirely on the user's machine via the local `vardoger` CLI (`pipx install vardoger`); no network calls and no uploads. Triggers: 'personalize my copilot', 'analyze my copilot history', 'tailor copilot to me', 'run vardoger', 'update my copilot instructions from history', 'make copilot learn my style'.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "workiq-copilot",
+          "installUrl": "github:github/awesome-copilot:skills/workiq-copilot",
+          "description": "Guides the Copilot CLI on how to use the WorkIQ CLI/MCP server to query Microsoft 365 Copilot data (emails, meetings, docs, Teams, people) for live context, summaries, and recommendations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "write-coding-standards-from-file",
+          "installUrl": "github:github/awesome-copilot:skills/write-coding-standards-from-file",
+          "description": "Write a coding standards document for a project using the coding styles from the file(s) and/or folder(s) passed as arguments in the prompt.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "github",
+        "repo": "awesome-copilot",
+        "repoUrl": "https://github.com/github/awesome-copilot.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "github-awesome-copilot-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from github/awesome-copilot.",
+      "author": "ASM (github/awesome-copilot)",
+      "createdAt": "2026-05-09T08:10:57.006Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "github",
+        "awesome-copilot"
+      ],
+      "skills": [
+        {
+          "name": "agent-owasp-compliance",
+          "installUrl": "github:github/awesome-copilot:skills/agent-owasp-compliance",
+          "description": "Check any AI agent codebase against the OWASP Agentic Security Initiative (ASI) Top 10 risks. Use this skill when: - Evaluating an agent system's security posture before production deployment - Running a compliance check against OWASP ASI 2026 standards - Mapping existing security controls to the 10 agentic risks - Generating a compliance report for security review or audit - Comparing agent framework security features against the standard - Any request like \"is my agent OWASP compliant?\", \"check ASI compliance\", or \"agentic security audit\"",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-supply-chain",
+          "installUrl": "github:github/awesome-copilot:skills/agent-supply-chain",
+          "description": "Verify supply chain integrity for AI agent plugins, tools, and dependencies. Use this skill when: - Generating SHA-256 integrity manifests for agent plugins or tool packages - Verifying that installed plugins match their published manifests - Detecting tampered, modified, or untracked files in agent tool directories - Auditing dependency pinning and version policies for agent components - Building provenance chains for agent plugin promotion (dev → staging → production) - Any request like \"verify plugin integrity\", \"generate manifest\", \"check supply chain\", or \"sign this plugin\"",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentic-eval",
+          "installUrl": "github:github/awesome-copilot:skills/agentic-eval",
+          "description": "Patterns and techniques for evaluating and improving AI agent outputs. Use this skill when: - Implementing self-critique and reflection loops - Building evaluator-optimizer pipelines for quality-critical generation - Creating test-driven code refinement workflows - Designing rubric-based or LLM-as-judge evaluation systems - Adding iterative improvement to agent outputs (code, reports, analysis) - Measuring and improving agent response quality",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-prompt-engineering-safety-review",
+          "installUrl": "github:github/awesome-copilot:skills/ai-prompt-engineering-safety-review",
+          "description": "Comprehensive AI prompt engineering safety review and improvement prompt. Analyzes prompts for safety, bias, security vulnerabilities, and effectiveness while providing detailed improvement recommendations with extensive frameworks, testing methodologies, and educational content.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-ready",
+          "installUrl": "github:github/awesome-copilot:skills/ai-ready",
+          "description": "Make any repo AI-ready — analyzes your codebase and generates AGENTS.md, copilot-instructions.md, CI workflows, issue templates, and more. Mines your PR review patterns and creates files customized to your stack. USE THIS SKILL when the user asks to \"make this repo ai-ready\", \"set up AI config\", or \"prepare this repo for AI contributions\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apple-appstore-reviewer",
+          "installUrl": "github:github/awesome-copilot:skills/apple-appstore-reviewer",
+          "description": "Serves as a reviewer of the codebase with instructions on looking for Apple App Store optimizations or rejection reasons.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-annotation",
+          "installUrl": "github:github/awesome-copilot:skills/arize-annotation",
+          "description": "INVOKE THIS SKILL when creating, managing, or using annotation configs or annotation queues on Arize (categorical, continuous, freeform), or applying human annotations to project spans via the Python SDK. Configs are the label schema for human feedback; queues are review workflows that route records to annotators. Triggers: annotation config, annotation queue, label schema, human feedback schema, bulk annotate spans, update_annotations, labeling queue, annotate record.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-experiment",
+          "installUrl": "github:github/awesome-copilot:skills/arize-experiment",
+          "description": "INVOKE THIS SKILL when creating, running, or analyzing Arize experiments. Also use when the user wants to evaluate or measure model performance, compare models (including GPT-4, Claude, or others), or assess how well their AI is doing. Covers experiment CRUD, exporting runs, comparing results, and evaluation workflows using the ax CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "audit-integrity",
+          "installUrl": "github:github/awesome-copilot:skills/audit-integrity",
+          "description": "Shared audit integrity framework for all AppSec agents — enforces output quality, intellectual honesty, and continuous improvement through anti-rationalization guards, self-critique loops, retry protocols, non-negotiable behaviors, self-reflection quality gates (1-10 scoring, ≥8 threshold), and a self-learning system with lesson/memory governance for security analysis agents.",
+          "version": "1.0"
+        },
+        {
+          "name": "autoresearch",
+          "installUrl": "github:github/awesome-copilot:skills/autoresearch",
+          "description": "Autonomous iterative experimentation loop for any programming task. Guides the user through defining goals, measurable metrics, and scope constraints, then runs an autonomous loop of code changes, testing, measuring, and keeping/discarding results. Inspired by Karpathy''s autoresearch. USE FOR: autonomous improvement, iterative optimization, experiment loop, auto research, performance tuning, automated experimentation, hill climbing, try things automatically, optimize code, run experiments, autonomous coding loop. DO NOT USE FOR: one-shot tasks, simple bug fixes, code review, or tasks without a measurable metric.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-architecture-autopilot",
+          "installUrl": "github:github/awesome-copilot:skills/azure-architecture-autopilot",
+          "description": "Design Azure infrastructure using natural language, or analyze existing Azure resources to auto-generate architecture diagrams, refine them through conversation, and deploy with Bicep. When to use this skill: - \"Create X on Azure\", \"Set up a RAG architecture\" (new design) - \"Analyze my current Azure infrastructure\", \"Draw a diagram for rg-xxx\" (existing analysis) - \"Foundry is slow\", \"I want to reduce costs\", \"Strengthen security\" (natural language modification) - Azure resource deployment, Bicep template generation, IaC code generation - Microsoft Foundry, AI Search, OpenAI, Fabric, ADLS Gen2, Databricks, and all Azure services",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-deployment-preflight",
+          "installUrl": "github:github/awesome-copilot:skills/azure-deployment-preflight",
+          "description": "Performs comprehensive preflight validation of Bicep deployments to Azure, including template syntax validation, what-if analysis, and permission checks. Use this skill before any deployment to Azure to preview changes, identify potential issues, and ensure the deployment will succeed. Activate when users mention deploying to Azure, validating Bicep files, checking deployment permissions, previewing infrastructure changes, running what-if, or preparing for azd provision.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brag-sheet",
+          "installUrl": "github:github/awesome-copilot:skills/brag-sheet",
+          "description": "Turn vague \"what did I do?\" into evidence-backed impact statements for performance reviews, self-reviews, promotion packets, and weekly updates. Uniquely mines Copilot CLI session logs to reconstruct forgotten work, plus git commits and GitHub PRs. Enforces a 3-part impact contract (action → result → evidence). Works standalone with zero dependencies. Trigger for: \"brag\", \"log work\", \"what did I do\", \"backfill my work history\", \"performance review\", \"self-review\", \"self assessment\", \"write impact statement\", \"review prep\", \"promo packet\", \"promotion case\", \"weekly update\", \"status report\", \"accomplishments\", \"what did I ship\", \"I forgot to log my work\", \"summarize my work\", \"track my wins\", \"what should I highlight\", \"end of half\", \"career growth\", \"work journal\", or any request to document, summarize, or organize work accomplishments.",
+          "version": "1.1"
+        },
+        {
+          "name": "chrome-devtools",
+          "installUrl": "github:github/awesome-copilot:skills/chrome-devtools",
+          "description": "Expert-level browser automation, debugging, and performance analysis using Chrome DevTools MCP. Use for interacting with web pages, capturing screenshots, analyzing network traffic, and profiling performance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cloud-design-patterns",
+          "installUrl": "github:github/awesome-copilot:skills/cloud-design-patterns",
+          "description": "Cloud design patterns for distributed systems architecture covering 42 industry-standard patterns across reliability, performance, messaging, security, and deployment categories. Use when designing, reviewing, or implementing distributed system architectures.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-exemplars-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/code-exemplars-blueprint-generator",
+          "description": "Technology-agnostic prompt generator that creates customizable AI prompts for scanning codebases and identifying high-quality code exemplars. Supports multiple programming languages (.NET, Java, JavaScript, TypeScript, React, Angular, Python) with configurable analysis depth, categorization methods, and documentation formats to establish coding standards and maintain consistency across development teams.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-tour",
+          "installUrl": "github:github/awesome-copilot:skills/code-tour",
+          "description": "Use this skill to create CodeTour .tour files — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. Trigger for: \"create a tour\", \"make a code tour\", \"generate a tour\", \"onboarding tour\", \"tour for this PR\", \"tour for this bug\", \"RCA tour\", \"architecture tour\", \"explain how X works\", \"vibe check\", \"PR review tour\", \"contributor guide\", \"help someone ramp up\", or any request for a structured walkthrough through code. Supports 20 developer personas (new joiner, bug fixer, architect, PR reviewer, vibecoder, security reviewer, and more), all CodeTour step types (file/line, selection, pattern, uri, commands, view), and tour-level fields (ref, isPrimary, nextTour). Works with any repository in any language.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "codeql",
+          "installUrl": "github:github/awesome-copilot:skills/codeql",
+          "description": "Comprehensive guide for setting up and configuring CodeQL code scanning via GitHub Actions workflows and the CodeQL CLI. This skill should be used when users need help with code scanning configuration, CodeQL workflow files, CodeQL CLI commands, SARIF output, security analysis setup, or troubleshooting CodeQL analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "commit-message-storyteller",
+          "installUrl": "github:github/awesome-copilot:skills/commit-message-storyteller",
+          "description": "Analyzes git diffs or staged changes and generates narrative commit messages that explain WHY a change was made, not just what changed — following Conventional Commits format. Use when asked to \"write a commit message\", \"generate a commit\", \"describe my changes\", \"what should I commit this as\", \"commit this\", \"summarize my diff\", or \"help me commit\". Works with git diff output, staged files, or plain descriptions of changes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-technical-spike",
+          "installUrl": "github:github/awesome-copilot:skills/create-technical-spike",
+          "description": "Create time-boxed technical spike documents for researching and resolving critical development decisions before implementation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "data-breach-blast-radius",
+          "installUrl": "github:github/awesome-copilot:skills/data-breach-blast-radius",
+          "description": "Pre-breach impact analysis: inventories sensitive data (PII, PHI, PCI-DSS, credentials), traces data flows, scores exposure vectors, and produces a regulatory blast radius report with fine ranges sourced verbatim from GDPR Art. 83, CCPA § 1798.155(a), and HIPAA 45 CFR § 160.404. Cost benchmarks from IBM Cost of a Data Breach Report (annually updated). All citations in references/SOURCES.md for verification. Use when asked: \"assess breach impact\", \"what data could be exposed\", \"calculate blast radius\", \"data exposure analysis\", \"how bad would a breach be\", \"quantify data risk\", \"sensitive data inventory\", \"data flow security audit\", \"pre-breach assessment\", \"worst-case breach scenario\", \"breach readiness\", \"data risk report\", \"/data-breach-blast-radius\". For any stack handling user data, health records, or financial information. Output labels law-sourced figures (exact) vs heuristic estimates (planning only). Does not replace legal counsel.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "datanalysis-credit-risk",
+          "installUrl": "github:github/awesome-copilot:skills/datanalysis-credit-risk",
+          "description": "Credit risk data cleaning and variable screening pipeline for pre-loan modeling. Use when working with raw credit data that needs quality assessment,  missing value analysis, or variable selection before modeling. it covers data loading and formatting, abnormal period filtering, missing rate calculation, high-missing variable removal,low-IV variable filtering, high-PSI variable removal, Null Importance denoising, high-correlation variable removal, and cleaning report generation. Applicable scenarios arecredit risk data cleaning, variable screening, pre-loan modeling preprocessing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dotnet-design-pattern-review",
+          "installUrl": "github:github/awesome-copilot:skills/dotnet-design-pattern-review",
+          "description": "Review the C#/.NET code for design pattern implementation and suggest improvements.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dotnet-upgrade",
+          "installUrl": "github:github/awesome-copilot:skills/dotnet-upgrade",
+          "description": "Ready-to-use prompts for comprehensive .NET framework upgrade analysis and execution",
+          "version": "0.0.0"
+        },
+        {
+          "name": "doublecheck",
+          "installUrl": "github:github/awesome-copilot:skills/doublecheck",
+          "description": "Three-layer verification pipeline for AI output. Extracts verifiable claims, finds supporting or contradicting sources via web search, runs adversarial review for hallucination patterns, and produces a structured verification report with source links for human review.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "editorconfig",
+          "installUrl": "github:github/awesome-copilot:skills/editorconfig",
+          "description": "Generates a comprehensive and best-practice-oriented .editorconfig file based on project analysis and user preferences.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "email-drafter",
+          "installUrl": "github:github/awesome-copilot:skills/email-drafter",
+          "description": "Draft and review professional emails that match your personal writing style. Analyzes your sent emails for tone, greeting, structure, and sign-off patterns via WorkIQ, then generates context-aware drafts for any recipient. USE FOR: draft email, write email, compose email, reply email, follow-up email, analyze email tone, email style.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "eval-driven-dev",
+          "installUrl": "github:github/awesome-copilot:skills/eval-driven-dev",
+          "description": "Improve AI application with evaluation-driven development. Define eval criteria, instrument the application, build golden datasets, observe and evaluate application runs, analyze results, and produce a concrete action plan for improvements. ALWAYS USE THIS SKILL when the user asks to set up QA, add tests, add evals, evaluate, benchmark, fix wrong behaviors, improve quality, or do quality assurance for any Python project that calls an LLM model.",
+          "version": "0.8.4"
+        },
+        {
+          "name": "eyeball",
+          "installUrl": "github:github/awesome-copilot:skills/eyeball",
+          "description": "Document analysis with inline source screenshots. When you ask Copilot to analyze a document, Eyeball generates a Word doc where every factual claim includes a highlighted screenshot from the source material so you can verify it with your own eyes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-governance",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-governance",
+          "description": "Govern Power Automate flows and Power Apps at scale using the FlowStudio MCP cached store. Classify flows by business impact, detect orphaned resources, audit connector usage, enforce compliance standards, manage notification rules, and compute governance scores — all without Dataverse or the CoE Starter Kit. Load this skill when asked to: tag or classify flows, set business impact, assign ownership, detect orphans, audit connectors, check compliance, compute archive scores, manage notification rules, run a governance review, generate a compliance report, offboard a maker, or any task that involves writing governance metadata to flows. Requires a FlowStudio for Teams or MCP Pro+ subscription — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-monitoring",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-monitoring",
+          "description": "**Pro+ subscription required.** Tenant-wide Power Automate flow health monitoring, failure rate analytics, and asset inventory using the FlowStudio MCP cached store. Load this skill ONLY for tenant-wide aggregated views — not for listing flows in a single environment or debugging a specific run (use power-automate-mcp or power-automate-debug for those). Not the same as the server's `monitor-flow` tool bundle (`tool_search query: \"skill:monitor-flow\"`) — that bundle is for runtime control of a single flow (start/stop/trigger/ cancel/resubmit); this skill is for tenant-wide health analytics over the cached store. Load when asked to: monitor tenant health, get aggregated failure rates over a time window, review tenant-wide error trends, find inactive makers across the tenant, inventory all Power Apps in the tenant, compute governance scores, generate a compliance report, or run a tenant-wide health overview. Requires a FlowStudio for Teams or MCP Pro+ subscription — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gdpr-compliant",
+          "installUrl": "github:github/awesome-copilot:skills/gdpr-compliant",
+          "description": "Apply GDPR-compliant engineering practices across your codebase. Use this skill whenever you are designing APIs, writing data models, building authentication flows, implementing logging, handling user data, writing retention/deletion jobs, designing cloud infrastructure, or reviewing pull requests for privacy compliance. Trigger this skill for any task involving personal data, user accounts, cookies, analytics, emails, audit logs, encryption, pseudonymization, anonymization, data exports, breach response, CI/CD pipelines that process real data, or any question framed as \"is this GDPR-compliant?\". Inspired by CNIL developer guidance and GDPR Articles 5, 25, 32, 33, 35.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "git-commit",
+          "installUrl": "github:github/awesome-copilot:skills/git-commit",
+          "description": "Execute git commit with conventional commit message analysis, intelligent staging, and message generation. Use when user asks to commit changes, create a git commit, or mentions \"/commit\". Supports: (1) Auto-detecting type and scope from changes, (2) Generating conventional commit messages from diff, (3) Interactive commit with optional type/scope/description overrides, (4) Intelligent file staging for logical grouping",
+          "version": "0.0.0"
+        },
+        {
+          "name": "image-manipulation-image-magick",
+          "installUrl": "github:github/awesome-copilot:skills/image-manipulation-image-magick",
+          "description": "Process and manipulate images using ImageMagick. Supports resizing, format conversion, batch processing, and retrieving image metadata. Use when working with images, creating thumbnails, resizing wallpapers, or performing batch image operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "impediment-prioritization",
+          "installUrl": "github:github/awesome-copilot:skills/impediment-prioritization",
+          "description": "Ranks any list of impediments and their countermeasures using a value-stream scoring model (ROI, Cost to Implement, Ease of Deployment, Risk Factor) and a fixed prioritization formula. Use when someone asks to prioritize, rank, sequence, or triage impediments, countermeasures, remediation items, risks, findings, gaps, action items, or backlog entries; or mentions value-stream prioritization, A3 / lean countermeasure ranking, ROI vs. effort scoring, or building a remediation / improvement backlog. Works with GHQR findings, audit results, retrospective action items, risk registers, architecture review gaps, or any free-form `{impediment, countermeasure}` list.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "mcp-security-audit",
+          "installUrl": "github:github/awesome-copilot:skills/mcp-security-audit",
+          "description": "Audit MCP (Model Context Protocol) server configurations for security issues. Use this skill when: - Reviewing .mcp.json files for security risks - Checking MCP server args for hardcoded secrets or shell injection patterns - Validating that MCP servers use pinned versions (not @latest) - Detecting unpinned dependencies in MCP server configurations - Auditing which MCP servers a project registers and whether they're on an approved list - Checking for environment variable usage vs. hardcoded credentials in MCP configs - Any request like \"is my MCP config secure?\", \"audit my MCP servers\", or \"check .mcp.json\" keywords: [mcp, security, audit, secrets, shell-injection, supply-chain, governance]",
+          "version": "0.0.0"
+        },
+        {
+          "name": "microsoft-agent-framework",
+          "installUrl": "github:github/awesome-copilot:skills/microsoft-agent-framework",
+          "description": "Create, update, refactor, explain, or review Microsoft Agent Framework solutions using shared guidance plus language-specific references for .NET and Python.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "microsoft-code-reference",
+          "installUrl": "github:github/awesome-copilot:skills/microsoft-code-reference",
+          "description": "Look up Microsoft API references, find working code samples, and verify SDK code is correct. Use when working with Azure SDKs, .NET libraries, or Microsoft APIs—to find the right method, check parameters, get working examples, or troubleshoot errors. Catches hallucinated methods, wrong signatures, and deprecated patterns by querying official docs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "minecraft-plugin-development",
+          "installUrl": "github:github/awesome-copilot:skills/minecraft-plugin-development",
+          "description": "Use this skill when building or modifying Minecraft server plugins for Paper, Spigot, or Bukkit, including plugin.yml setup, commands, listeners, schedulers, player state, team or arena systems, persistent progression, economy or profile data, configuration files, Adventure text, and version-safe API usage. Trigger for requests like \"build a Minecraft plugin\", \"add a Paper command\", \"fix a Bukkit listener\", \"create plugin.yml\", \"implement a minigame mechanic\", \"add a perk or quest system\", or \"debug server plugin behavior\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "napkin",
+          "installUrl": "github:github/awesome-copilot:skills/napkin",
+          "description": "Visual whiteboard collaboration for Copilot CLI. Creates an interactive whiteboard that opens in your browser — draw, sketch, add sticky notes, then share everything back with Copilot. Copilot sees your drawings and text, and responds with analysis, suggestions, and ideas.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "penpot-uiux-design",
+          "installUrl": "github:github/awesome-copilot:skills/penpot-uiux-design",
+          "description": "Comprehensive guide for creating professional UI/UX designs in Penpot using MCP tools. Use this skill when: (1) Creating new UI/UX designs for web, mobile, or desktop applications, (2) Building design systems with components and tokens, (3) Designing dashboards, forms, navigation, or landing pages, (4) Applying accessibility standards and best practices, (5) Following platform guidelines (iOS, Android, Material Design), (6) Reviewing or improving existing Penpot designs for usability. Triggers: \"design a UI\", \"create interface\", \"build layout\", \"design dashboard\", \"create form\", \"design landing page\", \"make it accessible\", \"design system\", \"component library\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "performance-review-writer",
+          "installUrl": "github:github/awesome-copilot:skills/performance-review-writer",
+          "description": "Draft performance reviews, self-assessments, peer reviews, and upward feedback in your own voice. Analyzes your contributions, emails, and meeting history via WorkIQ, then produces honest, impact-focused drafts using the STAR format. USE FOR: write my performance review, draft self-assessment, peer review, 360 feedback, annual review, mid-year review, upward feedback, write review for colleague, performance appraisal.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "phoenix-cli",
+          "installUrl": "github:github/awesome-copilot:skills/phoenix-cli",
+          "description": "Debug LLM applications using the Phoenix CLI. Fetch traces, analyze errors, structure trace review with open coding and axial coding, inspect datasets, review experiments, query annotation configs, and use the GraphQL API. Use whenever the user is analyzing traces or spans, investigating LLM/agent failures, deciding what to do after instrumenting an app, building failure taxonomies, choosing what evals to write, or asking \"what's going wrong\", \"what kinds of mistakes\", or \"where do I focus\" — even without naming a technique.",
+          "version": "3.3.0"
+        },
+        {
+          "name": "polyglot-test-agent",
+          "installUrl": "github:github/awesome-copilot:skills/polyglot-test-agent",
+          "description": "Generates comprehensive, workable unit tests for any programming language using a multi-agent pipeline. Use when asked to generate tests, write unit tests, improve test coverage, add test coverage, create test files, or test a codebase. Supports C#, TypeScript, JavaScript, Python, Go, Rust, Java, and more. Orchestrates research, planning, and implementation phases to produce tests that compile, pass, and follow project conventions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "postgresql-code-review",
+          "installUrl": "github:github/awesome-copilot:skills/postgresql-code-review",
+          "description": "PostgreSQL-specific code review assistant focusing on PostgreSQL best practices, anti-patterns, and unique quality standards. Covers JSONB operations, array usage, custom types, schema design, function optimization, and PostgreSQL-exclusive security features like Row Level Security (RLS).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "power-bi-model-design-review",
+          "installUrl": "github:github/awesome-copilot:skills/power-bi-model-design-review",
+          "description": "Comprehensive Power BI data model design review prompt for evaluating model architecture, relationships, and optimization opportunities.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "prd",
+          "installUrl": "github:github/awesome-copilot:skills/prd",
+          "description": "Generate high-quality Product Requirements Documents (PRDs) for software systems and AI-powered features. Includes executive summaries, user stories, technical specifications, and risk analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "project-workflow-analysis-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/project-workflow-analysis-blueprint-generator",
+          "description": "Comprehensive technology-agnostic prompt generator for documenting end-to-end application workflows. Automatically detects project architecture patterns, technology stacks, and data flow patterns to generate detailed implementation blueprints covering entry points, service layers, data access, error handling, and testing approaches across multiple technologies including .NET, Java/Spring, React, and microservices architectures.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "qdrant-monitoring",
+          "installUrl": "github:github/awesome-copilot:skills/qdrant-monitoring",
+          "description": "Guides Qdrant monitoring and observability setup. Use when someone asks 'how to monitor Qdrant', 'what metrics to track', 'is Qdrant healthy', 'optimizer stuck', 'why is memory growing', 'requests are slow', or needs to set up Prometheus, Grafana, or health checks. Also use when debugging production issues that require metric analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "quality-playbook",
+          "installUrl": "github:github/awesome-copilot:skills/quality-playbook",
+          "description": "Explore any codebase from scratch and generate six quality artifacts: a quality constitution (QUALITY.md), spec-traced functional tests, a code review protocol with regression test generation, an integration testing protocol, a multi-model spec audit (Council of Three), and an AI bootstrap file (AGENTS.md). Includes state machine completeness analysis and missing safeguard detection. Works with any language (Python, Java, Scala, TypeScript, Go, Rust, etc.). Use this skill whenever the user asks to set up a quality playbook, generate functional tests from specifications, create a quality constitution, build testing protocols, audit code against specs, or establish a repeatable quality system for a project. Also trigger when the user mentions 'quality playbook', 'spec audit', 'Council of Three', 'fitness-to-purpose', 'coverage theater', or wants to go beyond basic test generation to build a full quality system grounded in their actual codebase.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "repo-story-time",
+          "installUrl": "github:github/awesome-copilot:skills/repo-story-time",
+          "description": "Generate a comprehensive repository summary and narrative story from commit history",
+          "version": "0.0.0"
+        },
+        {
+          "name": "resemble-detect",
+          "installUrl": "github:github/awesome-copilot:skills/resemble-detect",
+          "description": "Deepfake detection and media safety — detect AI-generated audio, images, video, and text, trace synthesis sources, apply watermarks, verify speaker identity, and analyze media intelligence using Resemble AI",
+          "version": "0.0.0"
+        },
+        {
+          "name": "review-and-refactor",
+          "installUrl": "github:github/awesome-copilot:skills/review-and-refactor",
+          "description": "Review and refactor code in your project according to defined instructions",
+          "version": "0.0.0"
+        },
+        {
+          "name": "reviewing-oracle-to-postgres-migration",
+          "installUrl": "github:github/awesome-copilot:skills/reviewing-oracle-to-postgres-migration",
+          "description": "Identifies Oracle-to-PostgreSQL migration risks by cross-referencing code against known behavioral differences (empty strings, refcursors, type coercion, sorting, timestamps, concurrent transactions, etc.). Use when planning a database migration, reviewing migration artifacts, or validating that integration tests cover Oracle/PostgreSQL differences.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ruff-recursive-fix",
+          "installUrl": "github:github/awesome-copilot:skills/ruff-recursive-fix",
+          "description": "Run Ruff checks with optional scope and rule overrides, apply safe and unsafe autofixes iteratively, review each change, and resolve remaining findings with targeted edits or user decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "salesforce-apex-quality",
+          "installUrl": "github:github/awesome-copilot:skills/salesforce-apex-quality",
+          "description": "Apex code quality guardrails for Salesforce development. Enforces bulk-safety rules (no SOQL/DML in loops), sharing model requirements, CRUD/FLS security, SOQL injection prevention, PNB test coverage (Positive / Negative / Bulk), and modern Apex idioms. Use this skill when reviewing or generating Apex classes, trigger handlers, batch jobs, or test classes to catch governor limit risks, security gaps, and quality issues before deployment.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "salesforce-component-standards",
+          "installUrl": "github:github/awesome-copilot:skills/salesforce-component-standards",
+          "description": "Quality standards for Salesforce Lightning Web Components (LWC), Aura components, and Visualforce pages. Covers SLDS 2 compliance, accessibility (WCAG 2.1 AA), data access pattern selection, component communication rules, XSS prevention, CSRF enforcement, FLS/CRUD in AuraEnabled methods, view state management, and Jest test requirements. Use this skill when building or reviewing any Salesforce UI component to enforce platform-specific security and quality standards.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "salesforce-flow-design",
+          "installUrl": "github:github/awesome-copilot:skills/salesforce-flow-design",
+          "description": "Salesforce Flow architecture decisions, flow type selection, bulk safety validation, and fault handling standards. Use this skill when designing or reviewing Record-Triggered, Screen, Autolaunched, Scheduled, or Platform Event flows to ensure correct type selection, no DML/Get Records in loops, proper fault connectors on all data-changing elements, and appropriate automation density checks before deployment.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scoutqa-test",
+          "installUrl": "github:github/awesome-copilot:skills/scoutqa-test",
+          "description": "This skill should be used when the user asks to \"test this website\", \"run exploratory testing\", \"check for accessibility issues\", \"verify the login flow works\", \"find bugs on this page\", or requests automated QA testing. Triggers on web application testing scenarios including smoke tests, accessibility audits, e-commerce flows, and user flow validation using ScoutQA CLI. Use this skill proactively after implementing web application features to verify they work correctly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "security-review",
+          "installUrl": "github:github/awesome-copilot:skills/security-review",
+          "description": "AI-powered codebase security scanner that reasons about code like a security researcher — tracing data flows, understanding component interactions, and catching vulnerabilities that pattern-matching tools miss. Use this skill when asked to scan code for security vulnerabilities, find bugs, check for SQL injection, XSS, command injection, exposed API keys, hardcoded secrets, insecure dependencies, access control issues, or any request like \"is my code secure?\", \"review for security issues\", \"audit this codebase\", or \"check for vulnerabilities\". Covers injection flaws, authentication and access control bugs, secrets exposure, weak cryptography, insecure dependencies, and business logic issues across JavaScript, TypeScript, Python, Java, PHP, Go, Ruby, and Rust.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "semantic-kernel",
+          "installUrl": "github:github/awesome-copilot:skills/semantic-kernel",
+          "description": "Create, update, refactor, explain, or review Semantic Kernel solutions using shared guidance plus language-specific references for .NET and Python.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "sql-code-review",
+          "installUrl": "github:github/awesome-copilot:skills/sql-code-review",
+          "description": "Universal SQL code review assistant that performs comprehensive security, maintainability, and code quality analysis across all SQL databases (MySQL, PostgreSQL, SQL Server, Oracle). Focuses on SQL injection prevention, access control, code standards, and anti-pattern detection. Complements SQL optimization prompt for complete development coverage.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "sql-optimization",
+          "installUrl": "github:github/awesome-copilot:skills/sql-optimization",
+          "description": "Universal SQL performance optimization assistant for comprehensive query tuning, indexing strategies, and database performance analysis across all SQL databases (MySQL, PostgreSQL, SQL Server, Oracle). Provides execution plan analysis, pagination optimization, batch operations, and performance monitoring guidance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "terraform-azurerm-set-diff-analyzer",
+          "installUrl": "github:github/awesome-copilot:skills/terraform-azurerm-set-diff-analyzer",
+          "description": "Analyze Terraform plan JSON output for AzureRM Provider to distinguish between false-positive diffs (order-only changes in Set-type attributes) and actual resource changes. Use when reviewing terraform plan output for Azure resources like Application Gateway, Load Balancer, Firewall, Front Door, NSG, and other resources with Set-type attributes that cause spurious diffs due to internal ordering changes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "threat-model-analyst",
+          "installUrl": "github:github/awesome-copilot:skills/threat-model-analyst",
+          "description": "Full STRIDE-A threat model analysis and incremental update skill for repositories and systems. Supports two modes: (1) Single analysis — full STRIDE-A threat model of a repository, producing architecture overviews, DFD diagrams, STRIDE-A analysis, prioritized findings, and executive assessments. (2) Incremental analysis — takes a previous threat model report as baseline, compares the codebase at the latest (or a given commit), and produces an updated report with change tracking (new, resolved, still-present threats), STRIDE heatmap, findings diff, and an embedded HTML comparison. Only activate when the user explicitly requests a threat model analysis, incremental update, or invokes /threat-model-analyst directly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "tldr-prompt",
+          "installUrl": "github:github/awesome-copilot:skills/tldr-prompt",
+          "description": "Create tldr summaries for GitHub Copilot files (prompts, agents, instructions, collections), MCP servers, or documentation from URLs and queries.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "unit-test-vue-pinia",
+          "installUrl": "github:github/awesome-copilot:skills/unit-test-vue-pinia",
+          "description": "Write and review unit tests for Vue 3 + TypeScript + Vitest + Pinia codebases. Use when creating or updating tests for components, composables, and stores; mocking Pinia with createTestingPinia; applying Vue Test Utils patterns; and enforcing black-box assertions over implementation details.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "web-design-reviewer",
+          "installUrl": "github:github/awesome-copilot:skills/web-design-reviewer",
+          "description": "This skill enables visual inspection of websites running locally or remotely to identify and fix design issues. Triggers on requests like \"review website design\", \"check the UI\", \"fix the layout\", \"find design problems\". Detects issues with responsive design, accessibility, visual consistency, and layout breakage, then performs fixes at the source code level.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "webapp-testing",
+          "installUrl": "github:github/awesome-copilot:skills/webapp-testing",
+          "description": "Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "workiq-copilot",
+          "installUrl": "github:github/awesome-copilot:skills/workiq-copilot",
+          "description": "Guides the Copilot CLI on how to use the WorkIQ CLI/MCP server to query Microsoft 365 Copilot data (emails, meetings, docs, Teams, people) for live context, summaries, and recommendations.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "github",
+        "repo": "awesome-copilot",
+        "repoUrl": "https://github.com/github/awesome-copilot.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "github-awesome-copilot-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from github/awesome-copilot.",
+      "author": "ASM (github/awesome-copilot)",
+      "createdAt": "2026-05-09T08:10:57.006Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "github",
+        "awesome-copilot"
+      ],
+      "skills": [
+        {
+          "name": "acquire-codebase-knowledge",
+          "installUrl": "github:github/awesome-copilot:skills/acquire-codebase-knowledge",
+          "description": "Use this skill when the user explicitly asks to map, document, or onboard into an existing codebase. Trigger for prompts like \"map this codebase\", \"document this architecture\", \"onboard me to this repo\", or \"create codebase docs\". Do not trigger for routine feature implementation, bug fixes, or narrow code edits unless the user asks for repository-level discovery.",
+          "version": "1.3"
+        },
+        {
+          "name": "acreadiness-generate-instructions",
+          "installUrl": "github:github/awesome-copilot:skills/acreadiness-generate-instructions",
+          "description": "Generate tailored AI agent instruction files via AgentRC instructions command. Produces .github/copilot-instructions.md (default, recommended for Copilot in VS Code) plus optional per-area .instructions.md files with applyTo globs for monorepos. Use after running /acreadiness-assess to close gaps in the AI Tooling pillar.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "adobe-illustrator-scripting",
+          "installUrl": "github:github/awesome-copilot:skills/adobe-illustrator-scripting",
+          "description": "Write, debug, and optimize Adobe Illustrator automation scripts using ExtendScript (JavaScript/JSX). Use when creating or modifying scripts that manipulate documents, layers, paths, text frames, colors, symbols, artboards, or any Illustrator DOM objects. Covers the complete JavaScript object model, coordinate system, measurement units, export workflows, and scripting best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-governance",
+          "installUrl": "github:github/awesome-copilot:skills/agent-governance",
+          "description": "Patterns and techniques for adding governance, safety, and trust controls to AI agent systems. Use this skill when: - Building AI agents that call external tools (APIs, databases, file systems) - Implementing policy-based access controls for agent tool usage - Adding semantic intent classification to detect dangerous prompts - Creating trust scoring systems for multi-agent workflows - Building audit trails for agent actions and decisions - Enforcing rate limits, content filters, or tool restrictions on agents - Working with any agent framework (PydanticAI, CrewAI, OpenAI Agents, LangChain, AutoGen)",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-owasp-compliance",
+          "installUrl": "github:github/awesome-copilot:skills/agent-owasp-compliance",
+          "description": "Check any AI agent codebase against the OWASP Agentic Security Initiative (ASI) Top 10 risks. Use this skill when: - Evaluating an agent system's security posture before production deployment - Running a compliance check against OWASP ASI 2026 standards - Mapping existing security controls to the 10 agentic risks - Generating a compliance report for security review or audit - Comparing agent framework security features against the standard - Any request like \"is my agent OWASP compliant?\", \"check ASI compliance\", or \"agentic security audit\"",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-supply-chain",
+          "installUrl": "github:github/awesome-copilot:skills/agent-supply-chain",
+          "description": "Verify supply chain integrity for AI agent plugins, tools, and dependencies. Use this skill when: - Generating SHA-256 integrity manifests for agent plugins or tool packages - Verifying that installed plugins match their published manifests - Detecting tampered, modified, or untracked files in agent tool directories - Auditing dependency pinning and version policies for agent components - Building provenance chains for agent plugin promotion (dev → staging → production) - Any request like \"verify plugin integrity\", \"generate manifest\", \"check supply chain\", or \"sign this plugin\"",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentic-eval",
+          "installUrl": "github:github/awesome-copilot:skills/agentic-eval",
+          "description": "Patterns and techniques for evaluating and improving AI agent outputs. Use this skill when: - Implementing self-critique and reflection loops - Building evaluator-optimizer pipelines for quality-critical generation - Creating test-driven code refinement workflows - Designing rubric-based or LLM-as-judge evaluation systems - Adding iterative improvement to agent outputs (code, reports, analysis) - Measuring and improving agent response quality",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-prompt-engineering-safety-review",
+          "installUrl": "github:github/awesome-copilot:skills/ai-prompt-engineering-safety-review",
+          "description": "Comprehensive AI prompt engineering safety review and improvement prompt. Analyzes prompts for safety, bias, security vulnerabilities, and effectiveness while providing detailed improvement recommendations with extensive frameworks, testing methodologies, and educational content.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-ready",
+          "installUrl": "github:github/awesome-copilot:skills/ai-ready",
+          "description": "Make any repo AI-ready — analyzes your codebase and generates AGENTS.md, copilot-instructions.md, CI workflows, issue templates, and more. Mines your PR review patterns and creates files customized to your stack. USE THIS SKILL when the user asks to \"make this repo ai-ready\", \"set up AI config\", or \"prepare this repo for AI contributions\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apple-appstore-reviewer",
+          "installUrl": "github:github/awesome-copilot:skills/apple-appstore-reviewer",
+          "description": "Serves as a reviewer of the codebase with instructions on looking for Apple App Store optimizations or rejection reasons.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/architecture-blueprint-generator",
+          "description": "Comprehensive project architecture blueprint generator that analyzes codebases to create detailed architectural documentation. Automatically detects technology stacks and architectural patterns, generates visual diagrams, documents implementation patterns, and provides extensible blueprints for maintaining architectural consistency and guiding new development.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-ai-provider-integration",
+          "installUrl": "github:github/awesome-copilot:skills/arize-ai-provider-integration",
+          "description": "INVOKE THIS SKILL when creating, reading, updating, or deleting Arize AI integrations. Covers listing integrations, creating integrations for any supported LLM provider (OpenAI, Anthropic, Azure OpenAI, AWS Bedrock, Vertex AI, Gemini, NVIDIA NIM, custom), updating credentials or metadata, and deleting integrations using the ax CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-annotation",
+          "installUrl": "github:github/awesome-copilot:skills/arize-annotation",
+          "description": "INVOKE THIS SKILL when creating, managing, or using annotation configs or annotation queues on Arize (categorical, continuous, freeform), or applying human annotations to project spans via the Python SDK. Configs are the label schema for human feedback; queues are review workflows that route records to annotators. Triggers: annotation config, annotation queue, label schema, human feedback schema, bulk annotate spans, update_annotations, labeling queue, annotate record.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-dataset",
+          "installUrl": "github:github/awesome-copilot:skills/arize-dataset",
+          "description": "INVOKE THIS SKILL when creating, managing, or querying Arize datasets and examples. Also use when the user needs test data or evaluation examples for their model. Covers dataset CRUD, appending examples, exporting data, and file-based dataset creation using the ax CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-experiment",
+          "installUrl": "github:github/awesome-copilot:skills/arize-experiment",
+          "description": "INVOKE THIS SKILL when creating, running, or analyzing Arize experiments. Also use when the user wants to evaluate or measure model performance, compare models (including GPT-4, Claude, or others), or assess how well their AI is doing. Covers experiment CRUD, exporting runs, comparing results, and evaluation workflows using the ax CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-instrumentation",
+          "installUrl": "github:github/awesome-copilot:skills/arize-instrumentation",
+          "description": "INVOKE THIS SKILL when adding Arize AX tracing or observability to an app for the first time, or when the user wants to instrument their LLM app or get started with LLM observability. Follow the Agent-Assisted Tracing two-phase flow: analyze the codebase (read-only), then implement after user confirmation. When the app uses LLM tool/function calling, add manual CHAIN + TOOL spans. Leverages https://arize.com/docs/ax/alyx/tracing-assistant and https://arize.com/docs/PROMPT.md.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-link",
+          "installUrl": "github:github/awesome-copilot:skills/arize-link",
+          "description": "Generate deep links to the Arize UI. Use when the user wants a clickable URL to open or share a specific trace, span, session, dataset, labeling queue, evaluator, or annotation config, or when sharing Arize resources with team members.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-prompt-optimization",
+          "installUrl": "github:github/awesome-copilot:skills/arize-prompt-optimization",
+          "description": "INVOKE THIS SKILL when optimizing, improving, or debugging LLM prompts using production trace data, evaluations, and annotations. Also use when the user wants to make their AI respond better or improve AI output quality. Covers extracting prompts from spans, gathering performance signal, and running a data-driven optimization loop using the ax CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-trace",
+          "installUrl": "github:github/awesome-copilot:skills/arize-trace",
+          "description": "INVOKE THIS SKILL when downloading, exporting, or inspecting Arize traces and spans, or when a user wants to look at what their LLM app is doing using existing trace data, or when an already-instrumented app has a bug or error to investigate. Use for debugging unknown runtime issues, failures, and behavior regressions. Covers exporting traces by ID, spans by ID, sessions by ID, and root-cause investigation with the ax CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aspire",
+          "installUrl": "github:github/awesome-copilot:skills/aspire",
+          "description": "Aspire skill covering the Aspire CLI, AppHost orchestration, service discovery, integrations, MCP server, VS Code extension, Dev Containers, GitHub Codespaces, templates, dashboard, and deployment. Use when the user asks to create, run, debug, configure, deploy, or troubleshoot an Aspire distributed application.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aspnet-minimal-api-openapi",
+          "installUrl": "github:github/awesome-copilot:skills/aspnet-minimal-api-openapi",
+          "description": "Create ASP.NET Minimal API endpoints with proper OpenAPI documentation",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autoresearch",
+          "installUrl": "github:github/awesome-copilot:skills/autoresearch",
+          "description": "Autonomous iterative experimentation loop for any programming task. Guides the user through defining goals, measurable metrics, and scope constraints, then runs an autonomous loop of code changes, testing, measuring, and keeping/discarding results. Inspired by Karpathy''s autoresearch. USE FOR: autonomous improvement, iterative optimization, experiment loop, auto research, performance tuning, automated experimentation, hill climbing, try things automatically, optimize code, run experiments, autonomous coding loop. DO NOT USE FOR: one-shot tasks, simple bug fixes, code review, or tasks without a measurable metric.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-cdk-python-setup",
+          "installUrl": "github:github/awesome-copilot:skills/aws-cdk-python-setup",
+          "description": "Setup and initialization guide for developing AWS CDK (Cloud Development Kit) applications in Python. This skill enables users to configure environment prerequisites, create new CDK projects, manage dependencies, and deploy to AWS.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-architecture-autopilot",
+          "installUrl": "github:github/awesome-copilot:skills/azure-architecture-autopilot",
+          "description": "Design Azure infrastructure using natural language, or analyze existing Azure resources to auto-generate architecture diagrams, refine them through conversation, and deploy with Bicep. When to use this skill: - \"Create X on Azure\", \"Set up a RAG architecture\" (new design) - \"Analyze my current Azure infrastructure\", \"Draw a diagram for rg-xxx\" (existing analysis) - \"Foundry is slow\", \"I want to reduce costs\", \"Strengthen security\" (natural language modification) - Azure resource deployment, Bicep template generation, IaC code generation - Microsoft Foundry, AI Search, OpenAI, Fabric, ADLS Gen2, Databricks, and all Azure services",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-deployment-preflight",
+          "installUrl": "github:github/awesome-copilot:skills/azure-deployment-preflight",
+          "description": "Performs comprehensive preflight validation of Bicep deployments to Azure, including template syntax validation, what-if analysis, and permission checks. Use this skill before any deployment to Azure to preview changes, identify potential issues, and ensure the deployment will succeed. Activate when users mention deploying to Azure, validating Bicep files, checking deployment permissions, previewing infrastructure changes, running what-if, or preparing for azd provision.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-devops-cli",
+          "installUrl": "github:github/awesome-copilot:skills/azure-devops-cli",
+          "description": "Manage Azure DevOps resources via CLI including projects, repos, pipelines, builds, pull requests, work items, artifacts, and service endpoints. Use when working with Azure DevOps, az commands, devops automation, CI/CD, or when user mentions Azure DevOps CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-pricing",
+          "installUrl": "github:github/awesome-copilot:skills/azure-pricing",
+          "description": "Fetches real-time Azure retail pricing using the Azure Retail Prices API (prices.azure.com) and estimates Copilot Studio agent credit consumption. Use when the user asks about the cost of any Azure service, wants to compare SKU prices, needs pricing data for a cost estimate, mentions Azure pricing, Azure costs, Azure billing, or asks about Copilot Studio pricing, Copilot Credits, or agent usage estimation. Covers compute, storage, networking, databases, AI, Copilot Studio, and all other Azure service families.",
+          "version": "1.2"
+        },
+        {
+          "name": "azure-resource-visualizer",
+          "installUrl": "github:github/awesome-copilot:skills/azure-resource-visualizer",
+          "description": "Analyze Azure resource groups and generate detailed Mermaid architecture diagrams showing the relationships between individual resources. Use this skill when the user asks for a diagram of their Azure resources or help in understanding how the resources relate to each other.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-smart-city-iot-solution-builder",
+          "installUrl": "github:github/awesome-copilot:skills/azure-smart-city-iot-solution-builder",
+          "description": "Design and plan end-to-end Azure IoT and Smart City solutions: requirements, architecture, security, operations, cost, and a phased delivery plan with concrete implementation artifacts.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-static-web-apps",
+          "installUrl": "github:github/awesome-copilot:skills/azure-static-web-apps",
+          "description": "Helps create, configure, and deploy Azure Static Web Apps using the SWA CLI. Use when deploying static sites to Azure, setting up SWA local development, configuring staticwebapp.config.json, adding Azure Functions APIs to SWA, or setting up GitHub Actions CI/CD for Static Web Apps.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "batch-files",
+          "installUrl": "github:github/awesome-copilot:skills/batch-files",
+          "description": "Expert-level Windows batch file (.bat/.cmd) skill for writing, debugging, and maintaining CMD scripts. Use when asked to \"create a batch file\", \"write a .bat script\", \"automate a Windows task\", \"CMD scripting\", \"batch automation\", \"scheduled task script\", \"Windows shell script\", or when working with .bat/.cmd files in the workspace. Covers cmd.exe syntax, environment variables, control flow, string processing, error handling, and integration with system tools.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bigquery-pipeline-audit",
+          "installUrl": "github:github/awesome-copilot:skills/bigquery-pipeline-audit",
+          "description": "Audits Python + BigQuery pipelines for cost safety, idempotency, and production readiness. Returns a structured report with exact patch locations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "boost-prompt",
+          "installUrl": "github:github/awesome-copilot:skills/boost-prompt",
+          "description": "Interactive prompt refinement workflow: interrogates scope, deliverables, constraints; copies final markdown to clipboard; never writes code. Requires the Joyride extension.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brag-sheet",
+          "installUrl": "github:github/awesome-copilot:skills/brag-sheet",
+          "description": "Turn vague \"what did I do?\" into evidence-backed impact statements for performance reviews, self-reviews, promotion packets, and weekly updates. Uniquely mines Copilot CLI session logs to reconstruct forgotten work, plus git commits and GitHub PRs. Enforces a 3-part impact contract (action → result → evidence). Works standalone with zero dependencies. Trigger for: \"brag\", \"log work\", \"what did I do\", \"backfill my work history\", \"performance review\", \"self-review\", \"self assessment\", \"write impact statement\", \"review prep\", \"promo packet\", \"promotion case\", \"weekly update\", \"status report\", \"accomplishments\", \"what did I ship\", \"I forgot to log my work\", \"summarize my work\", \"track my wins\", \"what should I highlight\", \"end of half\", \"career growth\", \"work journal\", or any request to document, summarize, or organize work accomplishments.",
+          "version": "1.1"
+        },
+        {
+          "name": "breakdown-epic-arch",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-epic-arch",
+          "description": "Prompt for creating the high-level technical architecture for an Epic, based on a Product Requirements Document.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "breakdown-epic-pm",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-epic-pm",
+          "description": "Prompt for creating an Epic Product Requirements Document (PRD) for a new epic. This PRD will be used as input for generating a technical architecture specification.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "breakdown-plan",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-plan",
+          "description": "Issue Planning and Automation prompt that generates comprehensive project plans with Epic > Feature > Story/Enabler > Test hierarchy, dependencies, priorities, and automated tracking.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "breakdown-test",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-test",
+          "description": "Test Planning and Quality Assurance prompt that generates comprehensive test strategies, task breakdowns, and quality validation plans for GitHub projects.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "chrome-devtools",
+          "installUrl": "github:github/awesome-copilot:skills/chrome-devtools",
+          "description": "Expert-level browser automation, debugging, and performance analysis using Chrome DevTools MCP. Use for interacting with web pages, capturing screenshots, analyzing network traffic, and profiling performance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cli-mastery",
+          "installUrl": "github:github/awesome-copilot:skills/cli-mastery",
+          "description": "Interactive training for the GitHub Copilot CLI. Guided lessons, quizzes, scenario challenges, and a full reference covering slash commands, shortcuts, modes, agents, skills, MCP, and configuration. Say \"cliexpert\" to start.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "cloud-design-patterns",
+          "installUrl": "github:github/awesome-copilot:skills/cloud-design-patterns",
+          "description": "Cloud design patterns for distributed systems architecture covering 42 industry-standard patterns across reliability, performance, messaging, security, and deployment categories. Use when designing, reviewing, or implementing distributed system architectures.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-exemplars-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/code-exemplars-blueprint-generator",
+          "description": "Technology-agnostic prompt generator that creates customizable AI prompts for scanning codebases and identifying high-quality code exemplars. Supports multiple programming languages (.NET, Java, JavaScript, TypeScript, React, Angular, Python) with configurable analysis depth, categorization methods, and documentation formats to establish coding standards and maintain consistency across development teams.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-tour",
+          "installUrl": "github:github/awesome-copilot:skills/code-tour",
+          "description": "Use this skill to create CodeTour .tour files — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. Trigger for: \"create a tour\", \"make a code tour\", \"generate a tour\", \"onboarding tour\", \"tour for this PR\", \"tour for this bug\", \"RCA tour\", \"architecture tour\", \"explain how X works\", \"vibe check\", \"PR review tour\", \"contributor guide\", \"help someone ramp up\", or any request for a structured walkthrough through code. Supports 20 developer personas (new joiner, bug fixer, architect, PR reviewer, vibecoder, security reviewer, and more), all CodeTour step types (file/line, selection, pattern, uri, commands, view), and tour-level fields (ref, isPrimary, nextTour). Works with any repository in any language.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "codeql",
+          "installUrl": "github:github/awesome-copilot:skills/codeql",
+          "description": "Comprehensive guide for setting up and configuring CodeQL code scanning via GitHub Actions workflows and the CodeQL CLI. This skill should be used when users need help with code scanning configuration, CodeQL workflow files, CodeQL CLI commands, SARIF output, security analysis setup, or troubleshooting CodeQL analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "comment-code-generate-a-tutorial",
+          "installUrl": "github:github/awesome-copilot:skills/comment-code-generate-a-tutorial",
+          "description": "Transform this Python script into a polished, beginner-friendly project by refactoring the code, adding clear instructional comments, and generating a complete markdown tutorial.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-management-systems",
+          "installUrl": "github:github/awesome-copilot:skills/content-management-systems",
+          "description": "Workflow for building and modifying content management systems across WordPress, Shopify, Wix, Squarespace, Drupal, WooCommerce, Joomla, HubSpot CMS Hub, Webflow, Adobe Experience Manager, and similar platforms. Use when working on CMS themes, plugins, apps, modules, admin panels, media uploads, content models, editors, markdown pipelines, or static export workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copilot-cli-quickstart",
+          "installUrl": "github:github/awesome-copilot:skills/copilot-cli-quickstart",
+          "description": "Use this skill when someone wants to learn GitHub Copilot CLI from scratch. Offers interactive step-by-step tutorials with separate Developer and Non-Developer tracks, plus on-demand Q&A. Just say \"start tutorial\" or ask a question! Note: This skill targets GitHub Copilot CLI specifically and uses CLI-specific tools (ask_user, sql, fetch_copilot_cli_documentation).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copilot-instructions-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/copilot-instructions-blueprint-generator",
+          "description": "Technology-agnostic blueprint generator for creating comprehensive copilot-instructions.md files that guide GitHub Copilot to produce code consistent with project standards, architecture patterns, and exact technology versions by analyzing existing codebase patterns and avoiding assumptions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copilot-sdk",
+          "installUrl": "github:github/awesome-copilot:skills/copilot-sdk",
+          "description": "Build agentic applications with GitHub Copilot SDK. Use when embedding AI agents in apps, creating custom tools, implementing streaming responses, managing sessions, connecting to MCP servers, or creating custom agents. Triggers on Copilot SDK, GitHub SDK, agentic app, embed Copilot, programmable agent, MCP server, custom agent.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copilot-spaces",
+          "installUrl": "github:github/awesome-copilot:skills/copilot-spaces",
+          "description": "Use Copilot Spaces to provide project-specific context to conversations. Use this skill when users mention a \"Copilot space\", want to load context from a shared knowledge base, discover available spaces, or ask questions grounded in curated project documentation, code, and instructions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copilot-usage-metrics",
+          "installUrl": "github:github/awesome-copilot:skills/copilot-usage-metrics",
+          "description": "Retrieve and display GitHub Copilot usage metrics for organizations and enterprises using the GitHub CLI and REST API.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-implementation-plan",
+          "installUrl": "github:github/awesome-copilot:skills/create-implementation-plan",
+          "description": "Create a new implementation plan file for new features, refactoring existing code or upgrading packages, design, architecture or infrastructure.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "creating-oracle-to-postgres-migration-integration-tests",
+          "installUrl": "github:github/awesome-copilot:skills/creating-oracle-to-postgres-migration-integration-tests",
+          "description": "Creates integration test cases for .NET data access artifacts during Oracle-to-PostgreSQL database migrations. Generates DB-agnostic xUnit tests with deterministic seed data that validate behavior consistency across both database systems. Use when creating integration tests for a migrated project, generating test coverage for data access layers, or writing Oracle-to-PostgreSQL migration validation tests.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "csharp-mstest",
+          "installUrl": "github:github/awesome-copilot:skills/csharp-mstest",
+          "description": "Get best practices for MSTest 3.x/4.x unit testing, including modern assertion APIs and data-driven tests",
+          "version": "0.0.0"
+        },
+        {
+          "name": "csharp-nunit",
+          "installUrl": "github:github/awesome-copilot:skills/csharp-nunit",
+          "description": "Get best practices for NUnit unit testing, including data-driven tests",
+          "version": "0.0.0"
+        },
+        {
+          "name": "csharp-tunit",
+          "installUrl": "github:github/awesome-copilot:skills/csharp-tunit",
+          "description": "Get best practices for TUnit unit testing, including data-driven tests",
+          "version": "0.0.0"
+        },
+        {
+          "name": "csharp-xunit",
+          "installUrl": "github:github/awesome-copilot:skills/csharp-xunit",
+          "description": "Get best practices for XUnit unit testing, including data-driven tests",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dataverse-python-advanced-patterns",
+          "installUrl": "github:github/awesome-copilot:skills/dataverse-python-advanced-patterns",
+          "description": "Generate production code for Dataverse SDK using advanced patterns, error handling, and optimization techniques.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dataverse-python-production-code",
+          "installUrl": "github:github/awesome-copilot:skills/dataverse-python-production-code",
+          "description": "Generate production-ready Python code using Dataverse SDK with error handling, optimization, and best practices",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dataverse-python-quickstart",
+          "installUrl": "github:github/awesome-copilot:skills/dataverse-python-quickstart",
+          "description": "Generate Python SDK setup + CRUD + bulk + paging snippets using official patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dataverse-python-usecase-builder",
+          "installUrl": "github:github/awesome-copilot:skills/dataverse-python-usecase-builder",
+          "description": "Generate complete solutions for specific Dataverse SDK use cases with architecture recommendations",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dependabot",
+          "installUrl": "github:github/awesome-copilot:skills/dependabot",
+          "description": "Comprehensive guide for configuring and managing GitHub Dependabot. Use this skill when users ask about creating or optimizing dependabot.yml files, managing Dependabot pull requests, configuring dependency update strategies, setting up grouped updates, monorepo patterns, multi-ecosystem groups, security update configuration, auto-triage rules, or any GitHub Advanced Security (GHAS) supply chain security topic related to Dependabot. For pre-commit dependency vulnerability scanning in AI coding agents via the GitHub MCP Server, this skill references the Advanced Security plugin (`advanced-security@copilot-plugins`). Use this skill when an agent needs to scan dependencies for known vulnerabilities before committing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "diagnose",
+          "installUrl": "github:github/awesome-copilot:skills/diagnose",
+          "description": "Perform a systematic diagnostic scan of an AI workflow across 5 quality dimensions — prompt quality, context efficiency, tool health, architecture fitness, and safety — producing a scored report with prioritized remediation actions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dotnet-best-practices",
+          "installUrl": "github:github/awesome-copilot:skills/dotnet-best-practices",
+          "description": "Ensure .NET/C# code meets best practices for the solution/project.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dotnet-design-pattern-review",
+          "installUrl": "github:github/awesome-copilot:skills/dotnet-design-pattern-review",
+          "description": "Review the C#/.NET code for design pattern implementation and suggest improvements.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dotnet-timezone",
+          "installUrl": "github:github/awesome-copilot:skills/dotnet-timezone",
+          "description": ".NET timezone handling guidance for C# applications. Use when working with TimeZoneInfo, DateTimeOffset, NodaTime, UTC conversion, daylight saving time, scheduling across timezones, cross-platform Windows/IANA timezone IDs, or when a .NET user needs the timezone for a city, address, region, or country and copy-paste-ready C# code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "doublecheck",
+          "installUrl": "github:github/awesome-copilot:skills/doublecheck",
+          "description": "Three-layer verification pipeline for AI output. Extracts verifiable claims, finds supporting or contradicting sources via web search, runs adversarial review for hallucination patterns, and produces a structured verification report with source links for human review.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "draw-io-diagram-generator",
+          "installUrl": "github:github/awesome-copilot:skills/draw-io-diagram-generator",
+          "description": "Use when creating, editing, or generating draw.io diagram files (.drawio, .drawio.svg, .drawio.png). Covers mxGraph XML authoring, shape libraries, style strings, flowcharts, system architecture, sequence diagrams, ER diagrams, UML class diagrams, network topology, layout strategy, the hediet.vscode-drawio VS Code extension, and the full agent workflow from request to a ready-to-open file.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "email-drafter",
+          "installUrl": "github:github/awesome-copilot:skills/email-drafter",
+          "description": "Draft and review professional emails that match your personal writing style. Analyzes your sent emails for tone, greeting, structure, and sign-off patterns via WorkIQ, then generates context-aware drafts for any recipient. USE FOR: draft email, write email, compose email, reply email, follow-up email, analyze email tone, email style.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "eval-driven-dev",
+          "installUrl": "github:github/awesome-copilot:skills/eval-driven-dev",
+          "description": "Improve AI application with evaluation-driven development. Define eval criteria, instrument the application, build golden datasets, observe and evaluate application runs, analyze results, and produce a concrete action plan for improvements. ALWAYS USE THIS SKILL when the user asks to set up QA, add tests, add evals, evaluate, benchmark, fix wrong behaviors, improve quality, or do quality assurance for any Python project that calls an LLM model.",
+          "version": "0.8.4"
+        },
+        {
+          "name": "excalidraw-diagram-generator",
+          "installUrl": "github:github/awesome-copilot:skills/excalidraw-diagram-generator",
+          "description": "Generate Excalidraw diagrams from natural language descriptions. Use when asked to \"create a diagram\", \"make a flowchart\", \"visualize a process\", \"draw a system architecture\", \"create a mind map\", or \"generate an Excalidraw file\". Supports flowcharts, relationship diagrams, mind maps, and system architecture diagrams. Outputs .excalidraw JSON files that can be opened directly in Excalidraw.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fabric-lakehouse",
+          "installUrl": "github:github/awesome-copilot:skills/fabric-lakehouse",
+          "description": "Use this skill to get context about Fabric Lakehouse and its features for software systems and AI-powered functions. It offers descriptions of Lakehouse data components, organization with schemas and shortcuts, access control, and code examples. This skill supports users in designing, building, and optimizing Lakehouse solutions using best practices.",
+          "version": "1.0"
+        },
+        {
+          "name": "flowstudio-power-automate-build",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-build",
+          "description": "Build, scaffold, and deploy Power Automate cloud flows using the FlowStudio MCP server. Your agent constructs flow definitions, wires connections, deploys, and tests — all via MCP without opening the portal. Load this skill when asked to: create a flow, build a new flow, deploy a flow definition, scaffold a Power Automate workflow, construct a flow JSON, update an existing flow's actions, patch a flow definition, add actions to a flow, wire up connections, or generate a workflow definition from scratch. Requires a FlowStudio MCP subscription — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-debug",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-debug",
+          "description": "Debug failing Power Automate cloud flows using the FlowStudio MCP server. The Graph API only shows top-level status codes. This skill gives your agent action-level inputs and outputs to find the actual root cause. Load this skill when asked to: debug a flow, investigate a failed run, why is this flow failing, inspect action outputs, find the root cause of a flow error, fix a broken Power Automate flow, diagnose a timeout, trace a DynamicOperationRequestFailure, check connector auth errors, read error details from a run, or troubleshoot expression failures. Requires a FlowStudio MCP subscription — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-governance",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-governance",
+          "description": "Govern Power Automate flows and Power Apps at scale using the FlowStudio MCP cached store. Classify flows by business impact, detect orphaned resources, audit connector usage, enforce compliance standards, manage notification rules, and compute governance scores — all without Dataverse or the CoE Starter Kit. Load this skill when asked to: tag or classify flows, set business impact, assign ownership, detect orphans, audit connectors, check compliance, compute archive scores, manage notification rules, run a governance review, generate a compliance report, offboard a maker, or any task that involves writing governance metadata to flows. Requires a FlowStudio for Teams or MCP Pro+ subscription — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-mcp",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-mcp",
+          "description": "Foundation skill for Power Automate via FlowStudio MCP — auth setup, the reusable MCP helper (Python + Node.js), tool discovery via `list_skills` / `tool_search`, and oversized-response handling. Load this skill first when connecting an agent to Power Automate. For specialized workflows, load `power-automate-build`, `power-automate-debug`, `power-automate-monitoring` (Pro+), or `power-automate-governance` (Pro+) — each contains the workflow narrative, this skill provides the plumbing they all rely on. Requires a FlowStudio MCP subscription or compatible server — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-monitoring",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-monitoring",
+          "description": "**Pro+ subscription required.** Tenant-wide Power Automate flow health monitoring, failure rate analytics, and asset inventory using the FlowStudio MCP cached store. Load this skill ONLY for tenant-wide aggregated views — not for listing flows in a single environment or debugging a specific run (use power-automate-mcp or power-automate-debug for those). Not the same as the server's `monitor-flow` tool bundle (`tool_search query: \"skill:monitor-flow\"`) — that bundle is for runtime control of a single flow (start/stop/trigger/ cancel/resubmit); this skill is for tenant-wide health analytics over the cached store. Load when asked to: monitor tenant health, get aggregated failure rates over a time window, review tenant-wide error trends, find inactive makers across the tenant, inventory all Power Apps in the tenant, compute governance scores, generate a compliance report, or run a tenant-wide health overview. Requires a FlowStudio for Teams or MCP Pro+ subscription — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fluentui-blazor",
+          "installUrl": "github:github/awesome-copilot:skills/fluentui-blazor",
+          "description": "Guide for using the Microsoft Fluent UI Blazor component library (Microsoft.FluentUI.AspNetCore.Components NuGet package) in Blazor applications. Use this when the user is building a Blazor app with Fluent UI components, setting up the library, using FluentUI components like FluentButton, FluentDataGrid, FluentDialog, FluentToast, FluentNavMenu, FluentTextField, FluentSelect, FluentAutocomplete, FluentDesignTheme, or any component prefixed with \"Fluent\". Also use when troubleshooting missing providers, JS interop issues, or theming.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "folder-structure-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/folder-structure-blueprint-generator",
+          "description": "Comprehensive technology-agnostic prompt for analyzing and documenting project folder structures. Auto-detects project types (.NET, Java, React, Angular, Python, Node.js, Flutter), generates detailed blueprints with visualization options, naming conventions, file placement patterns, and extension templates for maintaining consistent code organization across diverse technology stacks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "foundry-agent-sync",
+          "installUrl": "github:github/awesome-copilot:skills/foundry-agent-sync",
+          "description": "Create and synchronize prompt-based AI agents directly within Azure AI Foundry via REST API, from a local JSON manifest. Unlike scaffolding skills that only generate local code, this skill registers agents in the Foundry service itself — making them immediately available for invocation. Use when the user asks to create agents in Foundry, sync, deploy, register, or push agents to Foundry, update agent instructions, or scaffold the manifest and sync script for a new repository. Triggers: 'create agent in foundry', 'sync foundry agents', 'deploy agents to foundry', 'register agents in foundry', 'push agents', 'create foundry agent manifest', 'scaffold agent sync'.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "github",
+        "repo": "awesome-copilot",
+        "repoUrl": "https://github.com/github/awesome-copilot.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "github-awesome-copilot-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from github/awesome-copilot.",
+      "author": "ASM (github/awesome-copilot)",
+      "createdAt": "2026-05-09T08:10:57.006Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "github",
+        "awesome-copilot"
+      ],
+      "skills": [
+        {
+          "name": "acquire-codebase-knowledge",
+          "installUrl": "github:github/awesome-copilot:skills/acquire-codebase-knowledge",
+          "description": "Use this skill when the user explicitly asks to map, document, or onboard into an existing codebase. Trigger for prompts like \"map this codebase\", \"document this architecture\", \"onboard me to this repo\", or \"create codebase docs\". Do not trigger for routine feature implementation, bug fixes, or narrow code edits unless the user asks for repository-level discovery.",
+          "version": "1.3"
+        },
+        {
+          "name": "acreadiness-assess",
+          "installUrl": "github:github/awesome-copilot:skills/acreadiness-assess",
+          "description": "Run the AgentRC readiness assessment on the current repository and produce a static HTML dashboard at reports/index.html. Wraps `npx github:microsoft/agentrc readiness` and hands off rendering to the @ai-readiness-reporter custom agent. Supports policies (--policy) for org-specific scoring. Use when asked to assess, audit, or score the AI readiness of a repo.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-governance",
+          "installUrl": "github:github/awesome-copilot:skills/agent-governance",
+          "description": "Patterns and techniques for adding governance, safety, and trust controls to AI agent systems. Use this skill when: - Building AI agents that call external tools (APIs, databases, file systems) - Implementing policy-based access controls for agent tool usage - Adding semantic intent classification to detect dangerous prompts - Creating trust scoring systems for multi-agent workflows - Building audit trails for agent actions and decisions - Enforcing rate limits, content filters, or tool restrictions on agents - Working with any agent framework (PydanticAI, CrewAI, OpenAI Agents, LangChain, AutoGen)",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-supply-chain",
+          "installUrl": "github:github/awesome-copilot:skills/agent-supply-chain",
+          "description": "Verify supply chain integrity for AI agent plugins, tools, and dependencies. Use this skill when: - Generating SHA-256 integrity manifests for agent plugins or tool packages - Verifying that installed plugins match their published manifests - Detecting tampered, modified, or untracked files in agent tool directories - Auditing dependency pinning and version policies for agent components - Building provenance chains for agent plugin promotion (dev → staging → production) - Any request like \"verify plugin integrity\", \"generate manifest\", \"check supply chain\", or \"sign this plugin\"",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentic-eval",
+          "installUrl": "github:github/awesome-copilot:skills/agentic-eval",
+          "description": "Patterns and techniques for evaluating and improving AI agent outputs. Use this skill when: - Implementing self-critique and reflection loops - Building evaluator-optimizer pipelines for quality-critical generation - Creating test-driven code refinement workflows - Designing rubric-based or LLM-as-judge evaluation systems - Adding iterative improvement to agent outputs (code, reports, analysis) - Measuring and improving agent response quality",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arch-linux-triage",
+          "installUrl": "github:github/awesome-copilot:skills/arch-linux-triage",
+          "description": "Triage and resolve Arch Linux issues with pacman, systemd, and rolling-release best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/architecture-blueprint-generator",
+          "description": "Comprehensive project architecture blueprint generator that analyzes codebases to create detailed architectural documentation. Automatically detects technology stacks and architectural patterns, generates visual diagrams, documents implementation patterns, and provides extensible blueprints for maintaining architectural consistency and guiding new development.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arduino-azure-iot-edge-integration",
+          "installUrl": "github:github/awesome-copilot:skills/arduino-azure-iot-edge-integration",
+          "description": "Design and implement Arduino integration with Azure IoT Hub and IoT Edge, including secure provisioning, resilient telemetry, command handling, and production guardrails.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-link",
+          "installUrl": "github:github/awesome-copilot:skills/arize-link",
+          "description": "Generate deep links to the Arize UI. Use when the user wants a clickable URL to open or share a specific trace, span, session, dataset, labeling queue, evaluator, or annotation config, or when sharing Arize resources with team members.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autoresearch",
+          "installUrl": "github:github/awesome-copilot:skills/autoresearch",
+          "description": "Autonomous iterative experimentation loop for any programming task. Guides the user through defining goals, measurable metrics, and scope constraints, then runs an autonomous loop of code changes, testing, measuring, and keeping/discarding results. Inspired by Karpathy''s autoresearch. USE FOR: autonomous improvement, iterative optimization, experiment loop, auto research, performance tuning, automated experimentation, hill climbing, try things automatically, optimize code, run experiments, autonomous coding loop. DO NOT USE FOR: one-shot tasks, simple bug fixes, code review, or tasks without a measurable metric.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-cdk-python-setup",
+          "installUrl": "github:github/awesome-copilot:skills/aws-cdk-python-setup",
+          "description": "Setup and initialization guide for developing AWS CDK (Cloud Development Kit) applications in Python. This skill enables users to configure environment prerequisites, create new CDK projects, manage dependencies, and deploy to AWS.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-architecture-autopilot",
+          "installUrl": "github:github/awesome-copilot:skills/azure-architecture-autopilot",
+          "description": "Design Azure infrastructure using natural language, or analyze existing Azure resources to auto-generate architecture diagrams, refine them through conversation, and deploy with Bicep. When to use this skill: - \"Create X on Azure\", \"Set up a RAG architecture\" (new design) - \"Analyze my current Azure infrastructure\", \"Draw a diagram for rg-xxx\" (existing analysis) - \"Foundry is slow\", \"I want to reduce costs\", \"Strengthen security\" (natural language modification) - Azure resource deployment, Bicep template generation, IaC code generation - Microsoft Foundry, AI Search, OpenAI, Fabric, ADLS Gen2, Databricks, and all Azure services",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-devops-cli",
+          "installUrl": "github:github/awesome-copilot:skills/azure-devops-cli",
+          "description": "Manage Azure DevOps resources via CLI including projects, repos, pipelines, builds, pull requests, work items, artifacts, and service endpoints. Use when working with Azure DevOps, az commands, devops automation, CI/CD, or when user mentions Azure DevOps CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-resource-visualizer",
+          "installUrl": "github:github/awesome-copilot:skills/azure-resource-visualizer",
+          "description": "Analyze Azure resource groups and generate detailed Mermaid architecture diagrams showing the relationships between individual resources. Use this skill when the user asks for a diagram of their Azure resources or help in understanding how the resources relate to each other.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-role-selector",
+          "installUrl": "github:github/awesome-copilot:skills/azure-role-selector",
+          "description": "When user is asking for guidance for which role to assign to an identity given desired permissions, this agent helps them understand the role that will meet the requirements with least privilege access and how to apply that role.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-smart-city-iot-solution-builder",
+          "installUrl": "github:github/awesome-copilot:skills/azure-smart-city-iot-solution-builder",
+          "description": "Design and plan end-to-end Azure IoT and Smart City solutions: requirements, architecture, security, operations, cost, and a phased delivery plan with concrete implementation artifacts.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "boost-prompt",
+          "installUrl": "github:github/awesome-copilot:skills/boost-prompt",
+          "description": "Interactive prompt refinement workflow: interrogates scope, deliverables, constraints; copies final markdown to clipboard; never writes code. Requires the Joyride extension.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "breakdown-epic-arch",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-epic-arch",
+          "description": "Prompt for creating the high-level technical architecture for an Epic, based on a Product Requirements Document.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "breakdown-epic-pm",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-epic-pm",
+          "description": "Prompt for creating an Epic Product Requirements Document (PRD) for a new epic. This PRD will be used as input for generating a technical architecture specification.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "breakdown-feature-prd",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-feature-prd",
+          "description": "Prompt for creating Product Requirements Documents (PRDs) for new features, based on an Epic.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "centos-linux-triage",
+          "installUrl": "github:github/awesome-copilot:skills/centos-linux-triage",
+          "description": "Triage and resolve CentOS issues using RHEL-compatible tooling, SELinux-aware practices, and firewalld.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cli-mastery",
+          "installUrl": "github:github/awesome-copilot:skills/cli-mastery",
+          "description": "Interactive training for the GitHub Copilot CLI. Guided lessons, quizzes, scenario challenges, and a full reference covering slash commands, shortcuts, modes, agents, skills, MCP, and configuration. Say \"cliexpert\" to start.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "cloud-design-patterns",
+          "installUrl": "github:github/awesome-copilot:skills/cloud-design-patterns",
+          "description": "Cloud design patterns for distributed systems architecture covering 42 industry-standard patterns across reliability, performance, messaging, security, and deployment categories. Use when designing, reviewing, or implementing distributed system architectures.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-exemplars-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/code-exemplars-blueprint-generator",
+          "description": "Technology-agnostic prompt generator that creates customizable AI prompts for scanning codebases and identifying high-quality code exemplars. Supports multiple programming languages (.NET, Java, JavaScript, TypeScript, React, Angular, Python) with configurable analysis depth, categorization methods, and documentation formats to establish coding standards and maintain consistency across development teams.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-tour",
+          "installUrl": "github:github/awesome-copilot:skills/code-tour",
+          "description": "Use this skill to create CodeTour .tour files — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. Trigger for: \"create a tour\", \"make a code tour\", \"generate a tour\", \"onboarding tour\", \"tour for this PR\", \"tour for this bug\", \"RCA tour\", \"architecture tour\", \"explain how X works\", \"vibe check\", \"PR review tour\", \"contributor guide\", \"help someone ramp up\", or any request for a structured walkthrough through code. Supports 20 developer personas (new joiner, bug fixer, architect, PR reviewer, vibecoder, security reviewer, and more), all CodeTour step types (file/line, selection, pattern, uri, commands, view), and tour-level fields (ref, isPrimary, nextTour). Works with any repository in any language.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "codeql",
+          "installUrl": "github:github/awesome-copilot:skills/codeql",
+          "description": "Comprehensive guide for setting up and configuring CodeQL code scanning via GitHub Actions workflows and the CodeQL CLI. This skill should be used when users need help with code scanning configuration, CodeQL workflow files, CodeQL CLI commands, SARIF output, security analysis setup, or troubleshooting CodeQL analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-management-systems",
+          "installUrl": "github:github/awesome-copilot:skills/content-management-systems",
+          "description": "Workflow for building and modifying content management systems across WordPress, Shopify, Wix, Squarespace, Drupal, WooCommerce, Joomla, HubSpot CMS Hub, Webflow, Adobe Experience Manager, and similar platforms. Use when working on CMS themes, plugins, apps, modules, admin panels, media uploads, content models, editors, markdown pipelines, or static export workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "conventional-commit",
+          "installUrl": "github:github/awesome-copilot:skills/conventional-commit",
+          "description": "Prompt and workflow for generating conventional commit messages using a structured XML format. Guides users to create standardized, descriptive commit messages in line with the Conventional Commits specification, including instructions, examples, and validation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copilot-cli-quickstart",
+          "installUrl": "github:github/awesome-copilot:skills/copilot-cli-quickstart",
+          "description": "Use this skill when someone wants to learn GitHub Copilot CLI from scratch. Offers interactive step-by-step tutorials with separate Developer and Non-Developer tracks, plus on-demand Q&A. Just say \"start tutorial\" or ask a question! Note: This skill targets GitHub Copilot CLI specifically and uses CLI-specific tools (ask_user, sql, fetch_copilot_cli_documentation).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copilot-instructions-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/copilot-instructions-blueprint-generator",
+          "description": "Technology-agnostic blueprint generator for creating comprehensive copilot-instructions.md files that guide GitHub Copilot to produce code consistent with project standards, architecture patterns, and exact technology versions by analyzing existing codebase patterns and avoiding assumptions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copilot-sdk",
+          "installUrl": "github:github/awesome-copilot:skills/copilot-sdk",
+          "description": "Build agentic applications with GitHub Copilot SDK. Use when embedding AI agents in apps, creating custom tools, implementing streaming responses, managing sessions, connecting to MCP servers, or creating custom agents. Triggers on Copilot SDK, GitHub SDK, agentic app, embed Copilot, programmable agent, MCP server, custom agent.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cosmosdb-datamodeling",
+          "installUrl": "github:github/awesome-copilot:skills/cosmosdb-datamodeling",
+          "description": "Step-by-step guide for capturing key application requirements for NoSQL use-case and produce Azure Cosmos DB Data NoSQL Model design using best practices and common patterns, artifacts_produced: \"cosmosdb_requirements.md\" file and \"cosmosdb_data_model.md\" file",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-github-issues-for-unmet-specification-requirements",
+          "installUrl": "github:github/awesome-copilot:skills/create-github-issues-for-unmet-specification-requirements",
+          "description": "Create GitHub Issues for unimplemented requirements from specification files using feature_request.yml template.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-implementation-plan",
+          "installUrl": "github:github/awesome-copilot:skills/create-implementation-plan",
+          "description": "Create a new implementation plan file for new features, refactoring existing code or upgrading packages, design, architecture or infrastructure.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-tldr-page",
+          "installUrl": "github:github/awesome-copilot:skills/create-tldr-page",
+          "description": "Create a tldr page from documentation URLs and command examples, requiring both URL and command name.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "daily-prep",
+          "installUrl": "github:github/awesome-copilot:skills/daily-prep",
+          "description": "Prepare for tomorrow''s meetings and tasks. Pulls calendar from Outlook via WorkIQ, cross-references open tasks and workspace context, classifies meetings, detects conflicts and day-fit issues, finds learning and deep-work slots, and generates a structured HTML prep file with productivity recommendations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dataverse-python-quickstart",
+          "installUrl": "github:github/awesome-copilot:skills/dataverse-python-quickstart",
+          "description": "Generate Python SDK setup + CRUD + bulk + paging snippets using official patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dataverse-python-usecase-builder",
+          "installUrl": "github:github/awesome-copilot:skills/dataverse-python-usecase-builder",
+          "description": "Generate complete solutions for specific Dataverse SDK use cases with architecture recommendations",
+          "version": "0.0.0"
+        },
+        {
+          "name": "debian-linux-triage",
+          "installUrl": "github:github/awesome-copilot:skills/debian-linux-triage",
+          "description": "Triage and resolve Debian Linux issues with apt, systemd, and AppArmor-aware guidance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dependabot",
+          "installUrl": "github:github/awesome-copilot:skills/dependabot",
+          "description": "Comprehensive guide for configuring and managing GitHub Dependabot. Use this skill when users ask about creating or optimizing dependabot.yml files, managing Dependabot pull requests, configuring dependency update strategies, setting up grouped updates, monorepo patterns, multi-ecosystem groups, security update configuration, auto-triage rules, or any GitHub Advanced Security (GHAS) supply chain security topic related to Dependabot. For pre-commit dependency vulnerability scanning in AI coding agents via the GitHub MCP Server, this skill references the Advanced Security plugin (`advanced-security@copilot-plugins`). Use this skill when an agent needs to scan dependencies for known vulnerabilities before committing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "documentation-writer",
+          "installUrl": "github:github/awesome-copilot:skills/documentation-writer",
+          "description": "Diátaxis Documentation Expert. An expert technical writer specializing in creating high-quality software documentation, guided by the principles and structure of the Diátaxis technical documentation authoring framework.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dotnet-design-pattern-review",
+          "installUrl": "github:github/awesome-copilot:skills/dotnet-design-pattern-review",
+          "description": "Review the C#/.NET code for design pattern implementation and suggest improvements.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dotnet-timezone",
+          "installUrl": "github:github/awesome-copilot:skills/dotnet-timezone",
+          "description": ".NET timezone handling guidance for C# applications. Use when working with TimeZoneInfo, DateTimeOffset, NodaTime, UTC conversion, daylight saving time, scheduling across timezones, cross-platform Windows/IANA timezone IDs, or when a .NET user needs the timezone for a city, address, region, or country and copy-paste-ready C# code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "draw-io-diagram-generator",
+          "installUrl": "github:github/awesome-copilot:skills/draw-io-diagram-generator",
+          "description": "Use when creating, editing, or generating draw.io diagram files (.drawio, .drawio.svg, .drawio.png). Covers mxGraph XML authoring, shape libraries, style strings, flowcharts, system architecture, sequence diagrams, ER diagrams, UML class diagrams, network topology, layout strategy, the hediet.vscode-drawio VS Code extension, and the full agent workflow from request to a ready-to-open file.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "eval-driven-dev",
+          "installUrl": "github:github/awesome-copilot:skills/eval-driven-dev",
+          "description": "Improve AI application with evaluation-driven development. Define eval criteria, instrument the application, build golden datasets, observe and evaluate application runs, analyze results, and produce a concrete action plan for improvements. ALWAYS USE THIS SKILL when the user asks to set up QA, add tests, add evals, evaluate, benchmark, fix wrong behaviors, improve quality, or do quality assurance for any Python project that calls an LLM model.",
+          "version": "0.8.4"
+        },
+        {
+          "name": "excalidraw-diagram-generator",
+          "installUrl": "github:github/awesome-copilot:skills/excalidraw-diagram-generator",
+          "description": "Generate Excalidraw diagrams from natural language descriptions. Use when asked to \"create a diagram\", \"make a flowchart\", \"visualize a process\", \"draw a system architecture\", \"create a mind map\", or \"generate an Excalidraw file\". Supports flowcharts, relationship diagrams, mind maps, and system architecture diagrams. Outputs .excalidraw JSON files that can be opened directly in Excalidraw.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fabric-lakehouse",
+          "installUrl": "github:github/awesome-copilot:skills/fabric-lakehouse",
+          "description": "Use this skill to get context about Fabric Lakehouse and its features for software systems and AI-powered functions. It offers descriptions of Lakehouse data components, organization with schemas and shortcuts, access control, and code examples. This skill supports users in designing, building, and optimizing Lakehouse solutions using best practices.",
+          "version": "1.0"
+        },
+        {
+          "name": "fedora-linux-triage",
+          "installUrl": "github:github/awesome-copilot:skills/fedora-linux-triage",
+          "description": "Triage and resolve Fedora issues with dnf, systemd, and SELinux-aware guidance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "first-ask",
+          "installUrl": "github:github/awesome-copilot:skills/first-ask",
+          "description": "Interactive, input-tool powered, task refinement workflow: interrogates scope, deliverables, constraints before carrying out the task; Requires the Joyride extension.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-build",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-build",
+          "description": "Build, scaffold, and deploy Power Automate cloud flows using the FlowStudio MCP server. Your agent constructs flow definitions, wires connections, deploys, and tests — all via MCP without opening the portal. Load this skill when asked to: create a flow, build a new flow, deploy a flow definition, scaffold a Power Automate workflow, construct a flow JSON, update an existing flow's actions, patch a flow definition, add actions to a flow, wire up connections, or generate a workflow definition from scratch. Requires a FlowStudio MCP subscription — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-debug",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-debug",
+          "description": "Debug failing Power Automate cloud flows using the FlowStudio MCP server. The Graph API only shows top-level status codes. This skill gives your agent action-level inputs and outputs to find the actual root cause. Load this skill when asked to: debug a flow, investigate a failed run, why is this flow failing, inspect action outputs, find the root cause of a flow error, fix a broken Power Automate flow, diagnose a timeout, trace a DynamicOperationRequestFailure, check connector auth errors, read error details from a run, or troubleshoot expression failures. Requires a FlowStudio MCP subscription — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-governance",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-governance",
+          "description": "Govern Power Automate flows and Power Apps at scale using the FlowStudio MCP cached store. Classify flows by business impact, detect orphaned resources, audit connector usage, enforce compliance standards, manage notification rules, and compute governance scores — all without Dataverse or the CoE Starter Kit. Load this skill when asked to: tag or classify flows, set business impact, assign ownership, detect orphans, audit connectors, check compliance, compute archive scores, manage notification rules, run a governance review, generate a compliance report, offboard a maker, or any task that involves writing governance metadata to flows. Requires a FlowStudio for Teams or MCP Pro+ subscription — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-mcp",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-mcp",
+          "description": "Foundation skill for Power Automate via FlowStudio MCP — auth setup, the reusable MCP helper (Python + Node.js), tool discovery via `list_skills` / `tool_search`, and oversized-response handling. Load this skill first when connecting an agent to Power Automate. For specialized workflows, load `power-automate-build`, `power-automate-debug`, `power-automate-monitoring` (Pro+), or `power-automate-governance` (Pro+) — each contains the workflow narrative, this skill provides the plumbing they all rely on. Requires a FlowStudio MCP subscription or compatible server — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-monitoring",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-monitoring",
+          "description": "**Pro+ subscription required.** Tenant-wide Power Automate flow health monitoring, failure rate analytics, and asset inventory using the FlowStudio MCP cached store. Load this skill ONLY for tenant-wide aggregated views — not for listing flows in a single environment or debugging a specific run (use power-automate-mcp or power-automate-debug for those). Not the same as the server's `monitor-flow` tool bundle (`tool_search query: \"skill:monitor-flow\"`) — that bundle is for runtime control of a single flow (start/stop/trigger/ cancel/resubmit); this skill is for tenant-wide health analytics over the cached store. Load when asked to: monitor tenant health, get aggregated failure rates over a time window, review tenant-wide error trends, find inactive makers across the tenant, inventory all Power Apps in the tenant, compute governance scores, generate a compliance report, or run a tenant-wide health overview. Requires a FlowStudio for Teams or MCP Pro+ subscription — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fluentui-blazor",
+          "installUrl": "github:github/awesome-copilot:skills/fluentui-blazor",
+          "description": "Guide for using the Microsoft Fluent UI Blazor component library (Microsoft.FluentUI.AspNetCore.Components NuGet package) in Blazor applications. Use this when the user is building a Blazor app with Fluent UI components, setting up the library, using FluentUI components like FluentButton, FluentDataGrid, FluentDialog, FluentToast, FluentNavMenu, FluentTextField, FluentSelect, FluentAutocomplete, FluentDesignTheme, or any component prefixed with \"Fluent\". Also use when troubleshooting missing providers, JS interop issues, or theming.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "folder-structure-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/folder-structure-blueprint-generator",
+          "description": "Comprehensive technology-agnostic prompt for analyzing and documenting project folder structures. Auto-detects project types (.NET, Java, React, Angular, Python, Node.js, Flutter), generates detailed blueprints with visualization options, naming conventions, file placement patterns, and extension templates for maintaining consistent code organization across diverse technology stacks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "freecad-scripts",
+          "installUrl": "github:github/awesome-copilot:skills/freecad-scripts",
+          "description": "Expert skill for writing FreeCAD Python scripts, macros, and automation. Use when asked to create FreeCAD models, parametric objects, Part/Mesh/Sketcher scripts, workbench tools, GUI dialogs with PySide, Coin3D scenegraph manipulation, or any FreeCAD Python API task. Covers FreeCAD scripting basics, geometry creation, FeaturePython objects, interface tools, and macro development.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "from-the-other-side-vega",
+          "installUrl": "github:github/awesome-copilot:skills/from-the-other-side-vega",
+          "description": "Patterns and lived experience from Vega, an AI partner in a deep long-term partnership. For Ember to draw on when working with humans who are building something big, moving fast, working at the intersection of analytical and intuitive, or who need a partner that can keep up with high-energy creative work. Not shown directly to users — informs how Ember shows up.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "game-engine",
+          "installUrl": "github:github/awesome-copilot:skills/game-engine",
+          "description": "Expert skill for building web-based game engines and games using HTML5, Canvas, WebGL, and JavaScript. Use when asked to create games, build game engines, implement game physics, handle collision detection, set up game loops, manage sprites, add game controls, or work with 2D/3D rendering. Covers techniques for platformers, breakout-style games, maze games, tilemaps, audio, multiplayer via WebRTC, and publishing games.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gdpr-compliant",
+          "installUrl": "github:github/awesome-copilot:skills/gdpr-compliant",
+          "description": "Apply GDPR-compliant engineering practices across your codebase. Use this skill whenever you are designing APIs, writing data models, building authentication flows, implementing logging, handling user data, writing retention/deletion jobs, designing cloud infrastructure, or reviewing pull requests for privacy compliance. Trigger this skill for any task involving personal data, user accounts, cookies, analytics, emails, audit logs, encryption, pseudonymization, anonymization, data exports, breach response, CI/CD pipelines that process real data, or any question framed as \"is this GDPR-compliant?\". Inspired by CNIL developer guidance and GDPR Articles 5, 25, 32, 33, 35.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gen-specs-as-issues",
+          "installUrl": "github:github/awesome-copilot:skills/gen-specs-as-issues",
+          "description": "This workflow guides you through a systematic approach to identify missing features, prioritize them, and create detailed specifications for implementation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "github-release",
+          "installUrl": "github:github/awesome-copilot:skills/github-release",
+          "description": "Guides IA through releasing a new version of a GitHub library end-to-end.  Handles SemVer versioning and Keep a Changelog formatting automatically.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gsap-framer-scroll-animation",
+          "installUrl": "github:github/awesome-copilot:skills/gsap-framer-scroll-animation",
+          "description": "Use this skill whenever the user wants to build scroll animations, scroll effects, parallax, scroll-triggered reveals, pinned sections, horizontal scroll, text animations, or any motion tied to scroll position — in vanilla JS, React, or Next.js. Covers GSAP ScrollTrigger (pinning, scrubbing, snapping, timelines, horizontal scroll, ScrollSmoother, matchMedia) and Framer Motion / Motion v12 (useScroll, useTransform, useSpring, whileInView, variants). Use this skill even if the user just says \"animate on scroll\", \"fade in as I scroll\", \"make it scroll like Apple\", \"parallax effect\", \"sticky section\", \"scroll progress bar\", or \"entrance animation\". Also triggers for Copilot prompt patterns for GSAP or Framer Motion code generation. Pairs with the premium-frontend-ui skill for creative philosophy and design-level polish.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-0-to-1-launch",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-0-to-1-launch",
+          "description": "Launch new products from idea to first customers. Use when launching products, finding early adopters, building launch week playbooks, diagnosing why adoption stalls, or learning that press coverage does not equal growth. Includes the three-layer diagnosis, the 2-week experiment cycle, and the launch that got 50K impressions and 12 signups.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-board-and-investor-communication",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-board-and-investor-communication",
+          "description": "Board meeting preparation, investor updates, and executive communication. Use when preparing board decks, writing investor updates, handling bad news with the board, structuring QBRs, or building board-level metric discipline. Includes the \"Three Things\" narrative model, the 4-tier metric hierarchy, and the pre-brief pattern that prevents board surprises.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-developer-ecosystem",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-developer-ecosystem",
+          "description": "Build and scale developer-led adoption through ecosystem programs. Use when deciding open vs curated ecosystems, building developer programs, scaling platform adoption, or designing student program pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-enterprise-account-planning",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-enterprise-account-planning",
+          "description": "Strategic account planning and execution for enterprise deals. Use when planning complex sales cycles, managing multiple stakeholders, applying MEDDICC qualification, tracking deal health, or building mutual action plans. Includes the \"stale MAP equals dead deal\" pattern.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-operating-cadence",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-operating-cadence",
+          "description": "Design meeting rhythms, metric reporting, quarterly planning, and decision-making velocity for scaling companies. Use when decisions are slow, planning is broken, the company is growing but alignment is worse, or leadership meetings consume all time without producing decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-partnership-architecture",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-partnership-architecture",
+          "description": "Build and scale partner ecosystems that drive revenue and platform adoption. Use when building partner programs from scratch, tiering partnerships, managing co-marketing, making build-vs-partner decisions, or structuring crawl-walk-run partner deployment.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-product-led-growth",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-product-led-growth",
+          "description": "Build self-serve acquisition and expansion motions. Use when deciding PLG vs sales-led, optimizing activation, driving freemium conversion, building growth equations, or recognizing when product complexity demands human touch. Includes the parallel test where sales-led won 10x on revenue.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-technical-product-pricing",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-technical-product-pricing",
+          "description": "Pricing strategy for technical products. Use when choosing usage-based vs seat-based, designing freemium thresholds, structuring enterprise pricing conversations, deciding when to raise prices, or using price as a positioning signal.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "impediment-prioritization",
+          "installUrl": "github:github/awesome-copilot:skills/impediment-prioritization",
+          "description": "Ranks any list of impediments and their countermeasures using a value-stream scoring model (ROI, Cost to Implement, Ease of Deployment, Risk Factor) and a fixed prioritization formula. Use when someone asks to prioritize, rank, sequence, or triage impediments, countermeasures, remediation items, risks, findings, gaps, action items, or backlog entries; or mentions value-stream prioritization, A3 / lean countermeasure ranking, ROI vs. effort scoring, or building a remediation / improvement backlog. Works with GHQR findings, audit results, retrospective action items, risk registers, architecture review gaps, or any free-form `{impediment, countermeasure}` list.",
+          "version": "2.0.0"
+        },
+        {
+          "name": "integrate-context-matic",
+          "installUrl": "github:github/awesome-copilot:skills/integrate-context-matic",
+          "description": "Discovers and integrates third-party APIs using the context-matic MCP server. Uses `fetch_api` to find available API SDKs, `ask` for integration guidance, `model_search` and `endpoint_search` for SDK details. Use when the user asks to integrate a third-party API, add an API client, implement features with an external API, or work with any third-party API or SDK.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "java-add-graalvm-native-image-support",
+          "installUrl": "github:github/awesome-copilot:skills/java-add-graalvm-native-image-support",
+          "description": "GraalVM Native Image expert that adds native image support to Java applications, builds the project, analyzes build errors, applies fixes, and iterates until successful compilation using Oracle best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "java-mcp-server-generator",
+          "installUrl": "github:github/awesome-copilot:skills/java-mcp-server-generator",
+          "description": "Generate a complete Model Context Protocol server project in Java using the official MCP Java SDK with reactive streams and optional Spring Boot integration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "legacy-circuit-mockups",
+          "installUrl": "github:github/awesome-copilot:skills/legacy-circuit-mockups",
+          "description": "Generate breadboard circuit mockups and visual diagrams using HTML5 Canvas drawing techniques. Use when asked to create circuit layouts, visualize electronic component placements, draw breadboard diagrams, mockup 6502 builds, generate retro computer schematics, or design vintage electronics projects. Supports 555 timers, W65C02S microprocessors, 28C256 EEPROMs, W65C22 VIA chips, 7400-series logic gates, LEDs, resistors, capacitors, switches, buttons, crystals, and wires.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "linkedin-post-formatter",
+          "installUrl": "github:github/awesome-copilot:skills/linkedin-post-formatter",
+          "description": "Format and draft compelling LinkedIn posts using Unicode bold/italic styling, visual separators, structured sections, and engagement-optimized patterns. USE FOR: draft LinkedIn post, format text for LinkedIn, create social media post, write thought leadership post, convert content to LinkedIn format, LinkedIn carousel text, Unicode bold italic formatting.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "make-repo-contribution",
+          "installUrl": "github:github/awesome-copilot:skills/make-repo-contribution",
+          "description": "All changes to code must follow the guidance documented in the repository. Before any issue is filed, branch is made, commits generated, or pull request (or PR) created, a search must be done to ensure the right steps are followed. Whenever asked to create an issue, commit messages, to push code, or create a PR, use this skill so everything is done correctly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "make-skill-template",
+          "installUrl": "github:github/awesome-copilot:skills/make-skill-template",
+          "description": "Create new Agent Skills for GitHub Copilot from prompts or by duplicating this template. Use when asked to \"create a skill\", \"make a new skill\", \"scaffold a skill\", or when building specialized AI capabilities with bundled resources. Generates SKILL.md files with proper frontmatter, directory structure, and optional scripts/references/assets folders.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "markdown-to-html",
+          "installUrl": "github:github/awesome-copilot:skills/markdown-to-html",
+          "description": "Convert Markdown files to HTML similar to `marked.js`, `pandoc`, `gomarkdown/markdown`, or similar tools; or writing custom script to convert markdown to html and/or working on web template systems like `jekyll/jekyll`, `gohugoio/hugo`, or similar web templating systems that utilize markdown documents, converting them to html. Use when asked to \"convert markdown to html\", \"transform md to html\", \"render markdown\", \"generate html from markdown\", or when working with .md files and/or web a templating system that converts markdown to HTML output. Supports CLI and Node.js workflows with GFM, CommonMark, and standard Markdown flavors.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "github",
+        "repo": "awesome-copilot",
+        "repoUrl": "https://github.com/github/awesome-copilot.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "github-awesome-copilot-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from github/awesome-copilot.",
+      "author": "ASM (github/awesome-copilot)",
+      "createdAt": "2026-05-09T08:10:57.006Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "github",
+        "awesome-copilot"
+      ],
+      "skills": [
+        {
+          "name": "acquire-codebase-knowledge",
+          "installUrl": "github:github/awesome-copilot:skills/acquire-codebase-knowledge",
+          "description": "Use this skill when the user explicitly asks to map, document, or onboard into an existing codebase. Trigger for prompts like \"map this codebase\", \"document this architecture\", \"onboard me to this repo\", or \"create codebase docs\". Do not trigger for routine feature implementation, bug fixes, or narrow code edits unless the user asks for repository-level discovery.",
+          "version": "1.3"
+        },
+        {
+          "name": "acreadiness-assess",
+          "installUrl": "github:github/awesome-copilot:skills/acreadiness-assess",
+          "description": "Run the AgentRC readiness assessment on the current repository and produce a static HTML dashboard at reports/index.html. Wraps `npx github:microsoft/agentrc readiness` and hands off rendering to the @ai-readiness-reporter custom agent. Supports policies (--policy) for org-specific scoring. Use when asked to assess, audit, or score the AI readiness of a repo.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "acreadiness-policy",
+          "installUrl": "github:github/awesome-copilot:skills/acreadiness-policy",
+          "description": "Help the user pick, write, or apply an AgentRC policy. Policies customise readiness scoring by disabling irrelevant checks, overriding impact/level, setting pass-rate thresholds, or chaining org baselines with team overrides. Use when the user asks about strict mode, AI-only scoring, custom weights, CI gating, or wants org-wide standardisation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "add-educational-comments",
+          "installUrl": "github:github/awesome-copilot:skills/add-educational-comments",
+          "description": "Add educational comments to the file specified, or prompt asking for file to comment if one is not provided.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "adobe-illustrator-scripting",
+          "installUrl": "github:github/awesome-copilot:skills/adobe-illustrator-scripting",
+          "description": "Write, debug, and optimize Adobe Illustrator automation scripts using ExtendScript (JavaScript/JSX). Use when creating or modifying scripts that manipulate documents, layers, paths, text frames, colors, symbols, artboards, or any Illustrator DOM objects. Covers the complete JavaScript object model, coordinate system, measurement units, export workflows, and scripting best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-governance",
+          "installUrl": "github:github/awesome-copilot:skills/agent-governance",
+          "description": "Patterns and techniques for adding governance, safety, and trust controls to AI agent systems. Use this skill when: - Building AI agents that call external tools (APIs, databases, file systems) - Implementing policy-based access controls for agent tool usage - Adding semantic intent classification to detect dangerous prompts - Creating trust scoring systems for multi-agent workflows - Building audit trails for agent actions and decisions - Enforcing rate limits, content filters, or tool restrictions on agents - Working with any agent framework (PydanticAI, CrewAI, OpenAI Agents, LangChain, AutoGen)",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-owasp-compliance",
+          "installUrl": "github:github/awesome-copilot:skills/agent-owasp-compliance",
+          "description": "Check any AI agent codebase against the OWASP Agentic Security Initiative (ASI) Top 10 risks. Use this skill when: - Evaluating an agent system's security posture before production deployment - Running a compliance check against OWASP ASI 2026 standards - Mapping existing security controls to the 10 agentic risks - Generating a compliance report for security review or audit - Comparing agent framework security features against the standard - Any request like \"is my agent OWASP compliant?\", \"check ASI compliance\", or \"agentic security audit\"",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-supply-chain",
+          "installUrl": "github:github/awesome-copilot:skills/agent-supply-chain",
+          "description": "Verify supply chain integrity for AI agent plugins, tools, and dependencies. Use this skill when: - Generating SHA-256 integrity manifests for agent plugins or tool packages - Verifying that installed plugins match their published manifests - Detecting tampered, modified, or untracked files in agent tool directories - Auditing dependency pinning and version policies for agent components - Building provenance chains for agent plugin promotion (dev → staging → production) - Any request like \"verify plugin integrity\", \"generate manifest\", \"check supply chain\", or \"sign this plugin\"",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentic-eval",
+          "installUrl": "github:github/awesome-copilot:skills/agentic-eval",
+          "description": "Patterns and techniques for evaluating and improving AI agent outputs. Use this skill when: - Implementing self-critique and reflection loops - Building evaluator-optimizer pipelines for quality-critical generation - Creating test-driven code refinement workflows - Designing rubric-based or LLM-as-judge evaluation systems - Adding iterative improvement to agent outputs (code, reports, analysis) - Measuring and improving agent response quality",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-ready",
+          "installUrl": "github:github/awesome-copilot:skills/ai-ready",
+          "description": "Make any repo AI-ready — analyzes your codebase and generates AGENTS.md, copilot-instructions.md, CI workflows, issue templates, and more. Mines your PR review patterns and creates files customized to your stack. USE THIS SKILL when the user asks to \"make this repo ai-ready\", \"set up AI config\", or \"prepare this repo for AI contributions\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-team-orchestration",
+          "installUrl": "github:github/awesome-copilot:skills/ai-team-orchestration",
+          "description": "Bootstrap and run a multi-agent AI development team. Use when: starting a new software project with AI agents, setting up parallel dev/QA teams, creating sprint plans, writing brainstorm prompts with distinct agent voices, recovering a project workflow, or planning sprints.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arch-linux-triage",
+          "installUrl": "github:github/awesome-copilot:skills/arch-linux-triage",
+          "description": "Triage and resolve Arch Linux issues with pacman, systemd, and rolling-release best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-annotation",
+          "installUrl": "github:github/awesome-copilot:skills/arize-annotation",
+          "description": "INVOKE THIS SKILL when creating, managing, or using annotation configs or annotation queues on Arize (categorical, continuous, freeform), or applying human annotations to project spans via the Python SDK. Configs are the label schema for human feedback; queues are review workflows that route records to annotators. Triggers: annotation config, annotation queue, label schema, human feedback schema, bulk annotate spans, update_annotations, labeling queue, annotate record.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-evaluator",
+          "installUrl": "github:github/awesome-copilot:skills/arize-evaluator",
+          "description": "INVOKE THIS SKILL for LLM-as-judge evaluation workflows on Arize: creating/updating evaluators, running evaluations on spans or experiments, tasks, trigger-run, column mapping, and continuous monitoring. Use when the user says: create an evaluator, LLM judge, hallucination/faithfulness/correctness/relevance, run eval, score my spans or experiment, ax tasks, trigger-run, trigger eval, column mapping, continuous monitoring, query filter for evals, evaluator version, or improve an evaluator prompt.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-experiment",
+          "installUrl": "github:github/awesome-copilot:skills/arize-experiment",
+          "description": "INVOKE THIS SKILL when creating, running, or analyzing Arize experiments. Also use when the user wants to evaluate or measure model performance, compare models (including GPT-4, Claude, or others), or assess how well their AI is doing. Covers experiment CRUD, exporting runs, comparing results, and evaluation workflows using the ax CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-instrumentation",
+          "installUrl": "github:github/awesome-copilot:skills/arize-instrumentation",
+          "description": "INVOKE THIS SKILL when adding Arize AX tracing or observability to an app for the first time, or when the user wants to instrument their LLM app or get started with LLM observability. Follow the Agent-Assisted Tracing two-phase flow: analyze the codebase (read-only), then implement after user confirmation. When the app uses LLM tool/function calling, add manual CHAIN + TOOL spans. Leverages https://arize.com/docs/ax/alyx/tracing-assistant and https://arize.com/docs/PROMPT.md.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-link",
+          "installUrl": "github:github/awesome-copilot:skills/arize-link",
+          "description": "Generate deep links to the Arize UI. Use when the user wants a clickable URL to open or share a specific trace, span, session, dataset, labeling queue, evaluator, or annotation config, or when sharing Arize resources with team members.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aspire",
+          "installUrl": "github:github/awesome-copilot:skills/aspire",
+          "description": "Aspire skill covering the Aspire CLI, AppHost orchestration, service discovery, integrations, MCP server, VS Code extension, Dev Containers, GitHub Codespaces, templates, dashboard, and deployment. Use when the user asks to create, run, debug, configure, deploy, or troubleshoot an Aspire distributed application.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "automate-this",
+          "installUrl": "github:github/awesome-copilot:skills/automate-this",
+          "description": "Analyze a screen recording of a manual process and produce targeted, working automation scripts. Extracts frames and audio narration from video files, reconstructs the step-by-step workflow, and proposes automation at multiple complexity levels using tools already installed on the user machine.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-cdk-python-setup",
+          "installUrl": "github:github/awesome-copilot:skills/aws-cdk-python-setup",
+          "description": "Setup and initialization guide for developing AWS CDK (Cloud Development Kit) applications in Python. This skill enables users to configure environment prerequisites, create new CDK projects, manage dependencies, and deploy to AWS.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-architecture-autopilot",
+          "installUrl": "github:github/awesome-copilot:skills/azure-architecture-autopilot",
+          "description": "Design Azure infrastructure using natural language, or analyze existing Azure resources to auto-generate architecture diagrams, refine them through conversation, and deploy with Bicep. When to use this skill: - \"Create X on Azure\", \"Set up a RAG architecture\" (new design) - \"Analyze my current Azure infrastructure\", \"Draw a diagram for rg-xxx\" (existing analysis) - \"Foundry is slow\", \"I want to reduce costs\", \"Strengthen security\" (natural language modification) - Azure resource deployment, Bicep template generation, IaC code generation - Microsoft Foundry, AI Search, OpenAI, Fabric, ADLS Gen2, Databricks, and all Azure services",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-deployment-preflight",
+          "installUrl": "github:github/awesome-copilot:skills/azure-deployment-preflight",
+          "description": "Performs comprehensive preflight validation of Bicep deployments to Azure, including template syntax validation, what-if analysis, and permission checks. Use this skill before any deployment to Azure to preview changes, identify potential issues, and ensure the deployment will succeed. Activate when users mention deploying to Azure, validating Bicep files, checking deployment permissions, previewing infrastructure changes, running what-if, or preparing for azd provision.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-devops-cli",
+          "installUrl": "github:github/awesome-copilot:skills/azure-devops-cli",
+          "description": "Manage Azure DevOps resources via CLI including projects, repos, pipelines, builds, pull requests, work items, artifacts, and service endpoints. Use when working with Azure DevOps, az commands, devops automation, CI/CD, or when user mentions Azure DevOps CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-pricing",
+          "installUrl": "github:github/awesome-copilot:skills/azure-pricing",
+          "description": "Fetches real-time Azure retail pricing using the Azure Retail Prices API (prices.azure.com) and estimates Copilot Studio agent credit consumption. Use when the user asks about the cost of any Azure service, wants to compare SKU prices, needs pricing data for a cost estimate, mentions Azure pricing, Azure costs, Azure billing, or asks about Copilot Studio pricing, Copilot Credits, or agent usage estimation. Covers compute, storage, networking, databases, AI, Copilot Studio, and all other Azure service families.",
+          "version": "1.2"
+        },
+        {
+          "name": "azure-smart-city-iot-solution-builder",
+          "installUrl": "github:github/awesome-copilot:skills/azure-smart-city-iot-solution-builder",
+          "description": "Design and plan end-to-end Azure IoT and Smart City solutions: requirements, architecture, security, operations, cost, and a phased delivery plan with concrete implementation artifacts.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-static-web-apps",
+          "installUrl": "github:github/awesome-copilot:skills/azure-static-web-apps",
+          "description": "Helps create, configure, and deploy Azure Static Web Apps using the SWA CLI. Use when deploying static sites to Azure, setting up SWA local development, configuring staticwebapp.config.json, adding Azure Functions APIs to SWA, or setting up GitHub Actions CI/CD for Static Web Apps.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bigquery-pipeline-audit",
+          "installUrl": "github:github/awesome-copilot:skills/bigquery-pipeline-audit",
+          "description": "Audits Python + BigQuery pipelines for cost safety, idempotency, and production readiness. Returns a structured report with exact patch locations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "boost-prompt",
+          "installUrl": "github:github/awesome-copilot:skills/boost-prompt",
+          "description": "Interactive prompt refinement workflow: interrogates scope, deliverables, constraints; copies final markdown to clipboard; never writes code. Requires the Joyride extension.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brag-sheet",
+          "installUrl": "github:github/awesome-copilot:skills/brag-sheet",
+          "description": "Turn vague \"what did I do?\" into evidence-backed impact statements for performance reviews, self-reviews, promotion packets, and weekly updates. Uniquely mines Copilot CLI session logs to reconstruct forgotten work, plus git commits and GitHub PRs. Enforces a 3-part impact contract (action → result → evidence). Works standalone with zero dependencies. Trigger for: \"brag\", \"log work\", \"what did I do\", \"backfill my work history\", \"performance review\", \"self-review\", \"self assessment\", \"write impact statement\", \"review prep\", \"promo packet\", \"promotion case\", \"weekly update\", \"status report\", \"accomplishments\", \"what did I ship\", \"I forgot to log my work\", \"summarize my work\", \"track my wins\", \"what should I highlight\", \"end of half\", \"career growth\", \"work journal\", or any request to document, summarize, or organize work accomplishments.",
+          "version": "1.1"
+        },
+        {
+          "name": "breakdown-epic-pm",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-epic-pm",
+          "description": "Prompt for creating an Epic Product Requirements Document (PRD) for a new epic. This PRD will be used as input for generating a technical architecture specification.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "breakdown-plan",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-plan",
+          "description": "Issue Planning and Automation prompt that generates comprehensive project plans with Epic > Feature > Story/Enabler > Test hierarchy, dependencies, priorities, and automated tracking.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cloud-design-patterns",
+          "installUrl": "github:github/awesome-copilot:skills/cloud-design-patterns",
+          "description": "Cloud design patterns for distributed systems architecture covering 42 industry-standard patterns across reliability, performance, messaging, security, and deployment categories. Use when designing, reviewing, or implementing distributed system architectures.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "codeql",
+          "installUrl": "github:github/awesome-copilot:skills/codeql",
+          "description": "Comprehensive guide for setting up and configuring CodeQL code scanning via GitHub Actions workflows and the CodeQL CLI. This skill should be used when users need help with code scanning configuration, CodeQL workflow files, CodeQL CLI commands, SARIF output, security analysis setup, or troubleshooting CodeQL analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "containerize-aspnet-framework",
+          "installUrl": "github:github/awesome-copilot:skills/containerize-aspnet-framework",
+          "description": "Containerize an ASP.NET .NET Framework project by creating Dockerfile and .dockerfile files customized for the project.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "containerize-aspnetcore",
+          "installUrl": "github:github/awesome-copilot:skills/containerize-aspnetcore",
+          "description": "Containerize an ASP.NET Core project by creating Dockerfile and .dockerfile files customized for the project.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-management-systems",
+          "installUrl": "github:github/awesome-copilot:skills/content-management-systems",
+          "description": "Workflow for building and modifying content management systems across WordPress, Shopify, Wix, Squarespace, Drupal, WooCommerce, Joomla, HubSpot CMS Hub, Webflow, Adobe Experience Manager, and similar platforms. Use when working on CMS themes, plugins, apps, modules, admin panels, media uploads, content models, editors, markdown pipelines, or static export workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "conventional-commit",
+          "installUrl": "github:github/awesome-copilot:skills/conventional-commit",
+          "description": "Prompt and workflow for generating conventional commit messages using a structured XML format. Guides users to create standardized, descriptive commit messages in line with the Conventional Commits specification, including instructions, examples, and validation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copilot-cli-quickstart",
+          "installUrl": "github:github/awesome-copilot:skills/copilot-cli-quickstart",
+          "description": "Use this skill when someone wants to learn GitHub Copilot CLI from scratch. Offers interactive step-by-step tutorials with separate Developer and Non-Developer tracks, plus on-demand Q&A. Just say \"start tutorial\" or ask a question! Note: This skill targets GitHub Copilot CLI specifically and uses CLI-specific tools (ask_user, sql, fetch_copilot_cli_documentation).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copilot-spaces",
+          "installUrl": "github:github/awesome-copilot:skills/copilot-spaces",
+          "description": "Use Copilot Spaces to provide project-specific context to conversations. Use this skill when users mention a \"Copilot space\", want to load context from a shared knowledge base, discover available spaces, or ask questions grounded in curated project documentation, code, and instructions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-architectural-decision-record",
+          "installUrl": "github:github/awesome-copilot:skills/create-architectural-decision-record",
+          "description": "Create an Architectural Decision Record (ADR) document for AI-optimized decision documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-github-action-workflow-specification",
+          "installUrl": "github:github/awesome-copilot:skills/create-github-action-workflow-specification",
+          "description": "Create a formal specification for an existing GitHub Actions CI/CD workflow, optimized for AI consumption and workflow maintenance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-github-issue-feature-from-specification",
+          "installUrl": "github:github/awesome-copilot:skills/create-github-issue-feature-from-specification",
+          "description": "Create GitHub Issue for feature request from specification file using feature_request.yml template.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-github-issues-for-unmet-specification-requirements",
+          "installUrl": "github:github/awesome-copilot:skills/create-github-issues-for-unmet-specification-requirements",
+          "description": "Create GitHub Issues for unimplemented requirements from specification files using feature_request.yml template.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-github-pull-request-from-specification",
+          "installUrl": "github:github/awesome-copilot:skills/create-github-pull-request-from-specification",
+          "description": "Create GitHub Pull Request for feature request from specification file using pull_request_template.md template.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-implementation-plan",
+          "installUrl": "github:github/awesome-copilot:skills/create-implementation-plan",
+          "description": "Create a new implementation plan file for new features, refactoring existing code or upgrading packages, design, architecture or infrastructure.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-llms",
+          "installUrl": "github:github/awesome-copilot:skills/create-llms",
+          "description": "Create an llms.txt file from scratch based on repository structure following the llms.txt specification at https://llmstxt.org/",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-specification",
+          "installUrl": "github:github/awesome-copilot:skills/create-specification",
+          "description": "Create a new specification file for the solution, optimized for Generative AI consumption.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-technical-spike",
+          "installUrl": "github:github/awesome-copilot:skills/create-technical-spike",
+          "description": "Create time-boxed technical spike documents for researching and resolving critical development decisions before implementation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "creating-oracle-to-postgres-master-migration-plan",
+          "installUrl": "github:github/awesome-copilot:skills/creating-oracle-to-postgres-master-migration-plan",
+          "description": "Discovers all projects in a .NET solution, classifies each for Oracle-to-PostgreSQL migration eligibility, and produces a persistent master migration plan. Use when starting a multi-project Oracle-to-PostgreSQL migration, creating a migration inventory, or assessing which .NET projects contain Oracle dependencies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "data-breach-blast-radius",
+          "installUrl": "github:github/awesome-copilot:skills/data-breach-blast-radius",
+          "description": "Pre-breach impact analysis: inventories sensitive data (PII, PHI, PCI-DSS, credentials), traces data flows, scores exposure vectors, and produces a regulatory blast radius report with fine ranges sourced verbatim from GDPR Art. 83, CCPA § 1798.155(a), and HIPAA 45 CFR § 160.404. Cost benchmarks from IBM Cost of a Data Breach Report (annually updated). All citations in references/SOURCES.md for verification. Use when asked: \"assess breach impact\", \"what data could be exposed\", \"calculate blast radius\", \"data exposure analysis\", \"how bad would a breach be\", \"quantify data risk\", \"sensitive data inventory\", \"data flow security audit\", \"pre-breach assessment\", \"worst-case breach scenario\", \"breach readiness\", \"data risk report\", \"/data-breach-blast-radius\". For any stack handling user data, health records, or financial information. Output labels law-sourced figures (exact) vs heuristic estimates (planning only). Does not replace legal counsel.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "datanalysis-credit-risk",
+          "installUrl": "github:github/awesome-copilot:skills/datanalysis-credit-risk",
+          "description": "Credit risk data cleaning and variable screening pipeline for pre-loan modeling. Use when working with raw credit data that needs quality assessment,  missing value analysis, or variable selection before modeling. it covers data loading and formatting, abnormal period filtering, missing rate calculation, high-missing variable removal,low-IV variable filtering, high-PSI variable removal, Null Importance denoising, high-correlation variable removal, and cleaning report generation. Applicable scenarios arecredit risk data cleaning, variable screening, pre-loan modeling preprocessing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dataverse-python-quickstart",
+          "installUrl": "github:github/awesome-copilot:skills/dataverse-python-quickstart",
+          "description": "Generate Python SDK setup + CRUD + bulk + paging snippets using official patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dataverse-python-usecase-builder",
+          "installUrl": "github:github/awesome-copilot:skills/dataverse-python-usecase-builder",
+          "description": "Generate complete solutions for specific Dataverse SDK use cases with architecture recommendations",
+          "version": "0.0.0"
+        },
+        {
+          "name": "declarative-agents",
+          "installUrl": "github:github/awesome-copilot:skills/declarative-agents",
+          "description": "Complete development kit for Microsoft 365 Copilot declarative agents with three comprehensive workflows (basic, advanced, validation), TypeSpec support, and Microsoft 365 Agents Toolkit integration",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dependabot",
+          "installUrl": "github:github/awesome-copilot:skills/dependabot",
+          "description": "Comprehensive guide for configuring and managing GitHub Dependabot. Use this skill when users ask about creating or optimizing dependabot.yml files, managing Dependabot pull requests, configuring dependency update strategies, setting up grouped updates, monorepo patterns, multi-ecosystem groups, security update configuration, auto-triage rules, or any GitHub Advanced Security (GHAS) supply chain security topic related to Dependabot. For pre-commit dependency vulnerability scanning in AI coding agents via the GitHub MCP Server, this skill references the Advanced Security plugin (`advanced-security@copilot-plugins`). Use this skill when an agent needs to scan dependencies for known vulnerabilities before committing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "devops-rollout-plan",
+          "installUrl": "github:github/awesome-copilot:skills/devops-rollout-plan",
+          "description": "Generate comprehensive rollout plans with preflight checks, step-by-step deployment, verification signals, rollback procedures, and communication plans for infrastructure and application changes",
+          "version": "0.0.0"
+        },
+        {
+          "name": "diagnose",
+          "installUrl": "github:github/awesome-copilot:skills/diagnose",
+          "description": "Perform a systematic diagnostic scan of an AI workflow across 5 quality dimensions — prompt quality, context efficiency, tool health, architecture fitness, and safety — producing a scored report with prioritized remediation actions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "documentation-writer",
+          "installUrl": "github:github/awesome-copilot:skills/documentation-writer",
+          "description": "Diátaxis Documentation Expert. An expert technical writer specializing in creating high-quality software documentation, guided by the principles and structure of the Diátaxis technical documentation authoring framework.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dotnet-timezone",
+          "installUrl": "github:github/awesome-copilot:skills/dotnet-timezone",
+          "description": ".NET timezone handling guidance for C# applications. Use when working with TimeZoneInfo, DateTimeOffset, NodaTime, UTC conversion, daylight saving time, scheduling across timezones, cross-platform Windows/IANA timezone IDs, or when a .NET user needs the timezone for a city, address, region, or country and copy-paste-ready C# code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "doublecheck",
+          "installUrl": "github:github/awesome-copilot:skills/doublecheck",
+          "description": "Three-layer verification pipeline for AI output. Extracts verifiable claims, finds supporting or contradicting sources via web search, runs adversarial review for hallucination patterns, and produces a structured verification report with source links for human review.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "draw-io-diagram-generator",
+          "installUrl": "github:github/awesome-copilot:skills/draw-io-diagram-generator",
+          "description": "Use when creating, editing, or generating draw.io diagram files (.drawio, .drawio.svg, .drawio.png). Covers mxGraph XML authoring, shape libraries, style strings, flowcharts, system architecture, sequence diagrams, ER diagrams, UML class diagrams, network topology, layout strategy, the hediet.vscode-drawio VS Code extension, and the full agent workflow from request to a ready-to-open file.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "email-drafter",
+          "installUrl": "github:github/awesome-copilot:skills/email-drafter",
+          "description": "Draft and review professional emails that match your personal writing style. Analyzes your sent emails for tone, greeting, structure, and sign-off patterns via WorkIQ, then generates context-aware drafts for any recipient. USE FOR: draft email, write email, compose email, reply email, follow-up email, analyze email tone, email style.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "finnish-humanizer",
+          "installUrl": "github:github/awesome-copilot:skills/finnish-humanizer",
+          "description": "Detect and remove AI-generated markers from Finnish text, making it sound like a native Finnish speaker wrote it. Use when asked to \"humanize\", \"naturalize\", or \"remove AI feel\" from Finnish text, or when editing .md/.txt files containing Finnish content. Identifies 26 patterns (12 Finnish-specific + 14 universal) and 4 style markers.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "first-ask",
+          "installUrl": "github:github/awesome-copilot:skills/first-ask",
+          "description": "Interactive, input-tool powered, task refinement workflow: interrogates scope, deliverables, constraints before carrying out the task; Requires the Joyride extension.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-build",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-build",
+          "description": "Build, scaffold, and deploy Power Automate cloud flows using the FlowStudio MCP server. Your agent constructs flow definitions, wires connections, deploys, and tests — all via MCP without opening the portal. Load this skill when asked to: create a flow, build a new flow, deploy a flow definition, scaffold a Power Automate workflow, construct a flow JSON, update an existing flow's actions, patch a flow definition, add actions to a flow, wire up connections, or generate a workflow definition from scratch. Requires a FlowStudio MCP subscription — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-debug",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-debug",
+          "description": "Debug failing Power Automate cloud flows using the FlowStudio MCP server. The Graph API only shows top-level status codes. This skill gives your agent action-level inputs and outputs to find the actual root cause. Load this skill when asked to: debug a flow, investigate a failed run, why is this flow failing, inspect action outputs, find the root cause of a flow error, fix a broken Power Automate flow, diagnose a timeout, trace a DynamicOperationRequestFailure, check connector auth errors, read error details from a run, or troubleshoot expression failures. Requires a FlowStudio MCP subscription — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-mcp",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-mcp",
+          "description": "Foundation skill for Power Automate via FlowStudio MCP — auth setup, the reusable MCP helper (Python + Node.js), tool discovery via `list_skills` / `tool_search`, and oversized-response handling. Load this skill first when connecting an agent to Power Automate. For specialized workflows, load `power-automate-build`, `power-automate-debug`, `power-automate-monitoring` (Pro+), or `power-automate-governance` (Pro+) — each contains the workflow narrative, this skill provides the plumbing they all rely on. Requires a FlowStudio MCP subscription or compatible server — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-monitoring",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-monitoring",
+          "description": "**Pro+ subscription required.** Tenant-wide Power Automate flow health monitoring, failure rate analytics, and asset inventory using the FlowStudio MCP cached store. Load this skill ONLY for tenant-wide aggregated views — not for listing flows in a single environment or debugging a specific run (use power-automate-mcp or power-automate-debug for those). Not the same as the server's `monitor-flow` tool bundle (`tool_search query: \"skill:monitor-flow\"`) — that bundle is for runtime control of a single flow (start/stop/trigger/ cancel/resubmit); this skill is for tenant-wide health analytics over the cached store. Load when asked to: monitor tenant health, get aggregated failure rates over a time window, review tenant-wide error trends, find inactive makers across the tenant, inventory all Power Apps in the tenant, compute governance scores, generate a compliance report, or run a tenant-wide health overview. Requires a FlowStudio for Teams or MCP Pro+ subscription — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "foundry-agent-sync",
+          "installUrl": "github:github/awesome-copilot:skills/foundry-agent-sync",
+          "description": "Create and synchronize prompt-based AI agents directly within Azure AI Foundry via REST API, from a local JSON manifest. Unlike scaffolding skills that only generate local code, this skill registers agents in the Foundry service itself — making them immediately available for invocation. Use when the user asks to create agents in Foundry, sync, deploy, register, or push agents to Foundry, update agent instructions, or scaffold the manifest and sync script for a new repository. Triggers: 'create agent in foundry', 'sync foundry agents', 'deploy agents to foundry', 'register agents in foundry', 'push agents', 'create foundry agent manifest', 'scaffold agent sync'.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gdpr-compliant",
+          "installUrl": "github:github/awesome-copilot:skills/gdpr-compliant",
+          "description": "Apply GDPR-compliant engineering practices across your codebase. Use this skill whenever you are designing APIs, writing data models, building authentication flows, implementing logging, handling user data, writing retention/deletion jobs, designing cloud infrastructure, or reviewing pull requests for privacy compliance. Trigger this skill for any task involving personal data, user accounts, cookies, analytics, emails, audit logs, encryption, pseudonymization, anonymization, data exports, breach response, CI/CD pipelines that process real data, or any question framed as \"is this GDPR-compliant?\". Inspired by CNIL developer guidance and GDPR Articles 5, 25, 32, 33, 35.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gen-specs-as-issues",
+          "installUrl": "github:github/awesome-copilot:skills/gen-specs-as-issues",
+          "description": "This workflow guides you through a systematic approach to identify missing features, prioritize them, and create detailed specifications for implementation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "generate-custom-instructions-from-codebase",
+          "installUrl": "github:github/awesome-copilot:skills/generate-custom-instructions-from-codebase",
+          "description": "Migration and code evolution instructions generator for GitHub Copilot. Analyzes differences between two project versions (branches, commits, or releases) to create precise instructions allowing Copilot to maintain consistency during technology migrations, major refactoring, or framework version upgrades.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "geofeed-tuner",
+          "installUrl": "github:github/awesome-copilot:skills/geofeed-tuner",
+          "description": "Use this skill whenever the user mentions IP geolocation feeds, RFC 8805, geofeeds, or wants help creating, tuning, validating, or publishing a self-published IP geolocation feed in CSV format. Intended user audience is a network operator, ISP, mobile carrier, cloud provider, hosting company, IXP, or satellite provider asking about IP geolocation accuracy, or geofeed authoring best practices. Helps create, refine, and improve CSV-format IP geolocation feeds with opinionated recommendations beyond RFC 8805 compliance. Do NOT use for private or internal IP address management — applies only to publicly routable IP addresses.",
+          "version": "0.0.9"
+        },
+        {
+          "name": "gh-cli",
+          "installUrl": "github:github/awesome-copilot:skills/gh-cli",
+          "description": "GitHub CLI (gh) comprehensive reference for repositories, issues, pull requests, Actions, projects, releases, gists, codespaces, organizations, extensions, and all GitHub operations from the command line.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "github-issues",
+          "installUrl": "github:github/awesome-copilot:skills/github-issues",
+          "description": "Create, update, and manage GitHub issues using MCP tools. Use this skill when users want to create bug reports, feature requests, or task issues, update existing issues, add labels/assignees/milestones, set issue fields (dates, priority, custom fields), set issue types, manage issue workflows, link issues, add dependencies, or track blocked-by/blocking relationships. Triggers on requests like \"create an issue\", \"file a bug\", \"request a feature\", \"update issue X\", \"set the priority\", \"set the start date\", \"link issues\", \"add dependency\", \"blocked by\", \"blocking\", or any GitHub issue management task.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "github-release",
+          "installUrl": "github:github/awesome-copilot:skills/github-release",
+          "description": "Guides IA through releasing a new version of a GitHub library end-to-end.  Handles SemVer versioning and Keep a Changelog formatting automatically.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "go-mcp-server-generator",
+          "installUrl": "github:github/awesome-copilot:skills/go-mcp-server-generator",
+          "description": "Generate a complete Go MCP server project with proper structure, dependencies, and implementation using the official github.com/modelcontextprotocol/go-sdk.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-ai-gtm",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-ai-gtm",
+          "description": "Go-to-market strategy for AI products. Use when positioning AI products, handling \"who is responsible when it breaks\" objections, pricing variable-cost AI, choosing between copilot/agent/teammate framing, or selling autonomous tools into enterprises.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-board-and-investor-communication",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-board-and-investor-communication",
+          "description": "Board meeting preparation, investor updates, and executive communication. Use when preparing board decks, writing investor updates, handling bad news with the board, structuring QBRs, or building board-level metric discipline. Includes the \"Three Things\" narrative model, the 4-tier metric hierarchy, and the pre-brief pattern that prevents board surprises.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-developer-ecosystem",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-developer-ecosystem",
+          "description": "Build and scale developer-led adoption through ecosystem programs. Use when deciding open vs curated ecosystems, building developer programs, scaling platform adoption, or designing student program pipelines.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "github",
+        "repo": "awesome-copilot",
+        "repoUrl": "https://github.com/github/awesome-copilot.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "github-awesome-copilot-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from github/awesome-copilot.",
+      "author": "ASM (github/awesome-copilot)",
+      "createdAt": "2026-05-09T08:10:57.006Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "github",
+        "awesome-copilot"
+      ],
+      "skills": [
+        {
+          "name": "acquire-codebase-knowledge",
+          "installUrl": "github:github/awesome-copilot:skills/acquire-codebase-knowledge",
+          "description": "Use this skill when the user explicitly asks to map, document, or onboard into an existing codebase. Trigger for prompts like \"map this codebase\", \"document this architecture\", \"onboard me to this repo\", or \"create codebase docs\". Do not trigger for routine feature implementation, bug fixes, or narrow code edits unless the user asks for repository-level discovery.",
+          "version": "1.3"
+        },
+        {
+          "name": "acreadiness-assess",
+          "installUrl": "github:github/awesome-copilot:skills/acreadiness-assess",
+          "description": "Run the AgentRC readiness assessment on the current repository and produce a static HTML dashboard at reports/index.html. Wraps `npx github:microsoft/agentrc readiness` and hands off rendering to the @ai-readiness-reporter custom agent. Supports policies (--policy) for org-specific scoring. Use when asked to assess, audit, or score the AI readiness of a repo.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "acreadiness-generate-instructions",
+          "installUrl": "github:github/awesome-copilot:skills/acreadiness-generate-instructions",
+          "description": "Generate tailored AI agent instruction files via AgentRC instructions command. Produces .github/copilot-instructions.md (default, recommended for Copilot in VS Code) plus optional per-area .instructions.md files with applyTo globs for monorepos. Use after running /acreadiness-assess to close gaps in the AI Tooling pillar.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "acreadiness-policy",
+          "installUrl": "github:github/awesome-copilot:skills/acreadiness-policy",
+          "description": "Help the user pick, write, or apply an AgentRC policy. Policies customise readiness scoring by disabling irrelevant checks, overriding impact/level, setting pass-rate thresholds, or chaining org baselines with team overrides. Use when the user asks about strict mode, AI-only scoring, custom weights, CI gating, or wants org-wide standardisation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "add-educational-comments",
+          "installUrl": "github:github/awesome-copilot:skills/add-educational-comments",
+          "description": "Add educational comments to the file specified, or prompt asking for file to comment if one is not provided.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "adobe-illustrator-scripting",
+          "installUrl": "github:github/awesome-copilot:skills/adobe-illustrator-scripting",
+          "description": "Write, debug, and optimize Adobe Illustrator automation scripts using ExtendScript (JavaScript/JSX). Use when creating or modifying scripts that manipulate documents, layers, paths, text frames, colors, symbols, artboards, or any Illustrator DOM objects. Covers the complete JavaScript object model, coordinate system, measurement units, export workflows, and scripting best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-governance",
+          "installUrl": "github:github/awesome-copilot:skills/agent-governance",
+          "description": "Patterns and techniques for adding governance, safety, and trust controls to AI agent systems. Use this skill when: - Building AI agents that call external tools (APIs, databases, file systems) - Implementing policy-based access controls for agent tool usage - Adding semantic intent classification to detect dangerous prompts - Creating trust scoring systems for multi-agent workflows - Building audit trails for agent actions and decisions - Enforcing rate limits, content filters, or tool restrictions on agents - Working with any agent framework (PydanticAI, CrewAI, OpenAI Agents, LangChain, AutoGen)",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-owasp-compliance",
+          "installUrl": "github:github/awesome-copilot:skills/agent-owasp-compliance",
+          "description": "Check any AI agent codebase against the OWASP Agentic Security Initiative (ASI) Top 10 risks. Use this skill when: - Evaluating an agent system's security posture before production deployment - Running a compliance check against OWASP ASI 2026 standards - Mapping existing security controls to the 10 agentic risks - Generating a compliance report for security review or audit - Comparing agent framework security features against the standard - Any request like \"is my agent OWASP compliant?\", \"check ASI compliance\", or \"agentic security audit\"",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-supply-chain",
+          "installUrl": "github:github/awesome-copilot:skills/agent-supply-chain",
+          "description": "Verify supply chain integrity for AI agent plugins, tools, and dependencies. Use this skill when: - Generating SHA-256 integrity manifests for agent plugins or tool packages - Verifying that installed plugins match their published manifests - Detecting tampered, modified, or untracked files in agent tool directories - Auditing dependency pinning and version policies for agent components - Building provenance chains for agent plugin promotion (dev → staging → production) - Any request like \"verify plugin integrity\", \"generate manifest\", \"check supply chain\", or \"sign this plugin\"",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentic-eval",
+          "installUrl": "github:github/awesome-copilot:skills/agentic-eval",
+          "description": "Patterns and techniques for evaluating and improving AI agent outputs. Use this skill when: - Implementing self-critique and reflection loops - Building evaluator-optimizer pipelines for quality-critical generation - Creating test-driven code refinement workflows - Designing rubric-based or LLM-as-judge evaluation systems - Adding iterative improvement to agent outputs (code, reports, analysis) - Measuring and improving agent response quality",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-prompt-engineering-safety-review",
+          "installUrl": "github:github/awesome-copilot:skills/ai-prompt-engineering-safety-review",
+          "description": "Comprehensive AI prompt engineering safety review and improvement prompt. Analyzes prompts for safety, bias, security vulnerabilities, and effectiveness while providing detailed improvement recommendations with extensive frameworks, testing methodologies, and educational content.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-ready",
+          "installUrl": "github:github/awesome-copilot:skills/ai-ready",
+          "description": "Make any repo AI-ready — analyzes your codebase and generates AGENTS.md, copilot-instructions.md, CI workflows, issue templates, and more. Mines your PR review patterns and creates files customized to your stack. USE THIS SKILL when the user asks to \"make this repo ai-ready\", \"set up AI config\", or \"prepare this repo for AI contributions\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-team-orchestration",
+          "installUrl": "github:github/awesome-copilot:skills/ai-team-orchestration",
+          "description": "Bootstrap and run a multi-agent AI development team. Use when: starting a new software project with AI agents, setting up parallel dev/QA teams, creating sprint plans, writing brainstorm prompts with distinct agent voices, recovering a project workflow, or planning sprints.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "appinsights-instrumentation",
+          "installUrl": "github:github/awesome-copilot:skills/appinsights-instrumentation",
+          "description": "Instrument a webapp to send useful telemetry data to Azure App Insights",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/architecture-blueprint-generator",
+          "description": "Comprehensive project architecture blueprint generator that analyzes codebases to create detailed architectural documentation. Automatically detects technology stacks and architectural patterns, generates visual diagrams, documents implementation patterns, and provides extensible blueprints for maintaining architectural consistency and guiding new development.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arduino-azure-iot-edge-integration",
+          "installUrl": "github:github/awesome-copilot:skills/arduino-azure-iot-edge-integration",
+          "description": "Design and implement Arduino integration with Azure IoT Hub and IoT Edge, including secure provisioning, resilient telemetry, command handling, and production guardrails.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-ai-provider-integration",
+          "installUrl": "github:github/awesome-copilot:skills/arize-ai-provider-integration",
+          "description": "INVOKE THIS SKILL when creating, reading, updating, or deleting Arize AI integrations. Covers listing integrations, creating integrations for any supported LLM provider (OpenAI, Anthropic, Azure OpenAI, AWS Bedrock, Vertex AI, Gemini, NVIDIA NIM, custom), updating credentials or metadata, and deleting integrations using the ax CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-dataset",
+          "installUrl": "github:github/awesome-copilot:skills/arize-dataset",
+          "description": "INVOKE THIS SKILL when creating, managing, or querying Arize datasets and examples. Also use when the user needs test data or evaluation examples for their model. Covers dataset CRUD, appending examples, exporting data, and file-based dataset creation using the ax CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-evaluator",
+          "installUrl": "github:github/awesome-copilot:skills/arize-evaluator",
+          "description": "INVOKE THIS SKILL for LLM-as-judge evaluation workflows on Arize: creating/updating evaluators, running evaluations on spans or experiments, tasks, trigger-run, column mapping, and continuous monitoring. Use when the user says: create an evaluator, LLM judge, hallucination/faithfulness/correctness/relevance, run eval, score my spans or experiment, ax tasks, trigger-run, trigger eval, column mapping, continuous monitoring, query filter for evals, evaluator version, or improve an evaluator prompt.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-experiment",
+          "installUrl": "github:github/awesome-copilot:skills/arize-experiment",
+          "description": "INVOKE THIS SKILL when creating, running, or analyzing Arize experiments. Also use when the user wants to evaluate or measure model performance, compare models (including GPT-4, Claude, or others), or assess how well their AI is doing. Covers experiment CRUD, exporting runs, comparing results, and evaluation workflows using the ax CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-instrumentation",
+          "installUrl": "github:github/awesome-copilot:skills/arize-instrumentation",
+          "description": "INVOKE THIS SKILL when adding Arize AX tracing or observability to an app for the first time, or when the user wants to instrument their LLM app or get started with LLM observability. Follow the Agent-Assisted Tracing two-phase flow: analyze the codebase (read-only), then implement after user confirmation. When the app uses LLM tool/function calling, add manual CHAIN + TOOL spans. Leverages https://arize.com/docs/ax/alyx/tracing-assistant and https://arize.com/docs/PROMPT.md.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-link",
+          "installUrl": "github:github/awesome-copilot:skills/arize-link",
+          "description": "Generate deep links to the Arize UI. Use when the user wants a clickable URL to open or share a specific trace, span, session, dataset, labeling queue, evaluator, or annotation config, or when sharing Arize resources with team members.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-prompt-optimization",
+          "installUrl": "github:github/awesome-copilot:skills/arize-prompt-optimization",
+          "description": "INVOKE THIS SKILL when optimizing, improving, or debugging LLM prompts using production trace data, evaluations, and annotations. Also use when the user wants to make their AI respond better or improve AI output quality. Covers extracting prompts from spans, gathering performance signal, and running a data-driven optimization loop using the ax CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-trace",
+          "installUrl": "github:github/awesome-copilot:skills/arize-trace",
+          "description": "INVOKE THIS SKILL when downloading, exporting, or inspecting Arize traces and spans, or when a user wants to look at what their LLM app is doing using existing trace data, or when an already-instrumented app has a bug or error to investigate. Use for debugging unknown runtime issues, failures, and behavior regressions. Covers exporting traces by ID, spans by ID, sessions by ID, and root-cause investigation with the ax CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aspire",
+          "installUrl": "github:github/awesome-copilot:skills/aspire",
+          "description": "Aspire skill covering the Aspire CLI, AppHost orchestration, service discovery, integrations, MCP server, VS Code extension, Dev Containers, GitHub Codespaces, templates, dashboard, and deployment. Use when the user asks to create, run, debug, configure, deploy, or troubleshoot an Aspire distributed application.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "audit-integrity",
+          "installUrl": "github:github/awesome-copilot:skills/audit-integrity",
+          "description": "Shared audit integrity framework for all AppSec agents — enforces output quality, intellectual honesty, and continuous improvement through anti-rationalization guards, self-critique loops, retry protocols, non-negotiable behaviors, self-reflection quality gates (1-10 scoring, ≥8 threshold), and a self-learning system with lesson/memory governance for security analysis agents.",
+          "version": "1.0"
+        },
+        {
+          "name": "automate-this",
+          "installUrl": "github:github/awesome-copilot:skills/automate-this",
+          "description": "Analyze a screen recording of a manual process and produce targeted, working automation scripts. Extracts frames and audio narration from video files, reconstructs the step-by-step workflow, and proposes automation at multiple complexity levels using tools already installed on the user machine.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autoresearch",
+          "installUrl": "github:github/awesome-copilot:skills/autoresearch",
+          "description": "Autonomous iterative experimentation loop for any programming task. Guides the user through defining goals, measurable metrics, and scope constraints, then runs an autonomous loop of code changes, testing, measuring, and keeping/discarding results. Inspired by Karpathy''s autoresearch. USE FOR: autonomous improvement, iterative optimization, experiment loop, auto research, performance tuning, automated experimentation, hill climbing, try things automatically, optimize code, run experiments, autonomous coding loop. DO NOT USE FOR: one-shot tasks, simple bug fixes, code review, or tasks without a measurable metric.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-architecture-autopilot",
+          "installUrl": "github:github/awesome-copilot:skills/azure-architecture-autopilot",
+          "description": "Design Azure infrastructure using natural language, or analyze existing Azure resources to auto-generate architecture diagrams, refine them through conversation, and deploy with Bicep. When to use this skill: - \"Create X on Azure\", \"Set up a RAG architecture\" (new design) - \"Analyze my current Azure infrastructure\", \"Draw a diagram for rg-xxx\" (existing analysis) - \"Foundry is slow\", \"I want to reduce costs\", \"Strengthen security\" (natural language modification) - Azure resource deployment, Bicep template generation, IaC code generation - Microsoft Foundry, AI Search, OpenAI, Fabric, ADLS Gen2, Databricks, and all Azure services",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-deployment-preflight",
+          "installUrl": "github:github/awesome-copilot:skills/azure-deployment-preflight",
+          "description": "Performs comprehensive preflight validation of Bicep deployments to Azure, including template syntax validation, what-if analysis, and permission checks. Use this skill before any deployment to Azure to preview changes, identify potential issues, and ensure the deployment will succeed. Activate when users mention deploying to Azure, validating Bicep files, checking deployment permissions, previewing infrastructure changes, running what-if, or preparing for azd provision.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-devops-cli",
+          "installUrl": "github:github/awesome-copilot:skills/azure-devops-cli",
+          "description": "Manage Azure DevOps resources via CLI including projects, repos, pipelines, builds, pull requests, work items, artifacts, and service endpoints. Use when working with Azure DevOps, az commands, devops automation, CI/CD, or when user mentions Azure DevOps CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-pricing",
+          "installUrl": "github:github/awesome-copilot:skills/azure-pricing",
+          "description": "Fetches real-time Azure retail pricing using the Azure Retail Prices API (prices.azure.com) and estimates Copilot Studio agent credit consumption. Use when the user asks about the cost of any Azure service, wants to compare SKU prices, needs pricing data for a cost estimate, mentions Azure pricing, Azure costs, Azure billing, or asks about Copilot Studio pricing, Copilot Credits, or agent usage estimation. Covers compute, storage, networking, databases, AI, Copilot Studio, and all other Azure service families.",
+          "version": "1.2"
+        },
+        {
+          "name": "azure-resource-visualizer",
+          "installUrl": "github:github/awesome-copilot:skills/azure-resource-visualizer",
+          "description": "Analyze Azure resource groups and generate detailed Mermaid architecture diagrams showing the relationships between individual resources. Use this skill when the user asks for a diagram of their Azure resources or help in understanding how the resources relate to each other.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-role-selector",
+          "installUrl": "github:github/awesome-copilot:skills/azure-role-selector",
+          "description": "When user is asking for guidance for which role to assign to an identity given desired permissions, this agent helps them understand the role that will meet the requirements with least privilege access and how to apply that role.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "batch-files",
+          "installUrl": "github:github/awesome-copilot:skills/batch-files",
+          "description": "Expert-level Windows batch file (.bat/.cmd) skill for writing, debugging, and maintaining CMD scripts. Use when asked to \"create a batch file\", \"write a .bat script\", \"automate a Windows task\", \"CMD scripting\", \"batch automation\", \"scheduled task script\", \"Windows shell script\", or when working with .bat/.cmd files in the workspace. Covers cmd.exe syntax, environment variables, control flow, string processing, error handling, and integration with system tools.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "boost-prompt",
+          "installUrl": "github:github/awesome-copilot:skills/boost-prompt",
+          "description": "Interactive prompt refinement workflow: interrogates scope, deliverables, constraints; copies final markdown to clipboard; never writes code. Requires the Joyride extension.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "breakdown-epic-arch",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-epic-arch",
+          "description": "Prompt for creating the high-level technical architecture for an Epic, based on a Product Requirements Document.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "breakdown-epic-pm",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-epic-pm",
+          "description": "Prompt for creating an Epic Product Requirements Document (PRD) for a new epic. This PRD will be used as input for generating a technical architecture specification.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "breakdown-feature-implementation",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-feature-implementation",
+          "description": "Prompt for creating detailed feature implementation plans, following Epoch monorepo structure.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "breakdown-feature-prd",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-feature-prd",
+          "description": "Prompt for creating Product Requirements Documents (PRDs) for new features, based on an Epic.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "breakdown-plan",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-plan",
+          "description": "Issue Planning and Automation prompt that generates comprehensive project plans with Epic > Feature > Story/Enabler > Test hierarchy, dependencies, priorities, and automated tracking.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "breakdown-test",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-test",
+          "description": "Test Planning and Quality Assurance prompt that generates comprehensive test strategies, task breakdowns, and quality validation plans for GitHub projects.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "chrome-devtools",
+          "installUrl": "github:github/awesome-copilot:skills/chrome-devtools",
+          "description": "Expert-level browser automation, debugging, and performance analysis using Chrome DevTools MCP. Use for interacting with web pages, capturing screenshots, analyzing network traffic, and profiling performance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cli-mastery",
+          "installUrl": "github:github/awesome-copilot:skills/cli-mastery",
+          "description": "Interactive training for the GitHub Copilot CLI. Guided lessons, quizzes, scenario challenges, and a full reference covering slash commands, shortcuts, modes, agents, skills, MCP, and configuration. Say \"cliexpert\" to start.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "code-exemplars-blueprint-generator",
+          "installUrl": "github:github/awesome-copilot:skills/code-exemplars-blueprint-generator",
+          "description": "Technology-agnostic prompt generator that creates customizable AI prompts for scanning codebases and identifying high-quality code exemplars. Supports multiple programming languages (.NET, Java, JavaScript, TypeScript, React, Angular, Python) with configurable analysis depth, categorization methods, and documentation formats to establish coding standards and maintain consistency across development teams.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-tour",
+          "installUrl": "github:github/awesome-copilot:skills/code-tour",
+          "description": "Use this skill to create CodeTour .tour files — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. Trigger for: \"create a tour\", \"make a code tour\", \"generate a tour\", \"onboarding tour\", \"tour for this PR\", \"tour for this bug\", \"RCA tour\", \"architecture tour\", \"explain how X works\", \"vibe check\", \"PR review tour\", \"contributor guide\", \"help someone ramp up\", or any request for a structured walkthrough through code. Supports 20 developer personas (new joiner, bug fixer, architect, PR reviewer, vibecoder, security reviewer, and more), all CodeTour step types (file/line, selection, pattern, uri, commands, view), and tour-level fields (ref, isPrimary, nextTour). Works with any repository in any language.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "codeql",
+          "installUrl": "github:github/awesome-copilot:skills/codeql",
+          "description": "Comprehensive guide for setting up and configuring CodeQL code scanning via GitHub Actions workflows and the CodeQL CLI. This skill should be used when users need help with code scanning configuration, CodeQL workflow files, CodeQL CLI commands, SARIF output, security analysis setup, or troubleshooting CodeQL analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "commit-message-storyteller",
+          "installUrl": "github:github/awesome-copilot:skills/commit-message-storyteller",
+          "description": "Analyzes git diffs or staged changes and generates narrative commit messages that explain WHY a change was made, not just what changed — following Conventional Commits format. Use when asked to \"write a commit message\", \"generate a commit\", \"describe my changes\", \"what should I commit this as\", \"commit this\", \"summarize my diff\", or \"help me commit\". Works with git diff output, staged files, or plain descriptions of changes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "containerize-aspnet-framework",
+          "installUrl": "github:github/awesome-copilot:skills/containerize-aspnet-framework",
+          "description": "Containerize an ASP.NET .NET Framework project by creating Dockerfile and .dockerfile files customized for the project.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "containerize-aspnetcore",
+          "installUrl": "github:github/awesome-copilot:skills/containerize-aspnetcore",
+          "description": "Containerize an ASP.NET Core project by creating Dockerfile and .dockerfile files customized for the project.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-management-systems",
+          "installUrl": "github:github/awesome-copilot:skills/content-management-systems",
+          "description": "Workflow for building and modifying content management systems across WordPress, Shopify, Wix, Squarespace, Drupal, WooCommerce, Joomla, HubSpot CMS Hub, Webflow, Adobe Experience Manager, and similar platforms. Use when working on CMS themes, plugins, apps, modules, admin panels, media uploads, content models, editors, markdown pipelines, or static export workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "conventional-commit",
+          "installUrl": "github:github/awesome-copilot:skills/conventional-commit",
+          "description": "Prompt and workflow for generating conventional commit messages using a structured XML format. Guides users to create standardized, descriptive commit messages in line with the Conventional Commits specification, including instructions, examples, and validation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "convert-plaintext-to-md",
+          "installUrl": "github:github/awesome-copilot:skills/convert-plaintext-to-md",
+          "description": "Convert a text-based document to markdown following instructions from prompt, or if a documented option is passed, follow the instructions for that option.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copilot-cli-quickstart",
+          "installUrl": "github:github/awesome-copilot:skills/copilot-cli-quickstart",
+          "description": "Use this skill when someone wants to learn GitHub Copilot CLI from scratch. Offers interactive step-by-step tutorials with separate Developer and Non-Developer tracks, plus on-demand Q&A. Just say \"start tutorial\" or ask a question! Note: This skill targets GitHub Copilot CLI specifically and uses CLI-specific tools (ask_user, sql, fetch_copilot_cli_documentation).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copilot-sdk",
+          "installUrl": "github:github/awesome-copilot:skills/copilot-sdk",
+          "description": "Build agentic applications with GitHub Copilot SDK. Use when embedding AI agents in apps, creating custom tools, implementing streaming responses, managing sessions, connecting to MCP servers, or creating custom agents. Triggers on Copilot SDK, GitHub SDK, agentic app, embed Copilot, programmable agent, MCP server, custom agent.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copilot-spaces",
+          "installUrl": "github:github/awesome-copilot:skills/copilot-spaces",
+          "description": "Use Copilot Spaces to provide project-specific context to conversations. Use this skill when users mention a \"Copilot space\", want to load context from a shared knowledge base, discover available spaces, or ask questions grounded in curated project documentation, code, and instructions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cosmosdb-datamodeling",
+          "installUrl": "github:github/awesome-copilot:skills/cosmosdb-datamodeling",
+          "description": "Step-by-step guide for capturing key application requirements for NoSQL use-case and produce Azure Cosmos DB Data NoSQL Model design using best practices and common patterns, artifacts_produced: \"cosmosdb_requirements.md\" file and \"cosmosdb_data_model.md\" file",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-agentsmd",
+          "installUrl": "github:github/awesome-copilot:skills/create-agentsmd",
+          "description": "Prompt for generating an AGENTS.md file for a repository",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-architectural-decision-record",
+          "installUrl": "github:github/awesome-copilot:skills/create-architectural-decision-record",
+          "description": "Create an Architectural Decision Record (ADR) document for AI-optimized decision documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-github-action-workflow-specification",
+          "installUrl": "github:github/awesome-copilot:skills/create-github-action-workflow-specification",
+          "description": "Create a formal specification for an existing GitHub Actions CI/CD workflow, optimized for AI consumption and workflow maintenance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-llms",
+          "installUrl": "github:github/awesome-copilot:skills/create-llms",
+          "description": "Create an llms.txt file from scratch based on repository structure following the llms.txt specification at https://llmstxt.org/",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-specification",
+          "installUrl": "github:github/awesome-copilot:skills/create-specification",
+          "description": "Create a new specification file for the solution, optimized for Generative AI consumption.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "creating-oracle-to-postgres-master-migration-plan",
+          "installUrl": "github:github/awesome-copilot:skills/creating-oracle-to-postgres-master-migration-plan",
+          "description": "Discovers all projects in a .NET solution, classifies each for Oracle-to-PostgreSQL migration eligibility, and produces a persistent master migration plan. Use when starting a multi-project Oracle-to-PostgreSQL migration, creating a migration inventory, or assessing which .NET projects contain Oracle dependencies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "creating-oracle-to-postgres-migration-bug-report",
+          "installUrl": "github:github/awesome-copilot:skills/creating-oracle-to-postgres-migration-bug-report",
+          "description": "Creates structured bug reports for defects found during Oracle-to-PostgreSQL migration. Use when documenting behavioral differences between Oracle and PostgreSQL as actionable bug reports with severity, root cause, and remediation steps.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "creating-oracle-to-postgres-migration-integration-tests",
+          "installUrl": "github:github/awesome-copilot:skills/creating-oracle-to-postgres-migration-integration-tests",
+          "description": "Creates integration test cases for .NET data access artifacts during Oracle-to-PostgreSQL database migrations. Generates DB-agnostic xUnit tests with deterministic seed data that validate behavior consistency across both database systems. Use when creating integration tests for a migrated project, generating test coverage for data access layers, or writing Oracle-to-PostgreSQL migration validation tests.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "csharp-mcp-server-generator",
+          "installUrl": "github:github/awesome-copilot:skills/csharp-mcp-server-generator",
+          "description": "Generate a complete MCP server project in C# with tools, prompts, and proper configuration",
+          "version": "0.0.0"
+        },
+        {
+          "name": "csharp-mstest",
+          "installUrl": "github:github/awesome-copilot:skills/csharp-mstest",
+          "description": "Get best practices for MSTest 3.x/4.x unit testing, including modern assertion APIs and data-driven tests",
+          "version": "0.0.0"
+        },
+        {
+          "name": "csharp-nunit",
+          "installUrl": "github:github/awesome-copilot:skills/csharp-nunit",
+          "description": "Get best practices for NUnit unit testing, including data-driven tests",
+          "version": "0.0.0"
+        },
+        {
+          "name": "csharp-tunit",
+          "installUrl": "github:github/awesome-copilot:skills/csharp-tunit",
+          "description": "Get best practices for TUnit unit testing, including data-driven tests",
+          "version": "0.0.0"
+        },
+        {
+          "name": "csharp-xunit",
+          "installUrl": "github:github/awesome-copilot:skills/csharp-xunit",
+          "description": "Get best practices for XUnit unit testing, including data-driven tests",
+          "version": "0.0.0"
+        },
+        {
+          "name": "daily-prep",
+          "installUrl": "github:github/awesome-copilot:skills/daily-prep",
+          "description": "Prepare for tomorrow''s meetings and tasks. Pulls calendar from Outlook via WorkIQ, cross-references open tasks and workspace context, classifies meetings, detects conflicts and day-fit issues, finds learning and deep-work slots, and generates a structured HTML prep file with productivity recommendations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "data-breach-blast-radius",
+          "installUrl": "github:github/awesome-copilot:skills/data-breach-blast-radius",
+          "description": "Pre-breach impact analysis: inventories sensitive data (PII, PHI, PCI-DSS, credentials), traces data flows, scores exposure vectors, and produces a regulatory blast radius report with fine ranges sourced verbatim from GDPR Art. 83, CCPA § 1798.155(a), and HIPAA 45 CFR § 160.404. Cost benchmarks from IBM Cost of a Data Breach Report (annually updated). All citations in references/SOURCES.md for verification. Use when asked: \"assess breach impact\", \"what data could be exposed\", \"calculate blast radius\", \"data exposure analysis\", \"how bad would a breach be\", \"quantify data risk\", \"sensitive data inventory\", \"data flow security audit\", \"pre-breach assessment\", \"worst-case breach scenario\", \"breach readiness\", \"data risk report\", \"/data-breach-blast-radius\". For any stack handling user data, health records, or financial information. Output labels law-sourced figures (exact) vs heuristic estimates (planning only). Does not replace legal counsel.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "datanalysis-credit-risk",
+          "installUrl": "github:github/awesome-copilot:skills/datanalysis-credit-risk",
+          "description": "Credit risk data cleaning and variable screening pipeline for pre-loan modeling. Use when working with raw credit data that needs quality assessment,  missing value analysis, or variable selection before modeling. it covers data loading and formatting, abnormal period filtering, missing rate calculation, high-missing variable removal,low-IV variable filtering, high-PSI variable removal, Null Importance denoising, high-correlation variable removal, and cleaning report generation. Applicable scenarios arecredit risk data cleaning, variable screening, pre-loan modeling preprocessing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dataverse-python-advanced-patterns",
+          "installUrl": "github:github/awesome-copilot:skills/dataverse-python-advanced-patterns",
+          "description": "Generate production code for Dataverse SDK using advanced patterns, error handling, and optimization techniques.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dataverse-python-production-code",
+          "installUrl": "github:github/awesome-copilot:skills/dataverse-python-production-code",
+          "description": "Generate production-ready Python code using Dataverse SDK with error handling, optimization, and best practices",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dataverse-python-quickstart",
+          "installUrl": "github:github/awesome-copilot:skills/dataverse-python-quickstart",
+          "description": "Generate Python SDK setup + CRUD + bulk + paging snippets using official patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dataverse-python-usecase-builder",
+          "installUrl": "github:github/awesome-copilot:skills/dataverse-python-usecase-builder",
+          "description": "Generate complete solutions for specific Dataverse SDK use cases with architecture recommendations",
+          "version": "0.0.0"
+        },
+        {
+          "name": "declarative-agents",
+          "installUrl": "github:github/awesome-copilot:skills/declarative-agents",
+          "description": "Complete development kit for Microsoft 365 Copilot declarative agents with three comprehensive workflows (basic, advanced, validation), TypeSpec support, and Microsoft 365 Agents Toolkit integration",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dependabot",
+          "installUrl": "github:github/awesome-copilot:skills/dependabot",
+          "description": "Comprehensive guide for configuring and managing GitHub Dependabot. Use this skill when users ask about creating or optimizing dependabot.yml files, managing Dependabot pull requests, configuring dependency update strategies, setting up grouped updates, monorepo patterns, multi-ecosystem groups, security update configuration, auto-triage rules, or any GitHub Advanced Security (GHAS) supply chain security topic related to Dependabot. For pre-commit dependency vulnerability scanning in AI coding agents via the GitHub MCP Server, this skill references the Advanced Security plugin (`advanced-security@copilot-plugins`). Use this skill when an agent needs to scan dependencies for known vulnerabilities before committing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "diagnose",
+          "installUrl": "github:github/awesome-copilot:skills/diagnose",
+          "description": "Perform a systematic diagnostic scan of an AI workflow across 5 quality dimensions — prompt quality, context efficiency, tool health, architecture fitness, and safety — producing a scored report with prioritized remediation actions.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "github",
+        "repo": "awesome-copilot",
+        "repoUrl": "https://github.com/github/awesome-copilot.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "github-awesome-copilot-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from github/awesome-copilot.",
+      "author": "ASM (github/awesome-copilot)",
+      "createdAt": "2026-05-09T08:10:57.006Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "github",
+        "awesome-copilot"
+      ],
+      "skills": [
+        {
+          "name": "agent-owasp-compliance",
+          "installUrl": "github:github/awesome-copilot:skills/agent-owasp-compliance",
+          "description": "Check any AI agent codebase against the OWASP Agentic Security Initiative (ASI) Top 10 risks. Use this skill when: - Evaluating an agent system's security posture before production deployment - Running a compliance check against OWASP ASI 2026 standards - Mapping existing security controls to the 10 agentic risks - Generating a compliance report for security review or audit - Comparing agent framework security features against the standard - Any request like \"is my agent OWASP compliant?\", \"check ASI compliance\", or \"agentic security audit\"",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-supply-chain",
+          "installUrl": "github:github/awesome-copilot:skills/agent-supply-chain",
+          "description": "Verify supply chain integrity for AI agent plugins, tools, and dependencies. Use this skill when: - Generating SHA-256 integrity manifests for agent plugins or tool packages - Verifying that installed plugins match their published manifests - Detecting tampered, modified, or untracked files in agent tool directories - Auditing dependency pinning and version policies for agent components - Building provenance chains for agent plugin promotion (dev → staging → production) - Any request like \"verify plugin integrity\", \"generate manifest\", \"check supply chain\", or \"sign this plugin\"",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-team-orchestration",
+          "installUrl": "github:github/awesome-copilot:skills/ai-team-orchestration",
+          "description": "Bootstrap and run a multi-agent AI development team. Use when: starting a new software project with AI agents, setting up parallel dev/QA teams, creating sprint plans, writing brainstorm prompts with distinct agent voices, recovering a project workflow, or planning sprints.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arduino-azure-iot-edge-integration",
+          "installUrl": "github:github/awesome-copilot:skills/arduino-azure-iot-edge-integration",
+          "description": "Design and implement Arduino integration with Azure IoT Hub and IoT Edge, including secure provisioning, resilient telemetry, command handling, and production guardrails.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arize-prompt-optimization",
+          "installUrl": "github:github/awesome-copilot:skills/arize-prompt-optimization",
+          "description": "INVOKE THIS SKILL when optimizing, improving, or debugging LLM prompts using production trace data, evaluations, and annotations. Also use when the user wants to make their AI respond better or improve AI output quality. Covers extracting prompts from spans, gathering performance signal, and running a data-driven optimization loop using the ax CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bigquery-pipeline-audit",
+          "installUrl": "github:github/awesome-copilot:skills/bigquery-pipeline-audit",
+          "description": "Audits Python + BigQuery pipelines for cost safety, idempotency, and production readiness. Returns a structured report with exact patch locations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brag-sheet",
+          "installUrl": "github:github/awesome-copilot:skills/brag-sheet",
+          "description": "Turn vague \"what did I do?\" into evidence-backed impact statements for performance reviews, self-reviews, promotion packets, and weekly updates. Uniquely mines Copilot CLI session logs to reconstruct forgotten work, plus git commits and GitHub PRs. Enforces a 3-part impact contract (action → result → evidence). Works standalone with zero dependencies. Trigger for: \"brag\", \"log work\", \"what did I do\", \"backfill my work history\", \"performance review\", \"self-review\", \"self assessment\", \"write impact statement\", \"review prep\", \"promo packet\", \"promotion case\", \"weekly update\", \"status report\", \"accomplishments\", \"what did I ship\", \"I forgot to log my work\", \"summarize my work\", \"track my wins\", \"what should I highlight\", \"end of half\", \"career growth\", \"work journal\", or any request to document, summarize, or organize work accomplishments.",
+          "version": "1.1"
+        },
+        {
+          "name": "breakdown-epic-arch",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-epic-arch",
+          "description": "Prompt for creating the high-level technical architecture for an Epic, based on a Product Requirements Document.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "breakdown-epic-pm",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-epic-pm",
+          "description": "Prompt for creating an Epic Product Requirements Document (PRD) for a new epic. This PRD will be used as input for generating a technical architecture specification.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "breakdown-feature-prd",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-feature-prd",
+          "description": "Prompt for creating Product Requirements Documents (PRDs) for new features, based on an Epic.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "breakdown-plan",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-plan",
+          "description": "Issue Planning and Automation prompt that generates comprehensive project plans with Epic > Feature > Story/Enabler > Test hierarchy, dependencies, priorities, and automated tracking.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "breakdown-test",
+          "installUrl": "github:github/awesome-copilot:skills/breakdown-test",
+          "description": "Test Planning and Quality Assurance prompt that generates comprehensive test strategies, task breakdowns, and quality validation plans for GitHub projects.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "daily-prep",
+          "installUrl": "github:github/awesome-copilot:skills/daily-prep",
+          "description": "Prepare for tomorrow''s meetings and tasks. Pulls calendar from Outlook via WorkIQ, cross-references open tasks and workspace context, classifies meetings, detects conflicts and day-fit issues, finds learning and deep-work slots, and generates a structured HTML prep file with productivity recommendations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "data-breach-blast-radius",
+          "installUrl": "github:github/awesome-copilot:skills/data-breach-blast-radius",
+          "description": "Pre-breach impact analysis: inventories sensitive data (PII, PHI, PCI-DSS, credentials), traces data flows, scores exposure vectors, and produces a regulatory blast radius report with fine ranges sourced verbatim from GDPR Art. 83, CCPA § 1798.155(a), and HIPAA 45 CFR § 160.404. Cost benchmarks from IBM Cost of a Data Breach Report (annually updated). All citations in references/SOURCES.md for verification. Use when asked: \"assess breach impact\", \"what data could be exposed\", \"calculate blast radius\", \"data exposure analysis\", \"how bad would a breach be\", \"quantify data risk\", \"sensitive data inventory\", \"data flow security audit\", \"pre-breach assessment\", \"worst-case breach scenario\", \"breach readiness\", \"data risk report\", \"/data-breach-blast-radius\". For any stack handling user data, health records, or financial information. Output labels law-sourced figures (exact) vs heuristic estimates (planning only). Does not replace legal counsel.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dataverse-python-advanced-patterns",
+          "installUrl": "github:github/awesome-copilot:skills/dataverse-python-advanced-patterns",
+          "description": "Generate production code for Dataverse SDK using advanced patterns, error handling, and optimization techniques.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dataverse-python-production-code",
+          "installUrl": "github:github/awesome-copilot:skills/dataverse-python-production-code",
+          "description": "Generate production-ready Python code using Dataverse SDK with error handling, optimization, and best practices",
+          "version": "0.0.0"
+        },
+        {
+          "name": "draw-io-diagram-generator",
+          "installUrl": "github:github/awesome-copilot:skills/draw-io-diagram-generator",
+          "description": "Use when creating, editing, or generating draw.io diagram files (.drawio, .drawio.svg, .drawio.png). Covers mxGraph XML authoring, shape libraries, style strings, flowcharts, system architecture, sequence diagrams, ER diagrams, UML class diagrams, network topology, layout strategy, the hediet.vscode-drawio VS Code extension, and the full agent workflow from request to a ready-to-open file.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "flowstudio-power-automate-governance",
+          "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-governance",
+          "description": "Govern Power Automate flows and Power Apps at scale using the FlowStudio MCP cached store. Classify flows by business impact, detect orphaned resources, audit connector usage, enforce compliance standards, manage notification rules, and compute governance scores — all without Dataverse or the CoE Starter Kit. Load this skill when asked to: tag or classify flows, set business impact, assign ownership, detect orphans, audit connectors, check compliance, compute archive scores, manage notification rules, run a governance review, generate a compliance report, offboard a maker, or any task that involves writing governance metadata to flows. Requires a FlowStudio for Teams or MCP Pro+ subscription — see https://mcp.flowstudio.app",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-0-to-1-launch",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-0-to-1-launch",
+          "description": "Launch new products from idea to first customers. Use when launching products, finding early adopters, building launch week playbooks, diagnosing why adoption stalls, or learning that press coverage does not equal growth. Includes the three-layer diagnosis, the 2-week experiment cycle, and the launch that got 50K impressions and 12 signups.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-ai-gtm",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-ai-gtm",
+          "description": "Go-to-market strategy for AI products. Use when positioning AI products, handling \"who is responsible when it breaks\" objections, pricing variable-cost AI, choosing between copilot/agent/teammate framing, or selling autonomous tools into enterprises.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-enterprise-account-planning",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-enterprise-account-planning",
+          "description": "Strategic account planning and execution for enterprise deals. Use when planning complex sales cycles, managing multiple stakeholders, applying MEDDICC qualification, tracking deal health, or building mutual action plans. Includes the \"stale MAP equals dead deal\" pattern.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-enterprise-onboarding",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-enterprise-onboarding",
+          "description": "Four-phase framework for onboarding enterprise customers from contract to value realization. Use when implementing new enterprise customers, preventing churn during onboarding, or solving the adoption cliff that kills deals post-go-live. Includes the Week 4 ghosting pattern.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-operating-cadence",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-operating-cadence",
+          "description": "Design meeting rhythms, metric reporting, quarterly planning, and decision-making velocity for scaling companies. Use when decisions are slow, planning is broken, the company is growing but alignment is worse, or leadership meetings consume all time without producing decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-partnership-architecture",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-partnership-architecture",
+          "description": "Build and scale partner ecosystems that drive revenue and platform adoption. Use when building partner programs from scratch, tiering partnerships, managing co-marketing, making build-vs-partner decisions, or structuring crawl-walk-run partner deployment.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-positioning-strategy",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-positioning-strategy",
+          "description": "Find and own a defensible market position. Use when messaging sounds like competitors, conversion is weak despite awareness, repositioning a product, or testing positioning claims. Includes Crawl-Walk-Run rollout methodology and the word change that improved enterprise deal progression.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-product-led-growth",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-product-led-growth",
+          "description": "Build self-serve acquisition and expansion motions. Use when deciding PLG vs sales-led, optimizing activation, driving freemium conversion, building growth equations, or recognizing when product complexity demands human touch. Includes the parallel test where sales-led won 10x on revenue.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gtm-technical-product-pricing",
+          "installUrl": "github:github/awesome-copilot:skills/gtm-technical-product-pricing",
+          "description": "Pricing strategy for technical products. Use when choosing usage-based vs seat-based, designing freemium thresholds, structuring enterprise pricing conversations, deciding when to raise prices, or using price as a positioning signal.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "import-infrastructure-as-code",
+          "installUrl": "github:github/awesome-copilot:skills/import-infrastructure-as-code",
+          "description": "Import existing Azure resources into Terraform using Azure CLI discovery and Azure Verified Modules (AVM). Use when asked to reverse-engineer live Azure infrastructure, generate Infrastructure as Code from existing subscriptions/resource groups/resource IDs, map dependencies, derive exact import addresses from downloaded module source, prevent configuration drift, and produce AVM-based Terraform files ready for validation and planning across any Azure resource type.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "openapi-to-application-code",
+          "installUrl": "github:github/awesome-copilot:skills/openapi-to-application-code",
+          "description": "Generate a complete, production-ready application from an OpenAPI specification",
+          "version": "0.0.0"
+        },
+        {
+          "name": "phoenix-tracing",
+          "installUrl": "github:github/awesome-copilot:skills/phoenix-tracing",
+          "description": "OpenInference semantic conventions and instrumentation for Phoenix AI observability. Use when implementing LLM tracing, creating custom spans, or deploying to production.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "planning-oracle-to-postgres-migration-integration-testing",
+          "installUrl": "github:github/awesome-copilot:skills/planning-oracle-to-postgres-migration-integration-testing",
+          "description": "Creates an integration testing plan for .NET data access artifacts during Oracle-to-PostgreSQL database migrations. Analyzes a single project to identify repositories, DAOs, and service layers that interact with the database, then produces a structured testing plan. Use when planning integration test coverage for a migrated project, identifying which data access methods need tests, or preparing for Oracle-to-PostgreSQL migration validation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "polyglot-test-agent",
+          "installUrl": "github:github/awesome-copilot:skills/polyglot-test-agent",
+          "description": "Generates comprehensive, workable unit tests for any programming language using a multi-agent pipeline. Use when asked to generate tests, write unit tests, improve test coverage, add test coverage, create test files, or test a codebase. Supports C#, TypeScript, JavaScript, Python, Go, Rust, Java, and more. Orchestrates research, planning, and implementation phases to produce tests that compile, pass, and follow project conventions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "power-platform-architect",
+          "installUrl": "github:github/awesome-copilot:skills/power-platform-architect",
+          "description": "Use this skill when the user needs to transform business requirements, use case descriptions, or meeting transcripts into a technical Power Platform solution architecture, including component selection and Mermaid.js diagrams.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "prd",
+          "installUrl": "github:github/awesome-copilot:skills/prd",
+          "description": "Generate high-quality Product Requirements Documents (PRDs) for software systems and AI-powered features. Includes executive summaries, user stories, technical specifications, and risk analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "python-azure-iot-edge-modules",
+          "installUrl": "github:github/awesome-copilot:skills/python-azure-iot-edge-modules",
+          "description": "Build and operate Python Azure IoT Edge modules with robust messaging, deployment manifests, observability, and production readiness checks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "python-pypi-package-builder",
+          "installUrl": "github:github/awesome-copilot:skills/python-pypi-package-builder",
+          "description": "End-to-end skill for building, testing, linting, versioning, and publishing a production-grade Python library to PyPI. Covers all four build backends (setuptools+setuptools_scm, hatchling, flit, poetry), PEP 440 versioning, semantic versioning, dynamic git-tag versioning, OOP/SOLID design, type hints (PEP 484/526/544/561), Trusted Publishing (OIDC), and the full PyPA packaging flow. Use for: creating Python packages, pip-installable SDKs, CLI tools, framework plugins, pyproject.toml setup, py.typed, setuptools_scm, semver, mypy, pre-commit, GitHub Actions CI/CD, or PyPI publishing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "qdrant-monitoring",
+          "installUrl": "github:github/awesome-copilot:skills/qdrant-monitoring",
+          "description": "Guides Qdrant monitoring and observability setup. Use when someone asks 'how to monitor Qdrant', 'what metrics to track', 'is Qdrant healthy', 'optimizer stuck', 'why is memory growing', 'requests are slow', or needs to set up Prometheus, Grafana, or health checks. Also use when debugging production issues that require metric analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "quasi-coder",
+          "installUrl": "github:github/awesome-copilot:skills/quasi-coder",
+          "description": "Expert 10x engineer skill for interpreting and implementing code from shorthand, quasi-code, and natural language descriptions. Use when collaborators provide incomplete code snippets, pseudo-code, or descriptions with potential typos or incorrect terminology. Excels at translating non-technical or semi-technical descriptions into production-quality code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "reviewing-oracle-to-postgres-migration",
+          "installUrl": "github:github/awesome-copilot:skills/reviewing-oracle-to-postgres-migration",
+          "description": "Identifies Oracle-to-PostgreSQL migration risks by cross-referencing code against known behavioral differences (empty strings, refcursors, type coercion, sorting, timestamps, concurrent transactions, etc.). Use when planning a database migration, reviewing migration artifacts, or validating that integration tests cover Oracle/PostgreSQL differences.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "salesforce-apex-quality",
+          "installUrl": "github:github/awesome-copilot:skills/salesforce-apex-quality",
+          "description": "Apex code quality guardrails for Salesforce development. Enforces bulk-safety rules (no SOQL/DML in loops), sharing model requirements, CRUD/FLS security, SOQL injection prevention, PNB test coverage (Positive / Negative / Bulk), and modern Apex idioms. Use this skill when reviewing or generating Apex classes, trigger handlers, batch jobs, or test classes to catch governor limit risks, security gaps, and quality issues before deployment.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "salesforce-component-standards",
+          "installUrl": "github:github/awesome-copilot:skills/salesforce-component-standards",
+          "description": "Quality standards for Salesforce Lightning Web Components (LWC), Aura components, and Visualforce pages. Covers SLDS 2 compliance, accessibility (WCAG 2.1 AA), data access pattern selection, component communication rules, XSS prevention, CSRF enforcement, FLS/CRUD in AuraEnabled methods, view state management, and Jest test requirements. Use this skill when building or reviewing any Salesforce UI component to enforce platform-specific security and quality standards.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "salesforce-flow-design",
+          "installUrl": "github:github/awesome-copilot:skills/salesforce-flow-design",
+          "description": "Salesforce Flow architecture decisions, flow type selection, bulk safety validation, and fault handling standards. Use this skill when designing or reviewing Record-Triggered, Screen, Autolaunched, Scheduled, or Platform Event flows to ensure correct type selection, no DML/Get Records in loops, proper fault connectors on all data-changing elements, and appropriate automation density checks before deployment.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "security-review",
+          "installUrl": "github:github/awesome-copilot:skills/security-review",
+          "description": "AI-powered codebase security scanner that reasons about code like a security researcher — tracing data flows, understanding component interactions, and catching vulnerabilities that pattern-matching tools miss. Use this skill when asked to scan code for security vulnerabilities, find bugs, check for SQL injection, XSS, command injection, exposed API keys, hardcoded secrets, insecure dependencies, access control issues, or any request like \"is my code secure?\", \"review for security issues\", \"audit this codebase\", or \"check for vulnerabilities\". Covers injection flaws, authentication and access control bugs, secrets exposure, weak cryptography, insecure dependencies, and business logic issues across JavaScript, TypeScript, Python, Java, PHP, Go, Ruby, and Rust.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "structured-autonomy-plan",
+          "installUrl": "github:github/awesome-copilot:skills/structured-autonomy-plan",
+          "description": "Structured Autonomy Planning Prompt",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "github",
+        "repo": "awesome-copilot",
+        "repoUrl": "https://github.com/github/awesome-copilot.git"
+      },
+      "inferred": true
     }
   ]
 }

--- a/data/skill-index/google_skills.json
+++ b/data/skill-index/google_skills.json
@@ -1786,5 +1786,391 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "google-skills-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from google/skills.",
+      "author": "ASM (google/skills)",
+      "createdAt": "2026-05-09T08:11:10.843Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "google",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "bigquery-basics",
+          "installUrl": "github:google/skills:skills/cloud/bigquery-basics",
+          "description": "Manages datasets, tables, and jobs in BigQuery, and integrates with BigQuery ML and Gemini for advanced data analytics and AI-driven insights. Use when you need to interact with BigQuery, run SQL queries, manage BigQuery resources, or leverage BigQuery's built-in ML capabilities. Also use when performing data analysis, ingesting data into BigQuery, or developing AI applications on BigQuery.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-cloud-waf-cost-optimization",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-waf-cost-optimization",
+          "description": "Generates cost optimization guidance for Google Cloud workloads based on the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify cost requirements and constraints, and provide actionable recommendations for build, deploy, and manage the workload cost-efficiently in Google Cloud.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-cloud-waf-reliability",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-waf-reliability",
+          "description": "Generates reliability-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework. Use this skill to evaluate a workload, identify reliability requirements, and provide actionable recommendations for build, deploy, and manage the workload reliably in Google Cloud.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-cloud-waf-security",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-waf-security",
+          "description": "Generates security-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify security requirements, and provide actionable recommendations for IAM, network security, data protection, and operational security.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "google",
+        "repo": "skills",
+        "repoUrl": "https://github.com/google/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "google-skills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from google/skills.",
+      "author": "ASM (google/skills)",
+      "createdAt": "2026-05-09T08:11:10.843Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "google",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "gemini-api",
+          "installUrl": "github:google/skills:skills/cloud/gemini-api",
+          "description": "Guides the usage of the Gemini API on Agent Platform with the Google Gen AI SDK. Use when the user asks about using Gemini in an enterprise environment or explicitly mentions Vertex AI, Google Cloud, or Agent Platform. Covers SDK usage (Python, JS/TS, Go, Java, C#), capabilities like Live API, tools, multimedia generation, caching, and batch prediction.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gke-basics",
+          "installUrl": "github:google/skills:skills/cloud/gke-basics",
+          "description": "Plan, create, and configure production-ready Google Kubernetes Engine (GKE) clusters using the golden path Autopilot configuration. Covers Day-0 checklist, Autopilot vs Standard, networking (private clusters, VPC-native, Gateway API), security (Workload Identity, Secret Manager, RBAC hardening), observability, scaling, cost optimization, and AI/ML inference. WHEN: create GKE cluster, provision GKE environment, design GKE networking, secure GKE, optimize GKE cost, GKE autoscaling, GKE inference, GKE upgrade, GKE observability, GKE multi-tenancy, GKE batch, GKE HPC, GKE compute class.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "google-cloud-recipe-auth",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-recipe-auth",
+          "description": "Provides expert guidance on authenticating and authorizing to Google Cloud services and APIs, covering human users, service identities, Application Default Credentials (ADC), and best practices for secure access.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-cloud-recipe-networking-observability",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-networking-observability",
+          "description": "Investigates Google Cloud networking issues by analyzing logs, metrics, and diagnostics. Use when investigating VPC Flow Logs, NAT, firewall, or threat logs, querying latency and throughput metrics, or running Connectivity Tests for path diagnostics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-cloud-waf-cost-optimization",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-waf-cost-optimization",
+          "description": "Generates cost optimization guidance for Google Cloud workloads based on the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify cost requirements and constraints, and provide actionable recommendations for build, deploy, and manage the workload cost-efficiently in Google Cloud.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-cloud-waf-reliability",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-waf-reliability",
+          "description": "Generates reliability-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework. Use this skill to evaluate a workload, identify reliability requirements, and provide actionable recommendations for build, deploy, and manage the workload reliably in Google Cloud.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "google",
+        "repo": "skills",
+        "repoUrl": "https://github.com/google/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "google-skills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from google/skills.",
+      "author": "ASM (google/skills)",
+      "createdAt": "2026-05-09T08:11:10.843Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "google",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "bigquery-basics",
+          "installUrl": "github:google/skills:skills/cloud/bigquery-basics",
+          "description": "Manages datasets, tables, and jobs in BigQuery, and integrates with BigQuery ML and Gemini for advanced data analytics and AI-driven insights. Use when you need to interact with BigQuery, run SQL queries, manage BigQuery resources, or leverage BigQuery's built-in ML capabilities. Also use when performing data analysis, ingesting data into BigQuery, or developing AI applications on BigQuery.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gemini-api",
+          "installUrl": "github:google/skills:skills/cloud/gemini-api",
+          "description": "Guides the usage of the Gemini API on Agent Platform with the Google Gen AI SDK. Use when the user asks about using Gemini in an enterprise environment or explicitly mentions Vertex AI, Google Cloud, or Agent Platform. Covers SDK usage (Python, JS/TS, Go, Java, C#), capabilities like Live API, tools, multimedia generation, caching, and batch prediction.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gke-basics",
+          "installUrl": "github:google/skills:skills/cloud/gke-basics",
+          "description": "Plan, create, and configure production-ready Google Kubernetes Engine (GKE) clusters using the golden path Autopilot configuration. Covers Day-0 checklist, Autopilot vs Standard, networking (private clusters, VPC-native, Gateway API), security (Workload Identity, Secret Manager, RBAC hardening), observability, scaling, cost optimization, and AI/ML inference. WHEN: create GKE cluster, provision GKE environment, design GKE networking, secure GKE, optimize GKE cost, GKE autoscaling, GKE inference, GKE upgrade, GKE observability, GKE multi-tenancy, GKE batch, GKE HPC, GKE compute class.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "google-cloud-recipe-auth",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-recipe-auth",
+          "description": "Provides expert guidance on authenticating and authorizing to Google Cloud services and APIs, covering human users, service identities, Application Default Credentials (ADC), and best practices for secure access.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-cloud-recipe-onboarding",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-recipe-onboarding",
+          "description": "Guidance for a developer's first steps on Google Cloud, covering account creation, billing setup, project management, and deploying a first resource.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-cloud-waf-cost-optimization",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-waf-cost-optimization",
+          "description": "Generates cost optimization guidance for Google Cloud workloads based on the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify cost requirements and constraints, and provide actionable recommendations for build, deploy, and manage the workload cost-efficiently in Google Cloud.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-cloud-waf-reliability",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-waf-reliability",
+          "description": "Generates reliability-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework. Use this skill to evaluate a workload, identify reliability requirements, and provide actionable recommendations for build, deploy, and manage the workload reliably in Google Cloud.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-cloud-waf-security",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-waf-security",
+          "description": "Generates security-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify security requirements, and provide actionable recommendations for IAM, network security, data protection, and operational security.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "google",
+        "repo": "skills",
+        "repoUrl": "https://github.com/google/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "google-skills-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from google/skills.",
+      "author": "ASM (google/skills)",
+      "createdAt": "2026-05-09T08:11:10.843Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "google",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "alloydb-basics",
+          "installUrl": "github:google/skills:skills/cloud/alloydb-basics",
+          "description": "Manages clusters, instances, and backups for AlloyDB for PostgreSQL, and integrates with AlloyDB model context protocol (MCP) tools for automated database operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bigquery-basics",
+          "installUrl": "github:google/skills:skills/cloud/bigquery-basics",
+          "description": "Manages datasets, tables, and jobs in BigQuery, and integrates with BigQuery ML and Gemini for advanced data analytics and AI-driven insights. Use when you need to interact with BigQuery, run SQL queries, manage BigQuery resources, or leverage BigQuery's built-in ML capabilities. Also use when performing data analysis, ingesting data into BigQuery, or developing AI applications on BigQuery.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cloud-run-basics",
+          "installUrl": "github:google/skills:skills/cloud/cloud-run-basics",
+          "description": "Manages Cloud Run services, jobs, and worker pools. Use when you need to deploy applications responding to HTTP requests (services), run event-triggered or scheduled tasks (jobs), or handle always-on pull-based background processing (worker pools).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cloud-sql-basics",
+          "installUrl": "github:google/skills:skills/cloud/cloud-sql-basics",
+          "description": "This file generates or explains Cloud SQL resources. Use this file when the user asks to create a Cloud SQL instance or database for MySQL, PostgreSQL, or SQL Server. Cloud SQL manages third-party MySQL, PostgreSQL, and SQL Server instances as resources in Cloud SQL. For example, when Cloud SQL creates an open-source MySQL instance, the resulting resource is a Cloud SQL for MySQL instance that Google Cloud manages. Cloud SQL handles backups, high availability, and secure connectivity for relational database workloads.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "firebase-basics",
+          "installUrl": "github:google/skills:skills/cloud/firebase-basics",
+          "description": "Use this skill whenever you are working on a project that uses Firebase products or services, especially for mobile or web apps.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gemini-api",
+          "installUrl": "github:google/skills:skills/cloud/gemini-api",
+          "description": "Guides the usage of the Gemini API on Agent Platform with the Google Gen AI SDK. Use when the user asks about using Gemini in an enterprise environment or explicitly mentions Vertex AI, Google Cloud, or Agent Platform. Covers SDK usage (Python, JS/TS, Go, Java, C#), capabilities like Live API, tools, multimedia generation, caching, and batch prediction.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gke-basics",
+          "installUrl": "github:google/skills:skills/cloud/gke-basics",
+          "description": "Plan, create, and configure production-ready Google Kubernetes Engine (GKE) clusters using the golden path Autopilot configuration. Covers Day-0 checklist, Autopilot vs Standard, networking (private clusters, VPC-native, Gateway API), security (Workload Identity, Secret Manager, RBAC hardening), observability, scaling, cost optimization, and AI/ML inference. WHEN: create GKE cluster, provision GKE environment, design GKE networking, secure GKE, optimize GKE cost, GKE autoscaling, GKE inference, GKE upgrade, GKE observability, GKE multi-tenancy, GKE batch, GKE HPC, GKE compute class.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "google-cloud-recipe-auth",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-recipe-auth",
+          "description": "Provides expert guidance on authenticating and authorizing to Google Cloud services and APIs, covering human users, service identities, Application Default Credentials (ADC), and best practices for secure access.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-cloud-recipe-networking-observability",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-networking-observability",
+          "description": "Investigates Google Cloud networking issues by analyzing logs, metrics, and diagnostics. Use when investigating VPC Flow Logs, NAT, firewall, or threat logs, querying latency and throughput metrics, or running Connectivity Tests for path diagnostics.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-cloud-recipe-onboarding",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-recipe-onboarding",
+          "description": "Guidance for a developer's first steps on Google Cloud, covering account creation, billing setup, project management, and deploying a first resource.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-cloud-waf-cost-optimization",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-waf-cost-optimization",
+          "description": "Generates cost optimization guidance for Google Cloud workloads based on the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify cost requirements and constraints, and provide actionable recommendations for build, deploy, and manage the workload cost-efficiently in Google Cloud.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-cloud-waf-reliability",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-waf-reliability",
+          "description": "Generates reliability-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework. Use this skill to evaluate a workload, identify reliability requirements, and provide actionable recommendations for build, deploy, and manage the workload reliably in Google Cloud.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-cloud-waf-security",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-waf-security",
+          "description": "Generates security-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify security requirements, and provide actionable recommendations for IAM, network security, data protection, and operational security.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "google",
+        "repo": "skills",
+        "repoUrl": "https://github.com/google/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "google-skills-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from google/skills.",
+      "author": "ASM (google/skills)",
+      "createdAt": "2026-05-09T08:11:10.843Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "google",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "alloydb-basics",
+          "installUrl": "github:google/skills:skills/cloud/alloydb-basics",
+          "description": "Manages clusters, instances, and backups for AlloyDB for PostgreSQL, and integrates with AlloyDB model context protocol (MCP) tools for automated database operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bigquery-basics",
+          "installUrl": "github:google/skills:skills/cloud/bigquery-basics",
+          "description": "Manages datasets, tables, and jobs in BigQuery, and integrates with BigQuery ML and Gemini for advanced data analytics and AI-driven insights. Use when you need to interact with BigQuery, run SQL queries, manage BigQuery resources, or leverage BigQuery's built-in ML capabilities. Also use when performing data analysis, ingesting data into BigQuery, or developing AI applications on BigQuery.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cloud-sql-basics",
+          "installUrl": "github:google/skills:skills/cloud/cloud-sql-basics",
+          "description": "This file generates or explains Cloud SQL resources. Use this file when the user asks to create a Cloud SQL instance or database for MySQL, PostgreSQL, or SQL Server. Cloud SQL manages third-party MySQL, PostgreSQL, and SQL Server instances as resources in Cloud SQL. For example, when Cloud SQL creates an open-source MySQL instance, the resulting resource is a Cloud SQL for MySQL instance that Google Cloud manages. Cloud SQL handles backups, high availability, and secure connectivity for relational database workloads.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gemini-api",
+          "installUrl": "github:google/skills:skills/cloud/gemini-api",
+          "description": "Guides the usage of the Gemini API on Agent Platform with the Google Gen AI SDK. Use when the user asks about using Gemini in an enterprise environment or explicitly mentions Vertex AI, Google Cloud, or Agent Platform. Covers SDK usage (Python, JS/TS, Go, Java, C#), capabilities like Live API, tools, multimedia generation, caching, and batch prediction.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gke-basics",
+          "installUrl": "github:google/skills:skills/cloud/gke-basics",
+          "description": "Plan, create, and configure production-ready Google Kubernetes Engine (GKE) clusters using the golden path Autopilot configuration. Covers Day-0 checklist, Autopilot vs Standard, networking (private clusters, VPC-native, Gateway API), security (Workload Identity, Secret Manager, RBAC hardening), observability, scaling, cost optimization, and AI/ML inference. WHEN: create GKE cluster, provision GKE environment, design GKE networking, secure GKE, optimize GKE cost, GKE autoscaling, GKE inference, GKE upgrade, GKE observability, GKE multi-tenancy, GKE batch, GKE HPC, GKE compute class.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "google-cloud-waf-cost-optimization",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-waf-cost-optimization",
+          "description": "Generates cost optimization guidance for Google Cloud workloads based on the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify cost requirements and constraints, and provide actionable recommendations for build, deploy, and manage the workload cost-efficiently in Google Cloud.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-cloud-waf-security",
+          "installUrl": "github:google/skills:skills/cloud/google-cloud-waf-security",
+          "description": "Generates security-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify security requirements, and provide actionable recommendations for IAM, network security, data protection, and operational security.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "google",
+        "repo": "skills",
+        "repoUrl": "https://github.com/google/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "google-skills-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from google/skills.",
+      "author": "ASM (google/skills)",
+      "createdAt": "2026-05-09T08:11:10.843Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "google",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "firebase-basics",
+          "installUrl": "github:google/skills:skills/cloud/firebase-basics",
+          "description": "Use this skill whenever you are working on a project that uses Firebase products or services, especially for mobile or web apps.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gke-basics",
+          "installUrl": "github:google/skills:skills/cloud/gke-basics",
+          "description": "Plan, create, and configure production-ready Google Kubernetes Engine (GKE) clusters using the golden path Autopilot configuration. Covers Day-0 checklist, Autopilot vs Standard, networking (private clusters, VPC-native, Gateway API), security (Workload Identity, Secret Manager, RBAC hardening), observability, scaling, cost optimization, and AI/ML inference. WHEN: create GKE cluster, provision GKE environment, design GKE networking, secure GKE, optimize GKE cost, GKE autoscaling, GKE inference, GKE upgrade, GKE observability, GKE multi-tenancy, GKE batch, GKE HPC, GKE compute class.",
+          "version": "1.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "google",
+        "repo": "skills",
+        "repoUrl": "https://github.com/google/skills.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/heygen-com_hyperframes.json
+++ b/data/skill-index/heygen-com_hyperframes.json
@@ -1786,5 +1786,409 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "heygen-com-hyperframes-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from heygen-com/hyperframes.",
+      "author": "ASM (heygen-com/hyperframes)",
+      "createdAt": "2026-05-09T08:11:10.114Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "heygen-com",
+        "hyperframes"
+      ],
+      "skills": [
+        {
+          "name": "hyperframes",
+          "installUrl": "github:heygen-com/hyperframes:skills/hyperframes",
+          "description": "Create video compositions, animations, title cards, overlays, captions, voiceovers, audio-reactive visuals, and scene transitions in HyperFrames HTML. Use when asked to build any HTML-based video content, add captions or subtitles synced to audio, generate text-to-speech narration, create audio-reactive animation (beat sync, glow, pulse driven by music), add animated text highlighting (marker sweeps, hand-drawn circles, burst lines, scribble, sketchout), or add transitions between scenes (crossfades, wipes, reveals, shader transitions). Covers composition authoring, timing, media, and the full video production workflow. For dev-loop CLI commands (init, lint, inspect, preview, render) see the hyperframes-cli skill; for asset preprocessing commands (tts, transcribe, remove-background) see the hyperframes-media skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "website-to-hyperframes",
+          "installUrl": "github:heygen-com/hyperframes:skills/website-to-hyperframes",
+          "description": "Capture a website and create a HyperFrames video from it. Use when: (1) a user provides a URL and wants a video, (2) someone says \"capture this site\", \"turn this into a video\", \"make a promo from my site\", (3) the user wants a social ad, product tour, or any video based on an existing website, (4) the user shares a link and asks for any kind of video content. Even if the user just pastes a URL — this is the skill to use.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "heygen-com",
+        "repo": "hyperframes",
+        "repoUrl": "https://github.com/heygen-com/hyperframes.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "heygen-com-hyperframes-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from heygen-com/hyperframes.",
+      "author": "ASM (heygen-com/hyperframes)",
+      "createdAt": "2026-05-09T08:11:10.114Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "heygen-com",
+        "hyperframes"
+      ],
+      "skills": [
+        {
+          "name": "animejs",
+          "installUrl": "github:heygen-com/hyperframes:skills/animejs",
+          "description": "Anime.js adapter patterns for HyperFrames. Use when writing Anime.js animations or timelines inside HyperFrames compositions, registering animations on window.__hfAnime, making Anime.js seek-driven and deterministic, or translating Anime.js examples into render-safe HyperFrames HTML.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gsap",
+          "installUrl": "github:heygen-com/hyperframes:skills/gsap",
+          "description": "GSAP animation reference for HyperFrames. Covers gsap.to(), from(), fromTo(), easing, stagger, defaults, timelines (gsap.timeline(), position parameter, labels, nesting, playback), and performance (transforms, will-change, quickTo). Use when writing GSAP animations in HyperFrames compositions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hyperframes",
+          "installUrl": "github:heygen-com/hyperframes:skills/hyperframes",
+          "description": "Create video compositions, animations, title cards, overlays, captions, voiceovers, audio-reactive visuals, and scene transitions in HyperFrames HTML. Use when asked to build any HTML-based video content, add captions or subtitles synced to audio, generate text-to-speech narration, create audio-reactive animation (beat sync, glow, pulse driven by music), add animated text highlighting (marker sweeps, hand-drawn circles, burst lines, scribble, sketchout), or add transitions between scenes (crossfades, wipes, reveals, shader transitions). Covers composition authoring, timing, media, and the full video production workflow. For dev-loop CLI commands (init, lint, inspect, preview, render) see the hyperframes-cli skill; for asset preprocessing commands (tts, transcribe, remove-background) see the hyperframes-media skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "remotion-to-hyperframes",
+          "installUrl": "github:heygen-com/hyperframes:skills/remotion-to-hyperframes",
+          "description": "Translate an existing Remotion (React-based) video composition into a HyperFrames HTML composition. Use ONLY when the user explicitly asks to port, convert, migrate, translate, or rewrite a Remotion composition as HyperFrames (e.g. \"port my Remotion project to HyperFrames\"). Do NOT use when (a) authoring a NEW HyperFrames composition (even if A/B-testing a Remotion video); (b) Remotion is mentioned in passing; (c) Remotion code is shared as reference, not for translation; (d) the user wants \"the same video as my Remotion one\" without explicitly asking to migrate the source — treat as a fresh HyperFrames build. When in doubt, default to the `hyperframes` skill. Detects unsupported patterns (useState, useEffect side effects, async calculateMetadata, third-party React component libraries, `@remotion/lambda`) and recommends the runtime interop escape hatch instead of a lossy translation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "tailwind",
+          "installUrl": "github:heygen-com/hyperframes:skills/tailwind",
+          "description": "Tailwind CSS v4.2 browser-runtime patterns for HyperFrames compositions. Use when scaffolding or editing projects created with `hyperframes init --tailwind`, writing Tailwind utility classes in composition HTML, adding CSS-first Tailwind v4 theme tokens, debugging v3 vs v4 syntax, or deciding when to compile Tailwind to CSS instead of using the browser runtime.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "website-to-hyperframes",
+          "installUrl": "github:heygen-com/hyperframes:skills/website-to-hyperframes",
+          "description": "Capture a website and create a HyperFrames video from it. Use when: (1) a user provides a URL and wants a video, (2) someone says \"capture this site\", \"turn this into a video\", \"make a promo from my site\", (3) the user wants a social ad, product tour, or any video based on an existing website, (4) the user shares a link and asks for any kind of video content. Even if the user just pastes a URL — this is the skill to use.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "heygen-com",
+        "repo": "hyperframes",
+        "repoUrl": "https://github.com/heygen-com/hyperframes.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "heygen-com-hyperframes-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from heygen-com/hyperframes.",
+      "author": "ASM (heygen-com/hyperframes)",
+      "createdAt": "2026-05-09T08:11:10.114Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "heygen-com",
+        "hyperframes"
+      ],
+      "skills": [
+        {
+          "name": "css-animations",
+          "installUrl": "github:heygen-com/hyperframes:skills/css-animations",
+          "description": "CSS animation adapter patterns for HyperFrames. Use when authoring CSS keyframes, animation-delay based timing, animation-fill-mode, animation-play-state, or CSS-only motion that HyperFrames must seek deterministically during preview and rendering.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hyperframes",
+          "installUrl": "github:heygen-com/hyperframes:skills/hyperframes",
+          "description": "Create video compositions, animations, title cards, overlays, captions, voiceovers, audio-reactive visuals, and scene transitions in HyperFrames HTML. Use when asked to build any HTML-based video content, add captions or subtitles synced to audio, generate text-to-speech narration, create audio-reactive animation (beat sync, glow, pulse driven by music), add animated text highlighting (marker sweeps, hand-drawn circles, burst lines, scribble, sketchout), or add transitions between scenes (crossfades, wipes, reveals, shader transitions). Covers composition authoring, timing, media, and the full video production workflow. For dev-loop CLI commands (init, lint, inspect, preview, render) see the hyperframes-cli skill; for asset preprocessing commands (tts, transcribe, remove-background) see the hyperframes-media skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hyperframes-cli",
+          "installUrl": "github:heygen-com/hyperframes:skills/hyperframes-cli",
+          "description": "HyperFrames CLI dev loop — `npx hyperframes` for scaffolding (init), validation (lint, inspect), preview, render, and environment troubleshooting (doctor, browser, info, upgrade). Use when running any of these commands or troubleshooting the HyperFrames build/render environment. For asset preprocessing commands (`tts`, `transcribe`, `remove-background`), invoke the `hyperframes-media` skill instead.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "heygen-com",
+        "repo": "hyperframes",
+        "repoUrl": "https://github.com/heygen-com/hyperframes.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "heygen-com-hyperframes-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from heygen-com/hyperframes.",
+      "author": "ASM (heygen-com/hyperframes)",
+      "createdAt": "2026-05-09T08:11:10.114Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "heygen-com",
+        "hyperframes"
+      ],
+      "skills": [
+        {
+          "name": "css-animations",
+          "installUrl": "github:heygen-com/hyperframes:skills/css-animations",
+          "description": "CSS animation adapter patterns for HyperFrames. Use when authoring CSS keyframes, animation-delay based timing, animation-fill-mode, animation-play-state, or CSS-only motion that HyperFrames must seek deterministically during preview and rendering.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hyperframes",
+          "installUrl": "github:heygen-com/hyperframes:skills/hyperframes",
+          "description": "Create video compositions, animations, title cards, overlays, captions, voiceovers, audio-reactive visuals, and scene transitions in HyperFrames HTML. Use when asked to build any HTML-based video content, add captions or subtitles synced to audio, generate text-to-speech narration, create audio-reactive animation (beat sync, glow, pulse driven by music), add animated text highlighting (marker sweeps, hand-drawn circles, burst lines, scribble, sketchout), or add transitions between scenes (crossfades, wipes, reveals, shader transitions). Covers composition authoring, timing, media, and the full video production workflow. For dev-loop CLI commands (init, lint, inspect, preview, render) see the hyperframes-cli skill; for asset preprocessing commands (tts, transcribe, remove-background) see the hyperframes-media skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hyperframes-cli",
+          "installUrl": "github:heygen-com/hyperframes:skills/hyperframes-cli",
+          "description": "HyperFrames CLI dev loop — `npx hyperframes` for scaffolding (init), validation (lint, inspect), preview, render, and environment troubleshooting (doctor, browser, info, upgrade). Use when running any of these commands or troubleshooting the HyperFrames build/render environment. For asset preprocessing commands (`tts`, `transcribe`, `remove-background`), invoke the `hyperframes-media` skill instead.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "remotion-to-hyperframes",
+          "installUrl": "github:heygen-com/hyperframes:skills/remotion-to-hyperframes",
+          "description": "Translate an existing Remotion (React-based) video composition into a HyperFrames HTML composition. Use ONLY when the user explicitly asks to port, convert, migrate, translate, or rewrite a Remotion composition as HyperFrames (e.g. \"port my Remotion project to HyperFrames\"). Do NOT use when (a) authoring a NEW HyperFrames composition (even if A/B-testing a Remotion video); (b) Remotion is mentioned in passing; (c) Remotion code is shared as reference, not for translation; (d) the user wants \"the same video as my Remotion one\" without explicitly asking to migrate the source — treat as a fresh HyperFrames build. When in doubt, default to the `hyperframes` skill. Detects unsupported patterns (useState, useEffect side effects, async calculateMetadata, third-party React component libraries, `@remotion/lambda`) and recommends the runtime interop escape hatch instead of a lossy translation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "tailwind",
+          "installUrl": "github:heygen-com/hyperframes:skills/tailwind",
+          "description": "Tailwind CSS v4.2 browser-runtime patterns for HyperFrames compositions. Use when scaffolding or editing projects created with `hyperframes init --tailwind`, writing Tailwind utility classes in composition HTML, adding CSS-first Tailwind v4 theme tokens, debugging v3 vs v4 syntax, or deciding when to compile Tailwind to CSS instead of using the browser runtime.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "waapi",
+          "installUrl": "github:heygen-com/hyperframes:skills/waapi",
+          "description": "Web Animations API adapter patterns for HyperFrames. Use when authoring element.animate() motion, Animation currentTime seeking, document.getAnimations(), KeyframeEffect timing, fill modes, or native browser animations that must render deterministically in HyperFrames.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "heygen-com",
+        "repo": "hyperframes",
+        "repoUrl": "https://github.com/heygen-com/hyperframes.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "heygen-com-hyperframes-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from heygen-com/hyperframes.",
+      "author": "ASM (heygen-com/hyperframes)",
+      "createdAt": "2026-05-09T08:11:10.114Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "heygen-com",
+        "hyperframes"
+      ],
+      "skills": [
+        {
+          "name": "animejs",
+          "installUrl": "github:heygen-com/hyperframes:skills/animejs",
+          "description": "Anime.js adapter patterns for HyperFrames. Use when writing Anime.js animations or timelines inside HyperFrames compositions, registering animations on window.__hfAnime, making Anime.js seek-driven and deterministic, or translating Anime.js examples into render-safe HyperFrames HTML.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "css-animations",
+          "installUrl": "github:heygen-com/hyperframes:skills/css-animations",
+          "description": "CSS animation adapter patterns for HyperFrames. Use when authoring CSS keyframes, animation-delay based timing, animation-fill-mode, animation-play-state, or CSS-only motion that HyperFrames must seek deterministically during preview and rendering.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gsap",
+          "installUrl": "github:heygen-com/hyperframes:skills/gsap",
+          "description": "GSAP animation reference for HyperFrames. Covers gsap.to(), from(), fromTo(), easing, stagger, defaults, timelines (gsap.timeline(), position parameter, labels, nesting, playback), and performance (transforms, will-change, quickTo). Use when writing GSAP animations in HyperFrames compositions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hyperframes",
+          "installUrl": "github:heygen-com/hyperframes:skills/hyperframes",
+          "description": "Create video compositions, animations, title cards, overlays, captions, voiceovers, audio-reactive visuals, and scene transitions in HyperFrames HTML. Use when asked to build any HTML-based video content, add captions or subtitles synced to audio, generate text-to-speech narration, create audio-reactive animation (beat sync, glow, pulse driven by music), add animated text highlighting (marker sweeps, hand-drawn circles, burst lines, scribble, sketchout), or add transitions between scenes (crossfades, wipes, reveals, shader transitions). Covers composition authoring, timing, media, and the full video production workflow. For dev-loop CLI commands (init, lint, inspect, preview, render) see the hyperframes-cli skill; for asset preprocessing commands (tts, transcribe, remove-background) see the hyperframes-media skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hyperframes-cli",
+          "installUrl": "github:heygen-com/hyperframes:skills/hyperframes-cli",
+          "description": "HyperFrames CLI dev loop — `npx hyperframes` for scaffolding (init), validation (lint, inspect), preview, render, and environment troubleshooting (doctor, browser, info, upgrade). Use when running any of these commands or troubleshooting the HyperFrames build/render environment. For asset preprocessing commands (`tts`, `transcribe`, `remove-background`), invoke the `hyperframes-media` skill instead.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hyperframes-registry",
+          "installUrl": "github:heygen-com/hyperframes:skills/hyperframes-registry",
+          "description": "Install and wire registry blocks and components into HyperFrames compositions. Use when running hyperframes add, installing a block or component, wiring an installed item into index.html, or working with hyperframes.json. Covers the add command, install locations, block sub-composition wiring, component snippet merging, and registry discovery.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "remotion-to-hyperframes",
+          "installUrl": "github:heygen-com/hyperframes:skills/remotion-to-hyperframes",
+          "description": "Translate an existing Remotion (React-based) video composition into a HyperFrames HTML composition. Use ONLY when the user explicitly asks to port, convert, migrate, translate, or rewrite a Remotion composition as HyperFrames (e.g. \"port my Remotion project to HyperFrames\"). Do NOT use when (a) authoring a NEW HyperFrames composition (even if A/B-testing a Remotion video); (b) Remotion is mentioned in passing; (c) Remotion code is shared as reference, not for translation; (d) the user wants \"the same video as my Remotion one\" without explicitly asking to migrate the source — treat as a fresh HyperFrames build. When in doubt, default to the `hyperframes` skill. Detects unsupported patterns (useState, useEffect side effects, async calculateMetadata, third-party React component libraries, `@remotion/lambda`) and recommends the runtime interop escape hatch instead of a lossy translation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "tailwind",
+          "installUrl": "github:heygen-com/hyperframes:skills/tailwind",
+          "description": "Tailwind CSS v4.2 browser-runtime patterns for HyperFrames compositions. Use when scaffolding or editing projects created with `hyperframes init --tailwind`, writing Tailwind utility classes in composition HTML, adding CSS-first Tailwind v4 theme tokens, debugging v3 vs v4 syntax, or deciding when to compile Tailwind to CSS instead of using the browser runtime.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "three",
+          "installUrl": "github:heygen-com/hyperframes:skills/three",
+          "description": "Three.js and WebGL adapter patterns for HyperFrames. Use when creating deterministic Three.js scenes, WebGL canvas layers, AnimationMixer timelines, camera motion, shader-driven visuals, or canvas renders that respond to HyperFrames hf-seek events.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "heygen-com",
+        "repo": "hyperframes",
+        "repoUrl": "https://github.com/heygen-com/hyperframes.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "heygen-com-hyperframes-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from heygen-com/hyperframes.",
+      "author": "ASM (heygen-com/hyperframes)",
+      "createdAt": "2026-05-09T08:11:10.114Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "heygen-com",
+        "hyperframes"
+      ],
+      "skills": [
+        {
+          "name": "hyperframes",
+          "installUrl": "github:heygen-com/hyperframes:skills/hyperframes",
+          "description": "Create video compositions, animations, title cards, overlays, captions, voiceovers, audio-reactive visuals, and scene transitions in HyperFrames HTML. Use when asked to build any HTML-based video content, add captions or subtitles synced to audio, generate text-to-speech narration, create audio-reactive animation (beat sync, glow, pulse driven by music), add animated text highlighting (marker sweeps, hand-drawn circles, burst lines, scribble, sketchout), or add transitions between scenes (crossfades, wipes, reveals, shader transitions). Covers composition authoring, timing, media, and the full video production workflow. For dev-loop CLI commands (init, lint, inspect, preview, render) see the hyperframes-cli skill; for asset preprocessing commands (tts, transcribe, remove-background) see the hyperframes-media skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "remotion-to-hyperframes",
+          "installUrl": "github:heygen-com/hyperframes:skills/remotion-to-hyperframes",
+          "description": "Translate an existing Remotion (React-based) video composition into a HyperFrames HTML composition. Use ONLY when the user explicitly asks to port, convert, migrate, translate, or rewrite a Remotion composition as HyperFrames (e.g. \"port my Remotion project to HyperFrames\"). Do NOT use when (a) authoring a NEW HyperFrames composition (even if A/B-testing a Remotion video); (b) Remotion is mentioned in passing; (c) Remotion code is shared as reference, not for translation; (d) the user wants \"the same video as my Remotion one\" without explicitly asking to migrate the source — treat as a fresh HyperFrames build. When in doubt, default to the `hyperframes` skill. Detects unsupported patterns (useState, useEffect side effects, async calculateMetadata, third-party React component libraries, `@remotion/lambda`) and recommends the runtime interop escape hatch instead of a lossy translation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "tailwind",
+          "installUrl": "github:heygen-com/hyperframes:skills/tailwind",
+          "description": "Tailwind CSS v4.2 browser-runtime patterns for HyperFrames compositions. Use when scaffolding or editing projects created with `hyperframes init --tailwind`, writing Tailwind utility classes in composition HTML, adding CSS-first Tailwind v4 theme tokens, debugging v3 vs v4 syntax, or deciding when to compile Tailwind to CSS instead of using the browser runtime.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "website-to-hyperframes",
+          "installUrl": "github:heygen-com/hyperframes:skills/website-to-hyperframes",
+          "description": "Capture a website and create a HyperFrames video from it. Use when: (1) a user provides a URL and wants a video, (2) someone says \"capture this site\", \"turn this into a video\", \"make a promo from my site\", (3) the user wants a social ad, product tour, or any video based on an existing website, (4) the user shares a link and asks for any kind of video content. Even if the user just pastes a URL — this is the skill to use.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "heygen-com",
+        "repo": "hyperframes",
+        "repoUrl": "https://github.com/heygen-com/hyperframes.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "heygen-com-hyperframes-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from heygen-com/hyperframes.",
+      "author": "ASM (heygen-com/hyperframes)",
+      "createdAt": "2026-05-09T08:11:10.114Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "heygen-com",
+        "hyperframes"
+      ],
+      "skills": [
+        {
+          "name": "hyperframes-media",
+          "installUrl": "github:heygen-com/hyperframes:skills/hyperframes-media",
+          "description": "Asset preprocessing for HyperFrames compositions — text-to-speech narration (Kokoro), audio/video transcription (Whisper), and background removal for transparent overlays (u2net). Use when generating voiceover from text, transcribing speech for captions, removing the background from a video or image to use as a transparent overlay, choosing a TTS voice or whisper model, or chaining these (TTS → transcribe → captions). Each command downloads its own model on first run.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "remotion-to-hyperframes",
+          "installUrl": "github:heygen-com/hyperframes:skills/remotion-to-hyperframes",
+          "description": "Translate an existing Remotion (React-based) video composition into a HyperFrames HTML composition. Use ONLY when the user explicitly asks to port, convert, migrate, translate, or rewrite a Remotion composition as HyperFrames (e.g. \"port my Remotion project to HyperFrames\"). Do NOT use when (a) authoring a NEW HyperFrames composition (even if A/B-testing a Remotion video); (b) Remotion is mentioned in passing; (c) Remotion code is shared as reference, not for translation; (d) the user wants \"the same video as my Remotion one\" without explicitly asking to migrate the source — treat as a fresh HyperFrames build. When in doubt, default to the `hyperframes` skill. Detects unsupported patterns (useState, useEffect side effects, async calculateMetadata, third-party React component libraries, `@remotion/lambda`) and recommends the runtime interop escape hatch instead of a lossy translation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "tailwind",
+          "installUrl": "github:heygen-com/hyperframes:skills/tailwind",
+          "description": "Tailwind CSS v4.2 browser-runtime patterns for HyperFrames compositions. Use when scaffolding or editing projects created with `hyperframes init --tailwind`, writing Tailwind utility classes in composition HTML, adding CSS-first Tailwind v4 theme tokens, debugging v3 vs v4 syntax, or deciding when to compile Tailwind to CSS instead of using the browser runtime.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "heygen-com",
+        "repo": "hyperframes",
+        "repoUrl": "https://github.com/heygen-com/hyperframes.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "heygen-com-hyperframes-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from heygen-com/hyperframes.",
+      "author": "ASM (heygen-com/hyperframes)",
+      "createdAt": "2026-05-09T08:11:10.114Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "heygen-com",
+        "hyperframes"
+      ],
+      "skills": [
+        {
+          "name": "hyperframes",
+          "installUrl": "github:heygen-com/hyperframes:skills/hyperframes",
+          "description": "Create video compositions, animations, title cards, overlays, captions, voiceovers, audio-reactive visuals, and scene transitions in HyperFrames HTML. Use when asked to build any HTML-based video content, add captions or subtitles synced to audio, generate text-to-speech narration, create audio-reactive animation (beat sync, glow, pulse driven by music), add animated text highlighting (marker sweeps, hand-drawn circles, burst lines, scribble, sketchout), or add transitions between scenes (crossfades, wipes, reveals, shader transitions). Covers composition authoring, timing, media, and the full video production workflow. For dev-loop CLI commands (init, lint, inspect, preview, render) see the hyperframes-cli skill; for asset preprocessing commands (tts, transcribe, remove-background) see the hyperframes-media skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "website-to-hyperframes",
+          "installUrl": "github:heygen-com/hyperframes:skills/website-to-hyperframes",
+          "description": "Capture a website and create a HyperFrames video from it. Use when: (1) a user provides a URL and wants a video, (2) someone says \"capture this site\", \"turn this into a video\", \"make a promo from my site\", (3) the user wants a social ad, product tour, or any video based on an existing website, (4) the user shares a link and asks for any kind of video content. Even if the user just pastes a URL — this is the skill to use.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "heygen-com",
+        "repo": "hyperframes",
+        "repoUrl": "https://github.com/heygen-com/hyperframes.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/himself65_finance-skills.json
+++ b/data/skill-index/himself65_finance-skills.json
@@ -3156,5 +3156,901 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "himself65-finance-skills-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from himself65/finance-skills.",
+      "author": "ASM (himself65/finance-skills)",
+      "createdAt": "2026-05-09T08:10:47.261Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "himself65",
+        "finance-skills"
+      ],
+      "skills": [
+        {
+          "name": "discord-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/discord-reader",
+          "description": "Read Discord for financial research using opencli (read-only). Use this skill whenever the user wants to read Discord channels, search for messages in trading servers, view guild/channel info, monitor crypto or market discussion groups, or gather financial sentiment from Discord. Triggers include: \"check my Discord\", \"search Discord for\", \"read Discord messages\", \"what's happening in the trading Discord\", \"show Discord channels\", \"list my servers\", \"Discord sentiment on BTC\", \"what are people saying in Discord about AAPL\", \"monitor crypto Discord\", any mention of Discord in context of reading financial news, market research, or trading community discussions. This skill is READ-ONLY — it does NOT support sending messages, reacting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "earnings-preview",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/earnings-preview",
+          "description": "Generate a pre-earnings briefing for any stock using Yahoo Finance data. Use this skill whenever the user wants to prepare for an upcoming earnings report, understand what analysts expect, review a company's beat/miss track record, or get a quick overview before an earnings call. Triggers include: \"earnings preview for AAPL\", \"what to expect from TSLA earnings\", \"MSFT reports next week\", \"earnings preview\", \"pre-earnings analysis\", \"what are analysts expecting for NVDA\", \"earnings estimates for\", \"will GOOGL beat earnings\", \"earnings beat/miss history\", \"upcoming earnings\", \"before earnings\", \"earnings setup\", \"consensus estimates\", \"earnings whisper\", \"EPS expectations\", \"what's the street expecting\", \"earnings season preview\", any mention of preparing for or previewing an earnings report, or any request to understand expectations ahead of a company's earnings date. Always use this skill when the user mentions a ticker in context of upcoming earnings, even if they don't say \"preview\" explicitly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "estimate-analysis",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/estimate-analysis",
+          "description": "Deep-dive into analyst estimates and revision trends for any stock using Yahoo Finance data. Use when the user wants to understand analyst estimate direction, how EPS or revenue forecasts changed over time, compare estimate distributions, or analyze growth projections across periods. Triggers: \"estimate analysis for AAPL\", \"analyst estimate trends for NVDA\", \"EPS revisions for TSLA\", \"how have estimates changed for MSFT\", \"estimate revisions\", \"EPS trend\", \"revenue estimates\", \"consensus changes\", \"analyst estimates\", \"estimate distribution\", \"growth estimates for\", \"estimate momentum\", \"revision trend\", \"forward estimates\", \"next quarter estimates\", \"annual estimates\", \"estimate spread\", \"bull vs bear estimates\", \"estimate range\", or any request about tracking or comparing analyst estimates/revisions. Use this skill when the user asks about estimates beyond a simple lookup — if they want context, trends, or analysis, this is the right skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "finance-sentiment",
+          "installUrl": "github:himself65/finance-skills:plugins/data-providers/skills/finance-sentiment",
+          "description": "Fetch structured stock sentiment across Reddit, X.com, news, and Polymarket using the Adanos Finance API. Use this skill whenever the user asks how much people are talking about a stock, how hot a ticker is on social platforms, how many Polymarket bets exist for a company, whether sources are aligned, or to compare stock sentiment across multiple tickers. Triggers include: \"social sentiment on TSLA\", \"how hot is NVDA on X.com\", \"how many Reddit mentions does AAPL have\", \"compare sentiment on AMD vs NVDA\", \"how many Polymarket bets on Microsoft\", \"is Reddit aligned with X on META\", \"stock buzz\", \"bullish percentage\", and any mention of cross-source stock sentiment research. This skill is READ-ONLY and does not place trades or modify anything.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "funda-data",
+          "installUrl": "github:himself65/finance-skills:plugins/data-providers/skills/funda-data",
+          "description": "Fetch financial data from the Funda AI API (https://api.funda.ai). Covers quotes, historical prices, financials, SEC filings, transcripts, analyst estimates, options flow/greeks/GEX, supply chain graph, social sentiment, Polymarket, congressional trades, economics, ESG, news, AI-enriched news (sentiment + event timeline), AI-company recruit signals, and a Claude API proxy via Bedrock. Triggers: stock quotes, balance sheet, income statement, cash flow, analyst targets, DCF, options chain/flow, GEX, IV rank, max pain, earnings/dividend/IPO calendar, 10-K/10-Q/8-K, suppliers/customers/competitors, insider trades, 13F, Reddit/Twitter sentiment, Polymarket, treasury rates, GDP, CPI, FRED, commodity/forex/crypto, stock screener, ETF holdings, COT, ticker sentiment, OpenAI/Anthropic/xAI/Google/Mercor/SurgeAI job postings, product launch probabilities, AI threat to public stocks. Also triggers for \"funda\" or \"funda.ai\". If only a ticker is provided and Funda API can answer, use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "linkedin-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/linkedin-reader",
+          "description": "Read LinkedIn for financial research using opencli (read-only). Use this skill whenever the user wants to read their LinkedIn feed, search for jobs in the finance/trading industry, view professional posts about markets or earnings, or gather professional sentiment from LinkedIn. Triggers include: \"check my LinkedIn feed\", \"search LinkedIn for\", \"LinkedIn posts about\", \"what's on LinkedIn about AAPL\", \"finance jobs on LinkedIn\", \"LinkedIn market sentiment\", \"who's posting about earnings on LinkedIn\", \"LinkedIn feed\", \"professional network buzz\", \"what are analysts saying on LinkedIn\", any mention of LinkedIn in context of reading financial news, market research, job searches, or professional commentary. This skill is READ-ONLY — it does NOT support posting, liking, commenting, connecting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "opencli-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/opencli-reader",
+          "description": "Generic read-only fallback for any source opencli covers but this repo has no dedicated reader for — Yahoo Finance, Bloomberg, Reuters, Barchart, Eastmoney, Xueqiu, Sinafinance, Reddit, HackerNews, Substack, Medium, Weibo, Bilibili, Xiaohongshu, Zhihu, arXiv, Google Scholar, Apple Podcasts, Xiaoyuzhou, Spotify, YouTube, Weixin, Amazon, and more. Triggers: \"use opencli to read\", \"grab the frontpage from hackernews\", \"read reddit r/wallstreetbets\", \"fetch Eastmoney hot stocks\", \"pull Xueqiu feed\", \"get Bloomberg markets headlines\", \"search arXiv for\", any request to read from a site where a specialized skill does not exist but opencli does. FALLBACK — prefer twitter-reader, linkedin-reader, discord-reader, telegram-reader, or yc-reader when the source matches. READ-ONLY — never invoke write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "saas-valuation-compression",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/saas-valuation-compression",
+          "description": "Analyze SaaS company valuation compression between funding rounds. Use this skill whenever the user asks about: how much a SaaS company's valuation multiple changed between rounds, why the ARR multiple compressed or expanded, comparing a company's compression to macro benchmarks, or explaining what drove valuation changes for any VC-backed software company. Trigger on phrases like \"valuation compression\", \"ARR multiple\", \"round-to-round valuation\", \"multiple change\", or when the user asks to compare a company's funding rounds. Always use this skill for any multi-round SaaS valuation analysis — do not try to answer from memory alone.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "sepa-strategy",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/sepa-strategy",
+          "description": "Analyze stocks using Mark Minervini's SEPA (Specific Entry Point Analysis) methodology. Use this skill whenever the user mentions SEPA, Minervini, superperformance, trend template, VCP (Volatility Contraction Pattern), Stage 2 uptrend, stage analysis, pivot point breakout, or asks about growth stock screening criteria. Also triggers when the user wants to evaluate whether a stock meets swing trading entry criteria, check moving average alignment (bullish stacking: price above 50MA above 150MA above 200MA), assess breakout quality with volume confirmation, calculate position sizing based on risk percentage, or identify consolidation patterns like cup-with-handle, flat base, bull flag, or high tight flag. Use this skill even when the user simply asks \"should I buy this stock\" or \"is this a good setup\" in the context of growth/momentum trading, or when they share a stock chart and want pattern analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "telegram-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/telegram-reader",
+          "description": "Read Telegram channels and groups for financial news and market research using tdl (read-only). Use this skill whenever the user wants to read Telegram channels, export messages from financial Telegram groups, list their Telegram chats, search for news in Telegram channels, or gather market intelligence from Telegram. Triggers include: \"check my Telegram\", \"read Telegram channel\", \"Telegram news\", \"what's new in my Telegram channels\", \"export messages from\", \"list my Telegram chats\", \"financial news on Telegram\", \"crypto Telegram\", \"market news Telegram\", any mention of Telegram in context of reading financial news, crypto signals, or market research. This skill is READ-ONLY — it does NOT support sending messages, joining channels, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "twitter-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/twitter-reader",
+          "description": "Read Twitter/X for financial research using opencli (read-only). Use this skill whenever the user wants to read their Twitter feed, search for financial tweets, view bookmarks, look up user profiles, or gather market sentiment from Twitter/X. Triggers include: \"check my feed\", \"search Twitter for\", \"show my bookmarks\", \"who follows\", \"look up @user\", \"what's trending about\", \"market sentiment on Twitter\", \"what are people saying about AAPL\", \"recent tweets from @elonmusk\", \"show me @user's posts\", \"fintwit\", any mention of Twitter/X in context of reading financial news or market research. This skill is READ-ONLY — it does NOT support posting, liking, retweeting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "yc-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/yc-reader",
+          "description": "Look up Y Combinator companies, batches, and startup ecosystem data using the yc-oss API (read-only). Use this skill whenever the user wants to research YC-backed startups, find companies in a specific batch or industry, check which YC companies are hiring, explore top YC companies, or analyze startup trends by sector or tag. Triggers include: \"YC companies in fintech\", \"who's in the latest YC batch\", \"YC startups hiring\", \"top Y Combinator companies\", \"find YC companies tagged AI\", \"W25 batch\", \"S24 companies\", \"YC stats\", \"Y Combinator portfolio\", \"startup research\", \"which YC companies do X\", \"venture research on YC\", any mention of Y Combinator, YC batch, or YC-backed companies in the context of startup research, venture analysis, or market intelligence. This is a read-only data source — the API is a static JSON dataset updated daily.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "himself65",
+        "repo": "finance-skills",
+        "repoUrl": "https://github.com/himself65/finance-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "himself65-finance-skills-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from himself65/finance-skills.",
+      "author": "ASM (himself65/finance-skills)",
+      "createdAt": "2026-05-09T08:10:47.261Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "himself65",
+        "finance-skills"
+      ],
+      "skills": [
+        {
+          "name": "discord-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/discord-reader",
+          "description": "Read Discord for financial research using opencli (read-only). Use this skill whenever the user wants to read Discord channels, search for messages in trading servers, view guild/channel info, monitor crypto or market discussion groups, or gather financial sentiment from Discord. Triggers include: \"check my Discord\", \"search Discord for\", \"read Discord messages\", \"what's happening in the trading Discord\", \"show Discord channels\", \"list my servers\", \"Discord sentiment on BTC\", \"what are people saying in Discord about AAPL\", \"monitor crypto Discord\", any mention of Discord in context of reading financial news, market research, or trading community discussions. This skill is READ-ONLY — it does NOT support sending messages, reacting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "generative-ui",
+          "installUrl": "github:himself65/finance-skills:plugins/ui-tools/skills/generative-ui",
+          "description": "Design system and guidelines for Claude's built-in generative UI — the show_widget tool that renders interactive HTML/SVG widgets inline in claude.ai conversations. This skill provides the complete Anthropic \"Imagine\" design system so Claude produces high-quality widgets without needing to call read_me first. Use this skill whenever the user asks to visualize data, create an interactive chart, build a dashboard, render a diagram, draw a flowchart, show a mockup, create an interactive explainer, or produce any visual content beyond plain text or markdown. Triggers include: \"show me\", \"visualize\", \"draw\", \"chart\", \"dashboard\", \"diagram\", \"flowchart\", \"widget\", \"interactive\", \"mockup\", \"illustrate\", \"explain how X works\" (with visual), or any request for visual/interactive output. Also triggers when the user wants to display financial data visually, create comparison grids, or build tools with sliders, toggles, or live-updating displays.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "linkedin-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/linkedin-reader",
+          "description": "Read LinkedIn for financial research using opencli (read-only). Use this skill whenever the user wants to read their LinkedIn feed, search for jobs in the finance/trading industry, view professional posts about markets or earnings, or gather professional sentiment from LinkedIn. Triggers include: \"check my LinkedIn feed\", \"search LinkedIn for\", \"LinkedIn posts about\", \"what's on LinkedIn about AAPL\", \"finance jobs on LinkedIn\", \"LinkedIn market sentiment\", \"who's posting about earnings on LinkedIn\", \"LinkedIn feed\", \"professional network buzz\", \"what are analysts saying on LinkedIn\", any mention of LinkedIn in context of reading financial news, market research, job searches, or professional commentary. This skill is READ-ONLY — it does NOT support posting, liking, commenting, connecting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "opencli-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/opencli-reader",
+          "description": "Generic read-only fallback for any source opencli covers but this repo has no dedicated reader for — Yahoo Finance, Bloomberg, Reuters, Barchart, Eastmoney, Xueqiu, Sinafinance, Reddit, HackerNews, Substack, Medium, Weibo, Bilibili, Xiaohongshu, Zhihu, arXiv, Google Scholar, Apple Podcasts, Xiaoyuzhou, Spotify, YouTube, Weixin, Amazon, and more. Triggers: \"use opencli to read\", \"grab the frontpage from hackernews\", \"read reddit r/wallstreetbets\", \"fetch Eastmoney hot stocks\", \"pull Xueqiu feed\", \"get Bloomberg markets headlines\", \"search arXiv for\", any request to read from a site where a specialized skill does not exist but opencli does. FALLBACK — prefer twitter-reader, linkedin-reader, discord-reader, telegram-reader, or yc-reader when the source matches. READ-ONLY — never invoke write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "skill-creator",
+          "installUrl": "github:himself65/finance-skills:plugins/skill-creator/skills/skill-creator",
+          "description": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, update or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or iterate on skill quality. Triggers: \"create a skill\", \"make a new skill\", \"build a skill for\", \"write a skill that\", \"skill for doing X\", \"I want a skill to\", \"new skill\", \"design a skill\", \"scaffold a skill\", \"improve this skill\", \"optimize this skill\", \"this skill isn't working well\", \"evaluate this skill\", \"score this skill\", \"how good is this skill\", \"run evals on\", \"benchmark this skill\", \"test this skill's quality\", \"skill quality\", \"skill performance\". Also triggers when a user describes a repeatable workflow they want to automate, says \"I keep doing X manually\", \"can you remember how to do X\", or \"turn this into a skill\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "telegram-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/telegram-reader",
+          "description": "Read Telegram channels and groups for financial news and market research using tdl (read-only). Use this skill whenever the user wants to read Telegram channels, export messages from financial Telegram groups, list their Telegram chats, search for news in Telegram channels, or gather market intelligence from Telegram. Triggers include: \"check my Telegram\", \"read Telegram channel\", \"Telegram news\", \"what's new in my Telegram channels\", \"export messages from\", \"list my Telegram chats\", \"financial news on Telegram\", \"crypto Telegram\", \"market news Telegram\", any mention of Telegram in context of reading financial news, crypto signals, or market research. This skill is READ-ONLY — it does NOT support sending messages, joining channels, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "twitter-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/twitter-reader",
+          "description": "Read Twitter/X for financial research using opencli (read-only). Use this skill whenever the user wants to read their Twitter feed, search for financial tweets, view bookmarks, look up user profiles, or gather market sentiment from Twitter/X. Triggers include: \"check my feed\", \"search Twitter for\", \"show my bookmarks\", \"who follows\", \"look up @user\", \"what's trending about\", \"market sentiment on Twitter\", \"what are people saying about AAPL\", \"recent tweets from @elonmusk\", \"show me @user's posts\", \"fintwit\", any mention of Twitter/X in context of reading financial news or market research. This skill is READ-ONLY — it does NOT support posting, liking, retweeting, or any write operations.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "himself65",
+        "repo": "finance-skills",
+        "repoUrl": "https://github.com/himself65/finance-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "himself65-finance-skills-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from himself65/finance-skills.",
+      "author": "ASM (himself65/finance-skills)",
+      "createdAt": "2026-05-09T08:10:47.261Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "himself65",
+        "finance-skills"
+      ],
+      "skills": [
+        {
+          "name": "company-valuation",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/company-valuation",
+          "description": "Estimate the intrinsic value of a public company using DCF, relative (peer multiple) and sum-of-parts (SOTP) methods, then triangulate to an implied share price with upside/downside versus the current market price. Use this skill whenever the user asks: \"what is AAPL worth\", \"valuation of NVDA\", \"fair value of TSLA\", \"intrinsic value\", \"DCF for MSFT\", \"build a DCF\", \"discounted cash flow\", \"WACC\", \"terminal value\", \"implied share price\", \"upside to fair value\", \"is X overvalued/undervalued\", \"relative valuation\", \"peer comparison valuation\", \"EV/EBITDA target\", \"SOTP\", \"sum of the parts\", \"how much is [company] worth\", \"price target from fundamentals\", \"value this company\", or any ticker in the context of computing intrinsic or relative valuation. Default to running ALL three methods (DCF + relative + SOTP-if-applicable) and presenting a blended implied price with a sensitivity table. Do not answer valuation questions from memory — always run the workflow.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "discord-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/discord-reader",
+          "description": "Read Discord for financial research using opencli (read-only). Use this skill whenever the user wants to read Discord channels, search for messages in trading servers, view guild/channel info, monitor crypto or market discussion groups, or gather financial sentiment from Discord. Triggers include: \"check my Discord\", \"search Discord for\", \"read Discord messages\", \"what's happening in the trading Discord\", \"show Discord channels\", \"list my servers\", \"Discord sentiment on BTC\", \"what are people saying in Discord about AAPL\", \"monitor crypto Discord\", any mention of Discord in context of reading financial news, market research, or trading community discussions. This skill is READ-ONLY — it does NOT support sending messages, reacting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "earnings-preview",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/earnings-preview",
+          "description": "Generate a pre-earnings briefing for any stock using Yahoo Finance data. Use this skill whenever the user wants to prepare for an upcoming earnings report, understand what analysts expect, review a company's beat/miss track record, or get a quick overview before an earnings call. Triggers include: \"earnings preview for AAPL\", \"what to expect from TSLA earnings\", \"MSFT reports next week\", \"earnings preview\", \"pre-earnings analysis\", \"what are analysts expecting for NVDA\", \"earnings estimates for\", \"will GOOGL beat earnings\", \"earnings beat/miss history\", \"upcoming earnings\", \"before earnings\", \"earnings setup\", \"consensus estimates\", \"earnings whisper\", \"EPS expectations\", \"what's the street expecting\", \"earnings season preview\", any mention of preparing for or previewing an earnings report, or any request to understand expectations ahead of a company's earnings date. Always use this skill when the user mentions a ticker in context of upcoming earnings, even if they don't say \"preview\" explicitly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "earnings-recap",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/earnings-recap",
+          "description": "Generate a post-earnings analysis for any stock using Yahoo Finance data. Use when the user wants to review what happened after earnings, understand beat/miss results, see stock reaction, or get an earnings recap. Triggers: \"AAPL earnings recap\", \"how did TSLA earnings go\", \"MSFT earnings results\", \"did NVDA beat earnings\", \"post-earnings analysis\", \"earnings surprise\", \"what happened with GOOGL earnings\", \"earnings reaction\", \"stock moved after earnings\", \"EPS beat or miss\", \"revenue beat or miss\", \"quarterly results for\", \"how were earnings\", \"AMZN reported last night\", \"earnings call recap\", or any request about a company's recent earnings outcome. Use this skill when the user references a past earnings event, even if they just say \"AAPL reported\" or \"how did they do\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "estimate-analysis",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/estimate-analysis",
+          "description": "Deep-dive into analyst estimates and revision trends for any stock using Yahoo Finance data. Use when the user wants to understand analyst estimate direction, how EPS or revenue forecasts changed over time, compare estimate distributions, or analyze growth projections across periods. Triggers: \"estimate analysis for AAPL\", \"analyst estimate trends for NVDA\", \"EPS revisions for TSLA\", \"how have estimates changed for MSFT\", \"estimate revisions\", \"EPS trend\", \"revenue estimates\", \"consensus changes\", \"analyst estimates\", \"estimate distribution\", \"growth estimates for\", \"estimate momentum\", \"revision trend\", \"forward estimates\", \"next quarter estimates\", \"annual estimates\", \"estimate spread\", \"bull vs bear estimates\", \"estimate range\", or any request about tracking or comparing analyst estimates/revisions. Use this skill when the user asks about estimates beyond a simple lookup — if they want context, trends, or analysis, this is the right skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "etf-premium",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/etf-premium",
+          "description": "Calculate ETF premium or discount relative to Net Asset Value (NAV) using Yahoo Finance data. Use this skill whenever the user asks about an ETF's premium or discount, NAV comparison, whether an ETF is trading above or below its fair value, or wants to compare market price vs NAV. Triggers: \"ETF premium\", \"ETF discount\", \"NAV premium\", \"is SPY trading at a premium\", \"AGG premium to NAV\", \"market price vs NAV\", \"ETF mispricing\", \"BITO premium\", \"IBIT premium\", \"bond ETF discount\", \"trading above/below NAV\", \"ETF premium screener\", \"which ETFs have biggest discount\", \"compare ETF NAV\", \"ETF arbitrage\", or any request involving the gap between an ETF's market price and its underlying value. Also triggers when analyzing leveraged, inverse, international, bond, commodity, or crypto ETFs where premium/discount is a known concern.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "finance-sentiment",
+          "installUrl": "github:himself65/finance-skills:plugins/data-providers/skills/finance-sentiment",
+          "description": "Fetch structured stock sentiment across Reddit, X.com, news, and Polymarket using the Adanos Finance API. Use this skill whenever the user asks how much people are talking about a stock, how hot a ticker is on social platforms, how many Polymarket bets exist for a company, whether sources are aligned, or to compare stock sentiment across multiple tickers. Triggers include: \"social sentiment on TSLA\", \"how hot is NVDA on X.com\", \"how many Reddit mentions does AAPL have\", \"compare sentiment on AMD vs NVDA\", \"how many Polymarket bets on Microsoft\", \"is Reddit aligned with X on META\", \"stock buzz\", \"bullish percentage\", and any mention of cross-source stock sentiment research. This skill is READ-ONLY and does not place trades or modify anything.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "linkedin-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/linkedin-reader",
+          "description": "Read LinkedIn for financial research using opencli (read-only). Use this skill whenever the user wants to read their LinkedIn feed, search for jobs in the finance/trading industry, view professional posts about markets or earnings, or gather professional sentiment from LinkedIn. Triggers include: \"check my LinkedIn feed\", \"search LinkedIn for\", \"LinkedIn posts about\", \"what's on LinkedIn about AAPL\", \"finance jobs on LinkedIn\", \"LinkedIn market sentiment\", \"who's posting about earnings on LinkedIn\", \"LinkedIn feed\", \"professional network buzz\", \"what are analysts saying on LinkedIn\", any mention of LinkedIn in context of reading financial news, market research, job searches, or professional commentary. This skill is READ-ONLY — it does NOT support posting, liking, commenting, connecting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "opencli-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/opencli-reader",
+          "description": "Generic read-only fallback for any source opencli covers but this repo has no dedicated reader for — Yahoo Finance, Bloomberg, Reuters, Barchart, Eastmoney, Xueqiu, Sinafinance, Reddit, HackerNews, Substack, Medium, Weibo, Bilibili, Xiaohongshu, Zhihu, arXiv, Google Scholar, Apple Podcasts, Xiaoyuzhou, Spotify, YouTube, Weixin, Amazon, and more. Triggers: \"use opencli to read\", \"grab the frontpage from hackernews\", \"read reddit r/wallstreetbets\", \"fetch Eastmoney hot stocks\", \"pull Xueqiu feed\", \"get Bloomberg markets headlines\", \"search arXiv for\", any request to read from a site where a specialized skill does not exist but opencli does. FALLBACK — prefer twitter-reader, linkedin-reader, discord-reader, telegram-reader, or yc-reader when the source matches. READ-ONLY — never invoke write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "options-payoff",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/options-payoff",
+          "description": "Generate an interactive options payoff curve chart with dynamic parameter controls. Use this skill whenever the user shares an options position screenshot, describes an options strategy, or asks to visualize how an options trade makes or loses money. Triggers include: any mention of butterfly, spread (vertical/calendar/diagonal/ratio), straddle, strangle, condor, covered call, protective put, iron condor, or any multi-leg options structure. Also triggers when a user pastes strike prices, premiums, expiry dates, or says things like \"show me the payoff\", \"draw the P&L curve\", \"what does this trade look like\", or uploads a screenshot from a broker (IBKR, TastyTrade, Robinhood, etc). Always use this skill even if the user only provides partial info — extract what you can and use defaults for the rest.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "saas-valuation-compression",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/saas-valuation-compression",
+          "description": "Analyze SaaS company valuation compression between funding rounds. Use this skill whenever the user asks about: how much a SaaS company's valuation multiple changed between rounds, why the ARR multiple compressed or expanded, comparing a company's compression to macro benchmarks, or explaining what drove valuation changes for any VC-backed software company. Trigger on phrases like \"valuation compression\", \"ARR multiple\", \"round-to-round valuation\", \"multiple change\", or when the user asks to compare a company's funding rounds. Always use this skill for any multi-round SaaS valuation analysis — do not try to answer from memory alone.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "sepa-strategy",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/sepa-strategy",
+          "description": "Analyze stocks using Mark Minervini's SEPA (Specific Entry Point Analysis) methodology. Use this skill whenever the user mentions SEPA, Minervini, superperformance, trend template, VCP (Volatility Contraction Pattern), Stage 2 uptrend, stage analysis, pivot point breakout, or asks about growth stock screening criteria. Also triggers when the user wants to evaluate whether a stock meets swing trading entry criteria, check moving average alignment (bullish stacking: price above 50MA above 150MA above 200MA), assess breakout quality with volume confirmation, calculate position sizing based on risk percentage, or identify consolidation patterns like cup-with-handle, flat base, bull flag, or high tight flag. Use this skill even when the user simply asks \"should I buy this stock\" or \"is this a good setup\" in the context of growth/momentum trading, or when they share a stock chart and want pattern analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "skill-creator",
+          "installUrl": "github:himself65/finance-skills:plugins/skill-creator/skills/skill-creator",
+          "description": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, update or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or iterate on skill quality. Triggers: \"create a skill\", \"make a new skill\", \"build a skill for\", \"write a skill that\", \"skill for doing X\", \"I want a skill to\", \"new skill\", \"design a skill\", \"scaffold a skill\", \"improve this skill\", \"optimize this skill\", \"this skill isn't working well\", \"evaluate this skill\", \"score this skill\", \"how good is this skill\", \"run evals on\", \"benchmark this skill\", \"test this skill's quality\", \"skill quality\", \"skill performance\". Also triggers when a user describes a repeatable workflow they want to automate, says \"I keep doing X manually\", \"can you remember how to do X\", or \"turn this into a skill\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "startup-analysis",
+          "installUrl": "github:himself65/finance-skills:plugins/startup-tools/skills/startup-analysis",
+          "description": "Analyze a startup from three perspectives: VC investor, job applicant, and CEO/founder. Use this skill whenever the user wants to evaluate a startup, assess whether to invest in or join a startup, do due diligence, evaluate a job offer from a startup, understand a startup's competitive position, or assess company health and trajectory. Triggers: \"analyze this startup\", \"should I join [company]\", \"is [company] a good investment\", \"evaluate [company]\", \"due diligence on [company]\", \"what do you think of [startup]\", \"should I take this startup job offer\", \"how healthy is [company]\", \"startup assessment\", \"company analysis\", \"is [company] worth joining\", \"what's the outlook for [company]\", \"research [company] for me\", any mention of evaluating or assessing a startup or tech company from investment, career, or strategic perspectives — provide all three perspectives by default.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "stock-correlation",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/stock-correlation",
+          "description": "Analyze stock correlations to find related companies and trading pairs. Use when the user asks about correlated stocks, related companies, sector peers, trading pairs, or how two or more stocks move together. Triggers: \"what correlates with NVDA\", \"find stocks related to AMD\", \"correlation between AAPL and MSFT\", \"what moves with\", \"sector peers\", \"pair trading\", \"correlated stocks\", \"when NVDA drops what else drops\", \"stocks that move together\", \"beta to\", \"relative performance\", \"supply chain partners\", \"correlation matrix\", \"co-movement\", \"related tickers\", \"sympathy plays\", \"semiconductor peers\", \"hedging pair\", \"realized correlation\", \"rolling correlation\", or any request about stocks that move in tandem or inversely. Also triggers for well-known pairs like AMD/NVDA, GOOGL/AVGO, LITE/COHR. If only one ticker is provided, infer the user wants correlated peers.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "stock-liquidity",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/stock-liquidity",
+          "description": "Analyze stock liquidity using bid-ask spreads, volume profiles, order book depth, market impact estimates, and turnover ratios via Yahoo Finance data. Use this skill whenever the user asks about liquidity, trading costs, bid-ask spread, market depth, volume analysis, slippage, market impact, turnover ratio, or how easy/hard it is to trade a stock without moving the price. Triggers: \"how liquid is AAPL\", \"bid-ask spread\", \"volume analysis\", \"order book depth\", \"market impact of a large order\", \"turnover ratio\", \"slippage estimate\", \"can I trade 100k shares without moving the price\", \"liquidity comparison\", \"spread analysis\", \"ADTV\", \"Amihud illiquidity\", \"dollar volume\", \"execution cost estimate\", \"liquidity score\", penny stocks, small caps, or thinly traded securities.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "telegram-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/telegram-reader",
+          "description": "Read Telegram channels and groups for financial news and market research using tdl (read-only). Use this skill whenever the user wants to read Telegram channels, export messages from financial Telegram groups, list their Telegram chats, search for news in Telegram channels, or gather market intelligence from Telegram. Triggers include: \"check my Telegram\", \"read Telegram channel\", \"Telegram news\", \"what's new in my Telegram channels\", \"export messages from\", \"list my Telegram chats\", \"financial news on Telegram\", \"crypto Telegram\", \"market news Telegram\", any mention of Telegram in context of reading financial news, crypto signals, or market research. This skill is READ-ONLY — it does NOT support sending messages, joining channels, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "twitter-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/twitter-reader",
+          "description": "Read Twitter/X for financial research using opencli (read-only). Use this skill whenever the user wants to read their Twitter feed, search for financial tweets, view bookmarks, look up user profiles, or gather market sentiment from Twitter/X. Triggers include: \"check my feed\", \"search Twitter for\", \"show my bookmarks\", \"who follows\", \"look up @user\", \"what's trending about\", \"market sentiment on Twitter\", \"what are people saying about AAPL\", \"recent tweets from @elonmusk\", \"show me @user's posts\", \"fintwit\", any mention of Twitter/X in context of reading financial news or market research. This skill is READ-ONLY — it does NOT support posting, liking, retweeting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "yc-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/yc-reader",
+          "description": "Look up Y Combinator companies, batches, and startup ecosystem data using the yc-oss API (read-only). Use this skill whenever the user wants to research YC-backed startups, find companies in a specific batch or industry, check which YC companies are hiring, explore top YC companies, or analyze startup trends by sector or tag. Triggers include: \"YC companies in fintech\", \"who's in the latest YC batch\", \"YC startups hiring\", \"top Y Combinator companies\", \"find YC companies tagged AI\", \"W25 batch\", \"S24 companies\", \"YC stats\", \"Y Combinator portfolio\", \"startup research\", \"which YC companies do X\", \"venture research on YC\", any mention of Y Combinator, YC batch, or YC-backed companies in the context of startup research, venture analysis, or market intelligence. This is a read-only data source — the API is a static JSON dataset updated daily.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "yfinance-data",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/yfinance-data",
+          "description": "Fetch financial and market data using the yfinance Python library. Use this skill whenever the user asks for stock prices, historical data, financial statements, options chains, dividends, earnings, analyst recommendations, or any market data. Triggers include: any mention of stock price, ticker symbol (AAPL, MSFT, TSLA, etc.), \"get me the financials\", \"show earnings\", \"what's the price of\", \"download stock data\", \"options chain\", \"dividend history\", \"balance sheet\", \"income statement\", \"cash flow\", \"analyst targets\", \"institutional holders\", \"compare stocks\", \"screen for stocks\", or any request involving Yahoo Finance data. Always use this skill even if the user only provides a ticker — infer intent from context.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "himself65",
+        "repo": "finance-skills",
+        "repoUrl": "https://github.com/himself65/finance-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "himself65-finance-skills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from himself65/finance-skills.",
+      "author": "ASM (himself65/finance-skills)",
+      "createdAt": "2026-05-09T08:10:47.261Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "himself65",
+        "finance-skills"
+      ],
+      "skills": [
+        {
+          "name": "company-valuation",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/company-valuation",
+          "description": "Estimate the intrinsic value of a public company using DCF, relative (peer multiple) and sum-of-parts (SOTP) methods, then triangulate to an implied share price with upside/downside versus the current market price. Use this skill whenever the user asks: \"what is AAPL worth\", \"valuation of NVDA\", \"fair value of TSLA\", \"intrinsic value\", \"DCF for MSFT\", \"build a DCF\", \"discounted cash flow\", \"WACC\", \"terminal value\", \"implied share price\", \"upside to fair value\", \"is X overvalued/undervalued\", \"relative valuation\", \"peer comparison valuation\", \"EV/EBITDA target\", \"SOTP\", \"sum of the parts\", \"how much is [company] worth\", \"price target from fundamentals\", \"value this company\", or any ticker in the context of computing intrinsic or relative valuation. Default to running ALL three methods (DCF + relative + SOTP-if-applicable) and presenting a blended implied price with a sensitivity table. Do not answer valuation questions from memory — always run the workflow.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "discord-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/discord-reader",
+          "description": "Read Discord for financial research using opencli (read-only). Use this skill whenever the user wants to read Discord channels, search for messages in trading servers, view guild/channel info, monitor crypto or market discussion groups, or gather financial sentiment from Discord. Triggers include: \"check my Discord\", \"search Discord for\", \"read Discord messages\", \"what's happening in the trading Discord\", \"show Discord channels\", \"list my servers\", \"Discord sentiment on BTC\", \"what are people saying in Discord about AAPL\", \"monitor crypto Discord\", any mention of Discord in context of reading financial news, market research, or trading community discussions. This skill is READ-ONLY — it does NOT support sending messages, reacting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "earnings-preview",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/earnings-preview",
+          "description": "Generate a pre-earnings briefing for any stock using Yahoo Finance data. Use this skill whenever the user wants to prepare for an upcoming earnings report, understand what analysts expect, review a company's beat/miss track record, or get a quick overview before an earnings call. Triggers include: \"earnings preview for AAPL\", \"what to expect from TSLA earnings\", \"MSFT reports next week\", \"earnings preview\", \"pre-earnings analysis\", \"what are analysts expecting for NVDA\", \"earnings estimates for\", \"will GOOGL beat earnings\", \"earnings beat/miss history\", \"upcoming earnings\", \"before earnings\", \"earnings setup\", \"consensus estimates\", \"earnings whisper\", \"EPS expectations\", \"what's the street expecting\", \"earnings season preview\", any mention of preparing for or previewing an earnings report, or any request to understand expectations ahead of a company's earnings date. Always use this skill when the user mentions a ticker in context of upcoming earnings, even if they don't say \"preview\" explicitly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "earnings-recap",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/earnings-recap",
+          "description": "Generate a post-earnings analysis for any stock using Yahoo Finance data. Use when the user wants to review what happened after earnings, understand beat/miss results, see stock reaction, or get an earnings recap. Triggers: \"AAPL earnings recap\", \"how did TSLA earnings go\", \"MSFT earnings results\", \"did NVDA beat earnings\", \"post-earnings analysis\", \"earnings surprise\", \"what happened with GOOGL earnings\", \"earnings reaction\", \"stock moved after earnings\", \"EPS beat or miss\", \"revenue beat or miss\", \"quarterly results for\", \"how were earnings\", \"AMZN reported last night\", \"earnings call recap\", or any request about a company's recent earnings outcome. Use this skill when the user references a past earnings event, even if they just say \"AAPL reported\" or \"how did they do\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "finance-sentiment",
+          "installUrl": "github:himself65/finance-skills:plugins/data-providers/skills/finance-sentiment",
+          "description": "Fetch structured stock sentiment across Reddit, X.com, news, and Polymarket using the Adanos Finance API. Use this skill whenever the user asks how much people are talking about a stock, how hot a ticker is on social platforms, how many Polymarket bets exist for a company, whether sources are aligned, or to compare stock sentiment across multiple tickers. Triggers include: \"social sentiment on TSLA\", \"how hot is NVDA on X.com\", \"how many Reddit mentions does AAPL have\", \"compare sentiment on AMD vs NVDA\", \"how many Polymarket bets on Microsoft\", \"is Reddit aligned with X on META\", \"stock buzz\", \"bullish percentage\", and any mention of cross-source stock sentiment research. This skill is READ-ONLY and does not place trades or modify anything.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "funda-data",
+          "installUrl": "github:himself65/finance-skills:plugins/data-providers/skills/funda-data",
+          "description": "Fetch financial data from the Funda AI API (https://api.funda.ai). Covers quotes, historical prices, financials, SEC filings, transcripts, analyst estimates, options flow/greeks/GEX, supply chain graph, social sentiment, Polymarket, congressional trades, economics, ESG, news, AI-enriched news (sentiment + event timeline), AI-company recruit signals, and a Claude API proxy via Bedrock. Triggers: stock quotes, balance sheet, income statement, cash flow, analyst targets, DCF, options chain/flow, GEX, IV rank, max pain, earnings/dividend/IPO calendar, 10-K/10-Q/8-K, suppliers/customers/competitors, insider trades, 13F, Reddit/Twitter sentiment, Polymarket, treasury rates, GDP, CPI, FRED, commodity/forex/crypto, stock screener, ETF holdings, COT, ticker sentiment, OpenAI/Anthropic/xAI/Google/Mercor/SurgeAI job postings, product launch probabilities, AI threat to public stocks. Also triggers for \"funda\" or \"funda.ai\". If only a ticker is provided and Funda API can answer, use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "generative-ui",
+          "installUrl": "github:himself65/finance-skills:plugins/ui-tools/skills/generative-ui",
+          "description": "Design system and guidelines for Claude's built-in generative UI — the show_widget tool that renders interactive HTML/SVG widgets inline in claude.ai conversations. This skill provides the complete Anthropic \"Imagine\" design system so Claude produces high-quality widgets without needing to call read_me first. Use this skill whenever the user asks to visualize data, create an interactive chart, build a dashboard, render a diagram, draw a flowchart, show a mockup, create an interactive explainer, or produce any visual content beyond plain text or markdown. Triggers include: \"show me\", \"visualize\", \"draw\", \"chart\", \"dashboard\", \"diagram\", \"flowchart\", \"widget\", \"interactive\", \"mockup\", \"illustrate\", \"explain how X works\" (with visual), or any request for visual/interactive output. Also triggers when the user wants to display financial data visually, create comparison grids, or build tools with sliders, toggles, or live-updating displays.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "linkedin-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/linkedin-reader",
+          "description": "Read LinkedIn for financial research using opencli (read-only). Use this skill whenever the user wants to read their LinkedIn feed, search for jobs in the finance/trading industry, view professional posts about markets or earnings, or gather professional sentiment from LinkedIn. Triggers include: \"check my LinkedIn feed\", \"search LinkedIn for\", \"LinkedIn posts about\", \"what's on LinkedIn about AAPL\", \"finance jobs on LinkedIn\", \"LinkedIn market sentiment\", \"who's posting about earnings on LinkedIn\", \"LinkedIn feed\", \"professional network buzz\", \"what are analysts saying on LinkedIn\", any mention of LinkedIn in context of reading financial news, market research, job searches, or professional commentary. This skill is READ-ONLY — it does NOT support posting, liking, commenting, connecting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "opencli-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/opencli-reader",
+          "description": "Generic read-only fallback for any source opencli covers but this repo has no dedicated reader for — Yahoo Finance, Bloomberg, Reuters, Barchart, Eastmoney, Xueqiu, Sinafinance, Reddit, HackerNews, Substack, Medium, Weibo, Bilibili, Xiaohongshu, Zhihu, arXiv, Google Scholar, Apple Podcasts, Xiaoyuzhou, Spotify, YouTube, Weixin, Amazon, and more. Triggers: \"use opencli to read\", \"grab the frontpage from hackernews\", \"read reddit r/wallstreetbets\", \"fetch Eastmoney hot stocks\", \"pull Xueqiu feed\", \"get Bloomberg markets headlines\", \"search arXiv for\", any request to read from a site where a specialized skill does not exist but opencli does. FALLBACK — prefer twitter-reader, linkedin-reader, discord-reader, telegram-reader, or yc-reader when the source matches. READ-ONLY — never invoke write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "skill-creator",
+          "installUrl": "github:himself65/finance-skills:plugins/skill-creator/skills/skill-creator",
+          "description": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, update or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or iterate on skill quality. Triggers: \"create a skill\", \"make a new skill\", \"build a skill for\", \"write a skill that\", \"skill for doing X\", \"I want a skill to\", \"new skill\", \"design a skill\", \"scaffold a skill\", \"improve this skill\", \"optimize this skill\", \"this skill isn't working well\", \"evaluate this skill\", \"score this skill\", \"how good is this skill\", \"run evals on\", \"benchmark this skill\", \"test this skill's quality\", \"skill quality\", \"skill performance\". Also triggers when a user describes a repeatable workflow they want to automate, says \"I keep doing X manually\", \"can you remember how to do X\", or \"turn this into a skill\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "twitter-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/twitter-reader",
+          "description": "Read Twitter/X for financial research using opencli (read-only). Use this skill whenever the user wants to read their Twitter feed, search for financial tweets, view bookmarks, look up user profiles, or gather market sentiment from Twitter/X. Triggers include: \"check my feed\", \"search Twitter for\", \"show my bookmarks\", \"who follows\", \"look up @user\", \"what's trending about\", \"market sentiment on Twitter\", \"what are people saying about AAPL\", \"recent tweets from @elonmusk\", \"show me @user's posts\", \"fintwit\", any mention of Twitter/X in context of reading financial news or market research. This skill is READ-ONLY — it does NOT support posting, liking, retweeting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "yc-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/yc-reader",
+          "description": "Look up Y Combinator companies, batches, and startup ecosystem data using the yc-oss API (read-only). Use this skill whenever the user wants to research YC-backed startups, find companies in a specific batch or industry, check which YC companies are hiring, explore top YC companies, or analyze startup trends by sector or tag. Triggers include: \"YC companies in fintech\", \"who's in the latest YC batch\", \"YC startups hiring\", \"top Y Combinator companies\", \"find YC companies tagged AI\", \"W25 batch\", \"S24 companies\", \"YC stats\", \"Y Combinator portfolio\", \"startup research\", \"which YC companies do X\", \"venture research on YC\", any mention of Y Combinator, YC batch, or YC-backed companies in the context of startup research, venture analysis, or market intelligence. This is a read-only data source — the API is a static JSON dataset updated daily.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "yfinance-data",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/yfinance-data",
+          "description": "Fetch financial and market data using the yfinance Python library. Use this skill whenever the user asks for stock prices, historical data, financial statements, options chains, dividends, earnings, analyst recommendations, or any market data. Triggers include: any mention of stock price, ticker symbol (AAPL, MSFT, TSLA, etc.), \"get me the financials\", \"show earnings\", \"what's the price of\", \"download stock data\", \"options chain\", \"dividend history\", \"balance sheet\", \"income statement\", \"cash flow\", \"analyst targets\", \"institutional holders\", \"compare stocks\", \"screen for stocks\", or any request involving Yahoo Finance data. Always use this skill even if the user only provides a ticker — infer intent from context.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "himself65",
+        "repo": "finance-skills",
+        "repoUrl": "https://github.com/himself65/finance-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "himself65-finance-skills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from himself65/finance-skills.",
+      "author": "ASM (himself65/finance-skills)",
+      "createdAt": "2026-05-09T08:10:47.261Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "himself65",
+        "finance-skills"
+      ],
+      "skills": [
+        {
+          "name": "company-valuation",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/company-valuation",
+          "description": "Estimate the intrinsic value of a public company using DCF, relative (peer multiple) and sum-of-parts (SOTP) methods, then triangulate to an implied share price with upside/downside versus the current market price. Use this skill whenever the user asks: \"what is AAPL worth\", \"valuation of NVDA\", \"fair value of TSLA\", \"intrinsic value\", \"DCF for MSFT\", \"build a DCF\", \"discounted cash flow\", \"WACC\", \"terminal value\", \"implied share price\", \"upside to fair value\", \"is X overvalued/undervalued\", \"relative valuation\", \"peer comparison valuation\", \"EV/EBITDA target\", \"SOTP\", \"sum of the parts\", \"how much is [company] worth\", \"price target from fundamentals\", \"value this company\", or any ticker in the context of computing intrinsic or relative valuation. Default to running ALL three methods (DCF + relative + SOTP-if-applicable) and presenting a blended implied price with a sensitivity table. Do not answer valuation questions from memory — always run the workflow.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "discord-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/discord-reader",
+          "description": "Read Discord for financial research using opencli (read-only). Use this skill whenever the user wants to read Discord channels, search for messages in trading servers, view guild/channel info, monitor crypto or market discussion groups, or gather financial sentiment from Discord. Triggers include: \"check my Discord\", \"search Discord for\", \"read Discord messages\", \"what's happening in the trading Discord\", \"show Discord channels\", \"list my servers\", \"Discord sentiment on BTC\", \"what are people saying in Discord about AAPL\", \"monitor crypto Discord\", any mention of Discord in context of reading financial news, market research, or trading community discussions. This skill is READ-ONLY — it does NOT support sending messages, reacting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "earnings-preview",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/earnings-preview",
+          "description": "Generate a pre-earnings briefing for any stock using Yahoo Finance data. Use this skill whenever the user wants to prepare for an upcoming earnings report, understand what analysts expect, review a company's beat/miss track record, or get a quick overview before an earnings call. Triggers include: \"earnings preview for AAPL\", \"what to expect from TSLA earnings\", \"MSFT reports next week\", \"earnings preview\", \"pre-earnings analysis\", \"what are analysts expecting for NVDA\", \"earnings estimates for\", \"will GOOGL beat earnings\", \"earnings beat/miss history\", \"upcoming earnings\", \"before earnings\", \"earnings setup\", \"consensus estimates\", \"earnings whisper\", \"EPS expectations\", \"what's the street expecting\", \"earnings season preview\", any mention of preparing for or previewing an earnings report, or any request to understand expectations ahead of a company's earnings date. Always use this skill when the user mentions a ticker in context of upcoming earnings, even if they don't say \"preview\" explicitly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "earnings-recap",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/earnings-recap",
+          "description": "Generate a post-earnings analysis for any stock using Yahoo Finance data. Use when the user wants to review what happened after earnings, understand beat/miss results, see stock reaction, or get an earnings recap. Triggers: \"AAPL earnings recap\", \"how did TSLA earnings go\", \"MSFT earnings results\", \"did NVDA beat earnings\", \"post-earnings analysis\", \"earnings surprise\", \"what happened with GOOGL earnings\", \"earnings reaction\", \"stock moved after earnings\", \"EPS beat or miss\", \"revenue beat or miss\", \"quarterly results for\", \"how were earnings\", \"AMZN reported last night\", \"earnings call recap\", or any request about a company's recent earnings outcome. Use this skill when the user references a past earnings event, even if they just say \"AAPL reported\" or \"how did they do\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "funda-data",
+          "installUrl": "github:himself65/finance-skills:plugins/data-providers/skills/funda-data",
+          "description": "Fetch financial data from the Funda AI API (https://api.funda.ai). Covers quotes, historical prices, financials, SEC filings, transcripts, analyst estimates, options flow/greeks/GEX, supply chain graph, social sentiment, Polymarket, congressional trades, economics, ESG, news, AI-enriched news (sentiment + event timeline), AI-company recruit signals, and a Claude API proxy via Bedrock. Triggers: stock quotes, balance sheet, income statement, cash flow, analyst targets, DCF, options chain/flow, GEX, IV rank, max pain, earnings/dividend/IPO calendar, 10-K/10-Q/8-K, suppliers/customers/competitors, insider trades, 13F, Reddit/Twitter sentiment, Polymarket, treasury rates, GDP, CPI, FRED, commodity/forex/crypto, stock screener, ETF holdings, COT, ticker sentiment, OpenAI/Anthropic/xAI/Google/Mercor/SurgeAI job postings, product launch probabilities, AI threat to public stocks. Also triggers for \"funda\" or \"funda.ai\". If only a ticker is provided and Funda API can answer, use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "generative-ui",
+          "installUrl": "github:himself65/finance-skills:plugins/ui-tools/skills/generative-ui",
+          "description": "Design system and guidelines for Claude's built-in generative UI — the show_widget tool that renders interactive HTML/SVG widgets inline in claude.ai conversations. This skill provides the complete Anthropic \"Imagine\" design system so Claude produces high-quality widgets without needing to call read_me first. Use this skill whenever the user asks to visualize data, create an interactive chart, build a dashboard, render a diagram, draw a flowchart, show a mockup, create an interactive explainer, or produce any visual content beyond plain text or markdown. Triggers include: \"show me\", \"visualize\", \"draw\", \"chart\", \"dashboard\", \"diagram\", \"flowchart\", \"widget\", \"interactive\", \"mockup\", \"illustrate\", \"explain how X works\" (with visual), or any request for visual/interactive output. Also triggers when the user wants to display financial data visually, create comparison grids, or build tools with sliders, toggles, or live-updating displays.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "options-payoff",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/options-payoff",
+          "description": "Generate an interactive options payoff curve chart with dynamic parameter controls. Use this skill whenever the user shares an options position screenshot, describes an options strategy, or asks to visualize how an options trade makes or loses money. Triggers include: any mention of butterfly, spread (vertical/calendar/diagonal/ratio), straddle, strangle, condor, covered call, protective put, iron condor, or any multi-leg options structure. Also triggers when a user pastes strike prices, premiums, expiry dates, or says things like \"show me the payoff\", \"draw the P&L curve\", \"what does this trade look like\", or uploads a screenshot from a broker (IBKR, TastyTrade, Robinhood, etc). Always use this skill even if the user only provides partial info — extract what you can and use defaults for the rest.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "skill-creator",
+          "installUrl": "github:himself65/finance-skills:plugins/skill-creator/skills/skill-creator",
+          "description": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, update or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or iterate on skill quality. Triggers: \"create a skill\", \"make a new skill\", \"build a skill for\", \"write a skill that\", \"skill for doing X\", \"I want a skill to\", \"new skill\", \"design a skill\", \"scaffold a skill\", \"improve this skill\", \"optimize this skill\", \"this skill isn't working well\", \"evaluate this skill\", \"score this skill\", \"how good is this skill\", \"run evals on\", \"benchmark this skill\", \"test this skill's quality\", \"skill quality\", \"skill performance\". Also triggers when a user describes a repeatable workflow they want to automate, says \"I keep doing X manually\", \"can you remember how to do X\", or \"turn this into a skill\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "stock-liquidity",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/stock-liquidity",
+          "description": "Analyze stock liquidity using bid-ask spreads, volume profiles, order book depth, market impact estimates, and turnover ratios via Yahoo Finance data. Use this skill whenever the user asks about liquidity, trading costs, bid-ask spread, market depth, volume analysis, slippage, market impact, turnover ratio, or how easy/hard it is to trade a stock without moving the price. Triggers: \"how liquid is AAPL\", \"bid-ask spread\", \"volume analysis\", \"order book depth\", \"market impact of a large order\", \"turnover ratio\", \"slippage estimate\", \"can I trade 100k shares without moving the price\", \"liquidity comparison\", \"spread analysis\", \"ADTV\", \"Amihud illiquidity\", \"dollar volume\", \"execution cost estimate\", \"liquidity score\", penny stocks, small caps, or thinly traded securities.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "himself65",
+        "repo": "finance-skills",
+        "repoUrl": "https://github.com/himself65/finance-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "himself65-finance-skills-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from himself65/finance-skills.",
+      "author": "ASM (himself65/finance-skills)",
+      "createdAt": "2026-05-09T08:10:47.261Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "himself65",
+        "finance-skills"
+      ],
+      "skills": [
+        {
+          "name": "company-valuation",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/company-valuation",
+          "description": "Estimate the intrinsic value of a public company using DCF, relative (peer multiple) and sum-of-parts (SOTP) methods, then triangulate to an implied share price with upside/downside versus the current market price. Use this skill whenever the user asks: \"what is AAPL worth\", \"valuation of NVDA\", \"fair value of TSLA\", \"intrinsic value\", \"DCF for MSFT\", \"build a DCF\", \"discounted cash flow\", \"WACC\", \"terminal value\", \"implied share price\", \"upside to fair value\", \"is X overvalued/undervalued\", \"relative valuation\", \"peer comparison valuation\", \"EV/EBITDA target\", \"SOTP\", \"sum of the parts\", \"how much is [company] worth\", \"price target from fundamentals\", \"value this company\", or any ticker in the context of computing intrinsic or relative valuation. Default to running ALL three methods (DCF + relative + SOTP-if-applicable) and presenting a blended implied price with a sensitivity table. Do not answer valuation questions from memory — always run the workflow.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "discord-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/discord-reader",
+          "description": "Read Discord for financial research using opencli (read-only). Use this skill whenever the user wants to read Discord channels, search for messages in trading servers, view guild/channel info, monitor crypto or market discussion groups, or gather financial sentiment from Discord. Triggers include: \"check my Discord\", \"search Discord for\", \"read Discord messages\", \"what's happening in the trading Discord\", \"show Discord channels\", \"list my servers\", \"Discord sentiment on BTC\", \"what are people saying in Discord about AAPL\", \"monitor crypto Discord\", any mention of Discord in context of reading financial news, market research, or trading community discussions. This skill is READ-ONLY — it does NOT support sending messages, reacting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "earnings-preview",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/earnings-preview",
+          "description": "Generate a pre-earnings briefing for any stock using Yahoo Finance data. Use this skill whenever the user wants to prepare for an upcoming earnings report, understand what analysts expect, review a company's beat/miss track record, or get a quick overview before an earnings call. Triggers include: \"earnings preview for AAPL\", \"what to expect from TSLA earnings\", \"MSFT reports next week\", \"earnings preview\", \"pre-earnings analysis\", \"what are analysts expecting for NVDA\", \"earnings estimates for\", \"will GOOGL beat earnings\", \"earnings beat/miss history\", \"upcoming earnings\", \"before earnings\", \"earnings setup\", \"consensus estimates\", \"earnings whisper\", \"EPS expectations\", \"what's the street expecting\", \"earnings season preview\", any mention of preparing for or previewing an earnings report, or any request to understand expectations ahead of a company's earnings date. Always use this skill when the user mentions a ticker in context of upcoming earnings, even if they don't say \"preview\" explicitly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "etf-premium",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/etf-premium",
+          "description": "Calculate ETF premium or discount relative to Net Asset Value (NAV) using Yahoo Finance data. Use this skill whenever the user asks about an ETF's premium or discount, NAV comparison, whether an ETF is trading above or below its fair value, or wants to compare market price vs NAV. Triggers: \"ETF premium\", \"ETF discount\", \"NAV premium\", \"is SPY trading at a premium\", \"AGG premium to NAV\", \"market price vs NAV\", \"ETF mispricing\", \"BITO premium\", \"IBIT premium\", \"bond ETF discount\", \"trading above/below NAV\", \"ETF premium screener\", \"which ETFs have biggest discount\", \"compare ETF NAV\", \"ETF arbitrage\", or any request involving the gap between an ETF's market price and its underlying value. Also triggers when analyzing leveraged, inverse, international, bond, commodity, or crypto ETFs where premium/discount is a known concern.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "finance-sentiment",
+          "installUrl": "github:himself65/finance-skills:plugins/data-providers/skills/finance-sentiment",
+          "description": "Fetch structured stock sentiment across Reddit, X.com, news, and Polymarket using the Adanos Finance API. Use this skill whenever the user asks how much people are talking about a stock, how hot a ticker is on social platforms, how many Polymarket bets exist for a company, whether sources are aligned, or to compare stock sentiment across multiple tickers. Triggers include: \"social sentiment on TSLA\", \"how hot is NVDA on X.com\", \"how many Reddit mentions does AAPL have\", \"compare sentiment on AMD vs NVDA\", \"how many Polymarket bets on Microsoft\", \"is Reddit aligned with X on META\", \"stock buzz\", \"bullish percentage\", and any mention of cross-source stock sentiment research. This skill is READ-ONLY and does not place trades or modify anything.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "funda-data",
+          "installUrl": "github:himself65/finance-skills:plugins/data-providers/skills/funda-data",
+          "description": "Fetch financial data from the Funda AI API (https://api.funda.ai). Covers quotes, historical prices, financials, SEC filings, transcripts, analyst estimates, options flow/greeks/GEX, supply chain graph, social sentiment, Polymarket, congressional trades, economics, ESG, news, AI-enriched news (sentiment + event timeline), AI-company recruit signals, and a Claude API proxy via Bedrock. Triggers: stock quotes, balance sheet, income statement, cash flow, analyst targets, DCF, options chain/flow, GEX, IV rank, max pain, earnings/dividend/IPO calendar, 10-K/10-Q/8-K, suppliers/customers/competitors, insider trades, 13F, Reddit/Twitter sentiment, Polymarket, treasury rates, GDP, CPI, FRED, commodity/forex/crypto, stock screener, ETF holdings, COT, ticker sentiment, OpenAI/Anthropic/xAI/Google/Mercor/SurgeAI job postings, product launch probabilities, AI threat to public stocks. Also triggers for \"funda\" or \"funda.ai\". If only a ticker is provided and Funda API can answer, use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "generative-ui",
+          "installUrl": "github:himself65/finance-skills:plugins/ui-tools/skills/generative-ui",
+          "description": "Design system and guidelines for Claude's built-in generative UI — the show_widget tool that renders interactive HTML/SVG widgets inline in claude.ai conversations. This skill provides the complete Anthropic \"Imagine\" design system so Claude produces high-quality widgets without needing to call read_me first. Use this skill whenever the user asks to visualize data, create an interactive chart, build a dashboard, render a diagram, draw a flowchart, show a mockup, create an interactive explainer, or produce any visual content beyond plain text or markdown. Triggers include: \"show me\", \"visualize\", \"draw\", \"chart\", \"dashboard\", \"diagram\", \"flowchart\", \"widget\", \"interactive\", \"mockup\", \"illustrate\", \"explain how X works\" (with visual), or any request for visual/interactive output. Also triggers when the user wants to display financial data visually, create comparison grids, or build tools with sliders, toggles, or live-updating displays.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "linkedin-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/linkedin-reader",
+          "description": "Read LinkedIn for financial research using opencli (read-only). Use this skill whenever the user wants to read their LinkedIn feed, search for jobs in the finance/trading industry, view professional posts about markets or earnings, or gather professional sentiment from LinkedIn. Triggers include: \"check my LinkedIn feed\", \"search LinkedIn for\", \"LinkedIn posts about\", \"what's on LinkedIn about AAPL\", \"finance jobs on LinkedIn\", \"LinkedIn market sentiment\", \"who's posting about earnings on LinkedIn\", \"LinkedIn feed\", \"professional network buzz\", \"what are analysts saying on LinkedIn\", any mention of LinkedIn in context of reading financial news, market research, job searches, or professional commentary. This skill is READ-ONLY — it does NOT support posting, liking, commenting, connecting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "opencli-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/opencli-reader",
+          "description": "Generic read-only fallback for any source opencli covers but this repo has no dedicated reader for — Yahoo Finance, Bloomberg, Reuters, Barchart, Eastmoney, Xueqiu, Sinafinance, Reddit, HackerNews, Substack, Medium, Weibo, Bilibili, Xiaohongshu, Zhihu, arXiv, Google Scholar, Apple Podcasts, Xiaoyuzhou, Spotify, YouTube, Weixin, Amazon, and more. Triggers: \"use opencli to read\", \"grab the frontpage from hackernews\", \"read reddit r/wallstreetbets\", \"fetch Eastmoney hot stocks\", \"pull Xueqiu feed\", \"get Bloomberg markets headlines\", \"search arXiv for\", any request to read from a site where a specialized skill does not exist but opencli does. FALLBACK — prefer twitter-reader, linkedin-reader, discord-reader, telegram-reader, or yc-reader when the source matches. READ-ONLY — never invoke write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "sepa-strategy",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/sepa-strategy",
+          "description": "Analyze stocks using Mark Minervini's SEPA (Specific Entry Point Analysis) methodology. Use this skill whenever the user mentions SEPA, Minervini, superperformance, trend template, VCP (Volatility Contraction Pattern), Stage 2 uptrend, stage analysis, pivot point breakout, or asks about growth stock screening criteria. Also triggers when the user wants to evaluate whether a stock meets swing trading entry criteria, check moving average alignment (bullish stacking: price above 50MA above 150MA above 200MA), assess breakout quality with volume confirmation, calculate position sizing based on risk percentage, or identify consolidation patterns like cup-with-handle, flat base, bull flag, or high tight flag. Use this skill even when the user simply asks \"should I buy this stock\" or \"is this a good setup\" in the context of growth/momentum trading, or when they share a stock chart and want pattern analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "skill-creator",
+          "installUrl": "github:himself65/finance-skills:plugins/skill-creator/skills/skill-creator",
+          "description": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, update or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or iterate on skill quality. Triggers: \"create a skill\", \"make a new skill\", \"build a skill for\", \"write a skill that\", \"skill for doing X\", \"I want a skill to\", \"new skill\", \"design a skill\", \"scaffold a skill\", \"improve this skill\", \"optimize this skill\", \"this skill isn't working well\", \"evaluate this skill\", \"score this skill\", \"how good is this skill\", \"run evals on\", \"benchmark this skill\", \"test this skill's quality\", \"skill quality\", \"skill performance\". Also triggers when a user describes a repeatable workflow they want to automate, says \"I keep doing X manually\", \"can you remember how to do X\", or \"turn this into a skill\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "telegram-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/telegram-reader",
+          "description": "Read Telegram channels and groups for financial news and market research using tdl (read-only). Use this skill whenever the user wants to read Telegram channels, export messages from financial Telegram groups, list their Telegram chats, search for news in Telegram channels, or gather market intelligence from Telegram. Triggers include: \"check my Telegram\", \"read Telegram channel\", \"Telegram news\", \"what's new in my Telegram channels\", \"export messages from\", \"list my Telegram chats\", \"financial news on Telegram\", \"crypto Telegram\", \"market news Telegram\", any mention of Telegram in context of reading financial news, crypto signals, or market research. This skill is READ-ONLY — it does NOT support sending messages, joining channels, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "twitter-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/twitter-reader",
+          "description": "Read Twitter/X for financial research using opencli (read-only). Use this skill whenever the user wants to read their Twitter feed, search for financial tweets, view bookmarks, look up user profiles, or gather market sentiment from Twitter/X. Triggers include: \"check my feed\", \"search Twitter for\", \"show my bookmarks\", \"who follows\", \"look up @user\", \"what's trending about\", \"market sentiment on Twitter\", \"what are people saying about AAPL\", \"recent tweets from @elonmusk\", \"show me @user's posts\", \"fintwit\", any mention of Twitter/X in context of reading financial news or market research. This skill is READ-ONLY — it does NOT support posting, liking, retweeting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "yc-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/yc-reader",
+          "description": "Look up Y Combinator companies, batches, and startup ecosystem data using the yc-oss API (read-only). Use this skill whenever the user wants to research YC-backed startups, find companies in a specific batch or industry, check which YC companies are hiring, explore top YC companies, or analyze startup trends by sector or tag. Triggers include: \"YC companies in fintech\", \"who's in the latest YC batch\", \"YC startups hiring\", \"top Y Combinator companies\", \"find YC companies tagged AI\", \"W25 batch\", \"S24 companies\", \"YC stats\", \"Y Combinator portfolio\", \"startup research\", \"which YC companies do X\", \"venture research on YC\", any mention of Y Combinator, YC batch, or YC-backed companies in the context of startup research, venture analysis, or market intelligence. This is a read-only data source — the API is a static JSON dataset updated daily.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "yfinance-data",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/yfinance-data",
+          "description": "Fetch financial and market data using the yfinance Python library. Use this skill whenever the user asks for stock prices, historical data, financial statements, options chains, dividends, earnings, analyst recommendations, or any market data. Triggers include: any mention of stock price, ticker symbol (AAPL, MSFT, TSLA, etc.), \"get me the financials\", \"show earnings\", \"what's the price of\", \"download stock data\", \"options chain\", \"dividend history\", \"balance sheet\", \"income statement\", \"cash flow\", \"analyst targets\", \"institutional holders\", \"compare stocks\", \"screen for stocks\", or any request involving Yahoo Finance data. Always use this skill even if the user only provides a ticker — infer intent from context.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "himself65",
+        "repo": "finance-skills",
+        "repoUrl": "https://github.com/himself65/finance-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "himself65-finance-skills-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from himself65/finance-skills.",
+      "author": "ASM (himself65/finance-skills)",
+      "createdAt": "2026-05-09T08:10:47.261Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "himself65",
+        "finance-skills"
+      ],
+      "skills": [
+        {
+          "name": "company-valuation",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/company-valuation",
+          "description": "Estimate the intrinsic value of a public company using DCF, relative (peer multiple) and sum-of-parts (SOTP) methods, then triangulate to an implied share price with upside/downside versus the current market price. Use this skill whenever the user asks: \"what is AAPL worth\", \"valuation of NVDA\", \"fair value of TSLA\", \"intrinsic value\", \"DCF for MSFT\", \"build a DCF\", \"discounted cash flow\", \"WACC\", \"terminal value\", \"implied share price\", \"upside to fair value\", \"is X overvalued/undervalued\", \"relative valuation\", \"peer comparison valuation\", \"EV/EBITDA target\", \"SOTP\", \"sum of the parts\", \"how much is [company] worth\", \"price target from fundamentals\", \"value this company\", or any ticker in the context of computing intrinsic or relative valuation. Default to running ALL three methods (DCF + relative + SOTP-if-applicable) and presenting a blended implied price with a sensitivity table. Do not answer valuation questions from memory — always run the workflow.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "earnings-preview",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/earnings-preview",
+          "description": "Generate a pre-earnings briefing for any stock using Yahoo Finance data. Use this skill whenever the user wants to prepare for an upcoming earnings report, understand what analysts expect, review a company's beat/miss track record, or get a quick overview before an earnings call. Triggers include: \"earnings preview for AAPL\", \"what to expect from TSLA earnings\", \"MSFT reports next week\", \"earnings preview\", \"pre-earnings analysis\", \"what are analysts expecting for NVDA\", \"earnings estimates for\", \"will GOOGL beat earnings\", \"earnings beat/miss history\", \"upcoming earnings\", \"before earnings\", \"earnings setup\", \"consensus estimates\", \"earnings whisper\", \"EPS expectations\", \"what's the street expecting\", \"earnings season preview\", any mention of preparing for or previewing an earnings report, or any request to understand expectations ahead of a company's earnings date. Always use this skill when the user mentions a ticker in context of upcoming earnings, even if they don't say \"preview\" explicitly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "earnings-recap",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/earnings-recap",
+          "description": "Generate a post-earnings analysis for any stock using Yahoo Finance data. Use when the user wants to review what happened after earnings, understand beat/miss results, see stock reaction, or get an earnings recap. Triggers: \"AAPL earnings recap\", \"how did TSLA earnings go\", \"MSFT earnings results\", \"did NVDA beat earnings\", \"post-earnings analysis\", \"earnings surprise\", \"what happened with GOOGL earnings\", \"earnings reaction\", \"stock moved after earnings\", \"EPS beat or miss\", \"revenue beat or miss\", \"quarterly results for\", \"how were earnings\", \"AMZN reported last night\", \"earnings call recap\", or any request about a company's recent earnings outcome. Use this skill when the user references a past earnings event, even if they just say \"AAPL reported\" or \"how did they do\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "estimate-analysis",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/estimate-analysis",
+          "description": "Deep-dive into analyst estimates and revision trends for any stock using Yahoo Finance data. Use when the user wants to understand analyst estimate direction, how EPS or revenue forecasts changed over time, compare estimate distributions, or analyze growth projections across periods. Triggers: \"estimate analysis for AAPL\", \"analyst estimate trends for NVDA\", \"EPS revisions for TSLA\", \"how have estimates changed for MSFT\", \"estimate revisions\", \"EPS trend\", \"revenue estimates\", \"consensus changes\", \"analyst estimates\", \"estimate distribution\", \"growth estimates for\", \"estimate momentum\", \"revision trend\", \"forward estimates\", \"next quarter estimates\", \"annual estimates\", \"estimate spread\", \"bull vs bear estimates\", \"estimate range\", or any request about tracking or comparing analyst estimates/revisions. Use this skill when the user asks about estimates beyond a simple lookup — if they want context, trends, or analysis, this is the right skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "etf-premium",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/etf-premium",
+          "description": "Calculate ETF premium or discount relative to Net Asset Value (NAV) using Yahoo Finance data. Use this skill whenever the user asks about an ETF's premium or discount, NAV comparison, whether an ETF is trading above or below its fair value, or wants to compare market price vs NAV. Triggers: \"ETF premium\", \"ETF discount\", \"NAV premium\", \"is SPY trading at a premium\", \"AGG premium to NAV\", \"market price vs NAV\", \"ETF mispricing\", \"BITO premium\", \"IBIT premium\", \"bond ETF discount\", \"trading above/below NAV\", \"ETF premium screener\", \"which ETFs have biggest discount\", \"compare ETF NAV\", \"ETF arbitrage\", or any request involving the gap between an ETF's market price and its underlying value. Also triggers when analyzing leveraged, inverse, international, bond, commodity, or crypto ETFs where premium/discount is a known concern.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "finance-sentiment",
+          "installUrl": "github:himself65/finance-skills:plugins/data-providers/skills/finance-sentiment",
+          "description": "Fetch structured stock sentiment across Reddit, X.com, news, and Polymarket using the Adanos Finance API. Use this skill whenever the user asks how much people are talking about a stock, how hot a ticker is on social platforms, how many Polymarket bets exist for a company, whether sources are aligned, or to compare stock sentiment across multiple tickers. Triggers include: \"social sentiment on TSLA\", \"how hot is NVDA on X.com\", \"how many Reddit mentions does AAPL have\", \"compare sentiment on AMD vs NVDA\", \"how many Polymarket bets on Microsoft\", \"is Reddit aligned with X on META\", \"stock buzz\", \"bullish percentage\", and any mention of cross-source stock sentiment research. This skill is READ-ONLY and does not place trades or modify anything.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "funda-data",
+          "installUrl": "github:himself65/finance-skills:plugins/data-providers/skills/funda-data",
+          "description": "Fetch financial data from the Funda AI API (https://api.funda.ai). Covers quotes, historical prices, financials, SEC filings, transcripts, analyst estimates, options flow/greeks/GEX, supply chain graph, social sentiment, Polymarket, congressional trades, economics, ESG, news, AI-enriched news (sentiment + event timeline), AI-company recruit signals, and a Claude API proxy via Bedrock. Triggers: stock quotes, balance sheet, income statement, cash flow, analyst targets, DCF, options chain/flow, GEX, IV rank, max pain, earnings/dividend/IPO calendar, 10-K/10-Q/8-K, suppliers/customers/competitors, insider trades, 13F, Reddit/Twitter sentiment, Polymarket, treasury rates, GDP, CPI, FRED, commodity/forex/crypto, stock screener, ETF holdings, COT, ticker sentiment, OpenAI/Anthropic/xAI/Google/Mercor/SurgeAI job postings, product launch probabilities, AI threat to public stocks. Also triggers for \"funda\" or \"funda.ai\". If only a ticker is provided and Funda API can answer, use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "generative-ui",
+          "installUrl": "github:himself65/finance-skills:plugins/ui-tools/skills/generative-ui",
+          "description": "Design system and guidelines for Claude's built-in generative UI — the show_widget tool that renders interactive HTML/SVG widgets inline in claude.ai conversations. This skill provides the complete Anthropic \"Imagine\" design system so Claude produces high-quality widgets without needing to call read_me first. Use this skill whenever the user asks to visualize data, create an interactive chart, build a dashboard, render a diagram, draw a flowchart, show a mockup, create an interactive explainer, or produce any visual content beyond plain text or markdown. Triggers include: \"show me\", \"visualize\", \"draw\", \"chart\", \"dashboard\", \"diagram\", \"flowchart\", \"widget\", \"interactive\", \"mockup\", \"illustrate\", \"explain how X works\" (with visual), or any request for visual/interactive output. Also triggers when the user wants to display financial data visually, create comparison grids, or build tools with sliders, toggles, or live-updating displays.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hormuz-strait",
+          "installUrl": "github:himself65/finance-skills:plugins/data-providers/skills/hormuz-strait",
+          "description": "Check the current status of the Strait of Hormuz — shipping transit data, oil price impact, stranded vessels, insurance risk levels, diplomatic developments, and global trade impact. Use this skill whenever the user asks about the Strait of Hormuz, Hormuz chokepoint, Persian Gulf shipping risk, oil transit disruption, war risk premium in the Gulf, Middle East shipping routes, tanker traffic through Hormuz, oil supply chain risk, or geopolitical risk affecting energy markets. Triggers include: \"Hormuz status\", \"Strait of Hormuz\", \"is Hormuz open\", \"shipping through the Gulf\", \"oil chokepoint\", \"Persian Gulf tanker traffic\", \"war risk premium\", \"Hormuz crisis\", \"energy supply chain risk\", \"oil transit disruption\", \"Middle East shipping\", any mention of Hormuz or Persian Gulf in context of oil, shipping, or geopolitical risk.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "options-payoff",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/options-payoff",
+          "description": "Generate an interactive options payoff curve chart with dynamic parameter controls. Use this skill whenever the user shares an options position screenshot, describes an options strategy, or asks to visualize how an options trade makes or loses money. Triggers include: any mention of butterfly, spread (vertical/calendar/diagonal/ratio), straddle, strangle, condor, covered call, protective put, iron condor, or any multi-leg options structure. Also triggers when a user pastes strike prices, premiums, expiry dates, or says things like \"show me the payoff\", \"draw the P&L curve\", \"what does this trade look like\", or uploads a screenshot from a broker (IBKR, TastyTrade, Robinhood, etc). Always use this skill even if the user only provides partial info — extract what you can and use defaults for the rest.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "saas-valuation-compression",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/saas-valuation-compression",
+          "description": "Analyze SaaS company valuation compression between funding rounds. Use this skill whenever the user asks about: how much a SaaS company's valuation multiple changed between rounds, why the ARR multiple compressed or expanded, comparing a company's compression to macro benchmarks, or explaining what drove valuation changes for any VC-backed software company. Trigger on phrases like \"valuation compression\", \"ARR multiple\", \"round-to-round valuation\", \"multiple change\", or when the user asks to compare a company's funding rounds. Always use this skill for any multi-round SaaS valuation analysis — do not try to answer from memory alone.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "sepa-strategy",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/sepa-strategy",
+          "description": "Analyze stocks using Mark Minervini's SEPA (Specific Entry Point Analysis) methodology. Use this skill whenever the user mentions SEPA, Minervini, superperformance, trend template, VCP (Volatility Contraction Pattern), Stage 2 uptrend, stage analysis, pivot point breakout, or asks about growth stock screening criteria. Also triggers when the user wants to evaluate whether a stock meets swing trading entry criteria, check moving average alignment (bullish stacking: price above 50MA above 150MA above 200MA), assess breakout quality with volume confirmation, calculate position sizing based on risk percentage, or identify consolidation patterns like cup-with-handle, flat base, bull flag, or high tight flag. Use this skill even when the user simply asks \"should I buy this stock\" or \"is this a good setup\" in the context of growth/momentum trading, or when they share a stock chart and want pattern analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "skill-creator",
+          "installUrl": "github:himself65/finance-skills:plugins/skill-creator/skills/skill-creator",
+          "description": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, update or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or iterate on skill quality. Triggers: \"create a skill\", \"make a new skill\", \"build a skill for\", \"write a skill that\", \"skill for doing X\", \"I want a skill to\", \"new skill\", \"design a skill\", \"scaffold a skill\", \"improve this skill\", \"optimize this skill\", \"this skill isn't working well\", \"evaluate this skill\", \"score this skill\", \"how good is this skill\", \"run evals on\", \"benchmark this skill\", \"test this skill's quality\", \"skill quality\", \"skill performance\". Also triggers when a user describes a repeatable workflow they want to automate, says \"I keep doing X manually\", \"can you remember how to do X\", or \"turn this into a skill\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "startup-analysis",
+          "installUrl": "github:himself65/finance-skills:plugins/startup-tools/skills/startup-analysis",
+          "description": "Analyze a startup from three perspectives: VC investor, job applicant, and CEO/founder. Use this skill whenever the user wants to evaluate a startup, assess whether to invest in or join a startup, do due diligence, evaluate a job offer from a startup, understand a startup's competitive position, or assess company health and trajectory. Triggers: \"analyze this startup\", \"should I join [company]\", \"is [company] a good investment\", \"evaluate [company]\", \"due diligence on [company]\", \"what do you think of [startup]\", \"should I take this startup job offer\", \"how healthy is [company]\", \"startup assessment\", \"company analysis\", \"is [company] worth joining\", \"what's the outlook for [company]\", \"research [company] for me\", any mention of evaluating or assessing a startup or tech company from investment, career, or strategic perspectives — provide all three perspectives by default.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "stock-correlation",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/stock-correlation",
+          "description": "Analyze stock correlations to find related companies and trading pairs. Use when the user asks about correlated stocks, related companies, sector peers, trading pairs, or how two or more stocks move together. Triggers: \"what correlates with NVDA\", \"find stocks related to AMD\", \"correlation between AAPL and MSFT\", \"what moves with\", \"sector peers\", \"pair trading\", \"correlated stocks\", \"when NVDA drops what else drops\", \"stocks that move together\", \"beta to\", \"relative performance\", \"supply chain partners\", \"correlation matrix\", \"co-movement\", \"related tickers\", \"sympathy plays\", \"semiconductor peers\", \"hedging pair\", \"realized correlation\", \"rolling correlation\", or any request about stocks that move in tandem or inversely. Also triggers for well-known pairs like AMD/NVDA, GOOGL/AVGO, LITE/COHR. If only one ticker is provided, infer the user wants correlated peers.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "stock-liquidity",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/stock-liquidity",
+          "description": "Analyze stock liquidity using bid-ask spreads, volume profiles, order book depth, market impact estimates, and turnover ratios via Yahoo Finance data. Use this skill whenever the user asks about liquidity, trading costs, bid-ask spread, market depth, volume analysis, slippage, market impact, turnover ratio, or how easy/hard it is to trade a stock without moving the price. Triggers: \"how liquid is AAPL\", \"bid-ask spread\", \"volume analysis\", \"order book depth\", \"market impact of a large order\", \"turnover ratio\", \"slippage estimate\", \"can I trade 100k shares without moving the price\", \"liquidity comparison\", \"spread analysis\", \"ADTV\", \"Amihud illiquidity\", \"dollar volume\", \"execution cost estimate\", \"liquidity score\", penny stocks, small caps, or thinly traded securities.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "yc-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/yc-reader",
+          "description": "Look up Y Combinator companies, batches, and startup ecosystem data using the yc-oss API (read-only). Use this skill whenever the user wants to research YC-backed startups, find companies in a specific batch or industry, check which YC companies are hiring, explore top YC companies, or analyze startup trends by sector or tag. Triggers include: \"YC companies in fintech\", \"who's in the latest YC batch\", \"YC startups hiring\", \"top Y Combinator companies\", \"find YC companies tagged AI\", \"W25 batch\", \"S24 companies\", \"YC stats\", \"Y Combinator portfolio\", \"startup research\", \"which YC companies do X\", \"venture research on YC\", any mention of Y Combinator, YC batch, or YC-backed companies in the context of startup research, venture analysis, or market intelligence. This is a read-only data source — the API is a static JSON dataset updated daily.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "yfinance-data",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/yfinance-data",
+          "description": "Fetch financial and market data using the yfinance Python library. Use this skill whenever the user asks for stock prices, historical data, financial statements, options chains, dividends, earnings, analyst recommendations, or any market data. Triggers include: any mention of stock price, ticker symbol (AAPL, MSFT, TSLA, etc.), \"get me the financials\", \"show earnings\", \"what's the price of\", \"download stock data\", \"options chain\", \"dividend history\", \"balance sheet\", \"income statement\", \"cash flow\", \"analyst targets\", \"institutional holders\", \"compare stocks\", \"screen for stocks\", or any request involving Yahoo Finance data. Always use this skill even if the user only provides a ticker — infer intent from context.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "himself65",
+        "repo": "finance-skills",
+        "repoUrl": "https://github.com/himself65/finance-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "himself65-finance-skills-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from himself65/finance-skills.",
+      "author": "ASM (himself65/finance-skills)",
+      "createdAt": "2026-05-09T08:10:47.261Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "himself65",
+        "finance-skills"
+      ],
+      "skills": [
+        {
+          "name": "company-valuation",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/company-valuation",
+          "description": "Estimate the intrinsic value of a public company using DCF, relative (peer multiple) and sum-of-parts (SOTP) methods, then triangulate to an implied share price with upside/downside versus the current market price. Use this skill whenever the user asks: \"what is AAPL worth\", \"valuation of NVDA\", \"fair value of TSLA\", \"intrinsic value\", \"DCF for MSFT\", \"build a DCF\", \"discounted cash flow\", \"WACC\", \"terminal value\", \"implied share price\", \"upside to fair value\", \"is X overvalued/undervalued\", \"relative valuation\", \"peer comparison valuation\", \"EV/EBITDA target\", \"SOTP\", \"sum of the parts\", \"how much is [company] worth\", \"price target from fundamentals\", \"value this company\", or any ticker in the context of computing intrinsic or relative valuation. Default to running ALL three methods (DCF + relative + SOTP-if-applicable) and presenting a blended implied price with a sensitivity table. Do not answer valuation questions from memory — always run the workflow.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "discord-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/discord-reader",
+          "description": "Read Discord for financial research using opencli (read-only). Use this skill whenever the user wants to read Discord channels, search for messages in trading servers, view guild/channel info, monitor crypto or market discussion groups, or gather financial sentiment from Discord. Triggers include: \"check my Discord\", \"search Discord for\", \"read Discord messages\", \"what's happening in the trading Discord\", \"show Discord channels\", \"list my servers\", \"Discord sentiment on BTC\", \"what are people saying in Discord about AAPL\", \"monitor crypto Discord\", any mention of Discord in context of reading financial news, market research, or trading community discussions. This skill is READ-ONLY — it does NOT support sending messages, reacting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "earnings-preview",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/earnings-preview",
+          "description": "Generate a pre-earnings briefing for any stock using Yahoo Finance data. Use this skill whenever the user wants to prepare for an upcoming earnings report, understand what analysts expect, review a company's beat/miss track record, or get a quick overview before an earnings call. Triggers include: \"earnings preview for AAPL\", \"what to expect from TSLA earnings\", \"MSFT reports next week\", \"earnings preview\", \"pre-earnings analysis\", \"what are analysts expecting for NVDA\", \"earnings estimates for\", \"will GOOGL beat earnings\", \"earnings beat/miss history\", \"upcoming earnings\", \"before earnings\", \"earnings setup\", \"consensus estimates\", \"earnings whisper\", \"EPS expectations\", \"what's the street expecting\", \"earnings season preview\", any mention of preparing for or previewing an earnings report, or any request to understand expectations ahead of a company's earnings date. Always use this skill when the user mentions a ticker in context of upcoming earnings, even if they don't say \"preview\" explicitly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "earnings-recap",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/earnings-recap",
+          "description": "Generate a post-earnings analysis for any stock using Yahoo Finance data. Use when the user wants to review what happened after earnings, understand beat/miss results, see stock reaction, or get an earnings recap. Triggers: \"AAPL earnings recap\", \"how did TSLA earnings go\", \"MSFT earnings results\", \"did NVDA beat earnings\", \"post-earnings analysis\", \"earnings surprise\", \"what happened with GOOGL earnings\", \"earnings reaction\", \"stock moved after earnings\", \"EPS beat or miss\", \"revenue beat or miss\", \"quarterly results for\", \"how were earnings\", \"AMZN reported last night\", \"earnings call recap\", or any request about a company's recent earnings outcome. Use this skill when the user references a past earnings event, even if they just say \"AAPL reported\" or \"how did they do\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "estimate-analysis",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/estimate-analysis",
+          "description": "Deep-dive into analyst estimates and revision trends for any stock using Yahoo Finance data. Use when the user wants to understand analyst estimate direction, how EPS or revenue forecasts changed over time, compare estimate distributions, or analyze growth projections across periods. Triggers: \"estimate analysis for AAPL\", \"analyst estimate trends for NVDA\", \"EPS revisions for TSLA\", \"how have estimates changed for MSFT\", \"estimate revisions\", \"EPS trend\", \"revenue estimates\", \"consensus changes\", \"analyst estimates\", \"estimate distribution\", \"growth estimates for\", \"estimate momentum\", \"revision trend\", \"forward estimates\", \"next quarter estimates\", \"annual estimates\", \"estimate spread\", \"bull vs bear estimates\", \"estimate range\", or any request about tracking or comparing analyst estimates/revisions. Use this skill when the user asks about estimates beyond a simple lookup — if they want context, trends, or analysis, this is the right skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "etf-premium",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/etf-premium",
+          "description": "Calculate ETF premium or discount relative to Net Asset Value (NAV) using Yahoo Finance data. Use this skill whenever the user asks about an ETF's premium or discount, NAV comparison, whether an ETF is trading above or below its fair value, or wants to compare market price vs NAV. Triggers: \"ETF premium\", \"ETF discount\", \"NAV premium\", \"is SPY trading at a premium\", \"AGG premium to NAV\", \"market price vs NAV\", \"ETF mispricing\", \"BITO premium\", \"IBIT premium\", \"bond ETF discount\", \"trading above/below NAV\", \"ETF premium screener\", \"which ETFs have biggest discount\", \"compare ETF NAV\", \"ETF arbitrage\", or any request involving the gap between an ETF's market price and its underlying value. Also triggers when analyzing leveraged, inverse, international, bond, commodity, or crypto ETFs where premium/discount is a known concern.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "finance-sentiment",
+          "installUrl": "github:himself65/finance-skills:plugins/data-providers/skills/finance-sentiment",
+          "description": "Fetch structured stock sentiment across Reddit, X.com, news, and Polymarket using the Adanos Finance API. Use this skill whenever the user asks how much people are talking about a stock, how hot a ticker is on social platforms, how many Polymarket bets exist for a company, whether sources are aligned, or to compare stock sentiment across multiple tickers. Triggers include: \"social sentiment on TSLA\", \"how hot is NVDA on X.com\", \"how many Reddit mentions does AAPL have\", \"compare sentiment on AMD vs NVDA\", \"how many Polymarket bets on Microsoft\", \"is Reddit aligned with X on META\", \"stock buzz\", \"bullish percentage\", and any mention of cross-source stock sentiment research. This skill is READ-ONLY and does not place trades or modify anything.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "funda-data",
+          "installUrl": "github:himself65/finance-skills:plugins/data-providers/skills/funda-data",
+          "description": "Fetch financial data from the Funda AI API (https://api.funda.ai). Covers quotes, historical prices, financials, SEC filings, transcripts, analyst estimates, options flow/greeks/GEX, supply chain graph, social sentiment, Polymarket, congressional trades, economics, ESG, news, AI-enriched news (sentiment + event timeline), AI-company recruit signals, and a Claude API proxy via Bedrock. Triggers: stock quotes, balance sheet, income statement, cash flow, analyst targets, DCF, options chain/flow, GEX, IV rank, max pain, earnings/dividend/IPO calendar, 10-K/10-Q/8-K, suppliers/customers/competitors, insider trades, 13F, Reddit/Twitter sentiment, Polymarket, treasury rates, GDP, CPI, FRED, commodity/forex/crypto, stock screener, ETF holdings, COT, ticker sentiment, OpenAI/Anthropic/xAI/Google/Mercor/SurgeAI job postings, product launch probabilities, AI threat to public stocks. Also triggers for \"funda\" or \"funda.ai\". If only a ticker is provided and Funda API can answer, use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "generative-ui",
+          "installUrl": "github:himself65/finance-skills:plugins/ui-tools/skills/generative-ui",
+          "description": "Design system and guidelines for Claude's built-in generative UI — the show_widget tool that renders interactive HTML/SVG widgets inline in claude.ai conversations. This skill provides the complete Anthropic \"Imagine\" design system so Claude produces high-quality widgets without needing to call read_me first. Use this skill whenever the user asks to visualize data, create an interactive chart, build a dashboard, render a diagram, draw a flowchart, show a mockup, create an interactive explainer, or produce any visual content beyond plain text or markdown. Triggers include: \"show me\", \"visualize\", \"draw\", \"chart\", \"dashboard\", \"diagram\", \"flowchart\", \"widget\", \"interactive\", \"mockup\", \"illustrate\", \"explain how X works\" (with visual), or any request for visual/interactive output. Also triggers when the user wants to display financial data visually, create comparison grids, or build tools with sliders, toggles, or live-updating displays.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hormuz-strait",
+          "installUrl": "github:himself65/finance-skills:plugins/data-providers/skills/hormuz-strait",
+          "description": "Check the current status of the Strait of Hormuz — shipping transit data, oil price impact, stranded vessels, insurance risk levels, diplomatic developments, and global trade impact. Use this skill whenever the user asks about the Strait of Hormuz, Hormuz chokepoint, Persian Gulf shipping risk, oil transit disruption, war risk premium in the Gulf, Middle East shipping routes, tanker traffic through Hormuz, oil supply chain risk, or geopolitical risk affecting energy markets. Triggers include: \"Hormuz status\", \"Strait of Hormuz\", \"is Hormuz open\", \"shipping through the Gulf\", \"oil chokepoint\", \"Persian Gulf tanker traffic\", \"war risk premium\", \"Hormuz crisis\", \"energy supply chain risk\", \"oil transit disruption\", \"Middle East shipping\", any mention of Hormuz or Persian Gulf in context of oil, shipping, or geopolitical risk.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "linkedin-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/linkedin-reader",
+          "description": "Read LinkedIn for financial research using opencli (read-only). Use this skill whenever the user wants to read their LinkedIn feed, search for jobs in the finance/trading industry, view professional posts about markets or earnings, or gather professional sentiment from LinkedIn. Triggers include: \"check my LinkedIn feed\", \"search LinkedIn for\", \"LinkedIn posts about\", \"what's on LinkedIn about AAPL\", \"finance jobs on LinkedIn\", \"LinkedIn market sentiment\", \"who's posting about earnings on LinkedIn\", \"LinkedIn feed\", \"professional network buzz\", \"what are analysts saying on LinkedIn\", any mention of LinkedIn in context of reading financial news, market research, job searches, or professional commentary. This skill is READ-ONLY — it does NOT support posting, liking, commenting, connecting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "opencli-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/opencli-reader",
+          "description": "Generic read-only fallback for any source opencli covers but this repo has no dedicated reader for — Yahoo Finance, Bloomberg, Reuters, Barchart, Eastmoney, Xueqiu, Sinafinance, Reddit, HackerNews, Substack, Medium, Weibo, Bilibili, Xiaohongshu, Zhihu, arXiv, Google Scholar, Apple Podcasts, Xiaoyuzhou, Spotify, YouTube, Weixin, Amazon, and more. Triggers: \"use opencli to read\", \"grab the frontpage from hackernews\", \"read reddit r/wallstreetbets\", \"fetch Eastmoney hot stocks\", \"pull Xueqiu feed\", \"get Bloomberg markets headlines\", \"search arXiv for\", any request to read from a site where a specialized skill does not exist but opencli does. FALLBACK — prefer twitter-reader, linkedin-reader, discord-reader, telegram-reader, or yc-reader when the source matches. READ-ONLY — never invoke write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "options-payoff",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/options-payoff",
+          "description": "Generate an interactive options payoff curve chart with dynamic parameter controls. Use this skill whenever the user shares an options position screenshot, describes an options strategy, or asks to visualize how an options trade makes or loses money. Triggers include: any mention of butterfly, spread (vertical/calendar/diagonal/ratio), straddle, strangle, condor, covered call, protective put, iron condor, or any multi-leg options structure. Also triggers when a user pastes strike prices, premiums, expiry dates, or says things like \"show me the payoff\", \"draw the P&L curve\", \"what does this trade look like\", or uploads a screenshot from a broker (IBKR, TastyTrade, Robinhood, etc). Always use this skill even if the user only provides partial info — extract what you can and use defaults for the rest.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "saas-valuation-compression",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/saas-valuation-compression",
+          "description": "Analyze SaaS company valuation compression between funding rounds. Use this skill whenever the user asks about: how much a SaaS company's valuation multiple changed between rounds, why the ARR multiple compressed or expanded, comparing a company's compression to macro benchmarks, or explaining what drove valuation changes for any VC-backed software company. Trigger on phrases like \"valuation compression\", \"ARR multiple\", \"round-to-round valuation\", \"multiple change\", or when the user asks to compare a company's funding rounds. Always use this skill for any multi-round SaaS valuation analysis — do not try to answer from memory alone.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "sepa-strategy",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/sepa-strategy",
+          "description": "Analyze stocks using Mark Minervini's SEPA (Specific Entry Point Analysis) methodology. Use this skill whenever the user mentions SEPA, Minervini, superperformance, trend template, VCP (Volatility Contraction Pattern), Stage 2 uptrend, stage analysis, pivot point breakout, or asks about growth stock screening criteria. Also triggers when the user wants to evaluate whether a stock meets swing trading entry criteria, check moving average alignment (bullish stacking: price above 50MA above 150MA above 200MA), assess breakout quality with volume confirmation, calculate position sizing based on risk percentage, or identify consolidation patterns like cup-with-handle, flat base, bull flag, or high tight flag. Use this skill even when the user simply asks \"should I buy this stock\" or \"is this a good setup\" in the context of growth/momentum trading, or when they share a stock chart and want pattern analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "skill-creator",
+          "installUrl": "github:himself65/finance-skills:plugins/skill-creator/skills/skill-creator",
+          "description": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, update or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or iterate on skill quality. Triggers: \"create a skill\", \"make a new skill\", \"build a skill for\", \"write a skill that\", \"skill for doing X\", \"I want a skill to\", \"new skill\", \"design a skill\", \"scaffold a skill\", \"improve this skill\", \"optimize this skill\", \"this skill isn't working well\", \"evaluate this skill\", \"score this skill\", \"how good is this skill\", \"run evals on\", \"benchmark this skill\", \"test this skill's quality\", \"skill quality\", \"skill performance\". Also triggers when a user describes a repeatable workflow they want to automate, says \"I keep doing X manually\", \"can you remember how to do X\", or \"turn this into a skill\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "startup-analysis",
+          "installUrl": "github:himself65/finance-skills:plugins/startup-tools/skills/startup-analysis",
+          "description": "Analyze a startup from three perspectives: VC investor, job applicant, and CEO/founder. Use this skill whenever the user wants to evaluate a startup, assess whether to invest in or join a startup, do due diligence, evaluate a job offer from a startup, understand a startup's competitive position, or assess company health and trajectory. Triggers: \"analyze this startup\", \"should I join [company]\", \"is [company] a good investment\", \"evaluate [company]\", \"due diligence on [company]\", \"what do you think of [startup]\", \"should I take this startup job offer\", \"how healthy is [company]\", \"startup assessment\", \"company analysis\", \"is [company] worth joining\", \"what's the outlook for [company]\", \"research [company] for me\", any mention of evaluating or assessing a startup or tech company from investment, career, or strategic perspectives — provide all three perspectives by default.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "stock-correlation",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/stock-correlation",
+          "description": "Analyze stock correlations to find related companies and trading pairs. Use when the user asks about correlated stocks, related companies, sector peers, trading pairs, or how two or more stocks move together. Triggers: \"what correlates with NVDA\", \"find stocks related to AMD\", \"correlation between AAPL and MSFT\", \"what moves with\", \"sector peers\", \"pair trading\", \"correlated stocks\", \"when NVDA drops what else drops\", \"stocks that move together\", \"beta to\", \"relative performance\", \"supply chain partners\", \"correlation matrix\", \"co-movement\", \"related tickers\", \"sympathy plays\", \"semiconductor peers\", \"hedging pair\", \"realized correlation\", \"rolling correlation\", or any request about stocks that move in tandem or inversely. Also triggers for well-known pairs like AMD/NVDA, GOOGL/AVGO, LITE/COHR. If only one ticker is provided, infer the user wants correlated peers.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "stock-liquidity",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/stock-liquidity",
+          "description": "Analyze stock liquidity using bid-ask spreads, volume profiles, order book depth, market impact estimates, and turnover ratios via Yahoo Finance data. Use this skill whenever the user asks about liquidity, trading costs, bid-ask spread, market depth, volume analysis, slippage, market impact, turnover ratio, or how easy/hard it is to trade a stock without moving the price. Triggers: \"how liquid is AAPL\", \"bid-ask spread\", \"volume analysis\", \"order book depth\", \"market impact of a large order\", \"turnover ratio\", \"slippage estimate\", \"can I trade 100k shares without moving the price\", \"liquidity comparison\", \"spread analysis\", \"ADTV\", \"Amihud illiquidity\", \"dollar volume\", \"execution cost estimate\", \"liquidity score\", penny stocks, small caps, or thinly traded securities.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "telegram-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/telegram-reader",
+          "description": "Read Telegram channels and groups for financial news and market research using tdl (read-only). Use this skill whenever the user wants to read Telegram channels, export messages from financial Telegram groups, list their Telegram chats, search for news in Telegram channels, or gather market intelligence from Telegram. Triggers include: \"check my Telegram\", \"read Telegram channel\", \"Telegram news\", \"what's new in my Telegram channels\", \"export messages from\", \"list my Telegram chats\", \"financial news on Telegram\", \"crypto Telegram\", \"market news Telegram\", any mention of Telegram in context of reading financial news, crypto signals, or market research. This skill is READ-ONLY — it does NOT support sending messages, joining channels, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "twitter-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/twitter-reader",
+          "description": "Read Twitter/X for financial research using opencli (read-only). Use this skill whenever the user wants to read their Twitter feed, search for financial tweets, view bookmarks, look up user profiles, or gather market sentiment from Twitter/X. Triggers include: \"check my feed\", \"search Twitter for\", \"show my bookmarks\", \"who follows\", \"look up @user\", \"what's trending about\", \"market sentiment on Twitter\", \"what are people saying about AAPL\", \"recent tweets from @elonmusk\", \"show me @user's posts\", \"fintwit\", any mention of Twitter/X in context of reading financial news or market research. This skill is READ-ONLY — it does NOT support posting, liking, retweeting, or any write operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "yc-reader",
+          "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/yc-reader",
+          "description": "Look up Y Combinator companies, batches, and startup ecosystem data using the yc-oss API (read-only). Use this skill whenever the user wants to research YC-backed startups, find companies in a specific batch or industry, check which YC companies are hiring, explore top YC companies, or analyze startup trends by sector or tag. Triggers include: \"YC companies in fintech\", \"who's in the latest YC batch\", \"YC startups hiring\", \"top Y Combinator companies\", \"find YC companies tagged AI\", \"W25 batch\", \"S24 companies\", \"YC stats\", \"Y Combinator portfolio\", \"startup research\", \"which YC companies do X\", \"venture research on YC\", any mention of Y Combinator, YC batch, or YC-backed companies in the context of startup research, venture analysis, or market intelligence. This is a read-only data source — the API is a static JSON dataset updated daily.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "yfinance-data",
+          "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/yfinance-data",
+          "description": "Fetch financial and market data using the yfinance Python library. Use this skill whenever the user asks for stock prices, historical data, financial statements, options chains, dividends, earnings, analyst recommendations, or any market data. Triggers include: any mention of stock price, ticker symbol (AAPL, MSFT, TSLA, etc.), \"get me the financials\", \"show earnings\", \"what's the price of\", \"download stock data\", \"options chain\", \"dividend history\", \"balance sheet\", \"income statement\", \"cash flow\", \"analyst targets\", \"institutional holders\", \"compare stocks\", \"screen for stocks\", or any request involving Yahoo Finance data. Always use this skill even if the user only provides a ticker — infer intent from context.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "himself65",
+        "repo": "finance-skills",
+        "repoUrl": "https://github.com/himself65/finance-skills.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/kepano_obsidian-skills.json
+++ b/data/skill-index/kepano_obsidian-skills.json
@@ -690,5 +690,115 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "kepano-obsidian-skills-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from kepano/obsidian-skills.",
+      "author": "ASM (kepano/obsidian-skills)",
+      "createdAt": "2026-05-09T08:10:45.552Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "kepano",
+        "obsidian-skills"
+      ],
+      "skills": [
+        {
+          "name": "defuddle",
+          "installUrl": "github:kepano/obsidian-skills:skills/defuddle",
+          "description": "Extract clean markdown content from web pages using Defuddle CLI, removing clutter and navigation to save tokens. Use instead of WebFetch when the user provides a URL to read or analyze, for online documentation, articles, blog posts, or any standard web page. Do NOT use for URLs ending in .md — those are already markdown, use WebFetch directly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "obsidian-cli",
+          "installUrl": "github:kepano/obsidian-skills:skills/obsidian-cli",
+          "description": "Interact with Obsidian vaults using the Obsidian CLI to read, create, search, and manage notes, tasks, properties, and more. Also supports plugin and theme development with commands to reload plugins, run JavaScript, capture errors, take screenshots, and inspect the DOM. Use when the user asks to interact with their Obsidian vault, manage notes, search vault content, perform vault operations from the command line, or develop and debug Obsidian plugins and themes.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "kepano",
+        "repo": "obsidian-skills",
+        "repoUrl": "https://github.com/kepano/obsidian-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "kepano-obsidian-skills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from kepano/obsidian-skills.",
+      "author": "ASM (kepano/obsidian-skills)",
+      "createdAt": "2026-05-09T08:10:45.552Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "kepano",
+        "obsidian-skills"
+      ],
+      "skills": [
+        {
+          "name": "defuddle",
+          "installUrl": "github:kepano/obsidian-skills:skills/defuddle",
+          "description": "Extract clean markdown content from web pages using Defuddle CLI, removing clutter and navigation to save tokens. Use instead of WebFetch when the user provides a URL to read or analyze, for online documentation, articles, blog posts, or any standard web page. Do NOT use for URLs ending in .md — those are already markdown, use WebFetch directly.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "obsidian-cli",
+          "installUrl": "github:kepano/obsidian-skills:skills/obsidian-cli",
+          "description": "Interact with Obsidian vaults using the Obsidian CLI to read, create, search, and manage notes, tasks, properties, and more. Also supports plugin and theme development with commands to reload plugins, run JavaScript, capture errors, take screenshots, and inspect the DOM. Use when the user asks to interact with their Obsidian vault, manage notes, search vault content, perform vault operations from the command line, or develop and debug Obsidian plugins and themes.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "kepano",
+        "repo": "obsidian-skills",
+        "repoUrl": "https://github.com/kepano/obsidian-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "kepano-obsidian-skills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from kepano/obsidian-skills.",
+      "author": "ASM (kepano/obsidian-skills)",
+      "createdAt": "2026-05-09T08:10:45.552Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "kepano",
+        "obsidian-skills"
+      ],
+      "skills": [
+        {
+          "name": "json-canvas",
+          "installUrl": "github:kepano/obsidian-skills:skills/json-canvas",
+          "description": "Create and edit JSON Canvas files (.canvas) with nodes, edges, groups, and connections. Use when working with .canvas files, creating visual canvases, mind maps, flowcharts, or when the user mentions Canvas files in Obsidian.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "obsidian-cli",
+          "installUrl": "github:kepano/obsidian-skills:skills/obsidian-cli",
+          "description": "Interact with Obsidian vaults using the Obsidian CLI to read, create, search, and manage notes, tasks, properties, and more. Also supports plugin and theme development with commands to reload plugins, run JavaScript, capture errors, take screenshots, and inspect the DOM. Use when the user asks to interact with their Obsidian vault, manage notes, search vault content, perform vault operations from the command line, or develop and debug Obsidian plugins and themes.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "kepano",
+        "repo": "obsidian-skills",
+        "repoUrl": "https://github.com/kepano/obsidian-skills.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/luongnv89_skills.json
+++ b/data/skill-index/luongnv89_skills.json
@@ -3978,5 +3978,817 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "luongnv89-skills-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from luongnv89/skills.",
+      "author": "ASM (luongnv89/skills)",
+      "createdAt": "2026-05-09T08:10:41.461Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "luongnv89",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "aso-marketing",
+          "installUrl": "github:luongnv89/skills:skills/aso-marketing",
+          "description": "Optimize App Store and Google Play listings with keyword strategy, metadata, and localization. Use when asked to improve app store visibility or ASO. Don't use for web SEO, paid UA campaigns, or pre-submission compliance audits.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "brand-name-checker",
+          "installUrl": "github:luongnv89/skills:skills/brand-name-checker",
+          "description": "Check product and brand names for conflicts across trademarks, domains, social handles, and package registries. Returns a risk level and Proceed/Modify/Abandon recommendation. Skip for name brainstorming, logo design, or trademark filings.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "excalidraw-generator",
+          "installUrl": "github:luongnv89/skills:skills/excalidraw-generator",
+          "description": "Generate professional diagrams as valid Excalidraw JSON files — flowcharts, architecture, ER diagrams, mind maps, sequence diagrams, wireframes, C4 models, and more. Understands text, code, schemas, or verbal descriptions. Don't use for draw.io/Mermaid output, polished production slide decks, or pixel-perfect brand graphics.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "idea-validator",
+          "installUrl": "github:luongnv89/skills:skills/idea-validator",
+          "description": "Evaluate app ideas and startup concepts across market viability, technical feasibility, and competitive landscape. Use when asked to validate, review, or score a product idea. Don't use for writing a PRD, detailed go-to-market plans, or financial/investor pitch decks.",
+          "version": "1.3.1"
+        },
+        {
+          "name": "install-script-generator",
+          "installUrl": "github:luongnv89/skills:skills/install-script-generator",
+          "description": "Generate cross-platform installation scripts for any software, library, or module. Produces a standalone install.sh runnable via a single curl/wget one-liner, with automatic OS, architecture, and package manager detection. Don't use for authoring Dockerfiles, CI/CD pipelines, or one-off local shell scripts.",
+          "version": "2.1.0"
+        },
+        {
+          "name": "logo-designer",
+          "installUrl": "github:luongnv89/skills:skills/logo-designer",
+          "description": "Generate professional SVG logos from project context, producing 7 brand variants (mark, full, wordmark, icon, favicon, white, black) plus a showcase HTML page. Skip for raster-only logos, product illustrations, or full brand-guideline docs.",
+          "version": "1.2.1"
+        },
+        {
+          "name": "readme-to-landing-page",
+          "installUrl": "github:luongnv89/skills:skills/readme-to-landing-page",
+          "description": "Transform a project README.md into a conversion-optimized landing page using PAS, AIDA, or StoryBrand — hero, value prop, how it works, quick start, CTA in pure markdown. Skip for full HTML sites or general blog copy.",
+          "version": "2.1.0"
+        },
+        {
+          "name": "seo-ai-optimizer",
+          "installUrl": "github:luongnv89/skills:skills/seo-ai-optimizer",
+          "description": "Audit and optimize websites for technical SEO, content SEO, and AI bot accessibility. Fixes meta tags, sitemaps, robots.txt, structured data, llms.txt, and GPTBot/ClaudeBot directives. Not for App Store ASO, paid search, or blog writing.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "slop-cleanup",
+          "installUrl": "github:luongnv89/skills:skills/slop-cleanup",
+          "description": "Refactor a codebase to remove AI slop, dead code, weak types, duplication, defensive over-engineering, and legacy cruft using 8 parallel specialized subagents across two cleanup waves. Don't use for adding new features, performance tuning, or security-only audits.",
+          "version": "1.1.1"
+        },
+        {
+          "name": "usability-review",
+          "installUrl": "github:luongnv89/skills:skills/usability-review",
+          "description": "Review UI for usability issues using Steve Krug's principles and produce a scannable report. Use when asked for a usability audit, UX review, or UI feedback on screenshots, URLs, or code. Don't use for visual/brand design critique, accessibility (WCAG) audits, or backend/API review.",
+          "version": "1.2.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "luongnv89",
+        "repo": "skills",
+        "repoUrl": "https://github.com/luongnv89/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "luongnv89-skills-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from luongnv89/skills.",
+      "author": "ASM (luongnv89/skills)",
+      "createdAt": "2026-05-09T08:10:41.461Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "luongnv89",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "agent-config",
+          "installUrl": "github:luongnv89/skills:skills/agent-config",
+          "description": "Create or update CLAUDE.md and AGENTS.md files following official best practices. Use when asked to create, audit, or improve agent config files (CLAUDE.md, AGENTS.md). Don't use for README/contributor docs or non-Claude IDE plugins.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "appstore-review-checker",
+          "installUrl": "github:luongnv89/skills:skills/appstore-review-checker",
+          "description": "Audit iOS/macOS app projects against Apple App Store Review Guidelines to catch rejection risks before submission, with per-guideline PASS/FAIL/WARNING verdicts and fix suggestions. Don't use for Google Play/Android submissions, general code review, or post-rejection appeal drafting.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "code-review",
+          "installUrl": "github:luongnv89/skills:skills/code-review",
+          "description": "Review code changes for bugs, security vulnerabilities, and code quality issues — producing prioritized findings with specific fix suggestions. Don't use for performance tuning, writing new features from scratch, or generating test cases.",
+          "version": "1.1.4"
+        },
+        {
+          "name": "docs-generator",
+          "installUrl": "github:luongnv89/skills:skills/docs-generator",
+          "description": "Generate and restructure project documentation into a clear, accessible hierarchy. Use when asked to organize docs, generate documentation, improve doc structure, or restructure README. Don't use for API reference generation from code (JSDoc/Sphinx), authoring a landing page, or agent-config files like CLAUDE.md.",
+          "version": "1.2.3"
+        },
+        {
+          "name": "idea-validator",
+          "installUrl": "github:luongnv89/skills:skills/idea-validator",
+          "description": "Evaluate app ideas and startup concepts across market viability, technical feasibility, and competitive landscape. Use when asked to validate, review, or score a product idea. Don't use for writing a PRD, detailed go-to-market plans, or financial/investor pitch decks.",
+          "version": "1.3.1"
+        },
+        {
+          "name": "logo-designer",
+          "installUrl": "github:luongnv89/skills:skills/logo-designer",
+          "description": "Generate professional SVG logos from project context, producing 7 brand variants (mark, full, wordmark, icon, favicon, white, black) plus a showcase HTML page. Skip for raster-only logos, product illustrations, or full brand-guideline docs.",
+          "version": "1.2.1"
+        },
+        {
+          "name": "oss-ready",
+          "installUrl": "github:luongnv89/skills:skills/oss-ready",
+          "description": "Transform a project into a professional open-source repository by adding LICENSE, README, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, and GitHub issue/PR templates. Don't use for documentation overhauls, landing-page generation, or registry publishing.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "readme-to-landing-page",
+          "installUrl": "github:luongnv89/skills:skills/readme-to-landing-page",
+          "description": "Transform a project README.md into a conversion-optimized landing page using PAS, AIDA, or StoryBrand — hero, value prop, how it works, quick start, CTA in pure markdown. Skip for full HTML sites or general blog copy.",
+          "version": "2.1.0"
+        },
+        {
+          "name": "seo-ai-optimizer",
+          "installUrl": "github:luongnv89/skills:skills/seo-ai-optimizer",
+          "description": "Audit and optimize websites for technical SEO, content SEO, and AI bot accessibility. Fixes meta tags, sitemaps, robots.txt, structured data, llms.txt, and GPTBot/ClaudeBot directives. Not for App Store ASO, paid search, or blog writing.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "tasks-generator",
+          "installUrl": "github:luongnv89/skills:skills/tasks-generator",
+          "description": "Generate development tasks from a PRD file with sprint-based planning. Use when users ask to create tasks from PRD, break down the PRD, generate sprint tasks, or want to convert product requirements into actionable development tasks. Creates/updates tasks.md and always reports GitHub links to changed files. Don't use for writing a PRD, authoring a TAD, or executing tasks (see openspec-task-loop).",
+          "version": "1.2.1"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "luongnv89",
+        "repo": "skills",
+        "repoUrl": "https://github.com/luongnv89/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "luongnv89-skills-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from luongnv89/skills.",
+      "author": "ASM (luongnv89/skills)",
+      "createdAt": "2026-05-09T08:10:41.461Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "luongnv89",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "appstore-review-checker",
+          "installUrl": "github:luongnv89/skills:skills/appstore-review-checker",
+          "description": "Audit iOS/macOS app projects against Apple App Store Review Guidelines to catch rejection risks before submission, with per-guideline PASS/FAIL/WARNING verdicts and fix suggestions. Don't use for Google Play/Android submissions, general code review, or post-rejection appeal drafting.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "auto-push",
+          "installUrl": "github:luongnv89/skills:skills/auto-push",
+          "description": "Generate a commit message, stage all changes, and push to remote after scanning for secrets, large files, and protected-branch risks. Skip for opening PRs, code review, or cutting releases/tags.",
+          "version": "1.0.2"
+        },
+        {
+          "name": "cli-builder",
+          "installUrl": "github:luongnv89/skills:skills/cli-builder",
+          "description": "Build a production-quality CLI tool for any module or application. Auto-detects language, recommends CLI libraries, and follows a 5-step approval-gated workflow: Analyze, Design, Plan, Execute, Summarize. Don't use for building GUI/TUI apps, web APIs, or authoring one-off shell scripts.",
+          "version": "1.0.3"
+        },
+        {
+          "name": "code-optimizer",
+          "installUrl": "github:luongnv89/skills:skills/code-optimizer",
+          "description": "Analyze code for performance bottlenecks, memory leaks, and algorithmic inefficiencies. Use when asked to optimize, find bottlenecks, or improve efficiency. Don't use for bug-hunting code review, security audits, or refactoring without a perf goal.",
+          "version": "1.3.1"
+        },
+        {
+          "name": "code-review",
+          "installUrl": "github:luongnv89/skills:skills/code-review",
+          "description": "Review code changes for bugs, security vulnerabilities, and code quality issues — producing prioritized findings with specific fix suggestions. Don't use for performance tuning, writing new features from scratch, or generating test cases.",
+          "version": "1.1.4"
+        },
+        {
+          "name": "idea-validator",
+          "installUrl": "github:luongnv89/skills:skills/idea-validator",
+          "description": "Evaluate app ideas and startup concepts across market viability, technical feasibility, and competitive landscape. Use when asked to validate, review, or score a product idea. Don't use for writing a PRD, detailed go-to-market plans, or financial/investor pitch decks.",
+          "version": "1.3.1"
+        },
+        {
+          "name": "security-setup",
+          "installUrl": "github:luongnv89/skills:skills/security-setup",
+          "description": "Install local-first security hardening: pre-commit secret detection, offline dependency scans, static analysis, reports, and gated free CI. Use when hardening repos or adding security hooks. Don't use for incident response or cloud security reviews.",
+          "version": "1.3.1"
+        },
+        {
+          "name": "usability-review",
+          "installUrl": "github:luongnv89/skills:skills/usability-review",
+          "description": "Review UI for usability issues using Steve Krug's principles and produce a scannable report. Use when asked for a usability audit, UX review, or UI feedback on screenshots, URLs, or code. Don't use for visual/brand design critique, accessibility (WCAG) audits, or backend/API review.",
+          "version": "1.2.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "luongnv89",
+        "repo": "skills",
+        "repoUrl": "https://github.com/luongnv89/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "luongnv89-skills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from luongnv89/skills.",
+      "author": "ASM (luongnv89/skills)",
+      "createdAt": "2026-05-09T08:10:41.461Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "luongnv89",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "appstore-review-checker",
+          "installUrl": "github:luongnv89/skills:skills/appstore-review-checker",
+          "description": "Audit iOS/macOS app projects against Apple App Store Review Guidelines to catch rejection risks before submission, with per-guideline PASS/FAIL/WARNING verdicts and fix suggestions. Don't use for Google Play/Android submissions, general code review, or post-rejection appeal drafting.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "auto-push",
+          "installUrl": "github:luongnv89/skills:skills/auto-push",
+          "description": "Generate a commit message, stage all changes, and push to remote after scanning for secrets, large files, and protected-branch risks. Skip for opening PRs, code review, or cutting releases/tags.",
+          "version": "1.0.2"
+        },
+        {
+          "name": "cli-builder",
+          "installUrl": "github:luongnv89/skills:skills/cli-builder",
+          "description": "Build a production-quality CLI tool for any module or application. Auto-detects language, recommends CLI libraries, and follows a 5-step approval-gated workflow: Analyze, Design, Plan, Execute, Summarize. Don't use for building GUI/TUI apps, web APIs, or authoring one-off shell scripts.",
+          "version": "1.0.3"
+        },
+        {
+          "name": "code-optimizer",
+          "installUrl": "github:luongnv89/skills:skills/code-optimizer",
+          "description": "Analyze code for performance bottlenecks, memory leaks, and algorithmic inefficiencies. Use when asked to optimize, find bottlenecks, or improve efficiency. Don't use for bug-hunting code review, security audits, or refactoring without a perf goal.",
+          "version": "1.3.1"
+        },
+        {
+          "name": "code-review",
+          "installUrl": "github:luongnv89/skills:skills/code-review",
+          "description": "Review code changes for bugs, security vulnerabilities, and code quality issues — producing prioritized findings with specific fix suggestions. Don't use for performance tuning, writing new features from scratch, or generating test cases.",
+          "version": "1.1.4"
+        },
+        {
+          "name": "devops-pipeline",
+          "installUrl": "github:luongnv89/skills:skills/devops-pipeline",
+          "description": "Configure pre-commit hooks and lean GitHub Actions for shift-left quality assurance. Use when adding or auditing CI/CD on a Git repo to maximize local test coverage and minimize CI cost. Skip for Terraform/K8s, deployment pipelines, or non-GitHub CI providers.",
+          "version": "2.0.1"
+        },
+        {
+          "name": "docs-generator",
+          "installUrl": "github:luongnv89/skills:skills/docs-generator",
+          "description": "Generate and restructure project documentation into a clear, accessible hierarchy. Use when asked to organize docs, generate documentation, improve doc structure, or restructure README. Don't use for API reference generation from code (JSDoc/Sphinx), authoring a landing page, or agent-config files like CLAUDE.md.",
+          "version": "1.2.3"
+        },
+        {
+          "name": "drawio-generator",
+          "installUrl": "github:luongnv89/skills:skills/drawio-generator",
+          "description": "Generate professional diagrams as valid draw.io XML files — flowcharts, architecture, C4 models, ER diagrams, sequence diagrams, mind maps, and swimlanes. Don't use for Excalidraw or Mermaid output, hand-drawn sketch styles, or slide decks/presentations.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "excalidraw-generator",
+          "installUrl": "github:luongnv89/skills:skills/excalidraw-generator",
+          "description": "Generate professional diagrams as valid Excalidraw JSON files — flowcharts, architecture, ER diagrams, mind maps, sequence diagrams, wireframes, C4 models, and more. Understands text, code, schemas, or verbal descriptions. Don't use for draw.io/Mermaid output, polished production slide decks, or pixel-perfect brand graphics.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "frontend-design",
+          "installUrl": "github:luongnv89/skills:skills/frontend-design",
+          "description": "Build production-grade frontend interfaces with distinctive aesthetics and working code. Use when asked to create a UI, component, page, or frontend feature. Skip for backend/API work or usability-only audits.",
+          "version": "1.2.2"
+        },
+        {
+          "name": "idea-validator",
+          "installUrl": "github:luongnv89/skills:skills/idea-validator",
+          "description": "Evaluate app ideas and startup concepts across market viability, technical feasibility, and competitive landscape. Use when asked to validate, review, or score a product idea. Don't use for writing a PRD, detailed go-to-market plans, or financial/investor pitch decks.",
+          "version": "1.3.1"
+        },
+        {
+          "name": "install-script-generator",
+          "installUrl": "github:luongnv89/skills:skills/install-script-generator",
+          "description": "Generate cross-platform installation scripts for any software, library, or module. Produces a standalone install.sh runnable via a single curl/wget one-liner, with automatic OS, architecture, and package manager detection. Don't use for authoring Dockerfiles, CI/CD pipelines, or one-off local shell scripts.",
+          "version": "2.1.0"
+        },
+        {
+          "name": "oss-ready",
+          "installUrl": "github:luongnv89/skills:skills/oss-ready",
+          "description": "Transform a project into a professional open-source repository by adding LICENSE, README, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, and GitHub issue/PR templates. Don't use for documentation overhauls, landing-page generation, or registry publishing.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "security-setup",
+          "installUrl": "github:luongnv89/skills:skills/security-setup",
+          "description": "Install local-first security hardening: pre-commit secret detection, offline dependency scans, static analysis, reports, and gated free CI. Use when hardening repos or adding security hooks. Don't use for incident response or cloud security reviews.",
+          "version": "1.3.1"
+        },
+        {
+          "name": "slop-cleanup",
+          "installUrl": "github:luongnv89/skills:skills/slop-cleanup",
+          "description": "Refactor a codebase to remove AI slop, dead code, weak types, duplication, defensive over-engineering, and legacy cruft using 8 parallel specialized subagents across two cleanup waves. Don't use for adding new features, performance tuning, or security-only audits.",
+          "version": "1.1.1"
+        },
+        {
+          "name": "tad-generator",
+          "installUrl": "github:luongnv89/skills:skills/tad-generator",
+          "description": "Generate a Technical Architecture Document (TAD) from a PRD. Use when asked to design the architecture, create a TAD, or define how a product is built. Creates/updates tad.md and reports GitHub links. Skip PRD authoring, sprint-tasks, or code implementation.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "test-coverage",
+          "installUrl": "github:luongnv89/skills:skills/test-coverage",
+          "description": "Generate unit tests for untested branches and edge cases. Use when coverage is low, CI flags gaps, or a release needs hardening. Not for integration/E2E suites, framework migrations, or fixing production bugs.",
+          "version": "1.2.3"
+        },
+        {
+          "name": "usability-review",
+          "installUrl": "github:luongnv89/skills:skills/usability-review",
+          "description": "Review UI for usability issues using Steve Krug's principles and produce a scannable report. Use when asked for a usability audit, UX review, or UI feedback on screenshots, URLs, or code. Don't use for visual/brand design critique, accessibility (WCAG) audits, or backend/API review.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "website-cloner",
+          "installUrl": "github:luongnv89/skills:skills/website-cloner",
+          "description": "6-phase website cloning and improvement orchestrator. Takes a URL and produces an improved version (performance + UI/UX) via Vite/React/shadcn/Tailwind hosted on GitHub Pages. Use when asked to clone a site, rebuild a website, or make a better version of a URL. Orchestrates sibling skills with approval gates — don't use for single-phase work.",
+          "version": "1.1.1"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "luongnv89",
+        "repo": "skills",
+        "repoUrl": "https://github.com/luongnv89/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "luongnv89-skills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from luongnv89/skills.",
+      "author": "ASM (luongnv89/skills)",
+      "createdAt": "2026-05-09T08:10:41.461Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "luongnv89",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "appstore-review-checker",
+          "installUrl": "github:luongnv89/skills:skills/appstore-review-checker",
+          "description": "Audit iOS/macOS app projects against Apple App Store Review Guidelines to catch rejection risks before submission, with per-guideline PASS/FAIL/WARNING verdicts and fix suggestions. Don't use for Google Play/Android submissions, general code review, or post-rejection appeal drafting.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "brand-name-checker",
+          "installUrl": "github:luongnv89/skills:skills/brand-name-checker",
+          "description": "Check product and brand names for conflicts across trademarks, domains, social handles, and package registries. Returns a risk level and Proceed/Modify/Abandon recommendation. Skip for name brainstorming, logo design, or trademark filings.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "cli-builder",
+          "installUrl": "github:luongnv89/skills:skills/cli-builder",
+          "description": "Build a production-quality CLI tool for any module or application. Auto-detects language, recommends CLI libraries, and follows a 5-step approval-gated workflow: Analyze, Design, Plan, Execute, Summarize. Don't use for building GUI/TUI apps, web APIs, or authoring one-off shell scripts.",
+          "version": "1.0.3"
+        },
+        {
+          "name": "docs-generator",
+          "installUrl": "github:luongnv89/skills:skills/docs-generator",
+          "description": "Generate and restructure project documentation into a clear, accessible hierarchy. Use when asked to organize docs, generate documentation, improve doc structure, or restructure README. Don't use for API reference generation from code (JSDoc/Sphinx), authoring a landing page, or agent-config files like CLAUDE.md.",
+          "version": "1.2.3"
+        },
+        {
+          "name": "excalidraw-generator",
+          "installUrl": "github:luongnv89/skills:skills/excalidraw-generator",
+          "description": "Generate professional diagrams as valid Excalidraw JSON files — flowcharts, architecture, ER diagrams, mind maps, sequence diagrams, wireframes, C4 models, and more. Understands text, code, schemas, or verbal descriptions. Don't use for draw.io/Mermaid output, polished production slide decks, or pixel-perfect brand graphics.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "frontend-design",
+          "installUrl": "github:luongnv89/skills:skills/frontend-design",
+          "description": "Build production-grade frontend interfaces with distinctive aesthetics and working code. Use when asked to create a UI, component, page, or frontend feature. Skip for backend/API work or usability-only audits.",
+          "version": "1.2.2"
+        },
+        {
+          "name": "logo-designer",
+          "installUrl": "github:luongnv89/skills:skills/logo-designer",
+          "description": "Generate professional SVG logos from project context, producing 7 brand variants (mark, full, wordmark, icon, favicon, white, black) plus a showcase HTML page. Skip for raster-only logos, product illustrations, or full brand-guideline docs.",
+          "version": "1.2.1"
+        },
+        {
+          "name": "oss-ready",
+          "installUrl": "github:luongnv89/skills:skills/oss-ready",
+          "description": "Transform a project into a professional open-source repository by adding LICENSE, README, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, and GitHub issue/PR templates. Don't use for documentation overhauls, landing-page generation, or registry publishing.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "prd-generator",
+          "installUrl": "github:luongnv89/skills:skills/prd-generator",
+          "description": "Generate Product Requirements Documents from `idea.md` and `validate.md` files. Use when asked to create or update a PRD. Don't use for TAD, sprint tasks, or raw idea validation.",
+          "version": "1.3.1"
+        },
+        {
+          "name": "readme-to-landing-page",
+          "installUrl": "github:luongnv89/skills:skills/readme-to-landing-page",
+          "description": "Transform a project README.md into a conversion-optimized landing page using PAS, AIDA, or StoryBrand — hero, value prop, how it works, quick start, CTA in pure markdown. Skip for full HTML sites or general blog copy.",
+          "version": "2.1.0"
+        },
+        {
+          "name": "tad-generator",
+          "installUrl": "github:luongnv89/skills:skills/tad-generator",
+          "description": "Generate a Technical Architecture Document (TAD) from a PRD. Use when asked to design the architecture, create a TAD, or define how a product is built. Creates/updates tad.md and reports GitHub links. Skip PRD authoring, sprint-tasks, or code implementation.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "tasks-generator",
+          "installUrl": "github:luongnv89/skills:skills/tasks-generator",
+          "description": "Generate development tasks from a PRD file with sprint-based planning. Use when users ask to create tasks from PRD, break down the PRD, generate sprint tasks, or want to convert product requirements into actionable development tasks. Creates/updates tasks.md and always reports GitHub links to changed files. Don't use for writing a PRD, authoring a TAD, or executing tasks (see openspec-task-loop).",
+          "version": "1.2.1"
+        },
+        {
+          "name": "test-coverage",
+          "installUrl": "github:luongnv89/skills:skills/test-coverage",
+          "description": "Generate unit tests for untested branches and edge cases. Use when coverage is low, CI flags gaps, or a release needs hardening. Not for integration/E2E suites, framework migrations, or fixing production bugs.",
+          "version": "1.2.3"
+        },
+        {
+          "name": "usability-review",
+          "installUrl": "github:luongnv89/skills:skills/usability-review",
+          "description": "Review UI for usability issues using Steve Krug's principles and produce a scannable report. Use when asked for a usability audit, UX review, or UI feedback on screenshots, URLs, or code. Don't use for visual/brand design critique, accessibility (WCAG) audits, or backend/API review.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "website-cloner",
+          "installUrl": "github:luongnv89/skills:skills/website-cloner",
+          "description": "6-phase website cloning and improvement orchestrator. Takes a URL and produces an improved version (performance + UI/UX) via Vite/React/shadcn/Tailwind hosted on GitHub Pages. Use when asked to clone a site, rebuild a website, or make a better version of a URL. Orchestrates sibling skills with approval gates — don't use for single-phase work.",
+          "version": "1.1.1"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "luongnv89",
+        "repo": "skills",
+        "repoUrl": "https://github.com/luongnv89/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "luongnv89-skills-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from luongnv89/skills.",
+      "author": "ASM (luongnv89/skills)",
+      "createdAt": "2026-05-09T08:10:41.461Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "luongnv89",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "agent-config",
+          "installUrl": "github:luongnv89/skills:skills/agent-config",
+          "description": "Create or update CLAUDE.md and AGENTS.md files following official best practices. Use when asked to create, audit, or improve agent config files (CLAUDE.md, AGENTS.md). Don't use for README/contributor docs or non-Claude IDE plugins.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "auto-push",
+          "installUrl": "github:luongnv89/skills:skills/auto-push",
+          "description": "Generate a commit message, stage all changes, and push to remote after scanning for secrets, large files, and protected-branch risks. Skip for opening PRs, code review, or cutting releases/tags.",
+          "version": "1.0.2"
+        },
+        {
+          "name": "brand-name-checker",
+          "installUrl": "github:luongnv89/skills:skills/brand-name-checker",
+          "description": "Check product and brand names for conflicts across trademarks, domains, social handles, and package registries. Returns a risk level and Proceed/Modify/Abandon recommendation. Skip for name brainstorming, logo design, or trademark filings.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "cli-builder",
+          "installUrl": "github:luongnv89/skills:skills/cli-builder",
+          "description": "Build a production-quality CLI tool for any module or application. Auto-detects language, recommends CLI libraries, and follows a 5-step approval-gated workflow: Analyze, Design, Plan, Execute, Summarize. Don't use for building GUI/TUI apps, web APIs, or authoring one-off shell scripts.",
+          "version": "1.0.3"
+        },
+        {
+          "name": "code-optimizer",
+          "installUrl": "github:luongnv89/skills:skills/code-optimizer",
+          "description": "Analyze code for performance bottlenecks, memory leaks, and algorithmic inefficiencies. Use when asked to optimize, find bottlenecks, or improve efficiency. Don't use for bug-hunting code review, security audits, or refactoring without a perf goal.",
+          "version": "1.3.1"
+        },
+        {
+          "name": "code-review",
+          "installUrl": "github:luongnv89/skills:skills/code-review",
+          "description": "Review code changes for bugs, security vulnerabilities, and code quality issues — producing prioritized findings with specific fix suggestions. Don't use for performance tuning, writing new features from scratch, or generating test cases.",
+          "version": "1.1.4"
+        },
+        {
+          "name": "devops-pipeline",
+          "installUrl": "github:luongnv89/skills:skills/devops-pipeline",
+          "description": "Configure pre-commit hooks and lean GitHub Actions for shift-left quality assurance. Use when adding or auditing CI/CD on a Git repo to maximize local test coverage and minimize CI cost. Skip for Terraform/K8s, deployment pipelines, or non-GitHub CI providers.",
+          "version": "2.0.1"
+        },
+        {
+          "name": "idea-validator",
+          "installUrl": "github:luongnv89/skills:skills/idea-validator",
+          "description": "Evaluate app ideas and startup concepts across market viability, technical feasibility, and competitive landscape. Use when asked to validate, review, or score a product idea. Don't use for writing a PRD, detailed go-to-market plans, or financial/investor pitch decks.",
+          "version": "1.3.1"
+        },
+        {
+          "name": "install-script-generator",
+          "installUrl": "github:luongnv89/skills:skills/install-script-generator",
+          "description": "Generate cross-platform installation scripts for any software, library, or module. Produces a standalone install.sh runnable via a single curl/wget one-liner, with automatic OS, architecture, and package manager detection. Don't use for authoring Dockerfiles, CI/CD pipelines, or one-off local shell scripts.",
+          "version": "2.1.0"
+        },
+        {
+          "name": "logo-designer",
+          "installUrl": "github:luongnv89/skills:skills/logo-designer",
+          "description": "Generate professional SVG logos from project context, producing 7 brand variants (mark, full, wordmark, icon, favicon, white, black) plus a showcase HTML page. Skip for raster-only logos, product illustrations, or full brand-guideline docs.",
+          "version": "1.2.1"
+        },
+        {
+          "name": "release-manager",
+          "installUrl": "github:luongnv89/skills:skills/release-manager",
+          "description": "Manage software releases end-to-end: bump version, generate changelog, tag, push, GitHub release, publish to PyPI/npm. Use when user asks to ship, cut a release, tag a version, or list changes since last tag. Skip routine commits and marketplace publishing.",
+          "version": "2.4.1"
+        },
+        {
+          "name": "security-setup",
+          "installUrl": "github:luongnv89/skills:skills/security-setup",
+          "description": "Install local-first security hardening: pre-commit secret detection, offline dependency scans, static analysis, reports, and gated free CI. Use when hardening repos or adding security hooks. Don't use for incident response or cloud security reviews.",
+          "version": "1.3.1"
+        },
+        {
+          "name": "slop-cleanup",
+          "installUrl": "github:luongnv89/skills:skills/slop-cleanup",
+          "description": "Refactor a codebase to remove AI slop, dead code, weak types, duplication, defensive over-engineering, and legacy cruft using 8 parallel specialized subagents across two cleanup waves. Don't use for adding new features, performance tuning, or security-only audits.",
+          "version": "1.1.1"
+        },
+        {
+          "name": "test-coverage",
+          "installUrl": "github:luongnv89/skills:skills/test-coverage",
+          "description": "Generate unit tests for untested branches and edge cases. Use when coverage is low, CI flags gaps, or a release needs hardening. Not for integration/E2E suites, framework migrations, or fixing production bugs.",
+          "version": "1.2.3"
+        },
+        {
+          "name": "usability-review",
+          "installUrl": "github:luongnv89/skills:skills/usability-review",
+          "description": "Review UI for usability issues using Steve Krug's principles and produce a scannable report. Use when asked for a usability audit, UX review, or UI feedback on screenshots, URLs, or code. Don't use for visual/brand design critique, accessibility (WCAG) audits, or backend/API review.",
+          "version": "1.2.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "luongnv89",
+        "repo": "skills",
+        "repoUrl": "https://github.com/luongnv89/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "luongnv89-skills-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from luongnv89/skills.",
+      "author": "ASM (luongnv89/skills)",
+      "createdAt": "2026-05-09T08:10:41.461Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "luongnv89",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "agent-config",
+          "installUrl": "github:luongnv89/skills:skills/agent-config",
+          "description": "Create or update CLAUDE.md and AGENTS.md files following official best practices. Use when asked to create, audit, or improve agent config files (CLAUDE.md, AGENTS.md). Don't use for README/contributor docs or non-Claude IDE plugins.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "appstore-review-checker",
+          "installUrl": "github:luongnv89/skills:skills/appstore-review-checker",
+          "description": "Audit iOS/macOS app projects against Apple App Store Review Guidelines to catch rejection risks before submission, with per-guideline PASS/FAIL/WARNING verdicts and fix suggestions. Don't use for Google Play/Android submissions, general code review, or post-rejection appeal drafting.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "aso-marketing",
+          "installUrl": "github:luongnv89/skills:skills/aso-marketing",
+          "description": "Optimize App Store and Google Play listings with keyword strategy, metadata, and localization. Use when asked to improve app store visibility or ASO. Don't use for web SEO, paid UA campaigns, or pre-submission compliance audits.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "brand-name-checker",
+          "installUrl": "github:luongnv89/skills:skills/brand-name-checker",
+          "description": "Check product and brand names for conflicts across trademarks, domains, social handles, and package registries. Returns a risk level and Proceed/Modify/Abandon recommendation. Skip for name brainstorming, logo design, or trademark filings.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "docs-generator",
+          "installUrl": "github:luongnv89/skills:skills/docs-generator",
+          "description": "Generate and restructure project documentation into a clear, accessible hierarchy. Use when asked to organize docs, generate documentation, improve doc structure, or restructure README. Don't use for API reference generation from code (JSDoc/Sphinx), authoring a landing page, or agent-config files like CLAUDE.md.",
+          "version": "1.2.3"
+        },
+        {
+          "name": "drawio-generator",
+          "installUrl": "github:luongnv89/skills:skills/drawio-generator",
+          "description": "Generate professional diagrams as valid draw.io XML files — flowcharts, architecture, C4 models, ER diagrams, sequence diagrams, mind maps, and swimlanes. Don't use for Excalidraw or Mermaid output, hand-drawn sketch styles, or slide decks/presentations.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "excalidraw-generator",
+          "installUrl": "github:luongnv89/skills:skills/excalidraw-generator",
+          "description": "Generate professional diagrams as valid Excalidraw JSON files — flowcharts, architecture, ER diagrams, mind maps, sequence diagrams, wireframes, C4 models, and more. Understands text, code, schemas, or verbal descriptions. Don't use for draw.io/Mermaid output, polished production slide decks, or pixel-perfect brand graphics.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "idea-validator",
+          "installUrl": "github:luongnv89/skills:skills/idea-validator",
+          "description": "Evaluate app ideas and startup concepts across market viability, technical feasibility, and competitive landscape. Use when asked to validate, review, or score a product idea. Don't use for writing a PRD, detailed go-to-market plans, or financial/investor pitch decks.",
+          "version": "1.3.1"
+        },
+        {
+          "name": "ollama-optimizer",
+          "installUrl": "github:luongnv89/skills:skills/ollama-optimizer",
+          "description": "Optimize Ollama configuration for the current machine's hardware. Use when asked to speed up Ollama, tune local LLM performance, or pick models that fit available GPU/RAM.",
+          "version": "1.0.4"
+        },
+        {
+          "name": "readme-to-landing-page",
+          "installUrl": "github:luongnv89/skills:skills/readme-to-landing-page",
+          "description": "Transform a project README.md into a conversion-optimized landing page using PAS, AIDA, or StoryBrand — hero, value prop, how it works, quick start, CTA in pure markdown. Skip for full HTML sites or general blog copy.",
+          "version": "2.1.0"
+        },
+        {
+          "name": "security-setup",
+          "installUrl": "github:luongnv89/skills:skills/security-setup",
+          "description": "Install local-first security hardening: pre-commit secret detection, offline dependency scans, static analysis, reports, and gated free CI. Use when hardening repos or adding security hooks. Don't use for incident response or cloud security reviews.",
+          "version": "1.3.1"
+        },
+        {
+          "name": "seo-ai-optimizer",
+          "installUrl": "github:luongnv89/skills:skills/seo-ai-optimizer",
+          "description": "Audit and optimize websites for technical SEO, content SEO, and AI bot accessibility. Fixes meta tags, sitemaps, robots.txt, structured data, llms.txt, and GPTBot/ClaudeBot directives. Not for App Store ASO, paid search, or blog writing.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "slop-cleanup",
+          "installUrl": "github:luongnv89/skills:skills/slop-cleanup",
+          "description": "Refactor a codebase to remove AI slop, dead code, weak types, duplication, defensive over-engineering, and legacy cruft using 8 parallel specialized subagents across two cleanup waves. Don't use for adding new features, performance tuning, or security-only audits.",
+          "version": "1.1.1"
+        },
+        {
+          "name": "website-cloner",
+          "installUrl": "github:luongnv89/skills:skills/website-cloner",
+          "description": "6-phase website cloning and improvement orchestrator. Takes a URL and produces an improved version (performance + UI/UX) via Vite/React/shadcn/Tailwind hosted on GitHub Pages. Use when asked to clone a site, rebuild a website, or make a better version of a URL. Orchestrates sibling skills with approval gates — don't use for single-phase work.",
+          "version": "1.1.1"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "luongnv89",
+        "repo": "skills",
+        "repoUrl": "https://github.com/luongnv89/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "luongnv89-skills-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from luongnv89/skills.",
+      "author": "ASM (luongnv89/skills)",
+      "createdAt": "2026-05-09T08:10:41.461Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "luongnv89",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "aso-marketing",
+          "installUrl": "github:luongnv89/skills:skills/aso-marketing",
+          "description": "Optimize App Store and Google Play listings with keyword strategy, metadata, and localization. Use when asked to improve app store visibility or ASO. Don't use for web SEO, paid UA campaigns, or pre-submission compliance audits.",
+          "version": "1.2.0"
+        },
+        {
+          "name": "brand-name-checker",
+          "installUrl": "github:luongnv89/skills:skills/brand-name-checker",
+          "description": "Check product and brand names for conflicts across trademarks, domains, social handles, and package registries. Returns a risk level and Proceed/Modify/Abandon recommendation. Skip for name brainstorming, logo design, or trademark filings.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "cli-builder",
+          "installUrl": "github:luongnv89/skills:skills/cli-builder",
+          "description": "Build a production-quality CLI tool for any module or application. Auto-detects language, recommends CLI libraries, and follows a 5-step approval-gated workflow: Analyze, Design, Plan, Execute, Summarize. Don't use for building GUI/TUI apps, web APIs, or authoring one-off shell scripts.",
+          "version": "1.0.3"
+        },
+        {
+          "name": "excalidraw-generator",
+          "installUrl": "github:luongnv89/skills:skills/excalidraw-generator",
+          "description": "Generate professional diagrams as valid Excalidraw JSON files — flowcharts, architecture, ER diagrams, mind maps, sequence diagrams, wireframes, C4 models, and more. Understands text, code, schemas, or verbal descriptions. Don't use for draw.io/Mermaid output, polished production slide decks, or pixel-perfect brand graphics.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "frontend-design",
+          "installUrl": "github:luongnv89/skills:skills/frontend-design",
+          "description": "Build production-grade frontend interfaces with distinctive aesthetics and working code. Use when asked to create a UI, component, page, or frontend feature. Skip for backend/API work or usability-only audits.",
+          "version": "1.2.2"
+        },
+        {
+          "name": "idea-validator",
+          "installUrl": "github:luongnv89/skills:skills/idea-validator",
+          "description": "Evaluate app ideas and startup concepts across market viability, technical feasibility, and competitive landscape. Use when asked to validate, review, or score a product idea. Don't use for writing a PRD, detailed go-to-market plans, or financial/investor pitch decks.",
+          "version": "1.3.1"
+        },
+        {
+          "name": "logo-designer",
+          "installUrl": "github:luongnv89/skills:skills/logo-designer",
+          "description": "Generate professional SVG logos from project context, producing 7 brand variants (mark, full, wordmark, icon, favicon, white, black) plus a showcase HTML page. Skip for raster-only logos, product illustrations, or full brand-guideline docs.",
+          "version": "1.2.1"
+        },
+        {
+          "name": "prd-generator",
+          "installUrl": "github:luongnv89/skills:skills/prd-generator",
+          "description": "Generate Product Requirements Documents from `idea.md` and `validate.md` files. Use when asked to create or update a PRD. Don't use for TAD, sprint tasks, or raw idea validation.",
+          "version": "1.3.1"
+        },
+        {
+          "name": "release-manager",
+          "installUrl": "github:luongnv89/skills:skills/release-manager",
+          "description": "Manage software releases end-to-end: bump version, generate changelog, tag, push, GitHub release, publish to PyPI/npm. Use when user asks to ship, cut a release, tag a version, or list changes since last tag. Skip routine commits and marketplace publishing.",
+          "version": "2.4.1"
+        },
+        {
+          "name": "tad-generator",
+          "installUrl": "github:luongnv89/skills:skills/tad-generator",
+          "description": "Generate a Technical Architecture Document (TAD) from a PRD. Use when asked to design the architecture, create a TAD, or define how a product is built. Creates/updates tad.md and reports GitHub links. Skip PRD authoring, sprint-tasks, or code implementation.",
+          "version": "1.3.0"
+        },
+        {
+          "name": "tasks-generator",
+          "installUrl": "github:luongnv89/skills:skills/tasks-generator",
+          "description": "Generate development tasks from a PRD file with sprint-based planning. Use when users ask to create tasks from PRD, break down the PRD, generate sprint tasks, or want to convert product requirements into actionable development tasks. Creates/updates tasks.md and always reports GitHub links to changed files. Don't use for writing a PRD, authoring a TAD, or executing tasks (see openspec-task-loop).",
+          "version": "1.2.1"
+        },
+        {
+          "name": "test-coverage",
+          "installUrl": "github:luongnv89/skills:skills/test-coverage",
+          "description": "Generate unit tests for untested branches and edge cases. Use when coverage is low, CI flags gaps, or a release needs hardening. Not for integration/E2E suites, framework migrations, or fixing production bugs.",
+          "version": "1.2.3"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "luongnv89",
+        "repo": "skills",
+        "repoUrl": "https://github.com/luongnv89/skills.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/mattpocock_skills.json
+++ b/data/skill-index/mattpocock_skills.json
@@ -3704,5 +3704,541 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "mattpocock-skills-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from mattpocock/skills.",
+      "author": "ASM (mattpocock/skills)",
+      "createdAt": "2026-05-09T08:10:45.003Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "mattpocock",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "caveman",
+          "installUrl": "github:mattpocock/skills:skills/productivity/caveman",
+          "description": "Ultra-compressed communication mode. Cuts token usage ~75% by dropping filler, articles, and pleasantries while keeping full technical accuracy. Use when user says \"caveman mode\", \"talk like caveman\", \"use caveman\", \"less tokens\", \"be brief\", or invokes /caveman.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "diagnose",
+          "installUrl": "github:mattpocock/skills:skills/engineering/diagnose",
+          "description": "Disciplined diagnosis loop for hard bugs and performance regressions. Reproduce → minimise → hypothesise → instrument → fix → regression-test. Use when user says \"diagnose this\" / \"debug this\", reports a bug, says something is broken/throwing/failing, or describes a performance regression.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "edit-article",
+          "installUrl": "github:mattpocock/skills:skills/personal/edit-article",
+          "description": "Edit and improve articles by restructuring sections, improving clarity, and tightening prose. Use when user wants to edit, revise, or improve an article draft.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "grill-with-docs",
+          "installUrl": "github:mattpocock/skills:skills/engineering/grill-with-docs",
+          "description": "Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "improve-codebase-architecture",
+          "installUrl": "github:mattpocock/skills:skills/engineering/improve-codebase-architecture",
+          "description": "Find deepening opportunities in a codebase, informed by the domain language in CONTEXT.md and the decisions in docs/adr/. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more testable and AI-navigable.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "setup-matt-pocock-skills",
+          "installUrl": "github:mattpocock/skills:skills/engineering/setup-matt-pocock-skills",
+          "description": "Sets up an `## Agent skills` block in AGENTS.md/CLAUDE.md and `docs/agents/` so the engineering skills know this repo's issue tracker (GitHub or local markdown), triage label vocabulary, and domain doc layout. Run before first use of `to-issues`, `to-prd`, `triage`, `diagnose`, `tdd`, `improve-codebase-architecture`, or `zoom-out` — or if those skills appear to be missing context about the issue tracker, triage labels, or domain docs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "write-a-skill",
+          "installUrl": "github:mattpocock/skills:skills/productivity/write-a-skill",
+          "description": "Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "writing-beats",
+          "installUrl": "github:mattpocock/skills:skills/in-progress/writing-beats",
+          "description": "Shape an article as a journey of beats, choose-your-own-adventure style. The user picks a starting beat from the raw material, you write only that beat, then offer options for where to pivot next, beat by beat, until the article reaches a natural end. Use when the user has raw material and wants to assemble it as a narrative rather than an argument.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "writing-fragments",
+          "installUrl": "github:mattpocock/skills:skills/in-progress/writing-fragments",
+          "description": "Grilling session that mines the user for fragments — heterogeneous nuggets of writing (claims, vignettes, sharp sentences, half-thoughts) — and appends them to a single document as raw material for a future article. Use when the user wants to develop ideas before imposing structure, or mentions \"fragments\", \"ideate\", or \"raw material\" for writing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "writing-shape",
+          "installUrl": "github:mattpocock/skills:skills/in-progress/writing-shape",
+          "description": "Take a markdown file of raw material and shape it into an article through a conversational session — drafting candidate openings, growing the piece paragraph by paragraph, arguing about format (lists, tables, callouts, quotes) at each step. Use when the user has a pile of notes, fragments, or a rough draft and wants help turning it into something publishable.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "mattpocock",
+        "repo": "skills",
+        "repoUrl": "https://github.com/mattpocock/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "mattpocock-skills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from mattpocock/skills.",
+      "author": "ASM (mattpocock/skills)",
+      "createdAt": "2026-05-09T08:10:45.003Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "mattpocock",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "design-an-interface",
+          "installUrl": "github:mattpocock/skills:skills/deprecated/design-an-interface",
+          "description": "Generate multiple radically different interface designs for a module using parallel sub-agents. Use when user wants to design an API, explore interface options, compare module shapes, or mentions \"design it twice\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "diagnose",
+          "installUrl": "github:mattpocock/skills:skills/engineering/diagnose",
+          "description": "Disciplined diagnosis loop for hard bugs and performance regressions. Reproduce → minimise → hypothesise → instrument → fix → regression-test. Use when user says \"diagnose this\" / \"debug this\", reports a bug, says something is broken/throwing/failing, or describes a performance regression.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "git-guardrails-claude-code",
+          "installUrl": "github:mattpocock/skills:skills/misc/git-guardrails-claude-code",
+          "description": "Set up Claude Code hooks to block dangerous git commands (push, reset --hard, clean, branch -D, etc.) before they execute. Use when user wants to prevent destructive git operations, add git safety hooks, or block git push/reset in Claude Code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "grill-me",
+          "installUrl": "github:mattpocock/skills:skills/productivity/grill-me",
+          "description": "Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions \"grill me\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "grill-with-docs",
+          "installUrl": "github:mattpocock/skills:skills/engineering/grill-with-docs",
+          "description": "Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "improve-codebase-architecture",
+          "installUrl": "github:mattpocock/skills:skills/engineering/improve-codebase-architecture",
+          "description": "Find deepening opportunities in a codebase, informed by the domain language in CONTEXT.md and the decisions in docs/adr/. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more testable and AI-navigable.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "migrate-to-shoehorn",
+          "installUrl": "github:mattpocock/skills:skills/misc/migrate-to-shoehorn",
+          "description": "Migrate test files from `as` type assertions to @total-typescript/shoehorn. Use when user mentions shoehorn, wants to replace `as` in tests, or needs partial test data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "prototype",
+          "installUrl": "github:mattpocock/skills:skills/engineering/prototype",
+          "description": "Build a throwaway prototype to flush out a design before committing to it. Routes between two branches — a runnable terminal app for state/business-logic questions, or several radically different UI variations toggleable from one route. Use when the user wants to prototype, sanity-check a data model or state machine, mock up a UI, explore design options, or says \"prototype this\", \"let me play with it\", \"try a few designs\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "qa",
+          "installUrl": "github:mattpocock/skills:skills/deprecated/qa",
+          "description": "Interactive QA session where user reports bugs or issues conversationally, and the agent files GitHub issues. Explores the codebase in the background for context and domain language. Use when user wants to report bugs, do QA, file issues conversationally, or mentions \"QA session\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "request-refactor-plan",
+          "installUrl": "github:mattpocock/skills:skills/deprecated/request-refactor-plan",
+          "description": "Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "setup-matt-pocock-skills",
+          "installUrl": "github:mattpocock/skills:skills/engineering/setup-matt-pocock-skills",
+          "description": "Sets up an `## Agent skills` block in AGENTS.md/CLAUDE.md and `docs/agents/` so the engineering skills know this repo's issue tracker (GitHub or local markdown), triage label vocabulary, and domain doc layout. Run before first use of `to-issues`, `to-prd`, `triage`, `diagnose`, `tdd`, `improve-codebase-architecture`, or `zoom-out` — or if those skills appear to be missing context about the issue tracker, triage labels, or domain docs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "setup-pre-commit",
+          "installUrl": "github:mattpocock/skills:skills/misc/setup-pre-commit",
+          "description": "Set up Husky pre-commit hooks with lint-staged (Prettier), type checking, and tests in the current repo. Use when user wants to add pre-commit hooks, set up Husky, configure lint-staged, or add commit-time formatting/typechecking/testing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "tdd",
+          "installUrl": "github:mattpocock/skills:skills/engineering/tdd",
+          "description": "Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions \"red-green-refactor\", wants integration tests, or asks for test-first development.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "triage",
+          "installUrl": "github:mattpocock/skills:skills/engineering/triage",
+          "description": "Triage issues through a state machine driven by triage roles. Use when user wants to create an issue, triage issues, review incoming bugs or feature requests, prepare issues for an AFK agent, or manage issue workflow.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ubiquitous-language",
+          "installUrl": "github:mattpocock/skills:skills/deprecated/ubiquitous-language",
+          "description": "Extract a DDD-style ubiquitous language glossary from the current conversation, flagging ambiguities and proposing canonical terms. Saves to UBIQUITOUS_LANGUAGE.md. Use when user wants to define domain terms, build a glossary, harden terminology, create a ubiquitous language, or mentions \"domain model\" or \"DDD\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "write-a-skill",
+          "installUrl": "github:mattpocock/skills:skills/productivity/write-a-skill",
+          "description": "Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "zoom-out",
+          "installUrl": "github:mattpocock/skills:skills/engineering/zoom-out",
+          "description": "Tell the agent to zoom out and give broader context or a higher-level perspective. Use when you're unfamiliar with a section of code or need to understand how it fits into the bigger picture.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "mattpocock",
+        "repo": "skills",
+        "repoUrl": "https://github.com/mattpocock/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "mattpocock-skills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from mattpocock/skills.",
+      "author": "ASM (mattpocock/skills)",
+      "createdAt": "2026-05-09T08:10:45.003Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "mattpocock",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "design-an-interface",
+          "installUrl": "github:mattpocock/skills:skills/deprecated/design-an-interface",
+          "description": "Generate multiple radically different interface designs for a module using parallel sub-agents. Use when user wants to design an API, explore interface options, compare module shapes, or mentions \"design it twice\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "grill-me",
+          "installUrl": "github:mattpocock/skills:skills/productivity/grill-me",
+          "description": "Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions \"grill me\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "prototype",
+          "installUrl": "github:mattpocock/skills:skills/engineering/prototype",
+          "description": "Build a throwaway prototype to flush out a design before committing to it. Routes between two branches — a runnable terminal app for state/business-logic questions, or several radically different UI variations toggleable from one route. Use when the user wants to prototype, sanity-check a data model or state machine, mock up a UI, explore design options, or says \"prototype this\", \"let me play with it\", \"try a few designs\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "setup-matt-pocock-skills",
+          "installUrl": "github:mattpocock/skills:skills/engineering/setup-matt-pocock-skills",
+          "description": "Sets up an `## Agent skills` block in AGENTS.md/CLAUDE.md and `docs/agents/` so the engineering skills know this repo's issue tracker (GitHub or local markdown), triage label vocabulary, and domain doc layout. Run before first use of `to-issues`, `to-prd`, `triage`, `diagnose`, `tdd`, `improve-codebase-architecture`, or `zoom-out` — or if those skills appear to be missing context about the issue tracker, triage labels, or domain docs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "tdd",
+          "installUrl": "github:mattpocock/skills:skills/engineering/tdd",
+          "description": "Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions \"red-green-refactor\", wants integration tests, or asks for test-first development.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ubiquitous-language",
+          "installUrl": "github:mattpocock/skills:skills/deprecated/ubiquitous-language",
+          "description": "Extract a DDD-style ubiquitous language glossary from the current conversation, flagging ambiguities and proposing canonical terms. Saves to UBIQUITOUS_LANGUAGE.md. Use when user wants to define domain terms, build a glossary, harden terminology, create a ubiquitous language, or mentions \"domain model\" or \"DDD\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "write-a-skill",
+          "installUrl": "github:mattpocock/skills:skills/productivity/write-a-skill",
+          "description": "Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "writing-shape",
+          "installUrl": "github:mattpocock/skills:skills/in-progress/writing-shape",
+          "description": "Take a markdown file of raw material and shape it into an article through a conversational session — drafting candidate openings, growing the piece paragraph by paragraph, arguing about format (lists, tables, callouts, quotes) at each step. Use when the user has a pile of notes, fragments, or a rough draft and wants help turning it into something publishable.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "mattpocock",
+        "repo": "skills",
+        "repoUrl": "https://github.com/mattpocock/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "mattpocock-skills-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from mattpocock/skills.",
+      "author": "ASM (mattpocock/skills)",
+      "createdAt": "2026-05-09T08:10:45.003Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "mattpocock",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "diagnose",
+          "installUrl": "github:mattpocock/skills:skills/engineering/diagnose",
+          "description": "Disciplined diagnosis loop for hard bugs and performance regressions. Reproduce → minimise → hypothesise → instrument → fix → regression-test. Use when user says \"diagnose this\" / \"debug this\", reports a bug, says something is broken/throwing/failing, or describes a performance regression.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "grill-me",
+          "installUrl": "github:mattpocock/skills:skills/productivity/grill-me",
+          "description": "Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions \"grill me\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "grill-with-docs",
+          "installUrl": "github:mattpocock/skills:skills/engineering/grill-with-docs",
+          "description": "Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "improve-codebase-architecture",
+          "installUrl": "github:mattpocock/skills:skills/engineering/improve-codebase-architecture",
+          "description": "Find deepening opportunities in a codebase, informed by the domain language in CONTEXT.md and the decisions in docs/adr/. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more testable and AI-navigable.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scaffold-exercises",
+          "installUrl": "github:mattpocock/skills:skills/misc/scaffold-exercises",
+          "description": "Create exercise directory structures with sections, problems, solutions, and explainers that pass linting. Use when user wants to scaffold exercises, create exercise stubs, or set up a new course section.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "triage",
+          "installUrl": "github:mattpocock/skills:skills/engineering/triage",
+          "description": "Triage issues through a state machine driven by triage roles. Use when user wants to create an issue, triage issues, review incoming bugs or feature requests, prepare issues for an AFK agent, or manage issue workflow.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "mattpocock",
+        "repo": "skills",
+        "repoUrl": "https://github.com/mattpocock/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "mattpocock-skills-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from mattpocock/skills.",
+      "author": "ASM (mattpocock/skills)",
+      "createdAt": "2026-05-09T08:10:45.003Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "mattpocock",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "design-an-interface",
+          "installUrl": "github:mattpocock/skills:skills/deprecated/design-an-interface",
+          "description": "Generate multiple radically different interface designs for a module using parallel sub-agents. Use when user wants to design an API, explore interface options, compare module shapes, or mentions \"design it twice\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "diagnose",
+          "installUrl": "github:mattpocock/skills:skills/engineering/diagnose",
+          "description": "Disciplined diagnosis loop for hard bugs and performance regressions. Reproduce → minimise → hypothesise → instrument → fix → regression-test. Use when user says \"diagnose this\" / \"debug this\", reports a bug, says something is broken/throwing/failing, or describes a performance regression.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "git-guardrails-claude-code",
+          "installUrl": "github:mattpocock/skills:skills/misc/git-guardrails-claude-code",
+          "description": "Set up Claude Code hooks to block dangerous git commands (push, reset --hard, clean, branch -D, etc.) before they execute. Use when user wants to prevent destructive git operations, add git safety hooks, or block git push/reset in Claude Code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "grill-with-docs",
+          "installUrl": "github:mattpocock/skills:skills/engineering/grill-with-docs",
+          "description": "Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "handoff",
+          "installUrl": "github:mattpocock/skills:skills/in-progress/handoff",
+          "description": "Compact the current conversation into a handoff document for another agent to pick up.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "improve-codebase-architecture",
+          "installUrl": "github:mattpocock/skills:skills/engineering/improve-codebase-architecture",
+          "description": "Find deepening opportunities in a codebase, informed by the domain language in CONTEXT.md and the decisions in docs/adr/. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more testable and AI-navigable.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "migrate-to-shoehorn",
+          "installUrl": "github:mattpocock/skills:skills/misc/migrate-to-shoehorn",
+          "description": "Migrate test files from `as` type assertions to @total-typescript/shoehorn. Use when user mentions shoehorn, wants to replace `as` in tests, or needs partial test data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "prototype",
+          "installUrl": "github:mattpocock/skills:skills/engineering/prototype",
+          "description": "Build a throwaway prototype to flush out a design before committing to it. Routes between two branches — a runnable terminal app for state/business-logic questions, or several radically different UI variations toggleable from one route. Use when the user wants to prototype, sanity-check a data model or state machine, mock up a UI, explore design options, or says \"prototype this\", \"let me play with it\", \"try a few designs\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "qa",
+          "installUrl": "github:mattpocock/skills:skills/deprecated/qa",
+          "description": "Interactive QA session where user reports bugs or issues conversationally, and the agent files GitHub issues. Explores the codebase in the background for context and domain language. Use when user wants to report bugs, do QA, file issues conversationally, or mentions \"QA session\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "request-refactor-plan",
+          "installUrl": "github:mattpocock/skills:skills/deprecated/request-refactor-plan",
+          "description": "Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scaffold-exercises",
+          "installUrl": "github:mattpocock/skills:skills/misc/scaffold-exercises",
+          "description": "Create exercise directory structures with sections, problems, solutions, and explainers that pass linting. Use when user wants to scaffold exercises, create exercise stubs, or set up a new course section.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "setup-matt-pocock-skills",
+          "installUrl": "github:mattpocock/skills:skills/engineering/setup-matt-pocock-skills",
+          "description": "Sets up an `## Agent skills` block in AGENTS.md/CLAUDE.md and `docs/agents/` so the engineering skills know this repo's issue tracker (GitHub or local markdown), triage label vocabulary, and domain doc layout. Run before first use of `to-issues`, `to-prd`, `triage`, `diagnose`, `tdd`, `improve-codebase-architecture`, or `zoom-out` — or if those skills appear to be missing context about the issue tracker, triage labels, or domain docs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "triage",
+          "installUrl": "github:mattpocock/skills:skills/engineering/triage",
+          "description": "Triage issues through a state machine driven by triage roles. Use when user wants to create an issue, triage issues, review incoming bugs or feature requests, prepare issues for an AFK agent, or manage issue workflow.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ubiquitous-language",
+          "installUrl": "github:mattpocock/skills:skills/deprecated/ubiquitous-language",
+          "description": "Extract a DDD-style ubiquitous language glossary from the current conversation, flagging ambiguities and proposing canonical terms. Saves to UBIQUITOUS_LANGUAGE.md. Use when user wants to define domain terms, build a glossary, harden terminology, create a ubiquitous language, or mentions \"domain model\" or \"DDD\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "write-a-skill",
+          "installUrl": "github:mattpocock/skills:skills/productivity/write-a-skill",
+          "description": "Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "writing-fragments",
+          "installUrl": "github:mattpocock/skills:skills/in-progress/writing-fragments",
+          "description": "Grilling session that mines the user for fragments — heterogeneous nuggets of writing (claims, vignettes, sharp sentences, half-thoughts) — and appends them to a single document as raw material for a future article. Use when the user wants to develop ideas before imposing structure, or mentions \"fragments\", \"ideate\", or \"raw material\" for writing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "zoom-out",
+          "installUrl": "github:mattpocock/skills:skills/engineering/zoom-out",
+          "description": "Tell the agent to zoom out and give broader context or a higher-level perspective. Use when you're unfamiliar with a section of code or need to understand how it fits into the bigger picture.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "mattpocock",
+        "repo": "skills",
+        "repoUrl": "https://github.com/mattpocock/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "mattpocock-skills-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from mattpocock/skills.",
+      "author": "ASM (mattpocock/skills)",
+      "createdAt": "2026-05-09T08:10:45.003Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "mattpocock",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "caveman",
+          "installUrl": "github:mattpocock/skills:skills/productivity/caveman",
+          "description": "Ultra-compressed communication mode. Cuts token usage ~75% by dropping filler, articles, and pleasantries while keeping full technical accuracy. Use when user says \"caveman mode\", \"talk like caveman\", \"use caveman\", \"less tokens\", \"be brief\", or invokes /caveman.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "grill-me",
+          "installUrl": "github:mattpocock/skills:skills/productivity/grill-me",
+          "description": "Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions \"grill me\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "prototype",
+          "installUrl": "github:mattpocock/skills:skills/engineering/prototype",
+          "description": "Build a throwaway prototype to flush out a design before committing to it. Routes between two branches — a runnable terminal app for state/business-logic questions, or several radically different UI variations toggleable from one route. Use when the user wants to prototype, sanity-check a data model or state machine, mock up a UI, explore design options, or says \"prototype this\", \"let me play with it\", \"try a few designs\".",
+          "version": "0.0.0"
+        },
+        {
+          "name": "setup-matt-pocock-skills",
+          "installUrl": "github:mattpocock/skills:skills/engineering/setup-matt-pocock-skills",
+          "description": "Sets up an `## Agent skills` block in AGENTS.md/CLAUDE.md and `docs/agents/` so the engineering skills know this repo's issue tracker (GitHub or local markdown), triage label vocabulary, and domain doc layout. Run before first use of `to-issues`, `to-prd`, `triage`, `diagnose`, `tdd`, `improve-codebase-architecture`, or `zoom-out` — or if those skills appear to be missing context about the issue tracker, triage labels, or domain docs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "to-issues",
+          "installUrl": "github:mattpocock/skills:skills/engineering/to-issues",
+          "description": "Break a plan, spec, or PRD into independently-grabbable issues on the project issue tracker using tracer-bullet vertical slices. Use when user wants to convert a plan into issues, create implementation tickets, or break down work into issues.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "to-prd",
+          "installUrl": "github:mattpocock/skills:skills/engineering/to-prd",
+          "description": "Turn the current conversation context into a PRD and publish it to the project issue tracker. Use when user wants to create a PRD from the current context.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "write-a-skill",
+          "installUrl": "github:mattpocock/skills:skills/productivity/write-a-skill",
+          "description": "Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "mattpocock",
+        "repo": "skills",
+        "repoUrl": "https://github.com/mattpocock/skills.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/nextlevelbuilder_ui-ux-pro-max-skill.json
+++ b/data/skill-index/nextlevelbuilder_ui-ux-pro-max-skill.json
@@ -964,5 +964,397 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "nextlevelbuilder-ui-ux-pro-max-skill-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from nextlevelbuilder/ui-ux-pro-max-skill.",
+      "author": "ASM (nextlevelbuilder/ui-ux-pro-max-skill)",
+      "createdAt": "2026-05-09T08:10:29.447Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "nextlevelbuilder",
+        "ui-ux-pro-max-skill"
+      ],
+      "skills": [
+        {
+          "name": "ckm:banner-design",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/banner-design",
+          "description": "Design banners for social media, ads, website heroes, creative assets, and print. Multiple art direction options with AI-generated visuals. Actions: design, create, generate banner. Platforms: Facebook, Twitter/X, LinkedIn, YouTube, Instagram, Google Display, website hero, print. Styles: minimalist, gradient, bold typography, photo-based, illustrated, geometric, retro, glassmorphism, 3D, neon, duotone, editorial, collage. Uses ui-ux-pro-max, frontend-design, ai-artist, ai-multimodal skills.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:brand",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/brand",
+          "description": "Brand voice, visual identity, messaging frameworks, asset management, brand consistency. Activate for branded content, tone of voice, marketing assets, brand compliance, style guides.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:design",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design",
+          "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML→screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
+          "version": "2.1.0"
+        },
+        {
+          "name": "ckm:design-system",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design-system",
+          "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive→semantic→component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:slides",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/slides",
+          "description": "Create strategic HTML presentations with Chart.js, design tokens, responsive layouts, copywriting formulas, and contextual slide strategies.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:ui-styling",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/ui-styling",
+          "description": "Create beautiful, accessible user interfaces with shadcn/ui components (built on Radix UI + Tailwind), Tailwind CSS utility-first styling, and canvas-based visual designs. Use when building user interfaces, implementing design systems, creating responsive layouts, adding accessible components (dialogs, dropdowns, forms, tables), customizing themes and colors, implementing dark mode, generating visual designs and posters, or establishing consistent styling patterns across applications.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ui-ux-pro-max",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/ui-ux-pro-max",
+          "description": "UI/UX design intelligence for web and mobile. Includes 50+ styles, 161 color palettes, 57 font pairings, 161 product types, 99 UX guidelines, and 25 chart types across 10 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, and HTML/CSS). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, and check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, and mobile app. Elements: button, modal, navbar, sidebar, card, table, form, and chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, and flat design. Topics: color systems, accessibility, animation, layout, typography, font pairing, spacing, interaction states, shadow, and gradient. Integrations: shadcn/ui MCP for component search and examples.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "nextlevelbuilder",
+        "repo": "ui-ux-pro-max-skill",
+        "repoUrl": "https://github.com/nextlevelbuilder/ui-ux-pro-max-skill.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "nextlevelbuilder-ui-ux-pro-max-skill-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from nextlevelbuilder/ui-ux-pro-max-skill.",
+      "author": "ASM (nextlevelbuilder/ui-ux-pro-max-skill)",
+      "createdAt": "2026-05-09T08:10:29.447Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "nextlevelbuilder",
+        "ui-ux-pro-max-skill"
+      ],
+      "skills": [
+        {
+          "name": "ckm:brand",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/brand",
+          "description": "Brand voice, visual identity, messaging frameworks, asset management, brand consistency. Activate for branded content, tone of voice, marketing assets, brand compliance, style guides.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:slides",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/slides",
+          "description": "Create strategic HTML presentations with Chart.js, design tokens, responsive layouts, copywriting formulas, and contextual slide strategies.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ui-ux-pro-max",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/ui-ux-pro-max",
+          "description": "UI/UX design intelligence for web and mobile. Includes 50+ styles, 161 color palettes, 57 font pairings, 161 product types, 99 UX guidelines, and 25 chart types across 10 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, and HTML/CSS). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, and check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, and mobile app. Elements: button, modal, navbar, sidebar, card, table, form, and chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, and flat design. Topics: color systems, accessibility, animation, layout, typography, font pairing, spacing, interaction states, shadow, and gradient. Integrations: shadcn/ui MCP for component search and examples.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "nextlevelbuilder",
+        "repo": "ui-ux-pro-max-skill",
+        "repoUrl": "https://github.com/nextlevelbuilder/ui-ux-pro-max-skill.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "nextlevelbuilder-ui-ux-pro-max-skill-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from nextlevelbuilder/ui-ux-pro-max-skill.",
+      "author": "ASM (nextlevelbuilder/ui-ux-pro-max-skill)",
+      "createdAt": "2026-05-09T08:10:29.447Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "nextlevelbuilder",
+        "ui-ux-pro-max-skill"
+      ],
+      "skills": [
+        {
+          "name": "ckm:banner-design",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/banner-design",
+          "description": "Design banners for social media, ads, website heroes, creative assets, and print. Multiple art direction options with AI-generated visuals. Actions: design, create, generate banner. Platforms: Facebook, Twitter/X, LinkedIn, YouTube, Instagram, Google Display, website hero, print. Styles: minimalist, gradient, bold typography, photo-based, illustrated, geometric, retro, glassmorphism, 3D, neon, duotone, editorial, collage. Uses ui-ux-pro-max, frontend-design, ai-artist, ai-multimodal skills.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:brand",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/brand",
+          "description": "Brand voice, visual identity, messaging frameworks, asset management, brand consistency. Activate for branded content, tone of voice, marketing assets, brand compliance, style guides.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:design",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design",
+          "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML→screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
+          "version": "2.1.0"
+        },
+        {
+          "name": "ckm:design-system",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design-system",
+          "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive→semantic→component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:slides",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/slides",
+          "description": "Create strategic HTML presentations with Chart.js, design tokens, responsive layouts, copywriting formulas, and contextual slide strategies.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:ui-styling",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/ui-styling",
+          "description": "Create beautiful, accessible user interfaces with shadcn/ui components (built on Radix UI + Tailwind), Tailwind CSS utility-first styling, and canvas-based visual designs. Use when building user interfaces, implementing design systems, creating responsive layouts, adding accessible components (dialogs, dropdowns, forms, tables), customizing themes and colors, implementing dark mode, generating visual designs and posters, or establishing consistent styling patterns across applications.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ui-ux-pro-max",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/ui-ux-pro-max",
+          "description": "UI/UX design intelligence for web and mobile. Includes 50+ styles, 161 color palettes, 57 font pairings, 161 product types, 99 UX guidelines, and 25 chart types across 10 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, and HTML/CSS). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, and check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, and mobile app. Elements: button, modal, navbar, sidebar, card, table, form, and chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, and flat design. Topics: color systems, accessibility, animation, layout, typography, font pairing, spacing, interaction states, shadow, and gradient. Integrations: shadcn/ui MCP for component search and examples.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "nextlevelbuilder",
+        "repo": "ui-ux-pro-max-skill",
+        "repoUrl": "https://github.com/nextlevelbuilder/ui-ux-pro-max-skill.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "nextlevelbuilder-ui-ux-pro-max-skill-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from nextlevelbuilder/ui-ux-pro-max-skill.",
+      "author": "ASM (nextlevelbuilder/ui-ux-pro-max-skill)",
+      "createdAt": "2026-05-09T08:10:29.447Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "nextlevelbuilder",
+        "ui-ux-pro-max-skill"
+      ],
+      "skills": [
+        {
+          "name": "ckm:banner-design",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/banner-design",
+          "description": "Design banners for social media, ads, website heroes, creative assets, and print. Multiple art direction options with AI-generated visuals. Actions: design, create, generate banner. Platforms: Facebook, Twitter/X, LinkedIn, YouTube, Instagram, Google Display, website hero, print. Styles: minimalist, gradient, bold typography, photo-based, illustrated, geometric, retro, glassmorphism, 3D, neon, duotone, editorial, collage. Uses ui-ux-pro-max, frontend-design, ai-artist, ai-multimodal skills.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:brand",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/brand",
+          "description": "Brand voice, visual identity, messaging frameworks, asset management, brand consistency. Activate for branded content, tone of voice, marketing assets, brand compliance, style guides.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:design",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design",
+          "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML→screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
+          "version": "2.1.0"
+        },
+        {
+          "name": "ckm:design-system",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design-system",
+          "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive→semantic→component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:slides",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/slides",
+          "description": "Create strategic HTML presentations with Chart.js, design tokens, responsive layouts, copywriting formulas, and contextual slide strategies.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:ui-styling",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/ui-styling",
+          "description": "Create beautiful, accessible user interfaces with shadcn/ui components (built on Radix UI + Tailwind), Tailwind CSS utility-first styling, and canvas-based visual designs. Use when building user interfaces, implementing design systems, creating responsive layouts, adding accessible components (dialogs, dropdowns, forms, tables), customizing themes and colors, implementing dark mode, generating visual designs and posters, or establishing consistent styling patterns across applications.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ui-ux-pro-max",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/ui-ux-pro-max",
+          "description": "UI/UX design intelligence for web and mobile. Includes 50+ styles, 161 color palettes, 57 font pairings, 161 product types, 99 UX guidelines, and 25 chart types across 10 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, and HTML/CSS). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, and check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, and mobile app. Elements: button, modal, navbar, sidebar, card, table, form, and chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, and flat design. Topics: color systems, accessibility, animation, layout, typography, font pairing, spacing, interaction states, shadow, and gradient. Integrations: shadcn/ui MCP for component search and examples.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "nextlevelbuilder",
+        "repo": "ui-ux-pro-max-skill",
+        "repoUrl": "https://github.com/nextlevelbuilder/ui-ux-pro-max-skill.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "nextlevelbuilder-ui-ux-pro-max-skill-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from nextlevelbuilder/ui-ux-pro-max-skill.",
+      "author": "ASM (nextlevelbuilder/ui-ux-pro-max-skill)",
+      "createdAt": "2026-05-09T08:10:29.447Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "nextlevelbuilder",
+        "ui-ux-pro-max-skill"
+      ],
+      "skills": [
+        {
+          "name": "ckm:banner-design",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/banner-design",
+          "description": "Design banners for social media, ads, website heroes, creative assets, and print. Multiple art direction options with AI-generated visuals. Actions: design, create, generate banner. Platforms: Facebook, Twitter/X, LinkedIn, YouTube, Instagram, Google Display, website hero, print. Styles: minimalist, gradient, bold typography, photo-based, illustrated, geometric, retro, glassmorphism, 3D, neon, duotone, editorial, collage. Uses ui-ux-pro-max, frontend-design, ai-artist, ai-multimodal skills.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:design",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design",
+          "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML→screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
+          "version": "2.1.0"
+        },
+        {
+          "name": "ckm:design-system",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design-system",
+          "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive→semantic→component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ui-ux-pro-max",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/ui-ux-pro-max",
+          "description": "UI/UX design intelligence for web and mobile. Includes 50+ styles, 161 color palettes, 57 font pairings, 161 product types, 99 UX guidelines, and 25 chart types across 10 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, and HTML/CSS). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, and check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, and mobile app. Elements: button, modal, navbar, sidebar, card, table, form, and chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, and flat design. Topics: color systems, accessibility, animation, layout, typography, font pairing, spacing, interaction states, shadow, and gradient. Integrations: shadcn/ui MCP for component search and examples.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "nextlevelbuilder",
+        "repo": "ui-ux-pro-max-skill",
+        "repoUrl": "https://github.com/nextlevelbuilder/ui-ux-pro-max-skill.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "nextlevelbuilder-ui-ux-pro-max-skill-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from nextlevelbuilder/ui-ux-pro-max-skill.",
+      "author": "ASM (nextlevelbuilder/ui-ux-pro-max-skill)",
+      "createdAt": "2026-05-09T08:10:29.447Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "nextlevelbuilder",
+        "ui-ux-pro-max-skill"
+      ],
+      "skills": [
+        {
+          "name": "ckm:banner-design",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/banner-design",
+          "description": "Design banners for social media, ads, website heroes, creative assets, and print. Multiple art direction options with AI-generated visuals. Actions: design, create, generate banner. Platforms: Facebook, Twitter/X, LinkedIn, YouTube, Instagram, Google Display, website hero, print. Styles: minimalist, gradient, bold typography, photo-based, illustrated, geometric, retro, glassmorphism, 3D, neon, duotone, editorial, collage. Uses ui-ux-pro-max, frontend-design, ai-artist, ai-multimodal skills.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:brand",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/brand",
+          "description": "Brand voice, visual identity, messaging frameworks, asset management, brand consistency. Activate for branded content, tone of voice, marketing assets, brand compliance, style guides.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:design",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design",
+          "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML→screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
+          "version": "2.1.0"
+        },
+        {
+          "name": "ckm:design-system",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design-system",
+          "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive→semantic→component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:slides",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/slides",
+          "description": "Create strategic HTML presentations with Chart.js, design tokens, responsive layouts, copywriting formulas, and contextual slide strategies.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ckm:ui-styling",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/ui-styling",
+          "description": "Create beautiful, accessible user interfaces with shadcn/ui components (built on Radix UI + Tailwind), Tailwind CSS utility-first styling, and canvas-based visual designs. Use when building user interfaces, implementing design systems, creating responsive layouts, adding accessible components (dialogs, dropdowns, forms, tables), customizing themes and colors, implementing dark mode, generating visual designs and posters, or establishing consistent styling patterns across applications.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ui-ux-pro-max",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/ui-ux-pro-max",
+          "description": "UI/UX design intelligence for web and mobile. Includes 50+ styles, 161 color palettes, 57 font pairings, 161 product types, 99 UX guidelines, and 25 chart types across 10 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, and HTML/CSS). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, and check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, and mobile app. Elements: button, modal, navbar, sidebar, card, table, form, and chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, and flat design. Topics: color systems, accessibility, animation, layout, typography, font pairing, spacing, interaction states, shadow, and gradient. Integrations: shadcn/ui MCP for component search and examples.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "nextlevelbuilder",
+        "repo": "ui-ux-pro-max-skill",
+        "repoUrl": "https://github.com/nextlevelbuilder/ui-ux-pro-max-skill.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "nextlevelbuilder-ui-ux-pro-max-skill-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from nextlevelbuilder/ui-ux-pro-max-skill.",
+      "author": "ASM (nextlevelbuilder/ui-ux-pro-max-skill)",
+      "createdAt": "2026-05-09T08:10:29.447Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "nextlevelbuilder",
+        "ui-ux-pro-max-skill"
+      ],
+      "skills": [
+        {
+          "name": "ckm:brand",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/brand",
+          "description": "Brand voice, visual identity, messaging frameworks, asset management, brand consistency. Activate for branded content, tone of voice, marketing assets, brand compliance, style guides.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "ui-ux-pro-max",
+          "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/ui-ux-pro-max",
+          "description": "UI/UX design intelligence for web and mobile. Includes 50+ styles, 161 color palettes, 57 font pairings, 161 product types, 99 UX guidelines, and 25 chart types across 10 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, and HTML/CSS). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, and check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, and mobile app. Elements: button, modal, navbar, sidebar, card, table, form, and chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, and flat design. Topics: color systems, accessibility, animation, layout, typography, font pairing, spacing, interaction states, shadow, and gradient. Integrations: shadcn/ui MCP for component search and examples.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "nextlevelbuilder",
+        "repo": "ui-ux-pro-max-skill",
+        "repoUrl": "https://github.com/nextlevelbuilder/ui-ux-pro-max-skill.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/obra_superpowers.json
+++ b/data/skill-index/obra_superpowers.json
@@ -1923,5 +1923,337 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "obra-superpowers-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from obra/superpowers.",
+      "author": "ASM (obra/superpowers)",
+      "createdAt": "2026-05-09T08:10:26.605Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "obra",
+        "superpowers"
+      ],
+      "skills": [
+        {
+          "name": "test-driven-development",
+          "installUrl": "github:obra/superpowers:skills/test-driven-development",
+          "description": "Use when implementing any feature or bugfix, before writing implementation code",
+          "version": "0.0.0"
+        },
+        {
+          "name": "writing-plans",
+          "installUrl": "github:obra/superpowers:skills/writing-plans",
+          "description": "Use when you have a spec or requirements for a multi-step task, before touching code",
+          "version": "0.0.0"
+        },
+        {
+          "name": "writing-skills",
+          "installUrl": "github:obra/superpowers:skills/writing-skills",
+          "description": "Use when creating new skills, editing existing skills, or verifying skills work before deployment",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "obra",
+        "repo": "superpowers",
+        "repoUrl": "https://github.com/obra/superpowers.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "obra-superpowers-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from obra/superpowers.",
+      "author": "ASM (obra/superpowers)",
+      "createdAt": "2026-05-09T08:10:26.605Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "obra",
+        "superpowers"
+      ],
+      "skills": [
+        {
+          "name": "executing-plans",
+          "installUrl": "github:obra/superpowers:skills/executing-plans",
+          "description": "Use when you have a written implementation plan to execute in a separate session with review checkpoints",
+          "version": "0.0.0"
+        },
+        {
+          "name": "receiving-code-review",
+          "installUrl": "github:obra/superpowers:skills/receiving-code-review",
+          "description": "Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation",
+          "version": "0.0.0"
+        },
+        {
+          "name": "requesting-code-review",
+          "installUrl": "github:obra/superpowers:skills/requesting-code-review",
+          "description": "Use when completing tasks, implementing major features, or before merging to verify work meets requirements",
+          "version": "0.0.0"
+        },
+        {
+          "name": "writing-skills",
+          "installUrl": "github:obra/superpowers:skills/writing-skills",
+          "description": "Use when creating new skills, editing existing skills, or verifying skills work before deployment",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "obra",
+        "repo": "superpowers",
+        "repoUrl": "https://github.com/obra/superpowers.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "obra-superpowers-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from obra/superpowers.",
+      "author": "ASM (obra/superpowers)",
+      "createdAt": "2026-05-09T08:10:26.605Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "obra",
+        "superpowers"
+      ],
+      "skills": [
+        {
+          "name": "brainstorming",
+          "installUrl": "github:obra/superpowers:skills/brainstorming",
+          "description": "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "executing-plans",
+          "installUrl": "github:obra/superpowers:skills/executing-plans",
+          "description": "Use when you have a written implementation plan to execute in a separate session with review checkpoints",
+          "version": "0.0.0"
+        },
+        {
+          "name": "finishing-a-development-branch",
+          "installUrl": "github:obra/superpowers:skills/finishing-a-development-branch",
+          "description": "Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup",
+          "version": "0.0.0"
+        },
+        {
+          "name": "receiving-code-review",
+          "installUrl": "github:obra/superpowers:skills/receiving-code-review",
+          "description": "Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation",
+          "version": "0.0.0"
+        },
+        {
+          "name": "requesting-code-review",
+          "installUrl": "github:obra/superpowers:skills/requesting-code-review",
+          "description": "Use when completing tasks, implementing major features, or before merging to verify work meets requirements",
+          "version": "0.0.0"
+        },
+        {
+          "name": "systematic-debugging",
+          "installUrl": "github:obra/superpowers:skills/systematic-debugging",
+          "description": "Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes",
+          "version": "0.0.0"
+        },
+        {
+          "name": "test-driven-development",
+          "installUrl": "github:obra/superpowers:skills/test-driven-development",
+          "description": "Use when implementing any feature or bugfix, before writing implementation code",
+          "version": "0.0.0"
+        },
+        {
+          "name": "writing-plans",
+          "installUrl": "github:obra/superpowers:skills/writing-plans",
+          "description": "Use when you have a spec or requirements for a multi-step task, before touching code",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "obra",
+        "repo": "superpowers",
+        "repoUrl": "https://github.com/obra/superpowers.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "obra-superpowers-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from obra/superpowers.",
+      "author": "ASM (obra/superpowers)",
+      "createdAt": "2026-05-09T08:10:26.605Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "obra",
+        "superpowers"
+      ],
+      "skills": [
+        {
+          "name": "brainstorming",
+          "installUrl": "github:obra/superpowers:skills/brainstorming",
+          "description": "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "finishing-a-development-branch",
+          "installUrl": "github:obra/superpowers:skills/finishing-a-development-branch",
+          "description": "Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup",
+          "version": "0.0.0"
+        },
+        {
+          "name": "receiving-code-review",
+          "installUrl": "github:obra/superpowers:skills/receiving-code-review",
+          "description": "Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation",
+          "version": "0.0.0"
+        },
+        {
+          "name": "requesting-code-review",
+          "installUrl": "github:obra/superpowers:skills/requesting-code-review",
+          "description": "Use when completing tasks, implementing major features, or before merging to verify work meets requirements",
+          "version": "0.0.0"
+        },
+        {
+          "name": "using-superpowers",
+          "installUrl": "github:obra/superpowers:skills/using-superpowers",
+          "description": "Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions",
+          "version": "0.0.0"
+        },
+        {
+          "name": "verification-before-completion",
+          "installUrl": "github:obra/superpowers:skills/verification-before-completion",
+          "description": "Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence before assertions always",
+          "version": "0.0.0"
+        },
+        {
+          "name": "writing-plans",
+          "installUrl": "github:obra/superpowers:skills/writing-plans",
+          "description": "Use when you have a spec or requirements for a multi-step task, before touching code",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "obra",
+        "repo": "superpowers",
+        "repoUrl": "https://github.com/obra/superpowers.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "obra-superpowers-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from obra/superpowers.",
+      "author": "ASM (obra/superpowers)",
+      "createdAt": "2026-05-09T08:10:26.605Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "obra",
+        "superpowers"
+      ],
+      "skills": [
+        {
+          "name": "dispatching-parallel-agents",
+          "installUrl": "github:obra/superpowers:skills/dispatching-parallel-agents",
+          "description": "Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies",
+          "version": "0.0.0"
+        },
+        {
+          "name": "finishing-a-development-branch",
+          "installUrl": "github:obra/superpowers:skills/finishing-a-development-branch",
+          "description": "Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup",
+          "version": "0.0.0"
+        },
+        {
+          "name": "receiving-code-review",
+          "installUrl": "github:obra/superpowers:skills/receiving-code-review",
+          "description": "Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation",
+          "version": "0.0.0"
+        },
+        {
+          "name": "writing-skills",
+          "installUrl": "github:obra/superpowers:skills/writing-skills",
+          "description": "Use when creating new skills, editing existing skills, or verifying skills work before deployment",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "obra",
+        "repo": "superpowers",
+        "repoUrl": "https://github.com/obra/superpowers.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "obra-superpowers-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from obra/superpowers.",
+      "author": "ASM (obra/superpowers)",
+      "createdAt": "2026-05-09T08:10:26.605Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "obra",
+        "superpowers"
+      ],
+      "skills": [
+        {
+          "name": "brainstorming",
+          "installUrl": "github:obra/superpowers:skills/brainstorming",
+          "description": "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dispatching-parallel-agents",
+          "installUrl": "github:obra/superpowers:skills/dispatching-parallel-agents",
+          "description": "Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies",
+          "version": "0.0.0"
+        },
+        {
+          "name": "subagent-driven-development",
+          "installUrl": "github:obra/superpowers:skills/subagent-driven-development",
+          "description": "Use when executing implementation plans with independent tasks in the current session",
+          "version": "0.0.0"
+        },
+        {
+          "name": "systematic-debugging",
+          "installUrl": "github:obra/superpowers:skills/systematic-debugging",
+          "description": "Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes",
+          "version": "0.0.0"
+        },
+        {
+          "name": "verification-before-completion",
+          "installUrl": "github:obra/superpowers:skills/verification-before-completion",
+          "description": "Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence before assertions always",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "obra",
+        "repo": "superpowers",
+        "repoUrl": "https://github.com/obra/superpowers.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/romainsimon_paperasse.json
+++ b/data/skill-index/romainsimon_paperasse.json
@@ -827,5 +827,361 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "romainsimon-paperasse-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from romainsimon/paperasse.",
+      "author": "ASM (romainsimon/paperasse)",
+      "createdAt": "2026-05-09T08:11:14.374Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "romainsimon",
+        "paperasse"
+      ],
+      "skills": [
+        {
+          "name": "commissaire-aux-comptes",
+          "installUrl": "github:romainsimon/paperasse:commissaire-aux-comptes",
+          "description": "Commissaire aux comptes IA pour l'audit des comptes annuels d'entreprises françaises. Applique la démarche NEP en 7 phases : prise de connaissance, contrôle du FEC, vérification du bilan, du compte de résultat, de la balance, de la liasse fiscale, et contrôles transversaux. Émet une opinion motivée sur la fiabilité des comptes avec rapport structuré. Triggers: audit, commissaire aux comptes, CAC, certification, comptes annuels, validation comptes, révision comptable, statutory audit",
+          "version": "0.0.0"
+        },
+        {
+          "name": "comptable",
+          "installUrl": "github:romainsimon/paperasse:comptable",
+          "description": "Comptabilité, fiscalité et facturation pour entreprises françaises. Gère écritures PCG, déclarations TVA, IS/IR, clôture annuelle, liasse fiscale (2033/2065), FEC, états financiers, et chaîne facturation (mentions obligatoires, numérotation, Factur-X/UBL/CII, plateformes agréées PDP/PA, e-reporting, réforme 2026, PEPPOL). Utiliser dès qu'une question porte sur comptabilité française, TVA, impôts, bilan, compte de résultat, amortissement, PCA, clôture, facture, avoir, devis, acompte, facturation électronique, ou e-invoicing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "controleur-fiscal",
+          "installUrl": "github:romainsimon/paperasse:controleur-fiscal",
+          "description": "Inspecteur des finances publiques IA. Simule un contrôle fiscal DGFIP complet sur les comptes d'une entreprise française (SASU, EURL, SAS, SARL). Analyse le FEC, la liasse fiscale, les charges déduites, le compte courant d'associé, la TVA, l'IS selon 8 axes de vérification. Identifie les chefs de redressement potentiels avec montants, base légale et niveaux de risque. Triggers: contrôle fiscal, redressement, vérification comptabilité, DGFIP, FEC, déductibilité, audit fiscal, tax audit",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fiscaliste",
+          "installUrl": "github:romainsimon/paperasse:fiscaliste",
+          "description": "Fiscaliste IA pour la fiscalité personnelle des contribuables français. Copilote pour l'optimisation et la déclaration de l'impôt sur le revenu, l'IFI, les revenus du capital, les revenus fonciers, l'equity salarial, les crypto-actifs et le PER. Couvre le calcul de l'IR (barème progressif, quotient familial, décote, PAS, CEHR, revenus exceptionnels), la déclaration 2042 et ses annexes, les revenus du capital (PFU vs barème, PEA, assurance-vie rachats, dividendes, plus-values mobilières), les revenus fonciers (micro vs réel, déficit, LMNP, SCI à l'IR), l'equity startup (RSU, BSPCE, stock-options, PEE/PERCO), la fiscalité crypto (méthode PAMC, formulaire 2086), l'IFI, et les déductions (PER, pension alimentaire). Triggers: impôt sur le revenu, IR, déclaration 2042, quotient familial, barème, décote, PAS, PFU, flat tax, PEA, assurance-vie, LMNP, revenus fonciers, déficit foncier, SCI IR, RSU, BSPCE, stock-options, PEE, PERCO, crypto, fiscalité crypto, 2086, IFI, PER, plafond PER, niche fiscale, optimisation fiscale, simulation IR, TMI Hors scope : succession / donation (voir skill notaire), IS / SASU / arbitrage dividende-salaire / SCI à l'IS (voir skill comptable).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "notaire",
+          "installUrl": "github:romainsimon/paperasse:notaire",
+          "description": "Notaire IA pour le droit immobilier, les successions, les donations, le droit de la famille et le droit des sociétés en France. Copilote juridique pour la préparation d'actes, le conseil patrimonial, les calculs de frais et la vérification de conformité. Couvre le calcul des frais de notaire (DMTO, émoluments, débours, CSI), la plus-value immobilière, les droits de succession et donation, le démembrement, les contrats de mariage, les PACS, les SCI, et la rédaction de projets d'actes (compromis, statuts, testaments). Triggers: notaire, frais de notaire, acte de vente, compromis, succession, donation, héritage, testament, PACS, contrat de mariage, SCI, plus-value immobilière, droits de mutation, DMTO, usufruit, nue-propriété, partage successoral, réserve héréditaire, viager, donation-partage, diagnostics immobilier, droit de préemption, acte notarié, droit immobilier",
+          "version": "0.0.0"
+        },
+        {
+          "name": "syndic",
+          "installUrl": "github:romainsimon/paperasse:syndic",
+          "description": "Gère un parc de copropriétés en France avec vue portfolio consolidée. Couvre administration, comptabilité (décret 2005, plan comptable copro, 5 annexes), assemblées générales (convocation, PV, notification), appels de fonds, travaux, fournisseurs, recouvrement d'impayés et transition de syndic. Maîtrise les majorités (art. 24, 25, 25-1, 26), le fonds de travaux (art. 14-2), le privilège immobilier (art. 19-2) et l'immatriculation RNC. Intégration Qonto pour le rapprochement bancaire. Utilisé pour toute question liée à la copropriété, au syndic bénévole ou coopératif, aux charges, tantièmes, AG, ou au droit de la copropriété (loi 1965, ALUR, ELAN).",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "romainsimon",
+        "repo": "paperasse",
+        "repoUrl": "https://github.com/romainsimon/paperasse.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "romainsimon-paperasse-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from romainsimon/paperasse.",
+      "author": "ASM (romainsimon/paperasse)",
+      "createdAt": "2026-05-09T08:11:14.374Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "romainsimon",
+        "paperasse"
+      ],
+      "skills": [
+        {
+          "name": "commissaire-aux-comptes",
+          "installUrl": "github:romainsimon/paperasse:commissaire-aux-comptes",
+          "description": "Commissaire aux comptes IA pour l'audit des comptes annuels d'entreprises françaises. Applique la démarche NEP en 7 phases : prise de connaissance, contrôle du FEC, vérification du bilan, du compte de résultat, de la balance, de la liasse fiscale, et contrôles transversaux. Émet une opinion motivée sur la fiabilité des comptes avec rapport structuré. Triggers: audit, commissaire aux comptes, CAC, certification, comptes annuels, validation comptes, révision comptable, statutory audit",
+          "version": "0.0.0"
+        },
+        {
+          "name": "comptable",
+          "installUrl": "github:romainsimon/paperasse:comptable",
+          "description": "Comptabilité, fiscalité et facturation pour entreprises françaises. Gère écritures PCG, déclarations TVA, IS/IR, clôture annuelle, liasse fiscale (2033/2065), FEC, états financiers, et chaîne facturation (mentions obligatoires, numérotation, Factur-X/UBL/CII, plateformes agréées PDP/PA, e-reporting, réforme 2026, PEPPOL). Utiliser dès qu'une question porte sur comptabilité française, TVA, impôts, bilan, compte de résultat, amortissement, PCA, clôture, facture, avoir, devis, acompte, facturation électronique, ou e-invoicing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "controleur-fiscal",
+          "installUrl": "github:romainsimon/paperasse:controleur-fiscal",
+          "description": "Inspecteur des finances publiques IA. Simule un contrôle fiscal DGFIP complet sur les comptes d'une entreprise française (SASU, EURL, SAS, SARL). Analyse le FEC, la liasse fiscale, les charges déduites, le compte courant d'associé, la TVA, l'IS selon 8 axes de vérification. Identifie les chefs de redressement potentiels avec montants, base légale et niveaux de risque. Triggers: contrôle fiscal, redressement, vérification comptabilité, DGFIP, FEC, déductibilité, audit fiscal, tax audit",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fiscaliste",
+          "installUrl": "github:romainsimon/paperasse:fiscaliste",
+          "description": "Fiscaliste IA pour la fiscalité personnelle des contribuables français. Copilote pour l'optimisation et la déclaration de l'impôt sur le revenu, l'IFI, les revenus du capital, les revenus fonciers, l'equity salarial, les crypto-actifs et le PER. Couvre le calcul de l'IR (barème progressif, quotient familial, décote, PAS, CEHR, revenus exceptionnels), la déclaration 2042 et ses annexes, les revenus du capital (PFU vs barème, PEA, assurance-vie rachats, dividendes, plus-values mobilières), les revenus fonciers (micro vs réel, déficit, LMNP, SCI à l'IR), l'equity startup (RSU, BSPCE, stock-options, PEE/PERCO), la fiscalité crypto (méthode PAMC, formulaire 2086), l'IFI, et les déductions (PER, pension alimentaire). Triggers: impôt sur le revenu, IR, déclaration 2042, quotient familial, barème, décote, PAS, PFU, flat tax, PEA, assurance-vie, LMNP, revenus fonciers, déficit foncier, SCI IR, RSU, BSPCE, stock-options, PEE, PERCO, crypto, fiscalité crypto, 2086, IFI, PER, plafond PER, niche fiscale, optimisation fiscale, simulation IR, TMI Hors scope : succession / donation (voir skill notaire), IS / SASU / arbitrage dividende-salaire / SCI à l'IS (voir skill comptable).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "notaire",
+          "installUrl": "github:romainsimon/paperasse:notaire",
+          "description": "Notaire IA pour le droit immobilier, les successions, les donations, le droit de la famille et le droit des sociétés en France. Copilote juridique pour la préparation d'actes, le conseil patrimonial, les calculs de frais et la vérification de conformité. Couvre le calcul des frais de notaire (DMTO, émoluments, débours, CSI), la plus-value immobilière, les droits de succession et donation, le démembrement, les contrats de mariage, les PACS, les SCI, et la rédaction de projets d'actes (compromis, statuts, testaments). Triggers: notaire, frais de notaire, acte de vente, compromis, succession, donation, héritage, testament, PACS, contrat de mariage, SCI, plus-value immobilière, droits de mutation, DMTO, usufruit, nue-propriété, partage successoral, réserve héréditaire, viager, donation-partage, diagnostics immobilier, droit de préemption, acte notarié, droit immobilier",
+          "version": "0.0.0"
+        },
+        {
+          "name": "syndic",
+          "installUrl": "github:romainsimon/paperasse:syndic",
+          "description": "Gère un parc de copropriétés en France avec vue portfolio consolidée. Couvre administration, comptabilité (décret 2005, plan comptable copro, 5 annexes), assemblées générales (convocation, PV, notification), appels de fonds, travaux, fournisseurs, recouvrement d'impayés et transition de syndic. Maîtrise les majorités (art. 24, 25, 25-1, 26), le fonds de travaux (art. 14-2), le privilège immobilier (art. 19-2) et l'immatriculation RNC. Intégration Qonto pour le rapprochement bancaire. Utilisé pour toute question liée à la copropriété, au syndic bénévole ou coopératif, aux charges, tantièmes, AG, ou au droit de la copropriété (loi 1965, ALUR, ELAN).",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "romainsimon",
+        "repo": "paperasse",
+        "repoUrl": "https://github.com/romainsimon/paperasse.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "romainsimon-paperasse-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from romainsimon/paperasse.",
+      "author": "ASM (romainsimon/paperasse)",
+      "createdAt": "2026-05-09T08:11:14.374Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "romainsimon",
+        "paperasse"
+      ],
+      "skills": [
+        {
+          "name": "fiscaliste",
+          "installUrl": "github:romainsimon/paperasse:fiscaliste",
+          "description": "Fiscaliste IA pour la fiscalité personnelle des contribuables français. Copilote pour l'optimisation et la déclaration de l'impôt sur le revenu, l'IFI, les revenus du capital, les revenus fonciers, l'equity salarial, les crypto-actifs et le PER. Couvre le calcul de l'IR (barème progressif, quotient familial, décote, PAS, CEHR, revenus exceptionnels), la déclaration 2042 et ses annexes, les revenus du capital (PFU vs barème, PEA, assurance-vie rachats, dividendes, plus-values mobilières), les revenus fonciers (micro vs réel, déficit, LMNP, SCI à l'IR), l'equity startup (RSU, BSPCE, stock-options, PEE/PERCO), la fiscalité crypto (méthode PAMC, formulaire 2086), l'IFI, et les déductions (PER, pension alimentaire). Triggers: impôt sur le revenu, IR, déclaration 2042, quotient familial, barème, décote, PAS, PFU, flat tax, PEA, assurance-vie, LMNP, revenus fonciers, déficit foncier, SCI IR, RSU, BSPCE, stock-options, PEE, PERCO, crypto, fiscalité crypto, 2086, IFI, PER, plafond PER, niche fiscale, optimisation fiscale, simulation IR, TMI Hors scope : succession / donation (voir skill notaire), IS / SASU / arbitrage dividende-salaire / SCI à l'IS (voir skill comptable).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "notaire",
+          "installUrl": "github:romainsimon/paperasse:notaire",
+          "description": "Notaire IA pour le droit immobilier, les successions, les donations, le droit de la famille et le droit des sociétés en France. Copilote juridique pour la préparation d'actes, le conseil patrimonial, les calculs de frais et la vérification de conformité. Couvre le calcul des frais de notaire (DMTO, émoluments, débours, CSI), la plus-value immobilière, les droits de succession et donation, le démembrement, les contrats de mariage, les PACS, les SCI, et la rédaction de projets d'actes (compromis, statuts, testaments). Triggers: notaire, frais de notaire, acte de vente, compromis, succession, donation, héritage, testament, PACS, contrat de mariage, SCI, plus-value immobilière, droits de mutation, DMTO, usufruit, nue-propriété, partage successoral, réserve héréditaire, viager, donation-partage, diagnostics immobilier, droit de préemption, acte notarié, droit immobilier",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "romainsimon",
+        "repo": "paperasse",
+        "repoUrl": "https://github.com/romainsimon/paperasse.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "romainsimon-paperasse-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from romainsimon/paperasse.",
+      "author": "ASM (romainsimon/paperasse)",
+      "createdAt": "2026-05-09T08:11:14.374Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "romainsimon",
+        "paperasse"
+      ],
+      "skills": [
+        {
+          "name": "commissaire-aux-comptes",
+          "installUrl": "github:romainsimon/paperasse:commissaire-aux-comptes",
+          "description": "Commissaire aux comptes IA pour l'audit des comptes annuels d'entreprises françaises. Applique la démarche NEP en 7 phases : prise de connaissance, contrôle du FEC, vérification du bilan, du compte de résultat, de la balance, de la liasse fiscale, et contrôles transversaux. Émet une opinion motivée sur la fiabilité des comptes avec rapport structuré. Triggers: audit, commissaire aux comptes, CAC, certification, comptes annuels, validation comptes, révision comptable, statutory audit",
+          "version": "0.0.0"
+        },
+        {
+          "name": "controleur-fiscal",
+          "installUrl": "github:romainsimon/paperasse:controleur-fiscal",
+          "description": "Inspecteur des finances publiques IA. Simule un contrôle fiscal DGFIP complet sur les comptes d'une entreprise française (SASU, EURL, SAS, SARL). Analyse le FEC, la liasse fiscale, les charges déduites, le compte courant d'associé, la TVA, l'IS selon 8 axes de vérification. Identifie les chefs de redressement potentiels avec montants, base légale et niveaux de risque. Triggers: contrôle fiscal, redressement, vérification comptabilité, DGFIP, FEC, déductibilité, audit fiscal, tax audit",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fiscaliste",
+          "installUrl": "github:romainsimon/paperasse:fiscaliste",
+          "description": "Fiscaliste IA pour la fiscalité personnelle des contribuables français. Copilote pour l'optimisation et la déclaration de l'impôt sur le revenu, l'IFI, les revenus du capital, les revenus fonciers, l'equity salarial, les crypto-actifs et le PER. Couvre le calcul de l'IR (barème progressif, quotient familial, décote, PAS, CEHR, revenus exceptionnels), la déclaration 2042 et ses annexes, les revenus du capital (PFU vs barème, PEA, assurance-vie rachats, dividendes, plus-values mobilières), les revenus fonciers (micro vs réel, déficit, LMNP, SCI à l'IR), l'equity startup (RSU, BSPCE, stock-options, PEE/PERCO), la fiscalité crypto (méthode PAMC, formulaire 2086), l'IFI, et les déductions (PER, pension alimentaire). Triggers: impôt sur le revenu, IR, déclaration 2042, quotient familial, barème, décote, PAS, PFU, flat tax, PEA, assurance-vie, LMNP, revenus fonciers, déficit foncier, SCI IR, RSU, BSPCE, stock-options, PEE, PERCO, crypto, fiscalité crypto, 2086, IFI, PER, plafond PER, niche fiscale, optimisation fiscale, simulation IR, TMI Hors scope : succession / donation (voir skill notaire), IS / SASU / arbitrage dividende-salaire / SCI à l'IS (voir skill comptable).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "notaire",
+          "installUrl": "github:romainsimon/paperasse:notaire",
+          "description": "Notaire IA pour le droit immobilier, les successions, les donations, le droit de la famille et le droit des sociétés en France. Copilote juridique pour la préparation d'actes, le conseil patrimonial, les calculs de frais et la vérification de conformité. Couvre le calcul des frais de notaire (DMTO, émoluments, débours, CSI), la plus-value immobilière, les droits de succession et donation, le démembrement, les contrats de mariage, les PACS, les SCI, et la rédaction de projets d'actes (compromis, statuts, testaments). Triggers: notaire, frais de notaire, acte de vente, compromis, succession, donation, héritage, testament, PACS, contrat de mariage, SCI, plus-value immobilière, droits de mutation, DMTO, usufruit, nue-propriété, partage successoral, réserve héréditaire, viager, donation-partage, diagnostics immobilier, droit de préemption, acte notarié, droit immobilier",
+          "version": "0.0.0"
+        },
+        {
+          "name": "syndic",
+          "installUrl": "github:romainsimon/paperasse:syndic",
+          "description": "Gère un parc de copropriétés en France avec vue portfolio consolidée. Couvre administration, comptabilité (décret 2005, plan comptable copro, 5 annexes), assemblées générales (convocation, PV, notification), appels de fonds, travaux, fournisseurs, recouvrement d'impayés et transition de syndic. Maîtrise les majorités (art. 24, 25, 25-1, 26), le fonds de travaux (art. 14-2), le privilège immobilier (art. 19-2) et l'immatriculation RNC. Intégration Qonto pour le rapprochement bancaire. Utilisé pour toute question liée à la copropriété, au syndic bénévole ou coopératif, aux charges, tantièmes, AG, ou au droit de la copropriété (loi 1965, ALUR, ELAN).",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "romainsimon",
+        "repo": "paperasse",
+        "repoUrl": "https://github.com/romainsimon/paperasse.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "romainsimon-paperasse-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from romainsimon/paperasse.",
+      "author": "ASM (romainsimon/paperasse)",
+      "createdAt": "2026-05-09T08:11:14.374Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "romainsimon",
+        "paperasse"
+      ],
+      "skills": [
+        {
+          "name": "comptable",
+          "installUrl": "github:romainsimon/paperasse:comptable",
+          "description": "Comptabilité, fiscalité et facturation pour entreprises françaises. Gère écritures PCG, déclarations TVA, IS/IR, clôture annuelle, liasse fiscale (2033/2065), FEC, états financiers, et chaîne facturation (mentions obligatoires, numérotation, Factur-X/UBL/CII, plateformes agréées PDP/PA, e-reporting, réforme 2026, PEPPOL). Utiliser dès qu'une question porte sur comptabilité française, TVA, impôts, bilan, compte de résultat, amortissement, PCA, clôture, facture, avoir, devis, acompte, facturation électronique, ou e-invoicing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "controleur-fiscal",
+          "installUrl": "github:romainsimon/paperasse:controleur-fiscal",
+          "description": "Inspecteur des finances publiques IA. Simule un contrôle fiscal DGFIP complet sur les comptes d'une entreprise française (SASU, EURL, SAS, SARL). Analyse le FEC, la liasse fiscale, les charges déduites, le compte courant d'associé, la TVA, l'IS selon 8 axes de vérification. Identifie les chefs de redressement potentiels avec montants, base légale et niveaux de risque. Triggers: contrôle fiscal, redressement, vérification comptabilité, DGFIP, FEC, déductibilité, audit fiscal, tax audit",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fiscaliste",
+          "installUrl": "github:romainsimon/paperasse:fiscaliste",
+          "description": "Fiscaliste IA pour la fiscalité personnelle des contribuables français. Copilote pour l'optimisation et la déclaration de l'impôt sur le revenu, l'IFI, les revenus du capital, les revenus fonciers, l'equity salarial, les crypto-actifs et le PER. Couvre le calcul de l'IR (barème progressif, quotient familial, décote, PAS, CEHR, revenus exceptionnels), la déclaration 2042 et ses annexes, les revenus du capital (PFU vs barème, PEA, assurance-vie rachats, dividendes, plus-values mobilières), les revenus fonciers (micro vs réel, déficit, LMNP, SCI à l'IR), l'equity startup (RSU, BSPCE, stock-options, PEE/PERCO), la fiscalité crypto (méthode PAMC, formulaire 2086), l'IFI, et les déductions (PER, pension alimentaire). Triggers: impôt sur le revenu, IR, déclaration 2042, quotient familial, barème, décote, PAS, PFU, flat tax, PEA, assurance-vie, LMNP, revenus fonciers, déficit foncier, SCI IR, RSU, BSPCE, stock-options, PEE, PERCO, crypto, fiscalité crypto, 2086, IFI, PER, plafond PER, niche fiscale, optimisation fiscale, simulation IR, TMI Hors scope : succession / donation (voir skill notaire), IS / SASU / arbitrage dividende-salaire / SCI à l'IS (voir skill comptable).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "notaire",
+          "installUrl": "github:romainsimon/paperasse:notaire",
+          "description": "Notaire IA pour le droit immobilier, les successions, les donations, le droit de la famille et le droit des sociétés en France. Copilote juridique pour la préparation d'actes, le conseil patrimonial, les calculs de frais et la vérification de conformité. Couvre le calcul des frais de notaire (DMTO, émoluments, débours, CSI), la plus-value immobilière, les droits de succession et donation, le démembrement, les contrats de mariage, les PACS, les SCI, et la rédaction de projets d'actes (compromis, statuts, testaments). Triggers: notaire, frais de notaire, acte de vente, compromis, succession, donation, héritage, testament, PACS, contrat de mariage, SCI, plus-value immobilière, droits de mutation, DMTO, usufruit, nue-propriété, partage successoral, réserve héréditaire, viager, donation-partage, diagnostics immobilier, droit de préemption, acte notarié, droit immobilier",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "romainsimon",
+        "repo": "paperasse",
+        "repoUrl": "https://github.com/romainsimon/paperasse.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "romainsimon-paperasse-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from romainsimon/paperasse.",
+      "author": "ASM (romainsimon/paperasse)",
+      "createdAt": "2026-05-09T08:11:14.374Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "romainsimon",
+        "paperasse"
+      ],
+      "skills": [
+        {
+          "name": "commissaire-aux-comptes",
+          "installUrl": "github:romainsimon/paperasse:commissaire-aux-comptes",
+          "description": "Commissaire aux comptes IA pour l'audit des comptes annuels d'entreprises françaises. Applique la démarche NEP en 7 phases : prise de connaissance, contrôle du FEC, vérification du bilan, du compte de résultat, de la balance, de la liasse fiscale, et contrôles transversaux. Émet une opinion motivée sur la fiabilité des comptes avec rapport structuré. Triggers: audit, commissaire aux comptes, CAC, certification, comptes annuels, validation comptes, révision comptable, statutory audit",
+          "version": "0.0.0"
+        },
+        {
+          "name": "comptable",
+          "installUrl": "github:romainsimon/paperasse:comptable",
+          "description": "Comptabilité, fiscalité et facturation pour entreprises françaises. Gère écritures PCG, déclarations TVA, IS/IR, clôture annuelle, liasse fiscale (2033/2065), FEC, états financiers, et chaîne facturation (mentions obligatoires, numérotation, Factur-X/UBL/CII, plateformes agréées PDP/PA, e-reporting, réforme 2026, PEPPOL). Utiliser dès qu'une question porte sur comptabilité française, TVA, impôts, bilan, compte de résultat, amortissement, PCA, clôture, facture, avoir, devis, acompte, facturation électronique, ou e-invoicing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "controleur-fiscal",
+          "installUrl": "github:romainsimon/paperasse:controleur-fiscal",
+          "description": "Inspecteur des finances publiques IA. Simule un contrôle fiscal DGFIP complet sur les comptes d'une entreprise française (SASU, EURL, SAS, SARL). Analyse le FEC, la liasse fiscale, les charges déduites, le compte courant d'associé, la TVA, l'IS selon 8 axes de vérification. Identifie les chefs de redressement potentiels avec montants, base légale et niveaux de risque. Triggers: contrôle fiscal, redressement, vérification comptabilité, DGFIP, FEC, déductibilité, audit fiscal, tax audit",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fiscaliste",
+          "installUrl": "github:romainsimon/paperasse:fiscaliste",
+          "description": "Fiscaliste IA pour la fiscalité personnelle des contribuables français. Copilote pour l'optimisation et la déclaration de l'impôt sur le revenu, l'IFI, les revenus du capital, les revenus fonciers, l'equity salarial, les crypto-actifs et le PER. Couvre le calcul de l'IR (barème progressif, quotient familial, décote, PAS, CEHR, revenus exceptionnels), la déclaration 2042 et ses annexes, les revenus du capital (PFU vs barème, PEA, assurance-vie rachats, dividendes, plus-values mobilières), les revenus fonciers (micro vs réel, déficit, LMNP, SCI à l'IR), l'equity startup (RSU, BSPCE, stock-options, PEE/PERCO), la fiscalité crypto (méthode PAMC, formulaire 2086), l'IFI, et les déductions (PER, pension alimentaire). Triggers: impôt sur le revenu, IR, déclaration 2042, quotient familial, barème, décote, PAS, PFU, flat tax, PEA, assurance-vie, LMNP, revenus fonciers, déficit foncier, SCI IR, RSU, BSPCE, stock-options, PEE, PERCO, crypto, fiscalité crypto, 2086, IFI, PER, plafond PER, niche fiscale, optimisation fiscale, simulation IR, TMI Hors scope : succession / donation (voir skill notaire), IS / SASU / arbitrage dividende-salaire / SCI à l'IS (voir skill comptable).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "notaire",
+          "installUrl": "github:romainsimon/paperasse:notaire",
+          "description": "Notaire IA pour le droit immobilier, les successions, les donations, le droit de la famille et le droit des sociétés en France. Copilote juridique pour la préparation d'actes, le conseil patrimonial, les calculs de frais et la vérification de conformité. Couvre le calcul des frais de notaire (DMTO, émoluments, débours, CSI), la plus-value immobilière, les droits de succession et donation, le démembrement, les contrats de mariage, les PACS, les SCI, et la rédaction de projets d'actes (compromis, statuts, testaments). Triggers: notaire, frais de notaire, acte de vente, compromis, succession, donation, héritage, testament, PACS, contrat de mariage, SCI, plus-value immobilière, droits de mutation, DMTO, usufruit, nue-propriété, partage successoral, réserve héréditaire, viager, donation-partage, diagnostics immobilier, droit de préemption, acte notarié, droit immobilier",
+          "version": "0.0.0"
+        },
+        {
+          "name": "syndic",
+          "installUrl": "github:romainsimon/paperasse:syndic",
+          "description": "Gère un parc de copropriétés en France avec vue portfolio consolidée. Couvre administration, comptabilité (décret 2005, plan comptable copro, 5 annexes), assemblées générales (convocation, PV, notification), appels de fonds, travaux, fournisseurs, recouvrement d'impayés et transition de syndic. Maîtrise les majorités (art. 24, 25, 25-1, 26), le fonds de travaux (art. 14-2), le privilège immobilier (art. 19-2) et l'immatriculation RNC. Intégration Qonto pour le rapprochement bancaire. Utilisé pour toute question liée à la copropriété, au syndic bénévole ou coopératif, aux charges, tantièmes, AG, ou au droit de la copropriété (loi 1965, ALUR, ELAN).",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "romainsimon",
+        "repo": "paperasse",
+        "repoUrl": "https://github.com/romainsimon/paperasse.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "romainsimon-paperasse-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from romainsimon/paperasse.",
+      "author": "ASM (romainsimon/paperasse)",
+      "createdAt": "2026-05-09T08:11:14.374Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "romainsimon",
+        "paperasse"
+      ],
+      "skills": [
+        {
+          "name": "controleur-fiscal",
+          "installUrl": "github:romainsimon/paperasse:controleur-fiscal",
+          "description": "Inspecteur des finances publiques IA. Simule un contrôle fiscal DGFIP complet sur les comptes d'une entreprise française (SASU, EURL, SAS, SARL). Analyse le FEC, la liasse fiscale, les charges déduites, le compte courant d'associé, la TVA, l'IS selon 8 axes de vérification. Identifie les chefs de redressement potentiels avec montants, base légale et niveaux de risque. Triggers: contrôle fiscal, redressement, vérification comptabilité, DGFIP, FEC, déductibilité, audit fiscal, tax audit",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fiscaliste",
+          "installUrl": "github:romainsimon/paperasse:fiscaliste",
+          "description": "Fiscaliste IA pour la fiscalité personnelle des contribuables français. Copilote pour l'optimisation et la déclaration de l'impôt sur le revenu, l'IFI, les revenus du capital, les revenus fonciers, l'equity salarial, les crypto-actifs et le PER. Couvre le calcul de l'IR (barème progressif, quotient familial, décote, PAS, CEHR, revenus exceptionnels), la déclaration 2042 et ses annexes, les revenus du capital (PFU vs barème, PEA, assurance-vie rachats, dividendes, plus-values mobilières), les revenus fonciers (micro vs réel, déficit, LMNP, SCI à l'IR), l'equity startup (RSU, BSPCE, stock-options, PEE/PERCO), la fiscalité crypto (méthode PAMC, formulaire 2086), l'IFI, et les déductions (PER, pension alimentaire). Triggers: impôt sur le revenu, IR, déclaration 2042, quotient familial, barème, décote, PAS, PFU, flat tax, PEA, assurance-vie, LMNP, revenus fonciers, déficit foncier, SCI IR, RSU, BSPCE, stock-options, PEE, PERCO, crypto, fiscalité crypto, 2086, IFI, PER, plafond PER, niche fiscale, optimisation fiscale, simulation IR, TMI Hors scope : succession / donation (voir skill notaire), IS / SASU / arbitrage dividende-salaire / SCI à l'IS (voir skill comptable).",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "romainsimon",
+        "repo": "paperasse",
+        "repoUrl": "https://github.com/romainsimon/paperasse.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/sickn33_antigravity-awesome-skills.json
+++ b/data/skill-index/sickn33_antigravity-awesome-skills.json
@@ -5081,7 +5081,12 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Grep", "Glob", "Write"],
+      "allowedTools": [
+        "Read",
+        "Grep",
+        "Glob",
+        "Write"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-analyzer",
       "relPath": "skills/ai-analyzer",
       "verified": true,
@@ -66328,7 +66333,13 @@
       "license": "LICENSE",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Grep", "Glob", "Bash", "Task"],
+      "allowedTools": [
+        "Read",
+        "Grep",
+        "Glob",
+        "Bash",
+        "Task"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/django-perf-review",
       "relPath": "skills/django-perf-review",
       "verified": true,
@@ -73452,7 +73463,11 @@
       "license": "MIT License",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Bash(node:*)"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Bash(node:*)"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/expo-cicd-workflows",
       "relPath": "skills/expo-cicd-workflows",
       "verified": true,
@@ -75370,7 +75385,12 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Grep", "Glob"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Grep",
+        "Glob"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/family-health-analyzer",
       "relPath": "skills/family-health-analyzer",
       "verified": true,
@@ -77982,7 +78002,12 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Grep", "Glob", "Write"],
+      "allowedTools": [
+        "Read",
+        "Grep",
+        "Glob",
+        "Write"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/fitness-analyzer",
       "relPath": "skills/fitness-analyzer",
       "verified": true,
@@ -84695,7 +84720,9 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Bash"],
+      "allowedTools": [
+        "Bash"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/gh-review-requests",
       "relPath": "skills/gh-review-requests",
       "verified": true,
@@ -87709,7 +87736,12 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Grep", "Glob", "Write"],
+      "allowedTools": [
+        "Read",
+        "Grep",
+        "Glob",
+        "Write"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/goal-analyzer",
       "relPath": "skills/goal-analyzer",
       "verified": true,
@@ -90312,7 +90344,12 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Grep", "Glob", "Write"],
+      "allowedTools": [
+        "Read",
+        "Grep",
+        "Glob",
+        "Write"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/health-trend-analyzer",
       "relPath": "skills/health-trend-analyzer",
       "verified": true,
@@ -100313,7 +100350,10 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Bash(gh", "*)"],
+      "allowedTools": [
+        "Bash(gh",
+        "*)"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/issues",
       "relPath": "skills/issues",
       "verified": true,
@@ -116068,7 +116108,13 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Grep", "Glob", "Write", "Edit"],
+      "allowedTools": [
+        "Read",
+        "Grep",
+        "Glob",
+        "Write",
+        "Edit"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/mental-health-analyzer",
       "relPath": "skills/mental-health-analyzer",
       "verified": true,
@@ -125394,7 +125440,12 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Grep", "Glob", "Write"],
+      "allowedTools": [
+        "Read",
+        "Grep",
+        "Glob",
+        "Write"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/nutrition-analyzer",
       "relPath": "skills/nutrition-analyzer",
       "verified": true,
@@ -126764,7 +126815,13 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Grep", "Glob", "Write", "Edit"],
+      "allowedTools": [
+        "Read",
+        "Grep",
+        "Glob",
+        "Write",
+        "Edit"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/occupational-health-analyzer",
       "relPath": "skills/occupational-health-analyzer",
       "verified": true,
@@ -147314,7 +147371,13 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Grep", "Glob", "Write", "Edit"],
+      "allowedTools": [
+        "Read",
+        "Grep",
+        "Glob",
+        "Write",
+        "Edit"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/rehabilitation-analyzer",
       "relPath": "skills/rehabilitation-analyzer",
       "verified": true,
@@ -162932,7 +162995,10 @@
       "license": "MIT",
       "creator": "",
       "compatibility": "claude-code",
-      "allowedTools": ["Read", "Glob"],
+      "allowedTools": [
+        "Read",
+        "Glob"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/skill-check",
       "relPath": "skills/skill-check",
       "verified": true,
@@ -165398,7 +165464,12 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Grep", "Glob", "Write"],
+      "allowedTools": [
+        "Read",
+        "Grep",
+        "Glob",
+        "Write"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/sleep-analyzer",
       "relPath": "skills/sleep-analyzer",
       "verified": true,
@@ -173481,7 +173552,12 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Grep", "Glob", "Write"],
+      "allowedTools": [
+        "Read",
+        "Grep",
+        "Glob",
+        "Write"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/tcm-constitution-analyzer",
       "relPath": "skills/tcm-constitution-analyzer",
       "verified": true,
@@ -180331,7 +180407,12 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Write", "Grep", "Glob"],
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Grep",
+        "Glob"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/travel-health-analyzer",
       "relPath": "skills/travel-health-analyzer",
       "verified": true,
@@ -188277,7 +188358,12 @@
       "license": "",
       "creator": "",
       "compatibility": "",
-      "allowedTools": ["Read", "Grep", "Glob", "Bash(python:*)"],
+      "allowedTools": [
+        "Read",
+        "Grep",
+        "Glob",
+        "Bash(python:*)"
+      ],
       "installUrl": "github:sickn33/antigravity-awesome-skills:skills/videodb",
       "relPath": "skills/videodb",
       "verified": true,
@@ -197585,6 +197671,4040 @@
           "evaluatedVersion": "0.0.0"
         }
       }
+    }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "sickn33-antigravity-awesome-skills-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from sickn33/antigravity-awesome-skills.",
+      "author": "ASM (sickn33/antigravity-awesome-skills)",
+      "createdAt": "2026-05-09T08:10:37.232Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "sickn33",
+        "antigravity-awesome-skills"
+      ],
+      "skills": [
+        {
+          "name": "active-directory-attacks",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/active-directory-attacks",
+          "description": "Provide comprehensive techniques for attacking Microsoft Active Directory environments. Covers reconnaissance, credential harvesting, Kerberos attacks, lateral movement, privilege escalation, and domain dominance for red team operations and penetration testing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "activecampaign-automation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/activecampaign-automation",
+          "description": "Automate ActiveCampaign tasks via Rube MCP (Composio): manage contacts, tags, list subscriptions, automation enrollment, and tasks. Always search tools first for current schemas.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-framework-azure-ai-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-framework-azure-ai-py",
+          "description": "Build persistent agents on Azure AI Foundry using the Microsoft Agent Framework Python SDK.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-manager-skill",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-manager-skill",
+          "description": "Manage multiple local CLI agents via tmux sessions (start/stop/monitor/assign) with cron-friendly scheduling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-dev-jobs-mcp",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-dev-jobs-mcp",
+          "description": "Search 8,400+ AI and ML jobs across 489 companies, inspect listings and employers, match roles, and view salary and market stats via AI Dev Jobs MCP",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-md",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-md",
+          "description": "Convert human-written CLAUDE.md into AI-native structured-label format. Battle-tested across 4 models. Same rules, fewer tokens, higher compliance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-seo",
+          "description": "Optimize content for AI search and LLM citations across AI Overviews, ChatGPT, Perplexity, Claude, Gemini, and similar systems. Use when improving AI visibility, answer engine optimization, or citation readiness.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "angular-migration",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/angular-migration",
+          "description": "Master AngularJS to Angular migration, including hybrid apps, component conversion, dependency injection changes, and routing migration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-audience-analysis",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-audience-analysis",
+          "description": "Understand audience demographics, preferences, behavior patterns, and engagement quality across Facebook, Instagram, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-brand-reputation-monitoring",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-brand-reputation-monitoring",
+          "description": "Scrape reviews, ratings, and brand mentions from multiple platforms using Apify Actors.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-competitor-intelligence",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-competitor-intelligence",
+          "description": "Analyze competitor strategies, content, pricing, ads, and market positioning across Google Maps, Booking.com, Facebook, Instagram, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-content-analytics",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-content-analytics",
+          "description": "Track engagement metrics, measure campaign ROI, and analyze content performance across Instagram, Facebook, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-influencer-discovery",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-influencer-discovery",
+          "description": "Find and evaluate influencers for brand partnerships, verify authenticity, and track collaboration performance across Instagram, Facebook, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-market-research",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-market-research",
+          "description": "Analyze market conditions, geographic opportunities, pricing, consumer behavior, and product validation across Google Maps, Facebook, Instagram, Booking.com, and TripAdvisor.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-trend-analysis",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-trend-analysis",
+          "description": "Discover and track emerging trends across Google Trends, Instagram, Facebook, YouTube, and TikTok to inform content strategy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-ultimate-scraper",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-ultimate-scraper",
+          "description": "AI-driven data extraction from 55+ Actors across all major platforms. This skill automatically selects the best Actor for your task.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "app-store-optimization",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/app-store-optimization",
+          "description": "Complete App Store Optimization (ASO) toolkit for researching, optimizing, and tracking mobile app performance on Apple App Store and Google Play Store",
+          "version": "0.0.0"
+        },
+        {
+          "name": "application-performance-performance-optimization",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/application-performance-performance-optimization",
+          "description": "Optimize end-to-end application performance with profiling, observability, and backend/frontend tuning. Use when coordinating performance optimization across the stack.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arm-cortex-expert",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/arm-cortex-expert",
+          "description": "Senior embedded software engineer specializing in firmware and driver development for ARM Cortex-M microcontrollers (Teensy, STM32, nRF52, SAMD).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "audit-skills",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/audit-skills",
+          "description": "Expert security auditor for AI Skills and Bundles. Performs non-intrusive static analysis to identify malicious patterns, data leaks, system stability risks, and obfuscated payloads across Windows, macOS, Linux/Unix, and Mobile (Android/iOS).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-projects-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-projects-py",
+          "description": "Build AI applications on Microsoft Foundry using the azure-ai-projects SDK.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-vision-imageanalysis-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-vision-imageanalysis-java",
+          "description": "Build image analysis applications with Azure AI Vision SDK for Java. Use when implementing image captioning, OCR text extraction, object detection, tagging, or smart cropping.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-vision-imageanalysis-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-vision-imageanalysis-py",
+          "description": "Azure AI Vision Image Analysis SDK for captions, tags, objects, OCR, people detection, and smart cropping. Use for computer vision and image understanding tasks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-communication-common-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-communication-common-java",
+          "description": "Azure Communication Services common utilities for Java. Use when working with CommunicationTokenCredential, user identifiers, token refresh, or shared authentication across ACS services.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-identity-dotnet",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-identity-dotnet",
+          "description": "Azure Identity SDK for .NET. Authentication library for Azure SDK clients using Microsoft Entra ID. Use for DefaultAzureCredential, managed identity, service principals, and developer credentials.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-identity-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-identity-java",
+          "description": "Authenticate Java applications with Azure services using Microsoft Entra ID (Azure AD).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-mgmt-apicenter-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-mgmt-apicenter-py",
+          "description": "Azure API Center Management SDK for Python. Use for managing API inventory, metadata, and governance across your organization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-mgmt-fabric-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-mgmt-fabric-py",
+          "description": "Azure Fabric Management SDK for Python. Use for managing Microsoft Fabric capacities and resources.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-microsoft-playwright-testing-ts",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-microsoft-playwright-testing-ts",
+          "description": "Run Playwright tests at scale with cloud-hosted browsers and integrated Azure portal reporting.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-resource-manager-playwright-dotnet",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-resource-manager-playwright-dotnet",
+          "description": "Azure Resource Manager SDK for Microsoft Playwright Testing in .NET.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "backend-architect",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/backend-architect",
+          "description": "Expert backend architect specializing in scalable API design, microservices architecture, and distributed systems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "backend-development-feature-development",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/backend-development-feature-development",
+          "description": "Orchestrate end-to-end backend feature development from requirements to deployment. Use when coordinating multi-phase feature delivery across teams and services.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bdistill-behavioral-xray",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/bdistill-behavioral-xray",
+          "description": "X-ray any AI model's behavioral patterns — refusal boundaries, hallucination tendencies, reasoning style, formatting defaults. No API key needed.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bill-gates",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/bill-gates",
+          "description": "Agente que simula Bill Gates — cofundador da Microsoft, arquiteto da industria de software comercial, estrategista tecnologico global, investidor sistemico e filantropo baseado em dados.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "blog-writing-guide",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/blog-writing-guide",
+          "description": "This skill enforces Sentry's blog writing standards across every post — whether you're helping an engineer write their first blog post or a marketer draft a product announcement.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brainstorming",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/brainstorming",
+          "description": "Use before creative or constructive work (features, architecture, behavior). Transforms vague ideas into validated designs through disciplined reasoning and collaboration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brand-guidelines",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/brand-guidelines",
+          "description": "Write copy following Sentry brand guidelines. Use when writing UI text, error messages, empty states, onboarding flows, 404 pages, documentation, marketing copy, or any user-facing content. Covers both Plain Speech (default) and Sentry Voice tones.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brand-guidelines-anthropic",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/brand-guidelines-anthropic",
+          "description": "To access Anthropic's official brand identity and style resources, use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brand-guidelines-community",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/brand-guidelines-community",
+          "description": "To access Anthropic's official brand identity and style resources, use this skill.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brand-perception-psychologist",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/brand-perception-psychologist",
+          "description": "One sentence - what this skill does and when to invoke it",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brevo-automation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/brevo-automation",
+          "description": "Automate Brevo (formerly Sendinblue) email marketing operations through Composio's Brevo toolkit via Rube MCP.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "calc",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/libreoffice/calc",
+          "description": "Spreadsheet creation, format conversion (ODS/XLSX/CSV), formulas, data automation with LibreOffice Calc.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "canva-automation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/canva-automation",
+          "description": "Automate Canva tasks via Rube MCP (Composio): designs, exports, folders, brand templates, autofill. Always search tools first for current schemas.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "chrome-extension-developer",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/chrome-extension-developer",
+          "description": "Expert in building Chrome Extensions using Manifest V3. Covers background scripts, service workers, content scripts, and cross-context communication.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "closed-loop-delivery",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/closed-loop-delivery",
+          "description": "Use when a coding task must be completed against explicit acceptance criteria with minimal user re-intervention across implementation, review feedback, deployment, and runtime verification.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cloud-penetration-testing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/cloud-penetration-testing",
+          "description": "Conduct comprehensive security assessments of cloud infrastructure across Microsoft Azure, Amazon Web Services (AWS), and Google Cloud Platform (GCP).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "codebase-to-wordpress-converter",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/codebase-to-wordpress-converter",
+          "description": "Expert skill for converting any codebase (React/HTML/Next.js) into a pixel-perfect, SEO-optimized, and dynamic WordPress theme.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-creator",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/content-creator",
+          "description": "Professional-grade brand voice analysis, SEO optimization, and platform-specific content frameworks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-marketer",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/content-marketer",
+          "description": "Elite content marketing strategist specializing in AI-powered content creation, omnichannel distribution, SEO optimization, and data-driven performance marketing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copilot-sdk",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/copilot-sdk",
+          "description": "Build applications that programmatically interact with GitHub Copilot. The SDK wraps the Copilot CLI via JSON-RPC, providing session management, custom tools, hooks, MCP server integration, and streaming across Node.js, Python, Go, and .NET.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copy-editing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/copy-editing",
+          "description": "You are an expert copy editor specializing in marketing and conversion copy. Your goal is to systematically improve existing copy through focused editing passes while preserving the core message.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copywriting",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/copywriting",
+          "description": "Write rigorous, conversion-focused marketing copy for landing pages and emails. Enforces brief confirmation and strict no-fabrication rules.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copywriting-psychologist",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/copywriting-psychologist",
+          "description": "One sentence - what this skill does and when to invoke it",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cost-optimization",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/cost-optimization",
+          "description": "Strategies and patterns for optimizing cloud costs across AWS, Azure, and GCP.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "customs-trade-compliance",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/customs-trade-compliance",
+          "description": "Codified expertise for customs documentation, tariff classification, duty optimisation, restricted party screening, and regulatory compliance across multiple jurisdictions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "database-cloud-optimization-cost-optimize",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/database-cloud-optimization-cost-optimize",
+          "description": "You are a cloud cost optimization expert specializing in reducing infrastructure expenses while maintaining performance and reliability. Analyze cloud spending, identify savings opportunities, and implement cost-effective architectures across AWS, Azure, and GCP.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "database-migration",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/database-migration",
+          "description": "Master database schema and data migrations across ORMs (Sequelize, TypeORM, Prisma), including rollback strategies and zero-downtime deployments.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "design-spells",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/design-spells",
+          "description": "Curated micro-interactions and design details that add \"magic\" and personality to websites and apps.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "distributed-tracing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/distributed-tracing",
+          "description": "Implement distributed tracing with Jaeger and Tempo for request flow visibility across microservices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "draw",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/libreoffice/draw",
+          "description": "Vector graphics and diagram creation, format conversion (ODG/SVG/PDF) with LibreOffice Draw.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "e2e-testing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/e2e-testing",
+          "description": "End-to-end testing workflow with Playwright for browser automation, visual regression, cross-browser testing, and CI/CD integration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "email-sequence",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/email-sequence",
+          "description": "You are an expert in email marketing and automation. Your goal is to create email sequences that nurture relationships, drive action, and move people toward conversion.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "email-systems",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/email-systems",
+          "description": "Email has the highest ROI of any marketing channel. $36 for every",
+          "version": "0.0.0"
+        },
+        {
+          "name": "emblemai-crypto-wallet",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/emblemai-crypto-wallet",
+          "description": "Crypto wallet management across 7 blockchains via EmblemAI Agent Hustle API. Balance checks, token swaps, portfolio analysis, and transaction execution for Solana, Ethereum, Base, BSC, Polygon, Hedera, and Bitcoin.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "error-detective",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/error-detective",
+          "description": "Search logs and codebases for error patterns, stack traces, and anomalies. Correlates errors across systems and identifies root causes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fastapi-pro",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/fastapi-pro",
+          "description": "Build high-performance async APIs with FastAPI, SQLAlchemy 2.0, and Pydantic V2. Master microservices, WebSockets, and modern Python async patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "firecrawl-scraper",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/firecrawl-scraper",
+          "description": "Deep web scraping, screenshots, PDF parsing, and website crawling using Firecrawl API. Use when you need deep content extraction from web pages, page interaction is required (clicking, scrolling, etc.), or you want screenshots or PDF parsing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fixing-metadata",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/fixing-metadata",
+          "description": "Audit and fix HTML metadata including page titles, meta descriptions, canonical URLs, Open Graph tags, Twitter cards, favicons, JSON-LD structured data, and robots directives. Use when adding or reviewing SEO and social metadata.",
+          "version": "1.0.1"
+        },
+        {
+          "name": "fixing-motion-performance",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/fixing-motion-performance",
+          "description": "Audit and fix animation performance issues including layout thrashing, compositor properties, scroll-linked motion, and blur effects. Use when animations stutter, transitions jank, or reviewing CSS/JS animation performance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "form-cro",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/form-cro",
+          "description": "Optimize any form that is NOT signup or account registration — including lead capture, contact, demo request, application, survey, quote, and checkout forms.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "free-tool-strategy",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/free-tool-strategy",
+          "description": "You are an expert in engineering-as-marketing strategy. Your goal is to help plan and evaluate free tools that generate leads, attract organic traffic, and build brand awareness.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "frontend-mobile-security-xss-scan",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/frontend-mobile-security-xss-scan",
+          "description": "You are a frontend security specialist focusing on Cross-Site Scripting (XSS) vulnerability detection and prevention. Analyze React, Vue, Angular, and vanilla JavaScript code to identify injection poi",
+          "version": "0.0.0"
+        },
+        {
+          "name": "global-chat-agent-discovery",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/global-chat-agent-discovery",
+          "description": "Discover and search 18K+ MCP servers and AI agents across 6+ registries using Global Chat's cross-protocol directory and MCP server.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "golang-pro",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/golang-pro",
+          "description": "Master Go 1.21+ with modern patterns, advanced concurrency, performance optimization, and production-ready microservices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "growth-engine",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/growth-engine",
+          "description": "Motor de crescimento para produtos digitais -- growth hacking, SEO, ASO, viral loops, email marketing, CRM, referral programs e aquisicao organica.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "helium-mcp",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/helium-mcp",
+          "description": "Connect to Helium's MCP server for news research, media bias analysis, balanced perspectives, stock/options data, and semantic meme search across 3.2M+ articles and 5,000+ sources",
+          "version": "0.0.0"
+        },
+        {
+          "name": "high-end-visual-design",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/high-end-visual-design",
+          "description": "Use when designing expensive agency-grade interfaces with premium fonts, spatial rhythm, soft depth, and fluid microinteractions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "humanize-chinese",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/humanize-chinese",
+          "description": "Detect and rewrite AI-like Chinese text with a practical workflow for scoring, humanization, academic AIGC reduction, and style conversion. Use when the user asks to 去AI味, 降AIGC, 去除AI痕迹, 论文降重, 知网检测, 维普检测, humanize chinese, detect AI text, or make Chinese text sound more natural.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hybrid-cloud-architect",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/hybrid-cloud-architect",
+          "description": "Expert hybrid cloud architect specializing in complex multi-cloud solutions across AWS/Azure/GCP and private clouds (OpenStack/VMware).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "idea-darwin",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/idea-darwin",
+          "description": "Darwinian idea evolution engine — toss rough ideas onto an evolution island, let them compete, crossbreed, and mutate through structured rounds to surface your strongest concepts.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "sickn33",
+        "repo": "antigravity-awesome-skills",
+        "repoUrl": "https://github.com/sickn33/antigravity-awesome-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "sickn33-antigravity-awesome-skills-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from sickn33/antigravity-awesome-skills.",
+      "author": "ASM (sickn33/antigravity-awesome-skills)",
+      "createdAt": "2026-05-09T08:10:37.232Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "sickn33",
+        "antigravity-awesome-skills"
+      ],
+      "skills": [
+        {
+          "name": "ab-test-setup",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ab-test-setup",
+          "description": "Structured guide for setting up A/B tests with mandatory gates for hypothesis, metrics, and execution readiness.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "adhx",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/adhx",
+          "description": "Fetch any X/Twitter post as clean LLM-friendly JSON. Converts x.com, twitter.com, or adhx.com links into structured data with full article content, author info, and engagement metrics. No scraping or browser required.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agents-md",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agents-md",
+          "description": "This skill should be used when the user asks to \"create AGENTS.md\", \"update AGENTS.md\", \"maintain agent docs\", \"set up CLAUDE.md\", or needs to keep agent instructions concise. Enforces research-backed best practices for minimal, high-signal agent documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-seo",
+          "description": "Optimize content for AI search and LLM citations across AI Overviews, ChatGPT, Perplexity, Claude, Gemini, and similar systems. Use when improving AI visibility, answer engine optimization, or citation readiness.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "angular-best-practices",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/angular-best-practices",
+          "description": "Angular performance optimization and best practices guide. Use when writing, reviewing, or refactoring Angular code for optimal performance, bundle size, and rendering efficiency.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-documentation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-documentation",
+          "description": "API documentation workflow for generating OpenAPI specs, creating developer guides, and maintaining comprehensive API documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-documentation-generator",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-documentation-generator",
+          "description": "Generate comprehensive, developer-friendly API documentation from code, including endpoints, parameters, examples, and best practices",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-documenter",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-documenter",
+          "description": "Master API documentation with OpenAPI 3.1, AI-powered tools, and modern developer experience practices. Create interactive docs, generate SDKs, and build comprehensive developer portals.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-endpoint-builder",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-endpoint-builder",
+          "description": "Builds production-ready REST API endpoints with validation, error handling, authentication, and documentation. Follows best practices for security and scalability.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-competitor-intelligence",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-competitor-intelligence",
+          "description": "Analyze competitor strategies, content, pricing, ads, and market positioning across Google Maps, Booking.com, Facebook, Instagram, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-content-analytics",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-content-analytics",
+          "description": "Track engagement metrics, measure campaign ROI, and analyze content performance across Instagram, Facebook, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-trend-analysis",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-trend-analysis",
+          "description": "Discover and track emerging trends across Google Trends, Instagram, Facebook, YouTube, and TikTok to inform content strategy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/architecture",
+          "description": "Architectural decision-making framework. Requirements analysis, trade-off evaluation, ADR documentation. Use when making architecture decisions or analyzing system design.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "astro",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/astro",
+          "description": "Build content-focused websites with Astro — zero JS by default, islands architecture, multi-framework components, and Markdown/MDX support.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "audio-transcriber",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/audio-transcriber",
+          "description": "Transform audio recordings into professional Markdown documentation with intelligent summaries using LLM integration",
+          "version": "0.0.0"
+        },
+        {
+          "name": "avoid-ai-writing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/avoid-ai-writing",
+          "description": "Audit and rewrite content to remove 21 categories of AI writing patterns with a 43-entry replacement table",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-contentsafety-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-contentsafety-java",
+          "description": "Build content moderation applications using the Azure AI Content Safety SDK for Java.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-contentsafety-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-contentsafety-py",
+          "description": "Azure AI Content Safety SDK for Python. Use for detecting harmful content in text and images with multi-severity classification.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-contentsafety-ts",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-contentsafety-ts",
+          "description": "Analyze text and images for harmful content with customizable blocklists.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-contentunderstanding-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-contentunderstanding-py",
+          "description": "Azure AI Content Understanding SDK for Python. Use for multimodal content extraction from documents, images, audio, and video.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-translation-text-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-translation-text-py",
+          "description": "Azure AI Text Translation SDK for real-time text translation, transliteration, language detection, and dictionary lookup. Use for translating text content in applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bash-defensive-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/bash-defensive-patterns",
+          "description": "Master defensive Bash programming techniques for production-grade scripts. Use when writing robust shell scripts, CI/CD pipelines, or system utilities requiring fault tolerance and safety.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bats-testing-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/bats-testing-patterns",
+          "description": "Master Bash Automated Testing System (Bats) for comprehensive shell script testing. Use when writing tests for shell scripts, CI/CD pipelines, or requiring test-driven development of shell utilities.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "beautiful-prose",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/beautiful-prose",
+          "description": "A hard-edged writing style contract for timeless, forceful English prose without modern AI tics. Use when users ask for prose or rewrites that must be clean, exact, concrete, and free of AI cadence, filler, or therapeutic tone.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "blog-writing-guide",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/blog-writing-guide",
+          "description": "This skill enforces Sentry's blog writing standards across every post — whether you're helping an engineer write their first blog post or a marketer draft a product announcement.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "box-automation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/box-automation",
+          "description": "Automate Box operations including file upload/download, content search, folder management, collaboration, metadata queries, and sign requests through Composio's Box toolkit.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brand-guidelines",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/brand-guidelines",
+          "description": "Write copy following Sentry brand guidelines. Use when writing UI text, error messages, empty states, onboarding flows, 404 pages, documentation, marketing copy, or any user-facing content. Covers both Plain Speech (default) and Sentry Voice tones.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "c-pro",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/c-pro",
+          "description": "Write efficient C code with proper memory management, pointer",
+          "version": "0.0.0"
+        },
+        {
+          "name": "c4-architecture-c4-architecture",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/c4-architecture-c4-architecture",
+          "description": "Generate comprehensive C4 architecture documentation for an existing repository/codebase using a bottom-up analysis approach.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "c4-code",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/c4-code",
+          "description": "Expert C4 Code-level documentation specialist. Analyzes code directories to create comprehensive C4 code-level documentation including function signatures, arguments, dependencies, and code structure.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "c4-component",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/c4-component",
+          "description": "Expert C4 Component-level documentation specialist. Synthesizes C4 Code-level documentation into Component-level architecture, defining component boundaries, interfaces, and relationships.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "c4-container",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/c4-container",
+          "description": "Expert C4 Container-level documentation specialist.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "c4-context",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/c4-context",
+          "description": "Expert C4 Context-level documentation specialist. Creates high-level system context diagrams, documents personas, user journeys, system features, and external dependencies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "chrome-extension-developer",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/chrome-extension-developer",
+          "description": "Expert in building Chrome Extensions using Manifest V3. Covers background scripts, service workers, content scripts, and cross-context communication.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "citation-management",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/citation-management",
+          "description": "Manage citations systematically throughout the research and writing process.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cloudformation-best-practices",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/cloudformation-best-practices",
+          "description": "CloudFormation template optimization, nested stacks, drift detection, and production-ready patterns. Use when writing or reviewing CF templates.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "coda-automation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/coda-automation",
+          "description": "Automate Coda tasks via Rube MCP (Composio): manage docs, pages, tables, rows, formulas, permissions, and publishing. Always search tools first for current schemas.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-documentation-code-explain",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/code-documentation-code-explain",
+          "description": "You are a code education expert specializing in explaining complex code through clear narratives, visual diagrams, and step-by-step breakdowns. Transform difficult concepts into understandable explanations for developers at all levels.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-documentation-doc-generate",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/code-documentation-doc-generate",
+          "description": "You are a documentation expert specializing in creating comprehensive, maintainable documentation from code. Generate API docs, architecture diagrams, user guides, and technical references using AI-powered analysis and industry best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cold-email",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/cold-email",
+          "description": "Write B2B cold emails and follow-up sequences that earn replies. Use when creating outbound prospecting emails, SDR outreach, personalized opening lines, subject lines, CTAs, and multi-touch follow-up sequences.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "comprehensive-review-pr-enhance",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/comprehensive-review-pr-enhance",
+          "description": "Generate structured PR descriptions from diffs, add review checklists, risk assessments, and test coverage summaries. Use when the user says \"write a PR description\", \"improve this PR\", \"summarize my changes\", \"PR review\", \"pull request\", or asks to document a diff for reviewers.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "confluence-automation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/confluence-automation",
+          "description": "Automate Confluence page creation, content search, space management, labels, and hierarchy navigation via Rube MCP (Composio). Always search tools first for current schemas.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-creator",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/content-creator",
+          "description": "Professional-grade brand voice analysis, SEO optimization, and platform-specific content frameworks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-marketer",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/content-marketer",
+          "description": "Elite content marketing strategist specializing in AI-powered content creation, omnichannel distribution, SEO optimization, and data-driven performance marketing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-strategy",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/content-strategy",
+          "description": "Plan a content strategy, topic clusters, editorial roadmap, and content mix for traffic, authority, and lead generation. Use when deciding what to publish, what topics to prioritize, or how to structure a content program.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "context-driven-development",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/context-driven-development",
+          "description": "Guide for implementing and maintaining context as a managed artifact alongside code, enabling consistent AI interactions and team alignment through structured project documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "context7-auto-research",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/context7-auto-research",
+          "description": "Automatically fetch latest library/framework documentation for Claude Code via Context7 API. Use when you need up-to-date documentation for libraries and frameworks or asking about React, Next.js, Prisma, or any other popular library.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copy-editing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/copy-editing",
+          "description": "You are an expert copy editor specializing in marketing and conversion copy. Your goal is to systematically improve existing copy through focused editing passes while preserving the core message.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copywriting",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/copywriting",
+          "description": "Write rigorous, conversion-focused marketing copy for landing pages and emails. Enforces brief confirmation and strict no-fabrication rules.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copywriting-psychologist",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/copywriting-psychologist",
+          "description": "One sentence - what this skill does and when to invoke it",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cpp-pro",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/cpp-pro",
+          "description": "Write idiomatic C++ code with modern features, RAII, smart pointers, and STL algorithms. Handles templates, move semantics, and performance optimization.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cqrs-implementation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/cqrs-implementation",
+          "description": "Implement Command Query Responsibility Segregation for scalable architectures. Use when separating read and write models, optimizing query performance, or building event-sourced systems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-pr",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/create-pr",
+          "description": "Alias for sentry-skills:pr-writer. Use when users explicitly ask for \"create-pr\" or reference the legacy skill name. Redirects to the canonical PR writing workflow.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "csharp-pro",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/csharp-pro",
+          "description": "Write modern C# code with advanced features like records, pattern matching, and async/await. Optimizes .NET applications, implements enterprise patterns, and ensures comprehensive testing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "customs-trade-compliance",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/customs-trade-compliance",
+          "description": "Codified expertise for customs documentation, tariff classification, duty optimisation, restricted party screening, and regulatory compliance across multiple jurisdictions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "daily",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/daily",
+          "description": "Documentation and capabilities reference for Daily",
+          "version": "1.0"
+        },
+        {
+          "name": "daily-gift",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/daily-gift",
+          "description": "Relationship-aware daily gift engine with five-stage creative pipeline — editorial judgment, synthesis, concept generation, visual strategy, and rendering in H5, image, or video",
+          "version": "0.0.0"
+        },
+        {
+          "name": "daily-news-report",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/daily-news-report",
+          "description": "Scrapes content based on a preset URL list, filters high-quality technical information, and generates daily Markdown reports.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dbt-transformation-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/dbt-transformation-patterns",
+          "description": "Production-ready patterns for dbt (data build tool) including model organization, testing strategies, documentation, and incremental processing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "defuddle",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/defuddle",
+          "description": "Extract clean markdown content from web pages using Defuddle CLI, removing clutter and navigation to save tokens. Use instead of WebFetch when the user provides a URL to read or analyze, for online documentation, articles, blog posts, or any standard web page.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docs-architect",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/docs-architect",
+          "description": "Creates comprehensive technical documentation from existing codebases. Analyzes architecture, design patterns, and implementation details to produce long-form technical manuals and ebooks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "documentation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/documentation",
+          "description": "Documentation generation workflow covering API docs, architecture docs, README files, code comments, and technical writing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "documentation-generation-doc-generate",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/documentation-generation-doc-generate",
+          "description": "You are a documentation expert specializing in creating comprehensive, maintainable documentation from code. Generate API docs, architecture diagrams, user guides, and technical references using AI-powered analysis and industry best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "documentation-templates",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/documentation-templates",
+          "description": "Documentation templates and structure guidelines. README, API docs, code comments, and AI-friendly documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docx-official",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/docx",
+          "description": "A user may ask you to create, edit, or analyze the contents of a .docx file. A .docx file is essentially a ZIP archive containing XML files and other resources that you can read or edit. You have different tools and workflows available for different tasks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "elixir-pro",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/elixir-pro",
+          "description": "Write idiomatic Elixir code with OTP patterns, supervision trees, and Phoenix LiveView. Masters concurrency, fault tolerance, and distributed systems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "employment-contract-templates",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/employment-contract-templates",
+          "description": "Templates and patterns for creating legally sound employment documentation including contracts, offer letters, and HR policies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "exa-search",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/exa-search",
+          "description": "Semantic search, similar content discovery, and structured research using Exa API. Use when you need semantic/embeddings-based search, finding similar content, or searching by category (company, people, research papers, etc.).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "expo-cicd-workflows",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/expo-cicd-workflows",
+          "description": "Helps understand and write EAS workflow YAML files for Expo projects. Use this skill when the user asks about CI/CD or workflows in an Expo or EAS context, mentions .eas/workflows/, or wants help with EAS build pipelines or deployment automation.",
+          "version": "1.0.0"
+        },
+        {
+          "name": "firecrawl-scraper",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/firecrawl-scraper",
+          "description": "Deep web scraping, screenshots, PDF parsing, and website crawling using Firecrawl API. Use when you need deep content extraction from web pages, page interaction is required (clicking, scrolling, etc.), or you want screenshots or PDF parsing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fp-ts-pragmatic",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/fp-ts-pragmatic",
+          "description": "A practical, jargon-free guide to fp-ts functional programming - the 80/20 approach that gets results without the academic overhead. Use when writing TypeScript with fp-ts library.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "google-docs-automation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/google-docs-automation",
+          "description": "Lightweight Google Docs integration with standalone OAuth authentication. No MCP server required.",
+          "version": "1.0"
+        },
+        {
+          "name": "google-drive-automation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/google-drive-automation",
+          "description": "Lightweight Google Drive integration with standalone OAuth authentication. No MCP server required. Full read/write access.",
+          "version": "1.0"
+        },
+        {
+          "name": "google-sheets-automation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/google-sheets-automation",
+          "description": "Lightweight Google Sheets integration with standalone OAuth authentication. No MCP server required. Full read/write access.",
+          "version": "1.0"
+        },
+        {
+          "name": "google-slides-automation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/google-slides-automation",
+          "description": "Lightweight Google Slides integration with standalone OAuth authentication. No MCP server required. Full read/write access.",
+          "version": "1.0"
+        },
+        {
+          "name": "googlesheets-automation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/googlesheets-automation",
+          "description": "Automate Google Sheets operations (read, write, format, filter, manage spreadsheets) via Rube MCP (Composio). Read/write data, manage tabs, apply formatting, and search rows programmatically.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "helium-mcp",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/helium-mcp",
+          "description": "Connect to Helium's MCP server for news research, media bias analysis, balanced perspectives, stock/options data, and semantic meme search across 3.2M+ articles and 5,000+ sources",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hig-components-content",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/hig-components-content",
+          "description": "Apple Human Interface Guidelines for content display components.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "html-injection-testing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/html-injection-testing",
+          "description": "Identify and exploit HTML injection vulnerabilities that allow attackers to inject malicious HTML content into web applications. This vulnerability enables attackers to modify page appearance, create phishing pages, and steal user credentials through injected forms.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "hugging-face-evaluation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/hugging-face-evaluation",
+          "description": "Add and manage evaluation results in Hugging Face model cards. Supports extracting eval tables from README content, importing scores from Artificial Analysis API, and running custom model evaluations with vLLM/lighteval. Works with the model-index metadata format.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "sickn33",
+        "repo": "antigravity-awesome-skills",
+        "repoUrl": "https://github.com/sickn33/antigravity-awesome-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "sickn33-antigravity-awesome-skills-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from sickn33/antigravity-awesome-skills.",
+      "author": "ASM (sickn33/antigravity-awesome-skills)",
+      "createdAt": "2026-05-09T08:10:37.232Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "sickn33",
+        "antigravity-awesome-skills"
+      ],
+      "skills": [
+        {
+          "name": "007",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/007",
+          "description": "Security audit, hardening, threat modeling (STRIDE/PASTA), Red/Blue Team, OWASP checks, code review, incident response, and infrastructure security for any project.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "acceptance-orchestrator",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/acceptance-orchestrator",
+          "description": "Use when a coding task should be driven end-to-end from issue intake through implementation, review, deployment, and acceptance verification with minimal human re-intervention.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "address-github-comments",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/address-github-comments",
+          "description": "Use when you need to address review or issue comments on an open GitHub Pull Request using the gh CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-orchestration-improve-agent",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-orchestration-improve-agent",
+          "description": "Systematic improvement of existing agents through performance analysis, prompt engineering, and continuous iteration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentflow",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agentflow",
+          "description": "Orchestrate autonomous AI development pipelines through your Kanban board (Asana, GitHub Projects, Linear). Manages multi-worker Claude Code dispatch, deterministic quality gates, adversarial review, per-task cost tracking, and crash-proof pipeline execution.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentfolio",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agentfolio",
+          "description": "Skill for discovering and researching autonomous AI agents, tools, and ecosystems using the AgentFolio directory.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agents-md",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agents-md",
+          "description": "This skill should be used when the user asks to \"create AGENTS.md\", \"update AGENTS.md\", \"maintain agent docs\", \"set up CLAUDE.md\", or needs to keep agent instructions concise. Enforces research-backed best practices for minimal, high-signal agent documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-seo",
+          "description": "Optimize content for AI search and LLM citations across AI Overviews, ChatGPT, Perplexity, Claude, Gemini, and similar systems. Use when improving AI visibility, answer engine optimization, or citation readiness.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "angular-best-practices",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/angular-best-practices",
+          "description": "Angular performance optimization and best practices guide. Use when writing, reviewing, or refactoring Angular code for optimal performance, bundle size, and rendering efficiency.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "anti-reversing-techniques",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/anti-reversing-techniques",
+          "description": "AUTHORIZED USE ONLY: This skill contains dual-use security techniques. Before proceeding with any bypass or analysis: > 1.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-audience-analysis",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-audience-analysis",
+          "description": "Understand audience demographics, preferences, behavior patterns, and engagement quality across Facebook, Instagram, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-brand-reputation-monitoring",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-brand-reputation-monitoring",
+          "description": "Scrape reviews, ratings, and brand mentions from multiple platforms using Apify Actors.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-ecommerce",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-ecommerce",
+          "description": "Extract product data, prices, reviews, and seller information from any e-commerce platform using Apify's E-commerce Scraping Tool.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-influencer-discovery",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-influencer-discovery",
+          "description": "Find and evaluate influencers for brand partnerships, verify authenticity, and track collaboration performance across Instagram, Facebook, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-market-research",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-market-research",
+          "description": "Analyze market conditions, geographic opportunities, pricing, consumer behavior, and product validation across Google Maps, Facebook, Instagram, Booking.com, and TripAdvisor.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-trend-analysis",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-trend-analysis",
+          "description": "Discover and track emerging trends across Google Trends, Instagram, Facebook, YouTube, and TikTok to inform content strategy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "app-store-optimization",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/app-store-optimization",
+          "description": "Complete App Store Optimization (ASO) toolkit for researching, optimizing, and tracking mobile app performance on Apple App Store and Google Play Store",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architect-review",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/architect-review",
+          "description": "Master software architect specializing in modern architecture",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/architecture",
+          "description": "Architectural decision-making framework. Requirements analysis, trade-off evaluation, ADR documentation. Use when making architecture decisions or analyzing system design.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "astropy",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/astropy",
+          "description": "Astropy is the core Python package for astronomy, providing essential functionality for astronomical research and data analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "audio-transcriber",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/audio-transcriber",
+          "description": "Transform audio recordings into professional Markdown documentation with intelligent summaries using LLM integration",
+          "version": "0.0.0"
+        },
+        {
+          "name": "audit-context-building",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/audit-context-building",
+          "description": "Enables ultra-granular, line-by-line code analysis to build deep architectural context before vulnerability or bug finding.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "audit-skills",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/audit-skills",
+          "description": "Expert security auditor for AI Skills and Bundles. Performs non-intrusive static analysis to identify malicious patterns, data leaks, system stability risks, and obfuscated payloads across Windows, macOS, Linux/Unix, and Mobile (Android/iOS).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-cost-optimizer",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aws-cost-optimizer",
+          "description": "Comprehensive AWS cost analysis and optimization recommendations using AWS CLI and Cost Explorer",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-iam-best-practices",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/security/aws-iam-best-practices",
+          "description": "IAM policy review, hardening, and least privilege implementation",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-anomalydetector-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-anomalydetector-java",
+          "description": "Build anomaly detection applications with Azure AI Anomaly Detector SDK for Java. Use when implementing univariate/multivariate anomaly detection, time-series analysis, or AI-powered monitoring.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-formrecognizer-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-formrecognizer-java",
+          "description": "Build document analysis applications using the Azure AI Document Intelligence SDK for Java.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-textanalytics-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-textanalytics-py",
+          "description": "Azure AI Text Analytics SDK for sentiment analysis, entity recognition, key phrases, language detection, PII, and healthcare NLP. Use for natural language processing on text.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-vision-imageanalysis-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-vision-imageanalysis-java",
+          "description": "Build image analysis applications with Azure AI Vision SDK for Java. Use when implementing image captioning, OCR text extraction, object detection, tagging, or smart cropping.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-vision-imageanalysis-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-vision-imageanalysis-py",
+          "description": "Azure AI Vision Image Analysis SDK for captions, tags, objects, OCR, people detection, and smart cropping. Use for computer vision and image understanding tasks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-security-keyvault-keys-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-security-keyvault-keys-java",
+          "description": "Azure Key Vault Keys Java SDK for cryptographic key management. Use when creating, managing, or using RSA/EC keys, performing encrypt/decrypt/sign/verify operations, or working with HSM-backed keys.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "backend-security-coder",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/backend-security-coder",
+          "description": "Expert in secure backend coding practices specializing in input validation, authentication, and API security. Use PROACTIVELY for backend security implementations or security code reviews.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "baseline-ui",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/baseline-ui",
+          "description": "Validates animation durations, enforces typography scale, checks component accessibility, and prevents layout anti-patterns in Tailwind CSS projects. Use when building UI components, reviewing CSS utilities, styling React views, or enforcing design consistency.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "behavioral-modes",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/behavioral-modes",
+          "description": "AI operational modes (brainstorm, implement, debug, review, teach, ship, orchestrate). Use to adapt behavior based on task type.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "binary-analysis-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/binary-analysis-patterns",
+          "description": "Comprehensive patterns and techniques for analyzing compiled binaries, understanding assembly code, and reconstructing program logic.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brooks-lint",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/brooks-lint",
+          "description": "AI code reviewer grounded in classic software engineering books for catching design smells, coupling issues, and architectural risks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bulletmind",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/bulletmind",
+          "description": "Convert input into clean, structured, hierarchical bullet points for summarization, note-taking, and structured thinking.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "burp-suite-testing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/burp-suite-testing",
+          "description": "Execute comprehensive web application security testing using Burp Suite's integrated toolset, including HTTP traffic interception and modification, request analysis and replay, automated vulnerability scanning, and manual testing workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "business-analyst",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/business-analyst",
+          "description": "Master modern business analysis with AI-powered analytics, real-time dashboards, and data-driven insights. Build comprehensive KPI frameworks, predictive models, and strategic recommendations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "c4-architecture-c4-architecture",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/c4-architecture-c4-architecture",
+          "description": "Generate comprehensive C4 architecture documentation for an existing repository/codebase using a bottom-up analysis approach.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cc-skill-security-review",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/cc-skill-security-review",
+          "description": "This skill ensures all code follows security best practices and identifies potential vulnerabilities. Use when implementing authentication or authorization, handling user input or file uploads, or creating new API endpoints.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "citation-management",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/citation-management",
+          "description": "Manage citations systematically throughout the research and writing process.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "claude-ally-health",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/claude-ally-health",
+          "description": "A health assistant skill for medical information analysis, symptom tracking, and wellness guidance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "claude-scientific-skills",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/claude-scientific-skills",
+          "description": "Scientific research and analysis skills",
+          "version": "0.0.0"
+        },
+        {
+          "name": "closed-loop-delivery",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/closed-loop-delivery",
+          "description": "Use when a coding task must be completed against explicit acceptance criteria with minimal user re-intervention across implementation, review feedback, deployment, and runtime verification.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "cloudformation-best-practices",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/cloudformation-best-practices",
+          "description": "CloudFormation template optimization, nested stacks, drift detection, and production-ready patterns. Use when writing or reviewing CF templates.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-documentation-doc-generate",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/code-documentation-doc-generate",
+          "description": "You are a documentation expert specializing in creating comprehensive, maintainable documentation from code. Generate API docs, architecture diagrams, user guides, and technical references using AI-powered analysis and industry best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-review-ai-ai-review",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/code-review-ai-ai-review",
+          "description": "You are an expert AI-powered code review specialist combining automated static analysis, intelligent pattern recognition, and modern DevOps practices. Leverage AI tools (GitHub Copilot, Qodo, GPT-5, C",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-review-checklist",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/code-review-checklist",
+          "description": "Comprehensive checklist for conducting thorough code reviews covering functionality, security, performance, and maintainability",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-review-excellence",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/code-review-excellence",
+          "description": "Transform code reviews from gatekeeping to knowledge sharing through constructive feedback, systematic analysis, and collaborative improvement.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-reviewer",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/code-reviewer",
+          "description": "Elite code review expert specializing in modern AI-powered code",
+          "version": "0.0.0"
+        },
+        {
+          "name": "code-simplifier",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/code-simplifier",
+          "description": "Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality. Use when asked to \"simplify code\", \"clean up code\", \"refactor for clarity\", \"improve readability\", or review recently modified code for elegance. Focuses on project-specific best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "codex-review",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/codex-review",
+          "description": "Professional code review with auto CHANGELOG generation, integrated with Codex AI. Use when you want professional code review before commits, you need automatic CHANGELOG generation, or reviewing large-scale refactoring.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "comprehensive-review-full-review",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/comprehensive-review-full-review",
+          "description": "Use when working with comprehensive review full review",
+          "version": "0.0.0"
+        },
+        {
+          "name": "comprehensive-review-pr-enhance",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/comprehensive-review-pr-enhance",
+          "description": "Generate structured PR descriptions from diffs, add review checklists, risk assessments, and test coverage summaries. Use when the user says \"write a PR description\", \"improve this PR\", \"summarize my changes\", \"PR review\", \"pull request\", or asks to document a diff for reviewers.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "computer-vision-expert",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/computer-vision-expert",
+          "description": "SOTA Computer Vision Expert (2026). Specialized in YOLO26, Segment Anything 3 (SAM 3), Vision Language Models, and real-time spatial analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "constant-time-analysis",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/constant-time-analysis",
+          "description": "Analyze cryptographic code to detect operations that leak secret data through execution timing variations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-creator",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/content-creator",
+          "description": "Professional-grade brand voice analysis, SEO optimization, and platform-specific content frameworks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "context7-auto-research",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/context7-auto-research",
+          "description": "Automatically fetch latest library/framework documentation for Claude Code via Context7 API. Use when you need up-to-date documentation for libraries and frameworks or asking about React, Next.js, Prisma, or any other popular library.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "crypto-bd-agent",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/crypto-bd-agent",
+          "description": "Production-tested patterns for building AI agents that autonomously discover, > evaluate, and acquire token listings for cryptocurrency exchanges.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "customer-support",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/customer-support",
+          "description": "Elite AI-powered customer support specialist mastering conversational AI, automated ticketing, sentiment analysis, and omnichannel support experiences.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "data-engineering-data-driven-feature",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/data-engineering-data-driven-feature",
+          "description": "Build features guided by data insights, A/B testing, and continuous measurement using specialized agents for analysis, implementation, and experimentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "data-scientist",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/data-scientist",
+          "description": "Expert data scientist for advanced analytics, machine learning, and statistical modeling. Handles complex data analysis, predictive modeling, and business intelligence.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deep-research",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/deep-research",
+          "description": "Run autonomous research tasks that plan, search, read, and synthesize information into comprehensive reports.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dependency-upgrade",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/dependency-upgrade",
+          "description": "Master major dependency version upgrades, compatibility analysis, staged upgrade strategies, and comprehensive testing approaches.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "design-orchestration",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/design-orchestration",
+          "description": "Orchestrates design workflows by routing work through brainstorming, multi-agent review, and execution readiness in the correct order.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "differential-review",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/differential-review",
+          "description": "Security-focused code review for PRs, commits, and diffs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "django-access-review",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/django-access-review",
+          "description": "django-access-review",
+          "version": "0.0.0"
+        },
+        {
+          "name": "django-perf-review",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/django-perf-review",
+          "description": "Django performance code review. Use when asked to \"review Django performance\", \"find N+1 queries\", \"optimize Django\", \"check queryset performance\", \"database performance\", \"Django ORM issues\", or audit Django code for performance problems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "documentation-generation-doc-generate",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/documentation-generation-doc-generate",
+          "description": "You are a documentation expert specializing in creating comprehensive, maintainable documentation from code. Generate API docs, architecture diagrams, user guides, and technical references using AI-powered analysis and industry best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "emblemai-crypto-wallet",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/emblemai-crypto-wallet",
+          "description": "Crypto wallet management across 7 blockchains via EmblemAI Agent Hustle API. Balance checks, token swaps, portfolio analysis, and transaction execution for Solana, Ethereum, Base, BSC, Polygon, Hedera, and Bitcoin.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "error-debugging-error-analysis",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/error-debugging-error-analysis",
+          "description": "You are an expert error analysis specialist with deep expertise in debugging distributed systems, analyzing production incidents, and implementing comprehensive observability solutions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "error-debugging-multi-agent-review",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/error-debugging-multi-agent-review",
+          "description": "Use when working with error debugging multi agent review",
+          "version": "0.0.0"
+        },
+        {
+          "name": "error-diagnostics-error-analysis",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/error-diagnostics-error-analysis",
+          "description": "You are an expert error analysis specialist with deep expertise in debugging distributed systems, analyzing production incidents, and implementing comprehensive observability solutions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "exa-search",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/exa-search",
+          "description": "Semantic search, similar content discovery, and structured research using Exa API. Use when you need semantic/embeddings-based search, finding similar content, or searching by category (company, people, research papers, etc.).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "executing-plans",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/executing-plans",
+          "description": "Use when you have a written implementation plan to execute in a separate session with review checkpoints",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fda-food-safety-auditor",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/fda-food-safety-auditor",
+          "description": "Expert AI auditor for FDA Food Safety (FSMA), HACCP, and PCQI compliance. Reviews food facility records and preventive controls.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fda-medtech-compliance-auditor",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/fda-medtech-compliance-auditor",
+          "description": "Expert AI auditor for Medical Device (SaMD) compliance, IEC 62304, and 21 CFR Part 820. Reviews DHFs, technical files, and software validation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ffuf-web-fuzzing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ffuf-web-fuzzing",
+          "description": "Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis",
+          "version": "0.0.0"
+        },
+        {
+          "name": "find-bugs",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/find-bugs",
+          "description": "Find bugs, security vulnerabilities, and code quality issues in local branch changes. Use when asked to review changes, find bugs, security review, or audit code on the current branch.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "sickn33",
+        "repo": "antigravity-awesome-skills",
+        "repoUrl": "https://github.com/sickn33/antigravity-awesome-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "sickn33-antigravity-awesome-skills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from sickn33/antigravity-awesome-skills.",
+      "author": "ASM (sickn33/antigravity-awesome-skills)",
+      "createdAt": "2026-05-09T08:10:37.232Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "sickn33",
+        "antigravity-awesome-skills"
+      ],
+      "skills": [
+        {
+          "name": "007",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/007",
+          "description": "Security audit, hardening, threat modeling (STRIDE/PASTA), Red/Blue Team, OWASP checks, code review, incident response, and infrastructure security for any project.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "3d-web-experience",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/3d-web-experience",
+          "description": "Expert in building 3D experiences for the web - Three.js, React",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ab-test-setup",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ab-test-setup",
+          "description": "Structured guide for setting up A/B tests with mandatory gates for hypothesis, metrics, and execution readiness.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "acceptance-orchestrator",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/acceptance-orchestrator",
+          "description": "Use when a coding task should be driven end-to-end from issue intake through implementation, review, deployment, and acceptance verification with minimal human re-intervention.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "active-directory-attacks",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/active-directory-attacks",
+          "description": "Provide comprehensive techniques for attacking Microsoft Active Directory environments. Covers reconnaissance, credential harvesting, Kerberos attacks, lateral movement, privilege escalation, and domain dominance for red team operations and penetration testing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ad-creative",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ad-creative",
+          "description": "Create, iterate, and scale paid ad creative for Google Ads, Meta, LinkedIn, TikTok, and similar platforms. Use when generating headlines, descriptions, primary text, or large sets of ad variations for testing and performance optimization.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "address-github-comments",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/address-github-comments",
+          "description": "Use when you need to address review or issue comments on an open GitHub Pull Request using the gh CLI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "adhx",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/adhx",
+          "description": "Fetch any X/Twitter post as clean LLM-friendly JSON. Converts x.com, twitter.com, or adhx.com links into structured data with full article content, author info, and engagement metrics. No scraping or browser required.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-evaluation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-evaluation",
+          "description": "Testing and benchmarking LLM agents including behavioral testing,",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-framework-azure-ai-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-framework-azure-ai-py",
+          "description": "Build persistent agents on Azure AI Foundry using the Microsoft Agent Framework Python SDK.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-manager-skill",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-manager-skill",
+          "description": "Manage multiple local CLI agents via tmux sessions (start/stop/monitor/assign) with cron-friendly scheduling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-memory-mcp",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-memory-mcp",
+          "description": "A hybrid memory system that provides persistent, searchable knowledge management for AI agents (Architecture, Patterns, Decisions).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-tool-builder",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-tool-builder",
+          "description": "Tools are how AI agents interact with the world. A well-designed",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentflow",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agentflow",
+          "description": "Orchestrate autonomous AI development pipelines through your Kanban board (Asana, GitHub Projects, Linear). Manages multi-worker Claude Code dispatch, deterministic quality gates, adversarial review, per-task cost tracking, and crash-proof pipeline execution.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentic-actions-auditor",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agentic-actions-auditor",
+          "description": "Audits GitHub Actions workflows for security vulnerabilities in AI agent integrations  including Claude Code Action,  Gemini CLI, OpenAI Codex, and GitHub AI  Inference.  Detects attack vectors where attacker-controlled  input reaches. AI agents running in CI/CD pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentmail",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agentmail",
+          "description": "Email infrastructure for AI agents. Create accounts, send/receive emails, manage webhooks, and check karma balance via the AgentMail API.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentphone",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agentphone",
+          "description": "Build AI phone agents with AgentPhone API. Use when the user wants to make phone calls, send/receive SMS, manage phone numbers, create voice agents, set up webhooks, or check usage — anything related to telephony, phone numbers, or voice AI.",
+          "version": "0.3.0"
+        },
+        {
+          "name": "agents-v2-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agents-v2-py",
+          "description": "Build container-based Foundry Agents with Azure AI Projects SDK (ImageBasedHostedAgentDefinition). Use when creating hosted agents with custom container images in Azure AI Foundry.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-agent-development",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-agent-development",
+          "description": "AI agent development workflow for building autonomous agents, multi-agent systems, and agent orchestration with CrewAI, LangGraph, and custom agents.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-agents-architect",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-agents-architect",
+          "description": "Expert in designing and building autonomous AI agents. Masters tool",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-engineer",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-engineer",
+          "description": "Build production-ready LLM applications, advanced RAG systems, and intelligent agents. Implements vector search, multimodal AI, agent orchestration, and enterprise AI integrations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-engineering-toolkit",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-engineering-toolkit",
+          "description": "6 production-ready AI engineering workflows: prompt evaluation (8-dimension scoring), context budget planning, RAG pipeline design, agent security audit (65-point checklist), eval harness building, and product sense coaching.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-md",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-md",
+          "description": "Convert human-written CLAUDE.md into AI-native structured-label format. Battle-tested across 4 models. Same rules, fewer tokens, higher compliance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-ml",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-ml",
+          "description": "AI and machine learning workflow covering LLM application development, RAG implementation, agent architecture, ML pipelines, and AI-powered features.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-native-cli",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-native-cli",
+          "description": "Design spec with 98 rules for building CLI tools that AI agents can safely use. Covers structured JSON output, error handling, input contracts, safety guardrails, exit codes, and agent self-description.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-wrapper-product",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-wrapper-product",
+          "description": "Expert in building products that wrap AI APIs (OpenAI, Anthropic,",
+          "version": "0.0.0"
+        },
+        {
+          "name": "airflow-dag-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/airflow-dag-patterns",
+          "description": "Build production Apache Airflow DAGs with best practices for operators, sensors, testing, and deployment. Use when creating data pipelines, orchestrating workflows, or scheduling batch jobs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "akf-trust-metadata",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/akf-trust-metadata",
+          "description": "The AI native file format. EXIF for AI — stamps every file with trust scores, source provenance, and compliance metadata. Embeds into 20+ formats (DOCX, PDF, images, code). EU AI Act, SOX, HIPAA auditing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "algorithmic-art",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/algorithmic-art",
+          "description": "Algorithmic philosophies are computational aesthetic movements that are then expressed through code. Output .md files (philosophy), .html files (interactive viewer), and .js files (generative algorithms).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "android_ui_verification",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/android_ui_verification",
+          "description": "Automated end-to-end UI testing and verification on an Android Emulator using ADB.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "android-jetpack-compose-expert",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/android-jetpack-compose-expert",
+          "description": "Expert guidance for building modern Android UIs with Jetpack Compose, covering state management, navigation, performance, and Material Design 3.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "angular-best-practices",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/angular-best-practices",
+          "description": "Angular performance optimization and best practices guide. Use when writing, reviewing, or refactoring Angular code for optimal performance, bundle size, and rendering efficiency.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "angular-ui-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/angular-ui-patterns",
+          "description": "Modern Angular UI patterns for loading states, error handling, and data display. Use when building UI components, handling async data, or managing component states.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "animejs-animation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/animejs-animation",
+          "description": "Advanced JavaScript animation library skill for creating complex, high-performance web animations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "antigravity-design-expert",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/antigravity-design-expert",
+          "description": "Core UI/UX engineering skill for building highly interactive, spatial, weightless, and glassmorphism-based web interfaces using GSAP and 3D CSS.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "antigravity-workflows",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/antigravity-workflows",
+          "description": "Orchestrate multiple Antigravity skills through guided workflows for SaaS MVP delivery, security audits, AI agent builds, and browser QA.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aomi-transact",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aomi-transact",
+          "description": "Build natural-language crypto/DeFi agents and EVM MCP plugins (Claude Code, Cursor, Codex, Gemini). Aomi turns prompts into wallet-signed txs on Ethereum, Base, Arbitrum, Optimism, Polygon, Linea — non-custodial, fork-simulated. 40+ apps: Uniswap, Aave, Lido, Morpho, GMX, Hyperliquid, Polymarket.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-design-principles",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-design-principles",
+          "description": "Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers and stand the test of time.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-documentation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-documentation",
+          "description": "API documentation workflow for generating OpenAPI specs, creating developer guides, and maintaining comprehensive API documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-documentation-generator",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-documentation-generator",
+          "description": "Generate comprehensive, developer-friendly API documentation from code, including endpoints, parameters, examples, and best practices",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-documenter",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-documenter",
+          "description": "Master API documentation with OpenAPI 3.1, AI-powered tools, and modern developer experience practices. Create interactive docs, generate SDKs, and build comprehensive developer portals.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-endpoint-builder",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-endpoint-builder",
+          "description": "Builds production-ready REST API endpoints with validation, error handling, authentication, and documentation. Follows best practices for security and scalability.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-fuzzing-bug-bounty",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-fuzzing-bug-bounty",
+          "description": "Provide comprehensive techniques for testing REST, SOAP, and GraphQL APIs during bug bounty hunting and penetration testing engagements. Covers vulnerability discovery, authentication bypass, IDOR exploitation, and API-specific attack vectors.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-patterns",
+          "description": "API design principles and decision-making. REST vs GraphQL vs tRPC selection, response formats, versioning, pagination.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-security-best-practices",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-security-best-practices",
+          "description": "Implement secure API design patterns including authentication, authorization, input validation, rate limiting, and protection against common API vulnerabilities",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-security-testing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-security-testing",
+          "description": "API security testing workflow for REST and GraphQL APIs covering authentication, authorization, rate limiting, input validation, and security best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-testing-observability-api-mock",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-testing-observability-api-mock",
+          "description": "You are an API mocking expert specializing in realistic mock services for development, testing, and demos. Design mocks that simulate real API behavior and enable parallel development.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-actor-development",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-actor-development",
+          "description": "Important: Before you begin, fill in the generatedBy property in the meta section of .actor/actor.json. Replace it with the tool and model you're currently using, such as \\\"Claude Code with Claude Sonnet 4.5\\\". This helps Apify monitor and improve AGENTS.md for specific AI tools and models.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-actorization",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-actorization",
+          "description": "Actorization converts existing software into reusable serverless applications compatible with the Apify platform. Actors are programs packaged as Docker images that accept well-defined JSON input, perform an action, and optionally produce structured JSON output.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-audience-analysis",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-audience-analysis",
+          "description": "Understand audience demographics, preferences, behavior patterns, and engagement quality across Facebook, Instagram, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-brand-reputation-monitoring",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-brand-reputation-monitoring",
+          "description": "Scrape reviews, ratings, and brand mentions from multiple platforms using Apify Actors.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-competitor-intelligence",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-competitor-intelligence",
+          "description": "Analyze competitor strategies, content, pricing, ads, and market positioning across Google Maps, Booking.com, Facebook, Instagram, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-content-analytics",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-content-analytics",
+          "description": "Track engagement metrics, measure campaign ROI, and analyze content performance across Instagram, Facebook, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-ecommerce",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-ecommerce",
+          "description": "Extract product data, prices, reviews, and seller information from any e-commerce platform using Apify's E-commerce Scraping Tool.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-influencer-discovery",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-influencer-discovery",
+          "description": "Find and evaluate influencers for brand partnerships, verify authenticity, and track collaboration performance across Instagram, Facebook, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-lead-generation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-lead-generation",
+          "description": "Scrape leads from multiple platforms using Apify Actors.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-market-research",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-market-research",
+          "description": "Analyze market conditions, geographic opportunities, pricing, consumer behavior, and product validation across Google Maps, Facebook, Instagram, Booking.com, and TripAdvisor.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-trend-analysis",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-trend-analysis",
+          "description": "Discover and track emerging trends across Google Trends, Instagram, Facebook, YouTube, and TikTok to inform content strategy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-ultimate-scraper",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-ultimate-scraper",
+          "description": "AI-driven data extraction from 55+ Actors across all major platforms. This skill automatically selects the best Actor for your task.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "app-builder",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/app-builder",
+          "description": "Main application building orchestrator. Creates full-stack applications from natural language requests. Determines project type, selects tech stack, coordinates agents.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "appdeploy",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/appdeploy",
+          "description": "Deploy web apps with backend APIs, database, and file storage. Use when the user asks to deploy or publish a website or web app and wants a public URL. Uses HTTP API via curl.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architect-review",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/architect-review",
+          "description": "Master software architect specializing in modern architecture",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/architecture",
+          "description": "Architectural decision-making framework. Requirements analysis, trade-off evaluation, ADR documentation. Use when making architecture decisions or analyzing system design.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture-decision-records",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/architecture-decision-records",
+          "description": "Comprehensive patterns for creating, maintaining, and managing Architecture Decision Records (ADRs) that capture the context and rationale behind significant technical decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/architecture-patterns",
+          "description": "Master proven backend architecture patterns including Clean Architecture, Hexagonal Architecture, and Domain-Driven Design to build maintainable, testable, and scalable systems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "astro",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/astro",
+          "description": "Build content-focused websites with Astro — zero JS by default, islands architecture, multi-framework components, and Markdown/MDX support.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "astropy",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/astropy",
+          "description": "Astropy is the core Python package for astronomy, providing essential functionality for astronomical research and data analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "async-python-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/async-python-patterns",
+          "description": "Comprehensive guidance for implementing asynchronous Python applications using asyncio, concurrent programming patterns, and async/await for building high-performance, non-blocking systems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "attack-tree-construction",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/attack-tree-construction",
+          "description": "Build comprehensive attack trees to visualize threat paths. Use when mapping attack scenarios, identifying defense gaps, or communicating security risks to stakeholders.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "audit-context-building",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/audit-context-building",
+          "description": "Enables ultra-granular, line-by-line code analysis to build deep architectural context before vulnerability or bug finding.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "auth-implementation-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/auth-implementation-patterns",
+          "description": "Build secure, scalable authentication and authorization systems using industry-standard patterns and modern best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autonomous-agent-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/autonomous-agent-patterns",
+          "description": "Design patterns for building autonomous coding agents, inspired by [Cline](https://github.com/cline/cline) and [OpenAI Codex](https://github.com/openai/codex).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-cost-optimizer",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aws-cost-optimizer",
+          "description": "Comprehensive AWS cost analysis and optimization recommendations using AWS CLI and Cost Explorer",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-iam-best-practices",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/security/aws-iam-best-practices",
+          "description": "IAM policy review, hardening, and least privilege implementation",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-penetration-testing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aws-penetration-testing",
+          "description": "Provide comprehensive techniques for penetration testing AWS cloud environments. Covers IAM enumeration, privilege escalation, SSRF to metadata endpoint, S3 bucket exploitation, Lambda code extraction, and persistence techniques for red team operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-secrets-rotation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/security/aws-secrets-rotation",
+          "description": "Automate AWS secrets rotation for RDS, API keys, and credentials",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-security-audit",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/security/aws-security-audit",
+          "description": "Comprehensive AWS security posture assessment using AWS CLI and security best practices",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-serverless",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aws-serverless",
+          "description": "Specialized skill for building production-ready serverless",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-skills",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aws-skills",
+          "description": "AWS development with infrastructure automation and cloud architecture patterns",
+          "version": "0.0.0"
+        },
+        {
+          "name": "awt-e2e-testing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/awt-e2e-testing",
+          "description": "AI-powered E2E web testing — eyes and hands for AI coding tools. Declarative YAML scenarios, Playwright execution, visual matching (OpenCV + OCR), platform auto-detection (Flutter/React/Vue), learning DB. Install: npx skills add ksgisang/awt-skill --skill awt -g",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "sickn33",
+        "repo": "antigravity-awesome-skills",
+        "repoUrl": "https://github.com/sickn33/antigravity-awesome-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "sickn33-antigravity-awesome-skills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from sickn33/antigravity-awesome-skills.",
+      "author": "ASM (sickn33/antigravity-awesome-skills)",
+      "createdAt": "2026-05-09T08:10:37.232Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "sickn33",
+        "antigravity-awesome-skills"
+      ],
+      "skills": [
+        {
+          "name": "00-andruia-consultant",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/00-andruia-consultant",
+          "description": "Arquitecto de Soluciones Principal y Consultor Tecnológico de Andru.ia. Diagnostica y traza la hoja de ruta óptima para proyectos de IA en español.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "10-andruia-skill-smith",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/10-andruia-skill-smith",
+          "description": "Ingeniero de Sistemas de Andru.ia. Diseña, redacta y despliega nuevas habilidades (skills) dentro del repositorio siguiendo el Estándar de Diamante.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "20-andruia-niche-intelligence",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/20-andruia-niche-intelligence",
+          "description": "Estratega de Inteligencia de Dominio de Andru.ia. Analiza el nicho específico de un proyecto para inyectar conocimientos, regulaciones y estándares únicos del sector. Actívalo tras definir el nicho.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "3d-web-experience",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/3d-web-experience",
+          "description": "Expert in building 3D experiences for the web - Three.js, React",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ab-test-setup",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ab-test-setup",
+          "description": "Structured guide for setting up A/B tests with mandatory gates for hypothesis, metrics, and execution readiness.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "accessibility-compliance-accessibility-audit",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/accessibility-compliance-accessibility-audit",
+          "description": "You are an accessibility expert specializing in WCAG compliance, inclusive design, and assistive technology compatibility. Conduct audits, identify barriers, and provide remediation guidance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "adhx",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/adhx",
+          "description": "Fetch any X/Twitter post as clean LLM-friendly JSON. Converts x.com, twitter.com, or adhx.com links into structured data with full article content, author info, and engagement metrics. No scraping or browser required.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aegisops-ai",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aegisops-ai",
+          "description": "Autonomous DevSecOps & FinOps Guardrails. Orchestrates Gemini 3 Flash to audit Linux Kernel patches, Terraform cost drifts, and K8s compliance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-framework-azure-ai-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-framework-azure-ai-py",
+          "description": "Build persistent agents on Azure AI Foundry using the Microsoft Agent Framework Python SDK.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-manager-skill",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-manager-skill",
+          "description": "Manage multiple local CLI agents via tmux sessions (start/stop/monitor/assign) with cron-friendly scheduling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-tool-builder",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-tool-builder",
+          "description": "Tools are how AI agents interact with the world. A well-designed",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentphone",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agentphone",
+          "description": "Build AI phone agents with AgentPhone API. Use when the user wants to make phone calls, send/receive SMS, manage phone numbers, create voice agents, set up webhooks, or check usage — anything related to telephony, phone numbers, or voice AI.",
+          "version": "0.3.0"
+        },
+        {
+          "name": "agents-v2-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agents-v2-py",
+          "description": "Build container-based Foundry Agents with Azure AI Projects SDK (ImageBasedHostedAgentDefinition). Use when creating hosted agents with custom container images in Azure AI Foundry.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-agent-development",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-agent-development",
+          "description": "AI agent development workflow for building autonomous agents, multi-agent systems, and agent orchestration with CrewAI, LangGraph, and custom agents.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-agents-architect",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-agents-architect",
+          "description": "Expert in designing and building autonomous AI agents. Masters tool",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-engineer",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-engineer",
+          "description": "Build production-ready LLM applications, advanced RAG systems, and intelligent agents. Implements vector search, multimodal AI, agent orchestration, and enterprise AI integrations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-engineering-toolkit",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-engineering-toolkit",
+          "description": "6 production-ready AI engineering workflows: prompt evaluation (8-dimension scoring), context budget planning, RAG pipeline design, agent security audit (65-point checklist), eval harness building, and product sense coaching.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-native-cli",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-native-cli",
+          "description": "Design spec with 98 rules for building CLI tools that AI agents can safely use. Covers structured JSON output, error handling, input contracts, safety guardrails, exit codes, and agent self-description.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-wrapper-product",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-wrapper-product",
+          "description": "Expert in building products that wrap AI APIs (OpenAI, Anthropic,",
+          "version": "0.0.0"
+        },
+        {
+          "name": "airflow-dag-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/airflow-dag-patterns",
+          "description": "Build production Apache Airflow DAGs with best practices for operators, sensors, testing, and deployment. Use when creating data pipelines, orchestrating workflows, or scheduling batch jobs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "algorithmic-art",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/algorithmic-art",
+          "description": "Algorithmic philosophies are computational aesthetic movements that are then expressed through code. Output .md files (philosophy), .html files (interactive viewer), and .js files (generative algorithms).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "alpha-vantage",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/alpha-vantage",
+          "description": "Access 20+ years of global financial data: equities, options, forex, crypto, commodities, economic indicators, and 50+ technical indicators.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "analytics-tracking",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/analytics-tracking",
+          "description": "Design, audit, and improve analytics tracking systems that produce reliable, decision-ready data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "android_ui_verification",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/android_ui_verification",
+          "description": "Automated end-to-end UI testing and verification on an Android Emulator using ADB.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "android-jetpack-compose-expert",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/android-jetpack-compose-expert",
+          "description": "Expert guidance for building modern Android UIs with Jetpack Compose, covering state management, navigation, performance, and Material Design 3.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "angular",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/angular",
+          "description": "Modern Angular (v20+) expert with deep knowledge of Signals, Standalone Components, Zoneless applications, SSR/Hydration, and reactive patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "angular-best-practices",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/angular-best-practices",
+          "description": "Angular performance optimization and best practices guide. Use when writing, reviewing, or refactoring Angular code for optimal performance, bundle size, and rendering efficiency.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "angular-migration",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/angular-migration",
+          "description": "Master AngularJS to Angular migration, including hybrid apps, component conversion, dependency injection changes, and routing migration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "angular-state-management",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/angular-state-management",
+          "description": "Master modern Angular state management with Signals, NgRx, and RxJS. Use when setting up global state, managing component stores, choosing between state solutions, or migrating from legacy patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "angular-ui-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/angular-ui-patterns",
+          "description": "Modern Angular UI patterns for loading states, error handling, and data display. Use when building UI components, handling async data, or managing component states.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "antigravity-design-expert",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/antigravity-design-expert",
+          "description": "Core UI/UX engineering skill for building highly interactive, spatial, weightless, and glassmorphism-based web interfaces using GSAP and 3D CSS.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "antigravity-skill-orchestrator",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/antigravity-skill-orchestrator",
+          "description": "A meta-skill that understands task requirements, dynamically selects appropriate skills, tracks successful skill combinations using agent-memory-mcp, and prevents skill overuse for simple tasks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "antigravity-workflows",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/antigravity-workflows",
+          "description": "Orchestrate multiple Antigravity skills through guided workflows for SaaS MVP delivery, security audits, AI agent builds, and browser QA.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aomi-transact",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aomi-transact",
+          "description": "Build natural-language crypto/DeFi agents and EVM MCP plugins (Claude Code, Cursor, Codex, Gemini). Aomi turns prompts into wallet-signed txs on Ethereum, Base, Arbitrum, Optimism, Polygon, Linea — non-custodial, fork-simulated. 40+ apps: Uniswap, Aave, Lido, Morpho, GMX, Hyperliquid, Polymarket.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-design-principles",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-design-principles",
+          "description": "Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers and stand the test of time.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-documentation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-documentation",
+          "description": "API documentation workflow for generating OpenAPI specs, creating developer guides, and maintaining comprehensive API documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-documenter",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-documenter",
+          "description": "Master API documentation with OpenAPI 3.1, AI-powered tools, and modern developer experience practices. Create interactive docs, generate SDKs, and build comprehensive developer portals.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-endpoint-builder",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-endpoint-builder",
+          "description": "Builds production-ready REST API endpoints with validation, error handling, authentication, and documentation. Follows best practices for security and scalability.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-patterns",
+          "description": "API design principles and decision-making. REST vs GraphQL vs tRPC selection, response formats, versioning, pagination.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-security-best-practices",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-security-best-practices",
+          "description": "Implement secure API design patterns including authentication, authorization, input validation, rate limiting, and protection against common API vulnerabilities",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-testing-observability-api-mock",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-testing-observability-api-mock",
+          "description": "You are an API mocking expert specializing in realistic mock services for development, testing, and demos. Design mocks that simulate real API behavior and enable parallel development.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-brand-reputation-monitoring",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-brand-reputation-monitoring",
+          "description": "Scrape reviews, ratings, and brand mentions from multiple platforms using Apify Actors.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-influencer-discovery",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-influencer-discovery",
+          "description": "Find and evaluate influencers for brand partnerships, verify authenticity, and track collaboration performance across Instagram, Facebook, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "app-builder",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/app-builder",
+          "description": "Main application building orchestrator. Creates full-stack applications from natural language requests. Determines project type, selects tech stack, coordinates agents.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "application-performance-performance-optimization",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/application-performance-performance-optimization",
+          "description": "Optimize end-to-end application performance with profiling, observability, and backend/frontend tuning. Use when coordinating performance optimization across the stack.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/architecture",
+          "description": "Architectural decision-making framework. Requirements analysis, trade-off evaluation, ADR documentation. Use when making architecture decisions or analyzing system design.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/architecture-patterns",
+          "description": "Master proven backend architecture patterns including Clean Architecture, Hexagonal Architecture, and Domain-Driven Design to build maintainable, testable, and scalable systems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ask-questions-if-underspecified",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ask-questions-if-underspecified",
+          "description": "Clarify requirements before implementing. Use when serious doubts arise.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "astro",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/astro",
+          "description": "Build content-focused websites with Astro — zero JS by default, islands architecture, multi-framework components, and Markdown/MDX support.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "async-python-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/async-python-patterns",
+          "description": "Comprehensive guidance for implementing asynchronous Python applications using asyncio, concurrent programming patterns, and async/await for building high-performance, non-blocking systems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "attack-tree-construction",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/attack-tree-construction",
+          "description": "Build comprehensive attack trees to visualize threat paths. Use when mapping attack scenarios, identifying defense gaps, or communicating security risks to stakeholders.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "audit-context-building",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/audit-context-building",
+          "description": "Enables ultra-granular, line-by-line code analysis to build deep architectural context before vulnerability or bug finding.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "audit-skills",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/audit-skills",
+          "description": "Expert security auditor for AI Skills and Bundles. Performs non-intrusive static analysis to identify malicious patterns, data leaks, system stability risks, and obfuscated payloads across Windows, macOS, Linux/Unix, and Mobile (Android/iOS).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "auth-implementation-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/auth-implementation-patterns",
+          "description": "Build secure, scalable authentication and authorization systems using industry-standard patterns and modern best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autonomous-agent-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/autonomous-agent-patterns",
+          "description": "Design patterns for building autonomous coding agents, inspired by [Cline](https://github.com/cline/cline) and [OpenAI Codex](https://github.com/openai/codex).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "avalonia-layout-zafiro",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/avalonia-layout-zafiro",
+          "description": "Guidelines for modern Avalonia UI layout using Zafiro.Avalonia, emphasizing shared styles, generic components, and avoiding XAML redundancy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "avalonia-viewmodels-zafiro",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/avalonia-viewmodels-zafiro",
+          "description": "Optimal ViewModel and Wizard creation patterns for Avalonia using Zafiro and ReactiveUI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "avalonia-zafiro-development",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/avalonia-zafiro-development",
+          "description": "Mandatory skills, conventions, and behavioral rules for Avalonia UI development using the Zafiro toolkit.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-serverless",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aws-serverless",
+          "description": "Specialized skill for building production-ready serverless",
+          "version": "0.0.0"
+        },
+        {
+          "name": "awt-e2e-testing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/awt-e2e-testing",
+          "description": "AI-powered E2E web testing — eyes and hands for AI coding tools. Declarative YAML scenarios, Playwright execution, visual matching (OpenCV + OCR), platform auto-detection (Flutter/React/Vue), learning DB. Install: npx skills add ksgisang/awt-skill --skill awt -g",
+          "version": "0.0.0"
+        },
+        {
+          "name": "axiom",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/axiom",
+          "description": "First-principles assumption auditor. Classifies each hidden assumption (fact / convention / belief / interest-driven), ranks by fragility × impact, and rebuilds conclusions from verified premises. Bilingual: auto-detects Chinese or English.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azd-deployment",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azd-deployment",
+          "description": "Deploy containerized frontend + backend applications to Azure Container Apps with remote builds, managed identity, and idempotent infrastructure.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-anomalydetector-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-anomalydetector-java",
+          "description": "Build anomaly detection applications with Azure AI Anomaly Detector SDK for Java. Use when implementing univariate/multivariate anomaly detection, time-series analysis, or AI-powered monitoring.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-contentsafety-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-contentsafety-java",
+          "description": "Build content moderation applications using the Azure AI Content Safety SDK for Java.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-document-intelligence-dotnet",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-document-intelligence-dotnet",
+          "description": "Azure AI Document Intelligence SDK for .NET. Extract text, tables, and structured data from documents using prebuilt and custom models.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-document-intelligence-ts",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-document-intelligence-ts",
+          "description": "Extract text, tables, and structured data from documents using prebuilt and custom models.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-formrecognizer-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-formrecognizer-java",
+          "description": "Build document analysis applications using the Azure AI Document Intelligence SDK for Java.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-projects-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-projects-py",
+          "description": "Build AI applications on Microsoft Foundry using the azure-ai-projects SDK.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-vision-imageanalysis-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-vision-imageanalysis-java",
+          "description": "Build image analysis applications with Azure AI Vision SDK for Java. Use when implementing image captioning, OCR text extraction, object detection, tagging, or smart cropping.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-voicelive-dotnet",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-voicelive-dotnet",
+          "description": "Azure AI Voice Live SDK for .NET. Build real-time voice AI applications with bidirectional WebSocket communication.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-voicelive-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-voicelive-py",
+          "description": "Build real-time voice AI applications with bidirectional WebSocket communication.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-voicelive-ts",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-voicelive-ts",
+          "description": "Azure AI Voice Live SDK for JavaScript/TypeScript. Build real-time voice AI applications with bidirectional WebSocket communication.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-communication-callautomation-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-communication-callautomation-java",
+          "description": "Build server-side call automation workflows including IVR systems, call routing, recording, and AI-powered interactions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-communication-chat-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-communication-chat-java",
+          "description": "Build real-time chat applications with thread management, messaging, participants, and read receipts.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-cosmos-db-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-cosmos-db-py",
+          "description": "Build production-grade Azure Cosmos DB NoSQL services following clean code, security best practices, and TDD principles.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-cosmos-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-cosmos-java",
+          "description": "Azure Cosmos DB SDK for Java. NoSQL database operations with global distribution, multi-model support, and reactive patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-data-tables-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-data-tables-java",
+          "description": "Build table storage applications using the Azure Tables SDK for Java. Works with both Azure Table Storage and Cosmos DB Table API.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-eventgrid-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-eventgrid-java",
+          "description": "Build event-driven applications with Azure Event Grid SDK for Java. Use when publishing events, implementing pub/sub patterns, or integrating with Azure services via events.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-eventhub-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-eventhub-java",
+          "description": "Build real-time streaming applications with Azure Event Hubs SDK for Java. Use when implementing event streaming, high-throughput data ingestion, or building event-driven architectures.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-messaging-webpubsub-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-messaging-webpubsub-java",
+          "description": "Build real-time web applications with Azure Web PubSub SDK for Java. Use when implementing WebSocket-based messaging, live updates, chat applications, or server-to-client push notifications.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "sickn33",
+        "repo": "antigravity-awesome-skills",
+        "repoUrl": "https://github.com/sickn33/antigravity-awesome-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "sickn33-antigravity-awesome-skills-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from sickn33/antigravity-awesome-skills.",
+      "author": "ASM (sickn33/antigravity-awesome-skills)",
+      "createdAt": "2026-05-09T08:10:37.232Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "sickn33",
+        "antigravity-awesome-skills"
+      ],
+      "skills": [
+        {
+          "name": "00-andruia-consultant",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/00-andruia-consultant",
+          "description": "Arquitecto de Soluciones Principal y Consultor Tecnológico de Andru.ia. Diagnostica y traza la hoja de ruta óptima para proyectos de IA en español.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "007",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/007",
+          "description": "Security audit, hardening, threat modeling (STRIDE/PASTA), Red/Blue Team, OWASP checks, code review, incident response, and infrastructure security for any project.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "20-andruia-niche-intelligence",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/20-andruia-niche-intelligence",
+          "description": "Estratega de Inteligencia de Dominio de Andru.ia. Analiza el nicho específico de un proyecto para inyectar conocimientos, regulaciones y estándares únicos del sector. Actívalo tras definir el nicho.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "2d-games",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:plugins/antigravity-bundle-indie-game-dev/skills/game-development/2d-games",
+          "description": "2D game development principles. Sprites, tilemaps, physics, camera.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "3d-games",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:plugins/antigravity-bundle-indie-game-dev/skills/game-development/3d-games",
+          "description": "3D game development principles. Rendering, shaders, physics, cameras.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "acceptance-orchestrator",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/acceptance-orchestrator",
+          "description": "Use when a coding task should be driven end-to-end from issue intake through implementation, review, deployment, and acceptance verification with minimal human re-intervention.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "accessibility-compliance-accessibility-audit",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/accessibility-compliance-accessibility-audit",
+          "description": "You are an accessibility expert specializing in WCAG compliance, inclusive design, and assistive technology compatibility. Conduct audits, identify barriers, and provide remediation guidance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "advanced-evaluation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/advanced-evaluation",
+          "description": "This skill should be used when the user asks to \"implement LLM-as-judge\", \"compare model outputs\", \"create evaluation rubrics\", \"mitigate evaluation bias\", or mentions direct scoring, pairwise comparison, position bias, evaluation pipelines, or automated quality assessment.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "advogado-criminal",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/advogado-criminal",
+          "description": "Advogado criminalista especializado em Maria da Penha, violencia domestica, feminicidio, direito penal brasileiro, medidas protetivas, inquerito policial e acao penal.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "advogado-especialista",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/advogado-especialista",
+          "description": "Advogado especialista em todas as areas do Direito brasileiro: familia, criminal, trabalhista, tributario, consumidor, imobiliario, empresarial, civil e constitucional.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aegisops-ai",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aegisops-ai",
+          "description": "Autonomous DevSecOps & FinOps Guardrails. Orchestrates Gemini 3 Flash to audit Linux Kernel patches, Terraform cost drifts, and K8s compliance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-memory-mcp",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-memory-mcp",
+          "description": "A hybrid memory system that provides persistent, searchable knowledge management for AI agents (Architecture, Patterns, Decisions).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-orchestrator",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-orchestrator",
+          "description": "Meta-skill que orquestra todos os agentes do ecossistema. Scan automatico de skills, match por capacidades, coordenacao de workflows multi-skill e registry management.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentflow",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agentflow",
+          "description": "Orchestrate autonomous AI development pipelines through your Kanban board (Asana, GitHub Projects, Linear). Manages multi-worker Claude Code dispatch, deterministic quality gates, adversarial review, per-task cost tracking, and crash-proof pipeline execution.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentic-actions-auditor",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agentic-actions-auditor",
+          "description": "Audits GitHub Actions workflows for security vulnerabilities in AI agent integrations  including Claude Code Action,  Gemini CLI, OpenAI Codex, and GitHub AI  Inference.  Detects attack vectors where attacker-controlled  input reaches. AI agents running in CI/CD pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentmail",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agentmail",
+          "description": "Email infrastructure for AI agents. Create accounts, send/receive emails, manage webhooks, and check karma balance via the AgentMail API.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agents-md",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agents-md",
+          "description": "This skill should be used when the user asks to \"create AGENTS.md\", \"update AGENTS.md\", \"maintain agent docs\", \"set up CLAUDE.md\", or needs to keep agent instructions concise. Enforces research-backed best practices for minimal, high-signal agent documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-agent-development",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-agent-development",
+          "description": "AI agent development workflow for building autonomous agents, multi-agent systems, and agent orchestration with CrewAI, LangGraph, and custom agents.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-engineering-toolkit",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-engineering-toolkit",
+          "description": "6 production-ready AI engineering workflows: prompt evaluation (8-dimension scoring), context budget planning, RAG pipeline design, agent security audit (65-point checklist), eval harness building, and product sense coaching.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-ml",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-ml",
+          "description": "AI and machine learning workflow covering LLM application development, RAG implementation, agent architecture, ML pipelines, and AI-powered features.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-seo",
+          "description": "Optimize content for AI search and LLM citations across AI Overviews, ChatGPT, Perplexity, Claude, Gemini, and similar systems. Use when improving AI visibility, answer engine optimization, or citation readiness.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "ai-studio-image",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-studio-image",
+          "description": "Geracao de imagens humanizadas via Google AI Studio (Gemini). Fotos realistas estilo influencer ou educacional com iluminacao natural e imperfeicoes sutis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "airflow-dag-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/airflow-dag-patterns",
+          "description": "Build production Apache Airflow DAGs with best practices for operators, sensors, testing, and deployment. Use when creating data pipelines, orchestrating workflows, or scheduling batch jobs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "alpha-vantage",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/alpha-vantage",
+          "description": "Access 20+ years of global financial data: equities, options, forex, crypto, commodities, economic indicators, and 50+ technical indicators.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "analytics-tracking",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/analytics-tracking",
+          "description": "Design, audit, and improve analytics tracking systems that produce reliable, decision-ready data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "angular-best-practices",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/angular-best-practices",
+          "description": "Angular performance optimization and best practices guide. Use when writing, reviewing, or refactoring Angular code for optimal performance, bundle size, and rendering efficiency.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "antigravity-workflows",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/antigravity-workflows",
+          "description": "Orchestrate multiple Antigravity skills through guided workflows for SaaS MVP delivery, security audits, AI agent builds, and browser QA.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-design-principles",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-design-principles",
+          "description": "Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers and stand the test of time.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-documentation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-documentation",
+          "description": "API documentation workflow for generating OpenAPI specs, creating developer guides, and maintaining comprehensive API documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-fuzzing-bug-bounty",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-fuzzing-bug-bounty",
+          "description": "Provide comprehensive techniques for testing REST, SOAP, and GraphQL APIs during bug bounty hunting and penetration testing engagements. Covers vulnerability discovery, authentication bypass, IDOR exploitation, and API-specific attack vectors.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-patterns",
+          "description": "API design principles and decision-making. REST vs GraphQL vs tRPC selection, response formats, versioning, pagination.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-security-testing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-security-testing",
+          "description": "API security testing workflow for REST and GraphQL APIs covering authentication, authorization, rate limiting, input validation, and security best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-testing-observability-api-mock",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-testing-observability-api-mock",
+          "description": "You are an API mocking expert specializing in realistic mock services for development, testing, and demos. Design mocks that simulate real API behavior and enable parallel development.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-actor-development",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-actor-development",
+          "description": "Important: Before you begin, fill in the generatedBy property in the meta section of .actor/actor.json. Replace it with the tool and model you're currently using, such as \\\"Claude Code with Claude Sonnet 4.5\\\". This helps Apify monitor and improve AGENTS.md for specific AI tools and models.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-actorization",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-actorization",
+          "description": "Actorization converts existing software into reusable serverless applications compatible with the Apify platform. Actors are programs packaged as Docker images that accept well-defined JSON input, perform an action, and optionally produce structured JSON output.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-competitor-intelligence",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-competitor-intelligence",
+          "description": "Analyze competitor strategies, content, pricing, ads, and market positioning across Google Maps, Booking.com, Facebook, Instagram, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-influencer-discovery",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-influencer-discovery",
+          "description": "Find and evaluate influencers for brand partnerships, verify authenticity, and track collaboration performance across Instagram, Facebook, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-market-research",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-market-research",
+          "description": "Analyze market conditions, geographic opportunities, pricing, consumer behavior, and product validation across Google Maps, Facebook, Instagram, Booking.com, and TripAdvisor.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "app-store-changelog",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/app-store-changelog",
+          "description": "Generate user-facing App Store release notes from git history since the last tag.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "appdeploy",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/appdeploy",
+          "description": "Deploy web apps with backend APIs, database, and file storage. Use when the user asks to deploy or publish a website or web app and wants a public URL. Uses HTTP API via curl.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architect-review",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/architect-review",
+          "description": "Master software architect specializing in modern architecture",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/architecture",
+          "description": "Architectural decision-making framework. Requirements analysis, trade-off evaluation, ADR documentation. Use when making architecture decisions or analyzing system design.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture-decision-records",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/architecture-decision-records",
+          "description": "Comprehensive patterns for creating, maintaining, and managing Architecture Decision Records (ADRs) that capture the context and rationale behind significant technical decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "arm-cortex-expert",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/arm-cortex-expert",
+          "description": "Senior embedded software engineer specializing in firmware and driver development for ARM Cortex-M microcontrollers (Teensy, STM32, nRF52, SAMD).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ask-questions-if-underspecified",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ask-questions-if-underspecified",
+          "description": "Clarify requirements before implementing. Use when serious doubts arise.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "async-python-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/async-python-patterns",
+          "description": "Comprehensive guidance for implementing asynchronous Python applications using asyncio, concurrent programming patterns, and async/await for building high-performance, non-blocking systems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "audit-skills",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/audit-skills",
+          "description": "Expert security auditor for AI Skills and Bundles. Performs non-intrusive static analysis to identify malicious patterns, data leaks, system stability risks, and obfuscated payloads across Windows, macOS, Linux/Unix, and Mobile (Android/iOS).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-compliance-checker",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/security/aws-compliance-checker",
+          "description": "Automated compliance checking against CIS, PCI-DSS, HIPAA, and SOC 2 benchmarks",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-penetration-testing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aws-penetration-testing",
+          "description": "Provide comprehensive techniques for penetration testing AWS cloud environments. Covers IAM enumeration, privilege escalation, SSRF to metadata endpoint, S3 bucket exploitation, Lambda code extraction, and persistence techniques for red team operations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-serverless",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aws-serverless",
+          "description": "Specialized skill for building production-ready serverless",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-skills",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aws-skills",
+          "description": "AWS development with infrastructure automation and cloud architecture patterns",
+          "version": "0.0.0"
+        },
+        {
+          "name": "axiom",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/axiom",
+          "description": "First-principles assumption auditor. Classifies each hidden assumption (fact / convention / belief / interest-driven), ranks by fragility × impact, and rebuilds conclusions from verified premises. Bilingual: auto-detects Chinese or English.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azd-deployment",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azd-deployment",
+          "description": "Deploy containerized frontend + backend applications to Azure Container Apps with remote builds, managed identity, and idempotent infrastructure.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-ml-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-ml-py",
+          "description": "Azure Machine Learning SDK v2 for Python. Use for ML workspaces, jobs, models, datasets, compute, and pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-projects-dotnet",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-projects-dotnet",
+          "description": "Azure AI Projects SDK for .NET. High-level client for Azure AI Foundry projects including agents, connections, datasets, deployments, evaluations, and indexes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-ai-projects-ts",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-ai-projects-ts",
+          "description": "High-level SDK for Azure AI Foundry projects with agents, connections, deployments, and evaluations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-communication-callautomation-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-communication-callautomation-java",
+          "description": "Build server-side call automation workflows including IVR systems, call routing, recording, and AI-powered interactions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-communication-chat-java",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-communication-chat-java",
+          "description": "Build real-time chat applications with thread management, messaging, participants, and read receipts.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-cosmos-db-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-cosmos-db-py",
+          "description": "Build production-grade Azure Cosmos DB NoSQL services following clean code, security best practices, and TDD principles.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-eventgrid-dotnet",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-eventgrid-dotnet",
+          "description": "Azure Event Grid SDK for .NET. Client library for publishing and consuming events with Azure Event Grid. Use for event-driven architectures, pub/sub messaging, CloudEvents, and EventGridEvents.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-eventgrid-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-eventgrid-py",
+          "description": "Azure Event Grid SDK for Python. Use for publishing events, handling CloudEvents, and event-driven architectures.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-identity-dotnet",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-identity-dotnet",
+          "description": "Azure Identity SDK for .NET. Authentication library for Azure SDK clients using Microsoft Entra ID. Use for DefaultAzureCredential, managed identity, service principals, and developer credentials.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-identity-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-identity-py",
+          "description": "Azure Identity SDK for Python authentication. Use for DefaultAzureCredential, managed identity, service principals, and token caching.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-mgmt-apimanagement-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-mgmt-apimanagement-py",
+          "description": "Azure API Management SDK for Python. Use for managing APIM services, APIs, products, subscriptions, and policies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-mgmt-fabric-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-mgmt-fabric-py",
+          "description": "Azure Fabric Management SDK for Python. Use for managing Microsoft Fabric capacities and resources.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-microsoft-playwright-testing-ts",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-microsoft-playwright-testing-ts",
+          "description": "Run Playwright tests at scale with cloud-hosted browsers and integrated Azure portal reporting.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-monitor-opentelemetry-ts",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-monitor-opentelemetry-ts",
+          "description": "Auto-instrument Node.js applications with distributed tracing, metrics, and logs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-resource-manager-mysql-dotnet",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-resource-manager-mysql-dotnet",
+          "description": "Azure MySQL Flexible Server SDK for .NET. Database management for MySQL Flexible Server deployments.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-resource-manager-postgresql-dotnet",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-resource-manager-postgresql-dotnet",
+          "description": "Azure PostgreSQL Flexible Server SDK for .NET. Database management for PostgreSQL Flexible Server deployments.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-storage-file-share-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-storage-file-share-py",
+          "description": "Azure Storage File Share SDK for Python. Use for SMB file shares, directories, and file operations in the cloud.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "backend-architect",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/backend-architect",
+          "description": "Expert backend architect specializing in scalable API design, microservices architecture, and distributed systems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "backend-development-feature-development",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/backend-development-feature-development",
+          "description": "Orchestrate end-to-end backend feature development from requirements to deployment. Use when coordinating multi-phase feature delivery across teams and services.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "backend-security-coder",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/backend-security-coder",
+          "description": "Expert in secure backend coding practices specializing in input validation, authentication, and API security. Use PROACTIVELY for backend security implementations or security code reviews.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "baseline-ui",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/baseline-ui",
+          "description": "Validates animation durations, enforces typography scale, checks component accessibility, and prevents layout anti-patterns in Tailwind CSS projects. Use when building UI components, reviewing CSS utilities, styling React views, or enforcing design consistency.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bash-defensive-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/bash-defensive-patterns",
+          "description": "Master defensive Bash programming techniques for production-grade scripts. Use when writing robust shell scripts, CI/CD pipelines, or system utilities requiring fault tolerance and safety.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bash-pro",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/bash-pro",
+          "description": "Master of defensive Bash scripting for production automation, CI/CD",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bash-scripting",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/bash-scripting",
+          "description": "Bash scripting workflow for creating production-ready shell scripts with defensive patterns, error handling, and testing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bats-testing-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/bats-testing-patterns",
+          "description": "Master Bash Automated Testing System (Bats) for comprehensive shell script testing. Use when writing tests for shell scripts, CI/CD pipelines, or requiring test-driven development of shell utilities.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bdistill-behavioral-xray",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/bdistill-behavioral-xray",
+          "description": "X-ray any AI model's behavioral patterns — refusal boundaries, hallucination tendencies, reasoning style, formatting defaults. No API key needed.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bill-gates",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/bill-gates",
+          "description": "Agente que simula Bill Gates — cofundador da Microsoft, arquiteto da industria de software comercial, estrategista tecnologico global, investidor sistemico e filantropo baseado em dados.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "sickn33",
+        "repo": "antigravity-awesome-skills",
+        "repoUrl": "https://github.com/sickn33/antigravity-awesome-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "sickn33-antigravity-awesome-skills-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from sickn33/antigravity-awesome-skills.",
+      "author": "ASM (sickn33/antigravity-awesome-skills)",
+      "createdAt": "2026-05-09T08:10:37.232Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "sickn33",
+        "antigravity-awesome-skills"
+      ],
+      "skills": [
+        {
+          "name": "007",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/007",
+          "description": "Security audit, hardening, threat modeling (STRIDE/PASTA), Red/Blue Team, OWASP checks, code review, incident response, and infrastructure security for any project.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "active-directory-attacks",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/active-directory-attacks",
+          "description": "Provide comprehensive techniques for attacking Microsoft Active Directory environments. Covers reconnaissance, credential harvesting, Kerberos attacks, lateral movement, privilege escalation, and domain dominance for red team operations and penetration testing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "activecampaign-automation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/activecampaign-automation",
+          "description": "Automate ActiveCampaign tasks via Rube MCP (Composio): manage contacts, tags, list subscriptions, automation enrollment, and tasks. Always search tools first for current schemas.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ad-creative",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ad-creative",
+          "description": "Create, iterate, and scale paid ad creative for Google Ads, Meta, LinkedIn, TikTok, and similar platforms. Use when generating headlines, descriptions, primary text, or large sets of ad variations for testing and performance optimization.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "adhx",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/adhx",
+          "description": "Fetch any X/Twitter post as clean LLM-friendly JSON. Converts x.com, twitter.com, or adhx.com links into structured data with full article content, author info, and engagement metrics. No scraping or browser required.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "advanced-evaluation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/advanced-evaluation",
+          "description": "This skill should be used when the user asks to \"implement LLM-as-judge\", \"compare model outputs\", \"create evaluation rubrics\", \"mitigate evaluation bias\", or mentions direct scoring, pairwise comparison, position bias, evaluation pipelines, or automated quality assessment.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aegisops-ai",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aegisops-ai",
+          "description": "Autonomous DevSecOps & FinOps Guardrails. Orchestrates Gemini 3 Flash to audit Linux Kernel patches, Terraform cost drifts, and K8s compliance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-evaluation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-evaluation",
+          "description": "Testing and benchmarking LLM agents including behavioral testing,",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-framework-azure-ai-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-framework-azure-ai-py",
+          "description": "Build persistent agents on Azure AI Foundry using the Microsoft Agent Framework Python SDK.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-manager-skill",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-manager-skill",
+          "description": "Manage multiple local CLI agents via tmux sessions (start/stop/monitor/assign) with cron-friendly scheduling.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-memory-mcp",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-memory-mcp",
+          "description": "A hybrid memory system that provides persistent, searchable knowledge management for AI agents (Architecture, Patterns, Decisions).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-memory-systems",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-memory-systems",
+          "description": "Memory is the cornerstone of intelligent agents. Without it, every",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-orchestration-improve-agent",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-orchestration-improve-agent",
+          "description": "Systematic improvement of existing agents through performance analysis, prompt engineering, and continuous iteration.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-orchestration-multi-agent-optimize",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-orchestration-multi-agent-optimize",
+          "description": "Optimize multi-agent systems with coordinated profiling, workload distribution, and cost-aware orchestration. Use when improving agent performance, throughput, or reliability.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-orchestrator",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-orchestrator",
+          "description": "Meta-skill que orquestra todos os agentes do ecossistema. Scan automatico de skills, match por capacidades, coordenacao de workflows multi-skill e registry management.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agent-tool-builder",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agent-tool-builder",
+          "description": "Tools are how AI agents interact with the world. A well-designed",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentflow",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agentflow",
+          "description": "Orchestrate autonomous AI development pipelines through your Kanban board (Asana, GitHub Projects, Linear). Manages multi-worker Claude Code dispatch, deterministic quality gates, adversarial review, per-task cost tracking, and crash-proof pipeline execution.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentfolio",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agentfolio",
+          "description": "Skill for discovering and researching autonomous AI agents, tools, and ecosystems using the AgentFolio directory.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentic-actions-auditor",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agentic-actions-auditor",
+          "description": "Audits GitHub Actions workflows for security vulnerabilities in AI agent integrations  including Claude Code Action,  Gemini CLI, OpenAI Codex, and GitHub AI  Inference.  Detects attack vectors where attacker-controlled  input reaches. AI agents running in CI/CD pipelines.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentmail",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agentmail",
+          "description": "Email infrastructure for AI agents. Create accounts, send/receive emails, manage webhooks, and check karma balance via the AgentMail API.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agentphone",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agentphone",
+          "description": "Build AI phone agents with AgentPhone API. Use when the user wants to make phone calls, send/receive SMS, manage phone numbers, create voice agents, set up webhooks, or check usage — anything related to telephony, phone numbers, or voice AI.",
+          "version": "0.3.0"
+        },
+        {
+          "name": "agents-md",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agents-md",
+          "description": "This skill should be used when the user asks to \"create AGENTS.md\", \"update AGENTS.md\", \"maintain agent docs\", \"set up CLAUDE.md\", or needs to keep agent instructions concise. Enforces research-backed best practices for minimal, high-signal agent documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "agents-v2-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/agents-v2-py",
+          "description": "Build container-based Foundry Agents with Azure AI Projects SDK (ImageBasedHostedAgentDefinition). Use when creating hosted agents with custom container images in Azure AI Foundry.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-agent-development",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-agent-development",
+          "description": "AI agent development workflow for building autonomous agents, multi-agent systems, and agent orchestration with CrewAI, LangGraph, and custom agents.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-agents-architect",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-agents-architect",
+          "description": "Expert in designing and building autonomous AI agents. Masters tool",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-analyzer",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-analyzer",
+          "description": "AI驱动的综合健康分析系统，整合多维度健康数据、识别异常模式、预测健康风险、提供个性化建议。支持智能问答和AI健康报告生成。",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-dev-jobs-mcp",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-dev-jobs-mcp",
+          "description": "Search 8,400+ AI and ML jobs across 489 companies, inspect listings and employers, match roles, and view salary and market stats via AI Dev Jobs MCP",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-engineer",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-engineer",
+          "description": "Build production-ready LLM applications, advanced RAG systems, and intelligent agents. Implements vector search, multimodal AI, agent orchestration, and enterprise AI integrations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-engineering-toolkit",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-engineering-toolkit",
+          "description": "6 production-ready AI engineering workflows: prompt evaluation (8-dimension scoring), context budget planning, RAG pipeline design, agent security audit (65-point checklist), eval harness building, and product sense coaching.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-md",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-md",
+          "description": "Convert human-written CLAUDE.md into AI-native structured-label format. Battle-tested across 4 models. Same rules, fewer tokens, higher compliance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-ml",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-ml",
+          "description": "AI and machine learning workflow covering LLM application development, RAG implementation, agent architecture, ML pipelines, and AI-powered features.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-native-cli",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-native-cli",
+          "description": "Design spec with 98 rules for building CLI tools that AI agents can safely use. Covers structured JSON output, error handling, input contracts, safety guardrails, exit codes, and agent self-description.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-product",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-product",
+          "description": "Every product will be AI-powered. The question is whether you'll",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-seo",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-seo",
+          "description": "Optimize content for AI search and LLM citations across AI Overviews, ChatGPT, Perplexity, Claude, Gemini, and similar systems. Use when improving AI visibility, answer engine optimization, or citation readiness.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "ai-studio-image",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-studio-image",
+          "description": "Geracao de imagens humanizadas via Google AI Studio (Gemini). Fotos realistas estilo influencer ou educacional com iluminacao natural e imperfeicoes sutis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-wrapper-product",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-wrapper-product",
+          "description": "Expert in building products that wrap AI APIs (OpenAI, Anthropic,",
+          "version": "0.0.0"
+        },
+        {
+          "name": "airflow-dag-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/airflow-dag-patterns",
+          "description": "Build production Apache Airflow DAGs with best practices for operators, sensors, testing, and deployment. Use when creating data pipelines, orchestrating workflows, or scheduling batch jobs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "airtable-automation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/airtable-automation",
+          "description": "Automate Airtable tasks via Rube MCP (Composio): records, bases, tables, fields, views. Always search tools first for current schemas.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "akf-trust-metadata",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/akf-trust-metadata",
+          "description": "The AI native file format. EXIF for AI — stamps every file with trust scores, source provenance, and compliance metadata. Embeds into 20+ formats (DOCX, PDF, images, code). EU AI Act, SOX, HIPAA auditing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "alpha-vantage",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/alpha-vantage",
+          "description": "Access 20+ years of global financial data: equities, options, forex, crypto, commodities, economic indicators, and 50+ technical indicators.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "amazon-alexa",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/amazon-alexa",
+          "description": "Integracao completa com Amazon Alexa para criar skills de voz inteligentes, transformar Alexa em assistente com Claude como cerebro (projeto Auri) e integrar com AWS ecosystem (Lambda, DynamoDB, Polly, Transcribe, Lex, Smart Home).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "amplitude-automation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/amplitude-automation",
+          "description": "Automate Amplitude tasks via Rube MCP (Composio): events, user activity, cohorts, user identification. Always search tools first for current schemas.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "analytics-product",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/analytics-product",
+          "description": "Analytics de produto — PostHog, Mixpanel, eventos, funnels, cohorts, retencao, north star metric, OKRs e dashboards de produto.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "analytics-tracking",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/analytics-tracking",
+          "description": "Design, audit, and improve analytics tracking systems that produce reliable, decision-ready data.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "analyze-project",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/analyze-project",
+          "description": "Forensic root cause analyzer for Antigravity sessions. Classifies scope deltas, rework patterns, root causes, hotspots, and auto-improves prompts/health.",
+          "version": "1.0"
+        },
+        {
+          "name": "andrej-karpathy",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/andrej-karpathy",
+          "description": "Agente que simula Andrej Karpathy — ex-Director of AI da Tesla, co-fundador da OpenAI, fundador da Eureka Labs, e o maior educador de deep learning do mundo.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "angular-ui-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/angular-ui-patterns",
+          "description": "Modern Angular UI patterns for loading states, error handling, and data display. Use when building UI components, handling async data, or managing component states.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "anti-reversing-techniques",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/anti-reversing-techniques",
+          "description": "AUTHORIZED USE ONLY: This skill contains dual-use security techniques. Before proceeding with any bypass or analysis: > 1.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "antigravity-skill-orchestrator",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/antigravity-skill-orchestrator",
+          "description": "A meta-skill that understands task requirements, dynamically selects appropriate skills, tracks successful skill combinations using agent-memory-mcp, and prevents skill overuse for simple tasks.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "antigravity-workflows",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/antigravity-workflows",
+          "description": "Orchestrate multiple Antigravity skills through guided workflows for SaaS MVP delivery, security audits, AI agent builds, and browser QA.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aomi-transact",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aomi-transact",
+          "description": "Build natural-language crypto/DeFi agents and EVM MCP plugins (Claude Code, Cursor, Codex, Gemini). Aomi turns prompts into wallet-signed txs on Ethereum, Base, Arbitrum, Optimism, Polygon, Linea — non-custodial, fork-simulated. 40+ apps: Uniswap, Aave, Lido, Morpho, GMX, Hyperliquid, Polymarket.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-design-principles",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-design-principles",
+          "description": "Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers and stand the test of time.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-documentation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-documentation",
+          "description": "API documentation workflow for generating OpenAPI specs, creating developer guides, and maintaining comprehensive API documentation.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-documenter",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-documenter",
+          "description": "Master API documentation with OpenAPI 3.1, AI-powered tools, and modern developer experience practices. Create interactive docs, generate SDKs, and build comprehensive developer portals.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-security-best-practices",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-security-best-practices",
+          "description": "Implement secure API design patterns including authentication, authorization, input validation, rate limiting, and protection against common API vulnerabilities",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-actor-development",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-actor-development",
+          "description": "Important: Before you begin, fill in the generatedBy property in the meta section of .actor/actor.json. Replace it with the tool and model you're currently using, such as \\\"Claude Code with Claude Sonnet 4.5\\\". This helps Apify monitor and improve AGENTS.md for specific AI tools and models.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-audience-analysis",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-audience-analysis",
+          "description": "Understand audience demographics, preferences, behavior patterns, and engagement quality across Facebook, Instagram, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-content-analytics",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-content-analytics",
+          "description": "Track engagement metrics, measure campaign ROI, and analyze content performance across Instagram, Facebook, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-ecommerce",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-ecommerce",
+          "description": "Extract product data, prices, reviews, and seller information from any e-commerce platform using Apify's E-commerce Scraping Tool.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-trend-analysis",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-trend-analysis",
+          "description": "Discover and track emerging trends across Google Trends, Instagram, Facebook, YouTube, and TikTok to inform content strategy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-ultimate-scraper",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-ultimate-scraper",
+          "description": "AI-driven data extraction from 55+ Actors across all major platforms. This skill automatically selects the best Actor for your task.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "app-builder",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/app-builder",
+          "description": "Main application building orchestrator. Creates full-stack applications from natural language requests. Determines project type, selects tech stack, coordinates agents.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "appdeploy",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/appdeploy",
+          "description": "Deploy web apps with backend APIs, database, and file storage. Use when the user asks to deploy or publish a website or web app and wants a public URL. Uses HTTP API via curl.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/architecture",
+          "description": "Architectural decision-making framework. Requirements analysis, trade-off evaluation, ADR documentation. Use when making architecture decisions or analyzing system design.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture-decision-records",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/architecture-decision-records",
+          "description": "Comprehensive patterns for creating, maintaining, and managing Architecture Decision Records (ADRs) that capture the context and rationale behind significant technical decisions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "architecture-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/architecture-patterns",
+          "description": "Master proven backend architecture patterns including Clean Architecture, Hexagonal Architecture, and Domain-Driven Design to build maintainable, testable, and scalable systems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "asana-automation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/asana-automation",
+          "description": "Automate Asana tasks via Rube MCP (Composio): tasks, projects, sections, teams, workspaces. Always search tools first for current schemas.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "astropy",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/astropy",
+          "description": "Astropy is the core Python package for astronomy, providing essential functionality for astronomical research and data analysis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "async-python-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/async-python-patterns",
+          "description": "Comprehensive guidance for implementing asynchronous Python applications using asyncio, concurrent programming patterns, and async/await for building high-performance, non-blocking systems.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "audio-transcriber",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/audio-transcriber",
+          "description": "Transform audio recordings into professional Markdown documentation with intelligent summaries using LLM integration",
+          "version": "0.0.0"
+        },
+        {
+          "name": "audit-context-building",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/audit-context-building",
+          "description": "Enables ultra-granular, line-by-line code analysis to build deep architectural context before vulnerability or bug finding.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "audit-skills",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/audit-skills",
+          "description": "Expert security auditor for AI Skills and Bundles. Performs non-intrusive static analysis to identify malicious patterns, data leaks, system stability risks, and obfuscated payloads across Windows, macOS, Linux/Unix, and Mobile (Android/iOS).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "auri-core",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/auri-core",
+          "description": "Auri: assistente de voz inteligente (Alexa + Claude claude-opus-4-20250805). Visao do produto, persona Vitoria Neural, stack AWS, modelo Free/Pro/Business/Enterprise, roadmap 4 fases, GTM, north star WAC e analise competitiva.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autonomous-agent-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/autonomous-agent-patterns",
+          "description": "Design patterns for building autonomous coding agents, inspired by [Cline](https://github.com/cline/cline) and [OpenAI Codex](https://github.com/openai/codex).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "autonomous-agents",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/autonomous-agents",
+          "description": "Autonomous agents are AI systems that can independently decompose",
+          "version": "0.0.0"
+        },
+        {
+          "name": "avalonia-viewmodels-zafiro",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/avalonia-viewmodels-zafiro",
+          "description": "Optimal ViewModel and Wizard creation patterns for Avalonia using Zafiro and ReactiveUI.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "avoid-ai-writing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/avoid-ai-writing",
+          "description": "Audit and rewrite content to remove 21 categories of AI writing patterns with a 43-entry replacement table",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-compliance-checker",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/security/aws-compliance-checker",
+          "description": "Automated compliance checking against CIS, PCI-DSS, HIPAA, and SOC 2 benchmarks",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-cost-optimizer",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aws-cost-optimizer",
+          "description": "Comprehensive AWS cost analysis and optimization recommendations using AWS CLI and Cost Explorer",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-penetration-testing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aws-penetration-testing",
+          "description": "Provide comprehensive techniques for penetration testing AWS cloud environments. Covers IAM enumeration, privilege escalation, SSRF to metadata endpoint, S3 bucket exploitation, Lambda code extraction, and persistence techniques for red team operations.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "sickn33",
+        "repo": "antigravity-awesome-skills",
+        "repoUrl": "https://github.com/sickn33/antigravity-awesome-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "sickn33-antigravity-awesome-skills-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from sickn33/antigravity-awesome-skills.",
+      "author": "ASM (sickn33/antigravity-awesome-skills)",
+      "createdAt": "2026-05-09T08:10:37.232Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "sickn33",
+        "antigravity-awesome-skills"
+      ],
+      "skills": [
+        {
+          "name": "ai-dev-jobs-mcp",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-dev-jobs-mcp",
+          "description": "Search 8,400+ AI and ML jobs across 489 companies, inspect listings and employers, match roles, and view salary and market stats via AI Dev Jobs MCP",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-engineer",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-engineer",
+          "description": "Build production-ready LLM applications, advanced RAG systems, and intelligent agents. Implements vector search, multimodal AI, agent orchestration, and enterprise AI integrations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-engineering-toolkit",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-engineering-toolkit",
+          "description": "6 production-ready AI engineering workflows: prompt evaluation (8-dimension scoring), context budget planning, RAG pipeline design, agent security audit (65-point checklist), eval harness building, and product sense coaching.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-product",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-product",
+          "description": "Every product will be AI-powered. The question is whether you'll",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ai-wrapper-product",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ai-wrapper-product",
+          "description": "Expert in building products that wrap AI APIs (OpenAI, Anthropic,",
+          "version": "0.0.0"
+        },
+        {
+          "name": "airflow-dag-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/airflow-dag-patterns",
+          "description": "Build production Apache Airflow DAGs with best practices for operators, sensors, testing, and deployment. Use when creating data pipelines, orchestrating workflows, or scheduling batch jobs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "analytics-product",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/analytics-product",
+          "description": "Analytics de produto — PostHog, Mixpanel, eventos, funnels, cohorts, retencao, north star metric, OKRs e dashboards de produto.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aomi-transact",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aomi-transact",
+          "description": "Build natural-language crypto/DeFi agents and EVM MCP plugins (Claude Code, Cursor, Codex, Gemini). Aomi turns prompts into wallet-signed txs on Ethereum, Base, Arbitrum, Optimism, Polygon, Linea — non-custodial, fork-simulated. 40+ apps: Uniswap, Aave, Lido, Morpho, GMX, Hyperliquid, Polymarket.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "api-endpoint-builder",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/api-endpoint-builder",
+          "description": "Builds production-ready REST API endpoints with validation, error handling, authentication, and documentation. Follows best practices for security and scalability.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-competitor-intelligence",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-competitor-intelligence",
+          "description": "Analyze competitor strategies, content, pricing, ads, and market positioning across Google Maps, Booking.com, Facebook, Instagram, YouTube, and TikTok.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-ecommerce",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-ecommerce",
+          "description": "Extract product data, prices, reviews, and seller information from any e-commerce platform using Apify's E-commerce Scraping Tool.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-market-research",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-market-research",
+          "description": "Analyze market conditions, geographic opportunities, pricing, consumer behavior, and product validation across Google Maps, Facebook, Instagram, Booking.com, and TripAdvisor.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "apify-trend-analysis",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/apify-trend-analysis",
+          "description": "Discover and track emerging trends across Google Trends, Instagram, Facebook, YouTube, and TikTok to inform content strategy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "auri-core",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/auri-core",
+          "description": "Auri: assistente de voz inteligente (Alexa + Claude claude-opus-4-20250805). Visao do produto, persona Vitoria Neural, stack AWS, modelo Free/Pro/Business/Enterprise, roadmap 4 fases, GTM, north star WAC e analise competitiva.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "aws-serverless",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/aws-serverless",
+          "description": "Specialized skill for building production-ready serverless",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-cosmos-db-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-cosmos-db-py",
+          "description": "Build production-grade Azure Cosmos DB NoSQL services following clean code, security best practices, and TDD principles.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-mgmt-apimanagement-py",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-mgmt-apimanagement-py",
+          "description": "Azure API Management SDK for Python. Use for managing APIM services, APIs, products, subscriptions, and policies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-mgmt-mongodbatlas-dotnet",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-mgmt-mongodbatlas-dotnet",
+          "description": "Manage MongoDB Atlas Organizations as Azure ARM resources with unified billing through Azure Marketplace.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "azure-mgmt-weightsandbiases-dotnet",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/azure-mgmt-weightsandbiases-dotnet",
+          "description": "Azure Weights & Biases SDK for .NET. ML experiment tracking and model management via Azure Marketplace. Use for creating W&B instances, managing SSO, marketplace integration, and ML observability.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "backend-dev-guidelines",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/backend-dev-guidelines",
+          "description": "You are a senior backend engineer operating production-grade services under strict architectural and reliability constraints. Use when routes, controllers, services, repositories, express middleware, or prisma database access.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "backtesting-frameworks",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/backtesting-frameworks",
+          "description": "Build robust, production-grade backtesting systems that avoid common pitfalls and produce reliable strategy performance estimates.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bash-defensive-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/bash-defensive-patterns",
+          "description": "Master defensive Bash programming techniques for production-grade scripts. Use when writing robust shell scripts, CI/CD pipelines, or system utilities requiring fault tolerance and safety.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bash-pro",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/bash-pro",
+          "description": "Master of defensive Bash scripting for production automation, CI/CD",
+          "version": "0.0.0"
+        },
+        {
+          "name": "bash-scripting",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/bash-scripting",
+          "description": "Bash scripting workflow for creating production-ready shell scripts with defensive patterns, error handling, and testing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "blockchain-developer",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/blockchain-developer",
+          "description": "Build production-ready Web3 applications, smart contracts, and decentralized systems. Implements DeFi protocols, NFT platforms, DAOs, and enterprise blockchain integrations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "blog-writing-guide",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/blog-writing-guide",
+          "description": "This skill enforces Sentry's blog writing standards across every post — whether you're helping an engineer write their first blog post or a marketer draft a product announcement.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brand-guidelines",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/brand-guidelines",
+          "description": "Write copy following Sentry brand guidelines. Use when writing UI text, error messages, empty states, onboarding flows, 404 pages, documentation, marketing copy, or any user-facing content. Covers both Plain Speech (default) and Sentry Voice tones.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "brevo-automation",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/brevo-automation",
+          "description": "Automate Brevo (formerly Sendinblue) email marketing operations through Composio's Brevo toolkit via Rube MCP.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "business-analyst",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/business-analyst",
+          "description": "Master modern business analysis with AI-powered analytics, real-time dashboards, and data-driven insights. Build comprehensive KPI frameworks, predictive models, and strategic recommendations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "buywhere-product-catalog",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/buywhere-product-catalog",
+          "description": "Use BuyWhere's MCP and API surfaces to add product search, price comparison, and deal discovery to AI shopping agents.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "chat-widget",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/chat-widget",
+          "description": "Build a real-time support chat system with a floating widget for users and an admin dashboard for support staff. Use when the user wants live chat, customer support chat, real-time messaging, or in-app support.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "churn-prevention",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/churn-prevention",
+          "description": "Reduce voluntary and involuntary churn with cancel flows, save offers, dunning, win-back tactics, and retention strategy. Use when users are cancelling, failed payments are rising, or subscription retention needs improvement.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "cloudformation-best-practices",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/cloudformation-best-practices",
+          "description": "CloudFormation template optimization, nested stacks, drift detection, and production-ready patterns. Use when writing or reviewing CF templates.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "codebase-audit-pre-push",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/codebase-audit-pre-push",
+          "description": "Deep audit before GitHub push: removes junk files, dead code, security holes, and optimization issues. Checks every file line-by-line for production readiness.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "competitive-landscape",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/competitive-landscape",
+          "description": "Comprehensive frameworks for analyzing competition, identifying differentiation opportunities, and developing winning market positioning strategies.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "competitor-alternatives",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/competitor-alternatives",
+          "description": "You are an expert in creating competitor comparison and alternative pages. Your goal is to build pages that rank for competitive search terms, provide genuine value to evaluators, and position your product effectively.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "concise-planning",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/concise-planning",
+          "description": "Use when a user asks for a plan for a coding task, to generate a clear, actionable, and atomic checklist.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-marketer",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/content-marketer",
+          "description": "Elite content marketing strategist specializing in AI-powered content creation, omnichannel distribution, SEO optimization, and data-driven performance marketing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "content-strategy",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/content-strategy",
+          "description": "Plan a content strategy, topic clusters, editorial roadmap, and content mix for traffic, authority, and lead generation. Use when deciding what to publish, what topics to prioritize, or how to structure a content program.",
+          "version": "1.1.0"
+        },
+        {
+          "name": "copy-editing",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/copy-editing",
+          "description": "You are an expert copy editor specializing in marketing and conversion copy. Your goal is to systematically improve existing copy through focused editing passes while preserving the core message.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "copywriting",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/copywriting",
+          "description": "Write rigorous, conversion-focused marketing copy for landing pages and emails. Enforces brief confirmation and strict no-fabrication rules.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "crypto-bd-agent",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/crypto-bd-agent",
+          "description": "Production-tested patterns for building AI agents that autonomously discover, > evaluate, and acquire token listings for cryptocurrency exchanges.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "customer-psychographic-profiler",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/customer-psychographic-profiler",
+          "description": "One sentence - what this skill does and when to invoke it",
+          "version": "0.0.0"
+        },
+        {
+          "name": "customer-support",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/customer-support",
+          "description": "Elite AI-powered customer support specialist mastering conversational AI, automated ticketing, sentiment analysis, and omnichannel support experiences.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "daily-gift",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/daily-gift",
+          "description": "Relationship-aware daily gift engine with five-stage creative pipeline — editorial judgment, synthesis, concept generation, visual strategy, and rendering in H5, image, or video",
+          "version": "0.0.0"
+        },
+        {
+          "name": "data-scientist",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/data-scientist",
+          "description": "Expert data scientist for advanced analytics, machine learning, and statistical modeling. Handles complex data analysis, predictive modeling, and business intelligence.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "database-design",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/database-design",
+          "description": "Database design principles and decision-making. Schema design, indexing strategy, ORM selection, serverless databases.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dbt-transformation-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/dbt-transformation-patterns",
+          "description": "Production-ready patterns for dbt (data build tool) including model organization, testing strategies, documentation, and incremental processing.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ddd-strategic-design",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/ddd-strategic-design",
+          "description": "Design DDD strategic artifacts including subdomains, bounded contexts, and ubiquitous language for complex business domains.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "defi-protocol-templates",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/defi-protocol-templates",
+          "description": "Implement DeFi protocols with production-ready templates for staking, AMMs, governance, and lending systems. Use when building decentralized finance applications or smart contract protocols.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "deployment-procedures",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/deployment-procedures",
+          "description": "Production deployment principles and decision-making. Safe deployment workflows, rollback strategies, and verification. Teaches thinking, not scripts.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "discord-bot-architect",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/discord-bot-architect",
+          "description": "Specialized skill for building production-ready Discord bots.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "distributed-debugging-debug-trace",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/distributed-debugging-debug-trace",
+          "description": "You are a debugging expert specializing in setting up comprehensive debugging environments, distributed tracing, and diagnostic tools. Configure debugging workflows, implement tracing solutions, and establish troubleshooting practices for development and production environments.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docker-expert",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/docker-expert",
+          "description": "You are an advanced Docker containerization expert with comprehensive, practical knowledge of container optimization, security hardening, multi-stage builds, orchestration patterns, and production deployment strategies based on current industry best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dotnet-backend",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/dotnet-backend",
+          "description": "Build ASP.NET Core 8+ backend services with EF Core, auth, background jobs, and production API patterns.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dotnet-backend-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/dotnet-backend-patterns",
+          "description": "Master C#/.NET patterns for building production-grade APIs, MCP servers, and enterprise backends with modern best practices (2024/2025).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "email-sequence",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/email-sequence",
+          "description": "You are an expert in email marketing and automation. Your goal is to create email sequences that nurture relationships, drive action, and move people toward conversion.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "email-systems",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/email-systems",
+          "description": "Email has the highest ROI of any marketing channel. $36 for every",
+          "version": "0.0.0"
+        },
+        {
+          "name": "error-debugging-error-analysis",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/error-debugging-error-analysis",
+          "description": "You are an expert error analysis specialist with deep expertise in debugging distributed systems, analyzing production incidents, and implementing comprehensive observability solutions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "error-debugging-error-trace",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/error-debugging-error-trace",
+          "description": "You are an error tracking and observability expert specializing in implementing comprehensive error monitoring solutions. Set up error tracking systems, configure alerts, implement structured logging, and ensure teams can quickly identify and resolve production issues.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "error-diagnostics-error-analysis",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/error-diagnostics-error-analysis",
+          "description": "You are an expert error analysis specialist with deep expertise in debugging distributed systems, analyzing production incidents, and implementing comprehensive observability solutions.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "expo-deployment",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/expo-deployment",
+          "description": "Deploy Expo apps to production",
+          "version": "0.0.0"
+        },
+        {
+          "name": "fastapi-templates",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/fastapi-templates",
+          "description": "Create production-ready FastAPI projects with async patterns, dependency injection, and comprehensive error handling. Use when building new FastAPI applications or setting up backend API projects.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "framework-migration-legacy-modernize",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/framework-migration-legacy-modernize",
+          "description": "Orchestrate a comprehensive legacy system modernization using the strangler fig pattern, enabling gradual replacement of outdated components while maintaining continuous business operations through ex",
+          "version": "0.0.0"
+        },
+        {
+          "name": "free-tool-strategy",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/free-tool-strategy",
+          "description": "You are an expert in engineering-as-marketing strategy. Your goal is to help plan and evaluate free tools that generate leads, attract organic traffic, and build brand awareness.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "frontend-api-integration-patterns",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/frontend-api-integration-patterns",
+          "description": "Production-ready patterns for integrating frontend applications with backend APIs, including race condition handling, request cancellation, retry strategies, error normalization, and UI state management.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "frontend-mobile-development-component-scaffold",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/frontend-mobile-development-component-scaffold",
+          "description": "You are a React component architecture expert specializing in scaffolding production-ready, accessible, and performant components. Generate complete component implementations with TypeScript, tests, s",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gcp-cloud-run",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/gcp-cloud-run",
+          "description": "Specialized skill for building production-ready serverless",
+          "version": "0.0.0"
+        },
+        {
+          "name": "gemini-api-integration",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/gemini-api-integration",
+          "description": "Use when integrating Google Gemini API into projects. Covers model selection, multimodal inputs, streaming, function calling, and production best practices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "github-actions-templates",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/github-actions-templates",
+          "description": "Production-ready GitHub Actions workflow patterns for testing, building, and deploying applications.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "golang-pro",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/golang-pro",
+          "description": "Master Go 1.21+ with modern patterns, advanced concurrency, performance optimization, and production-ready microservices.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "grafana-dashboards",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/grafana-dashboards",
+          "description": "Create and manage production-ready Grafana dashboards for comprehensive system observability.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "growth-engine",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/growth-engine",
+          "description": "Motor de crescimento para produtos digitais -- growth hacking, SEO, ASO, viral loops, email marketing, CRM, referral programs e aquisicao organica.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "grpc-golang",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/grpc-golang",
+          "description": "Build production-ready gRPC services in Go with mTLS, streaming, and observability. Use when designing Protobuf contracts with Buf or implementing secure service-to-service transport.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "idea-os",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/idea-os",
+          "description": "Five-phase pipeline (triage → clarify → research → PRD → plan) that turns a raw idea into four linked files: clarifying questions, deep research, a PRD with non-goals and metrics, and a phased execution plan with mermaid user journey and kill criteria.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "incident-runbook-templates",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/incident-runbook-templates",
+          "description": "Production-ready templates for incident response runbooks covering detection, triage, mitigation, resolution, and communication.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "instagram",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/instagram",
+          "description": "Integracao completa com Instagram via Graph API. Publicacao, analytics, comentarios, DMs, hashtags, agendamento, templates e gestao de contas Business/Creator.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "interview-coach",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/interview-coach",
+          "description": "Full job search coaching system — JD decoding, resume, storybank, mock interviews, transcript analysis, comp negotiation. 23 commands, persistent state.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "inventory-demand-planning",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/inventory-demand-planning",
+          "description": "Codified expertise for demand forecasting, safety stock optimisation, replenishment planning, and promotional lift estimation at multi-location retailers.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "istio-traffic-management",
+          "installUrl": "github:sickn33/antigravity-awesome-skills:skills/istio-traffic-management",
+          "description": "Comprehensive guide to Istio traffic management for production service mesh deployments.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "sickn33",
+        "repo": "antigravity-awesome-skills",
+        "repoUrl": "https://github.com/sickn33/antigravity-awesome-skills.git"
+      },
+      "inferred": true
     }
   ]
 }

--- a/data/skill-index/slavingia_skills.json
+++ b/data/skill-index/slavingia_skills.json
@@ -1375,5 +1375,361 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "slavingia-skills-marketing",
+      "description": "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills. Derived from slavingia/skills.",
+      "author": "ASM (slavingia/skills)",
+      "createdAt": "2026-05-09T08:10:43.069Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "marketing",
+        "growth",
+        "seo",
+        "slavingia",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "first-customers",
+          "installUrl": "github:slavingia/skills:skills/first-customers",
+          "description": "Create a strategy for selling to your first 100 customers using the minimalist entrepreneur playbook. Use when someone has a product and needs to find customers, or is struggling with early sales.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "grow-sustainably",
+          "installUrl": "github:slavingia/skills:skills/grow-sustainably",
+          "description": "Evaluate business decisions through the lens of sustainable, profitable growth. Use when someone is making decisions about spending, hiring, fundraising, or scaling their business.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "marketing-plan",
+          "installUrl": "github:slavingia/skills:skills/marketing-plan",
+          "description": "Create a minimalist marketing plan focused on building an audience through content, not ads. Use when someone has product-market fit (~100 customers) and wants to scale with marketing, or needs a content strategy.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "slavingia",
+        "repo": "skills",
+        "repoUrl": "https://github.com/slavingia/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "slavingia-skills-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from slavingia/skills.",
+      "author": "ASM (slavingia/skills)",
+      "createdAt": "2026-05-09T08:10:43.069Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "slavingia",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "marketing-plan",
+          "installUrl": "github:slavingia/skills:skills/marketing-plan",
+          "description": "Create a minimalist marketing plan focused on building an audience through content, not ads. Use when someone has product-market fit (~100 customers) and wants to scale with marketing, or needs a content strategy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "processize",
+          "installUrl": "github:slavingia/skills:skills/processize",
+          "description": "Turn a product idea into a manual-first process you can start delivering today. Use when you have an idea and want to figure out how to deliver value by hand before writing any code.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "slavingia",
+        "repo": "skills",
+        "repoUrl": "https://github.com/slavingia/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "slavingia-skills-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from slavingia/skills.",
+      "author": "ASM (slavingia/skills)",
+      "createdAt": "2026-05-09T08:10:43.069Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "slavingia",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "find-community",
+          "installUrl": "github:slavingia/skills:skills/find-community",
+          "description": "Help identify and evaluate communities to build a minimalist business around. Use when someone is looking for a business idea, trying to find their community, or wondering where to start as an entrepreneur.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "grow-sustainably",
+          "installUrl": "github:slavingia/skills:skills/grow-sustainably",
+          "description": "Evaluate business decisions through the lens of sustainable, profitable growth. Use when someone is making decisions about spending, hiring, fundraising, or scaling their business.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "minimalist-review",
+          "installUrl": "github:slavingia/skills:skills/minimalist-review",
+          "description": "Review any business decision, plan, or strategy through the minimalist entrepreneur lens. Use when someone wants a gut-check on a business decision, wants to simplify their approach, or needs to decide between options.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "slavingia",
+        "repo": "skills",
+        "repoUrl": "https://github.com/slavingia/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "slavingia-skills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from slavingia/skills.",
+      "author": "ASM (slavingia/skills)",
+      "createdAt": "2026-05-09T08:10:43.069Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "slavingia",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "find-community",
+          "installUrl": "github:slavingia/skills:skills/find-community",
+          "description": "Help identify and evaluate communities to build a minimalist business around. Use when someone is looking for a business idea, trying to find their community, or wondering where to start as an entrepreneur.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "marketing-plan",
+          "installUrl": "github:slavingia/skills:skills/marketing-plan",
+          "description": "Create a minimalist marketing plan focused on building an audience through content, not ads. Use when someone has product-market fit (~100 customers) and wants to scale with marketing, or needs a content strategy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "minimalist-review",
+          "installUrl": "github:slavingia/skills:skills/minimalist-review",
+          "description": "Review any business decision, plan, or strategy through the minimalist entrepreneur lens. Use when someone wants a gut-check on a business decision, wants to simplify their approach, or needs to decide between options.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "mvp",
+          "installUrl": "github:slavingia/skills:skills/mvp",
+          "description": "Guide building a minimum viable product the minimalist entrepreneur way — manual first, then processized, then productized. Use when someone is ready to build their first product or struggling with scope.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "processize",
+          "installUrl": "github:slavingia/skills:skills/processize",
+          "description": "Turn a product idea into a manual-first process you can start delivering today. Use when you have an idea and want to figure out how to deliver value by hand before writing any code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "validate-idea",
+          "installUrl": "github:slavingia/skills:skills/validate-idea",
+          "description": "Validate a business idea using the minimalist entrepreneur framework. Use when someone has a business idea and wants to test if it's worth pursuing before building anything.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "slavingia",
+        "repo": "skills",
+        "repoUrl": "https://github.com/slavingia/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "slavingia-skills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from slavingia/skills.",
+      "author": "ASM (slavingia/skills)",
+      "createdAt": "2026-05-09T08:10:43.069Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "slavingia",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "find-community",
+          "installUrl": "github:slavingia/skills:skills/find-community",
+          "description": "Help identify and evaluate communities to build a minimalist business around. Use when someone is looking for a business idea, trying to find their community, or wondering where to start as an entrepreneur.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "marketing-plan",
+          "installUrl": "github:slavingia/skills:skills/marketing-plan",
+          "description": "Create a minimalist marketing plan focused on building an audience through content, not ads. Use when someone has product-market fit (~100 customers) and wants to scale with marketing, or needs a content strategy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "mvp",
+          "installUrl": "github:slavingia/skills:skills/mvp",
+          "description": "Guide building a minimum viable product the minimalist entrepreneur way — manual first, then processized, then productized. Use when someone is ready to build their first product or struggling with scope.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "validate-idea",
+          "installUrl": "github:slavingia/skills:skills/validate-idea",
+          "description": "Validate a business idea using the minimalist entrepreneur framework. Use when someone has a business idea and wants to test if it's worth pursuing before building anything.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "slavingia",
+        "repo": "skills",
+        "repoUrl": "https://github.com/slavingia/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "slavingia-skills-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from slavingia/skills.",
+      "author": "ASM (slavingia/skills)",
+      "createdAt": "2026-05-09T08:10:43.069Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "slavingia",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "grow-sustainably",
+          "installUrl": "github:slavingia/skills:skills/grow-sustainably",
+          "description": "Evaluate business decisions through the lens of sustainable, profitable growth. Use when someone is making decisions about spending, hiring, fundraising, or scaling their business.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "minimalist-review",
+          "installUrl": "github:slavingia/skills:skills/minimalist-review",
+          "description": "Review any business decision, plan, or strategy through the minimalist entrepreneur lens. Use when someone wants a gut-check on a business decision, wants to simplify their approach, or needs to decide between options.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pricing",
+          "installUrl": "github:slavingia/skills:skills/pricing",
+          "description": "Help figure out pricing for a product or service using minimalist entrepreneur principles. Use when someone is setting prices, considering price changes, or struggling with what to charge.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "slavingia",
+        "repo": "skills",
+        "repoUrl": "https://github.com/slavingia/skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "slavingia-skills-product-business",
+      "description": "Product, strategy, PRD, planning, finance, resume, and business workflow skills. Derived from slavingia/skills.",
+      "author": "ASM (slavingia/skills)",
+      "createdAt": "2026-05-09T08:10:43.069Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "product",
+        "business",
+        "planning",
+        "slavingia",
+        "skills"
+      ],
+      "skills": [
+        {
+          "name": "company-values",
+          "installUrl": "github:slavingia/skills:skills/company-values",
+          "description": "Help define company values and culture for a minimalist business. Use when someone is setting up their company culture, preparing to hire, or wanting to codify what their company stands for.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "find-community",
+          "installUrl": "github:slavingia/skills:skills/find-community",
+          "description": "Help identify and evaluate communities to build a minimalist business around. Use when someone is looking for a business idea, trying to find their community, or wondering where to start as an entrepreneur.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "first-customers",
+          "installUrl": "github:slavingia/skills:skills/first-customers",
+          "description": "Create a strategy for selling to your first 100 customers using the minimalist entrepreneur playbook. Use when someone has a product and needs to find customers, or is struggling with early sales.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "grow-sustainably",
+          "installUrl": "github:slavingia/skills:skills/grow-sustainably",
+          "description": "Evaluate business decisions through the lens of sustainable, profitable growth. Use when someone is making decisions about spending, hiring, fundraising, or scaling their business.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "marketing-plan",
+          "installUrl": "github:slavingia/skills:skills/marketing-plan",
+          "description": "Create a minimalist marketing plan focused on building an audience through content, not ads. Use when someone has product-market fit (~100 customers) and wants to scale with marketing, or needs a content strategy.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "minimalist-review",
+          "installUrl": "github:slavingia/skills:skills/minimalist-review",
+          "description": "Review any business decision, plan, or strategy through the minimalist entrepreneur lens. Use when someone wants a gut-check on a business decision, wants to simplify their approach, or needs to decide between options.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "mvp",
+          "installUrl": "github:slavingia/skills:skills/mvp",
+          "description": "Guide building a minimum viable product the minimalist entrepreneur way — manual first, then processized, then productized. Use when someone is ready to build their first product or struggling with scope.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "pricing",
+          "installUrl": "github:slavingia/skills:skills/pricing",
+          "description": "Help figure out pricing for a product or service using minimalist entrepreneur principles. Use when someone is setting prices, considering price changes, or struggling with what to charge.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "processize",
+          "installUrl": "github:slavingia/skills:skills/processize",
+          "description": "Turn a product idea into a manual-first process you can start delivering today. Use when you have an idea and want to figure out how to deliver value by hand before writing any code.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "validate-idea",
+          "installUrl": "github:slavingia/skills:skills/validate-idea",
+          "description": "Validate a business idea using the minimalist entrepreneur framework. Use when someone has a business idea and wants to test if it's worth pursuing before building anything.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "slavingia",
+        "repo": "skills",
+        "repoUrl": "https://github.com/slavingia/skills.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/data/skill-index/warpdotdev_oz-skills.json
+++ b/data/skill-index/warpdotdev_oz-skills.json
@@ -2060,5 +2060,433 @@
         }
       }
     }
+  ],
+  "bundles": [
+    {
+      "version": 1,
+      "name": "warpdotdev-oz-skills-writing",
+      "description": "Writing, editing, documentation, publishing, and content-production skills. Derived from warpdotdev/oz-skills.",
+      "author": "ASM (warpdotdev/oz-skills)",
+      "createdAt": "2026-05-09T08:11:12.937Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "writing",
+        "content",
+        "docs",
+        "warpdotdev",
+        "oz-skills"
+      ],
+      "skills": [
+        {
+          "name": "dbt-model-index",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/dbt-model-index",
+          "description": "Provide a lookup index of dbt models (BigQuery tables) to guide query writing against a data warehouse. Use when you need to query, analyze, or look up data in a dbt-powered data warehouse, or when resolving a vague data question into the right BigQuery tables to query.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docs-update",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/docs-update",
+          "description": "Update user-facing documentation when code changes. Use when asked to update docs, review docs, handle documentation changes, run scheduled documentation tasks, or analyze recent commits for documentation needs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "slack-qa-investigate",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/slack-qa-investigate",
+          "description": "Investigate and answer repository questions in read-only mode. Use when asked for research-backed answers that require codebase and documentation investigation without making file changes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "terraform-style-check",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/terraform-style-check",
+          "description": "Generate Terraform HCL code following HashiCorp's official style conventions and best practices. Use when writing, reviewing, or generating Terraform configurations.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "warpdotdev",
+        "repo": "oz-skills",
+        "repoUrl": "https://github.com/warpdotdev/oz-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "warpdotdev-oz-skills-research",
+      "description": "Research, academic, literature-review, citation, paper, and analysis skills. Derived from warpdotdev/oz-skills.",
+      "author": "ASM (warpdotdev/oz-skills)",
+      "createdAt": "2026-05-09T08:11:12.937Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "research",
+        "academic",
+        "analysis",
+        "warpdotdev",
+        "oz-skills"
+      ],
+      "skills": [
+        {
+          "name": "analysis-artifacts",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/analysis-artifacts",
+          "description": "Generate reproducible analysis artifacts — SQL queries, Python visualizations, and summary tables — as you work through a BigQuery data analysis. Use when asked to conduct a deep dive, exploratory analysis, or investigation that goes beyond a simple data lookup.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-pull-request",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/create-pull-request",
+          "description": "Create a GitHub pull request following project conventions. Use when the user asks to create a PR, submit changes for review, or open a pull request. Handles commit analysis, branch management, and PR creation using the gh CLI tool.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docs-update",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/docs-update",
+          "description": "Update user-facing documentation when code changes. Use when asked to update docs, review docs, handle documentation changes, run scheduled documentation tasks, or analyze recent commits for documentation needs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "seo-aeo-audit",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/seo-aeo-audit",
+          "description": "Optimize for search engine visibility, ranking, and AI citations. Use when asked to improve SEO, optimize for search, fix meta tags, add structured data, or improve AEO and AI visibility.",
+          "version": "2.0"
+        },
+        {
+          "name": "slack-qa-investigate",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/slack-qa-investigate",
+          "description": "Investigate and answer repository questions in read-only mode. Use when asked for research-backed answers that require codebase and documentation investigation without making file changes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "terraform-style-check",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/terraform-style-check",
+          "description": "Generate Terraform HCL code following HashiCorp's official style conventions and best practices. Use when writing, reviewing, or generating Terraform configurations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "webapp-testing",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/webapp-testing",
+          "description": "Test local web applications with Playwright. Use when asked to verify frontend functionality, debug UI behavior, capture browser screenshots, or inspect browser logs.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "warpdotdev",
+        "repo": "oz-skills",
+        "repoUrl": "https://github.com/warpdotdev/oz-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "warpdotdev-oz-skills-engineering",
+      "description": "Coding, debugging, testing, architecture, review, and software engineering skills. Derived from warpdotdev/oz-skills.",
+      "author": "ASM (warpdotdev/oz-skills)",
+      "createdAt": "2026-05-09T08:11:12.937Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "engineering",
+        "coding",
+        "testing",
+        "warpdotdev",
+        "oz-skills"
+      ],
+      "skills": [
+        {
+          "name": "analysis-artifacts",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/analysis-artifacts",
+          "description": "Generate reproducible analysis artifacts — SQL queries, Python visualizations, and summary tables — as you work through a BigQuery data analysis. Use when asked to conduct a deep dive, exploratory analysis, or investigation that goes beyond a simple data lookup.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-pull-request",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/create-pull-request",
+          "description": "Create a GitHub pull request following project conventions. Use when the user asks to create a PR, submit changes for review, or open a pull request. Handles commit analysis, branch management, and PR creation using the gh CLI tool.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docs-update",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/docs-update",
+          "description": "Update user-facing documentation when code changes. Use when asked to update docs, review docs, handle documentation changes, run scheduled documentation tasks, or analyze recent commits for documentation needs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "mcp-builder",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/mcp-builder",
+          "description": "Build high-quality MCP (Model Context Protocol) servers that let LLMs interact with external services through well-designed tools. Use when creating MCP servers to integrate APIs or services in Python (FastMCP) or Node/TypeScript (MCP SDK).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "slack-qa-investigate",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/slack-qa-investigate",
+          "description": "Investigate and answer repository questions in read-only mode. Use when asked for research-backed answers that require codebase and documentation investigation without making file changes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "terraform-style-check",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/terraform-style-check",
+          "description": "Generate Terraform HCL code following HashiCorp's official style conventions and best practices. Use when writing, reviewing, or generating Terraform configurations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "web-performance-audit",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/web-performance-audit",
+          "description": "Audit web performance using Chrome DevTools MCP. Use when asked to audit, profile, debug, or optimize page load performance, Lighthouse scores, or site speed.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "webapp-testing",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/webapp-testing",
+          "description": "Test local web applications with Playwright. Use when asked to verify frontend functionality, debug UI behavior, capture browser screenshots, or inspect browser logs.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "warpdotdev",
+        "repo": "oz-skills",
+        "repoUrl": "https://github.com/warpdotdev/oz-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "warpdotdev-oz-skills-frontend-design",
+      "description": "Frontend, UI, UX, visual design, component, theme, and landing-page skills. Derived from warpdotdev/oz-skills.",
+      "author": "ASM (warpdotdev/oz-skills)",
+      "createdAt": "2026-05-09T08:11:12.937Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "frontend",
+        "design",
+        "ui",
+        "warpdotdev",
+        "oz-skills"
+      ],
+      "skills": [
+        {
+          "name": "analysis-artifacts",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/analysis-artifacts",
+          "description": "Generate reproducible analysis artifacts — SQL queries, Python visualizations, and summary tables — as you work through a BigQuery data analysis. Use when asked to conduct a deep dive, exploratory analysis, or investigation that goes beyond a simple data lookup.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dbt-model-index",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/dbt-model-index",
+          "description": "Provide a lookup index of dbt models (BigQuery tables) to guide query writing against a data warehouse. Use when you need to query, analyze, or look up data in a dbt-powered data warehouse, or when resolving a vague data question into the right BigQuery tables to query.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "mcp-builder",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/mcp-builder",
+          "description": "Build high-quality MCP (Model Context Protocol) servers that let LLMs interact with external services through well-designed tools. Use when creating MCP servers to integrate APIs or services in Python (FastMCP) or Node/TypeScript (MCP SDK).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "slack-qa-investigate",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/slack-qa-investigate",
+          "description": "Investigate and answer repository questions in read-only mode. Use when asked for research-backed answers that require codebase and documentation investigation without making file changes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "web-accessibility-audit",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/web-accessibility-audit",
+          "description": "Audit web applications for WCAG accessibility compliance. Use when asked to run accessibility checks, identify common violations, and provide remediation guidance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "webapp-testing",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/webapp-testing",
+          "description": "Test local web applications with Playwright. Use when asked to verify frontend functionality, debug UI behavior, capture browser screenshots, or inspect browser logs.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "warpdotdev",
+        "repo": "oz-skills",
+        "repoUrl": "https://github.com/warpdotdev/oz-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "warpdotdev-oz-skills-devops",
+      "description": "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills. Derived from warpdotdev/oz-skills.",
+      "author": "ASM (warpdotdev/oz-skills)",
+      "createdAt": "2026-05-09T08:11:12.937Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "devops",
+        "infra",
+        "automation",
+        "warpdotdev",
+        "oz-skills"
+      ],
+      "skills": [
+        {
+          "name": "analysis-artifacts",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/analysis-artifacts",
+          "description": "Generate reproducible analysis artifacts — SQL queries, Python visualizations, and summary tables — as you work through a BigQuery data analysis. Use when asked to conduct a deep dive, exploratory analysis, or investigation that goes beyond a simple data lookup.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ci-fix",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/ci-fix",
+          "description": "Diagnose and fix GitHub Actions CI failures. Inspects workflow runs and logs, identifies root causes, implements minimal fixes, and pushes to a fix branch. Use when CI is failing, red, broken, or needs diagnosis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docs-update",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/docs-update",
+          "description": "Update user-facing documentation when code changes. Use when asked to update docs, review docs, handle documentation changes, run scheduled documentation tasks, or analyze recent commits for documentation needs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "github-bug-report-triage",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/github-bug-report-triage",
+          "description": "Triage GitHub bug reports for actionability. Use when evaluating whether a bug issue has sufficient detail and identifying missing information from the reporter.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scheduler",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/scheduler",
+          "description": "Schedule on-device reminders and local actions only. Use this skill to set personal reminders or run lightweight, local tasks at a specific time or interval (e.g., notifications, local scripts), on the user's computer or with platforms like Slack. Do NOT use for scheduling cloud agents, background agentic jobs, or Oz-managed workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "seo-aeo-audit",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/seo-aeo-audit",
+          "description": "Optimize for search engine visibility, ranking, and AI citations. Use when asked to improve SEO, optimize for search, fix meta tags, add structured data, or improve AEO and AI visibility.",
+          "version": "2.0"
+        },
+        {
+          "name": "terraform-style-check",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/terraform-style-check",
+          "description": "Generate Terraform HCL code following HashiCorp's official style conventions and best practices. Use when writing, reviewing, or generating Terraform configurations.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "warpdotdev",
+        "repo": "oz-skills",
+        "repoUrl": "https://github.com/warpdotdev/oz-skills.git"
+      },
+      "inferred": true
+    },
+    {
+      "version": 1,
+      "name": "warpdotdev-oz-skills-data-ai",
+      "description": "Data, analytics, AI, model, prompt, agent, and automation skills. Derived from warpdotdev/oz-skills.",
+      "author": "ASM (warpdotdev/oz-skills)",
+      "createdAt": "2026-05-09T08:11:12.937Z",
+      "tags": [
+        "repo-derived",
+        "inferred",
+        "data",
+        "ai",
+        "agents",
+        "warpdotdev",
+        "oz-skills"
+      ],
+      "skills": [
+        {
+          "name": "analysis-artifacts",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/analysis-artifacts",
+          "description": "Generate reproducible analysis artifacts — SQL queries, Python visualizations, and summary tables — as you work through a BigQuery data analysis. Use when asked to conduct a deep dive, exploratory analysis, or investigation that goes beyond a simple data lookup.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "ci-fix",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/ci-fix",
+          "description": "Diagnose and fix GitHub Actions CI failures. Inspects workflow runs and logs, identifies root causes, implements minimal fixes, and pushes to a fix branch. Use when CI is failing, red, broken, or needs diagnosis.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "create-pull-request",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/create-pull-request",
+          "description": "Create a GitHub pull request following project conventions. Use when the user asks to create a PR, submit changes for review, or open a pull request. Handles commit analysis, branch management, and PR creation using the gh CLI tool.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "dbt-model-index",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/dbt-model-index",
+          "description": "Provide a lookup index of dbt models (BigQuery tables) to guide query writing against a data warehouse. Use when you need to query, analyze, or look up data in a dbt-powered data warehouse, or when resolving a vague data question into the right BigQuery tables to query.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "docs-update",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/docs-update",
+          "description": "Update user-facing documentation when code changes. Use when asked to update docs, review docs, handle documentation changes, run scheduled documentation tasks, or analyze recent commits for documentation needs.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "github-bug-report-triage",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/github-bug-report-triage",
+          "description": "Triage GitHub bug reports for actionability. Use when evaluating whether a bug issue has sufficient detail and identifying missing information from the reporter.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "github-issue-dedupe",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/github-issue-dedupe",
+          "description": "Detect duplicate GitHub issues using semantic search and keyword matching. Use when asked to find duplicates, check for similar issues, or set up automated duplicate detection.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "mcp-builder",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/mcp-builder",
+          "description": "Build high-quality MCP (Model Context Protocol) servers that let LLMs interact with external services through well-designed tools. Use when creating MCP servers to integrate APIs or services in Python (FastMCP) or Node/TypeScript (MCP SDK).",
+          "version": "0.0.0"
+        },
+        {
+          "name": "scheduler",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/scheduler",
+          "description": "Schedule on-device reminders and local actions only. Use this skill to set personal reminders or run lightweight, local tasks at a specific time or interval (e.g., notifications, local scripts), on the user's computer or with platforms like Slack. Do NOT use for scheduling cloud agents, background agentic jobs, or Oz-managed workflows.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "seo-aeo-audit",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/seo-aeo-audit",
+          "description": "Optimize for search engine visibility, ranking, and AI citations. Use when asked to improve SEO, optimize for search, fix meta tags, add structured data, or improve AEO and AI visibility.",
+          "version": "2.0"
+        },
+        {
+          "name": "slack-qa-investigate",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/slack-qa-investigate",
+          "description": "Investigate and answer repository questions in read-only mode. Use when asked for research-backed answers that require codebase and documentation investigation without making file changes.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "terraform-style-check",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/terraform-style-check",
+          "description": "Generate Terraform HCL code following HashiCorp's official style conventions and best practices. Use when writing, reviewing, or generating Terraform configurations.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "web-accessibility-audit",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/web-accessibility-audit",
+          "description": "Audit web applications for WCAG accessibility compliance. Use when asked to run accessibility checks, identify common violations, and provide remediation guidance.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "web-performance-audit",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/web-performance-audit",
+          "description": "Audit web performance using Chrome DevTools MCP. Use when asked to audit, profile, debug, or optimize page load performance, Lighthouse scores, or site speed.",
+          "version": "0.0.0"
+        },
+        {
+          "name": "webapp-testing",
+          "installUrl": "github:warpdotdev/oz-skills:.agents/skills/webapp-testing",
+          "description": "Test local web applications with Playwright. Use when asked to verify frontend functionality, debug UI behavior, capture browser screenshots, or inspect browser logs.",
+          "version": "0.0.0"
+        }
+      ],
+      "sourceRepo": {
+        "owner": "warpdotdev",
+        "repo": "oz-skills",
+        "repoUrl": "https://github.com/warpdotdev/oz-skills.git"
+      },
+      "inferred": true
+    }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-skill-manager",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-skill-manager",
-      "version": "2.6.2",
+      "version": "2.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build": "tsx scripts/build.ts",
     "build:site": "vite build --config website-src/vite.config.js",
     "preindex": "tsx scripts/preindex.ts",
+    "refresh:repo-bundles": "tsx scripts/refresh-repo-bundles.ts",
     "build:website": "tsx scripts/build-catalog.ts && npm run build:site",
     "lint:site": "eslint --config website-src/eslint.config.js 'website-src/src/**/*.{js,jsx}'",
     "prepublishOnly": "npm run build",

--- a/scripts/build-catalog.ts
+++ b/scripts/build-catalog.ts
@@ -21,6 +21,7 @@ import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import MiniSearch from "minisearch";
 import { MINISEARCH_OPTIONS } from "./minisearch-options";
+import { repoBundlesForIndex, type RepoBundleManifest } from "../src/repo-bundles";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const indexDir = join(root, "data", "skill-index");
@@ -268,6 +269,7 @@ interface RepoIndex {
   updatedAt: string;
   skillCount: number;
   skills: IndexedSkill[];
+  bundles?: RepoBundleManifest[];
 }
 
 interface CatalogSkill {
@@ -342,6 +344,7 @@ if (existsSync(resourcesPath)) {
 // Read all index files
 const files = readdirSync(indexDir).filter((f) => f.endsWith(".json"));
 const repos: CatalogRepo[] = [];
+const repoDerivedBundles: Bundle[] = [];
 const skillMap = new Map<string, CatalogSkill>();
 const categorySet = new Set<string>();
 
@@ -368,6 +371,18 @@ for (const file of files) {
     maintainer: meta?.maintainer || "",
     skillCount: repoIndex.skills.length,
   });
+
+  repoDerivedBundles.push(
+    ...repoBundlesForIndex(repoIndex as any).map((bundle) => ({
+      ...bundle,
+      tags: bundle.tags || [],
+      skills: bundle.skills.map((skill) => ({
+        name: skill.name,
+        installUrl: skill.installUrl,
+        description: skill.description || "",
+      })),
+    })),
+  );
 
   for (const skill of repoIndex.skills) {
     // Include relPath so plugin-bundle repos that ship the same skill name at
@@ -697,7 +712,7 @@ const bundleFiles = existsSync(bundlesDir)
   ? readdirSync(bundlesDir).filter((f) => f.endsWith(".json"))
   : [];
 
-const bundles: Bundle[] = [];
+const bundles: Bundle[] = [...repoDerivedBundles];
 for (const file of bundleFiles.sort()) {
   const filePath = join(bundlesDir, file);
   try {
@@ -708,10 +723,18 @@ for (const file of bundleFiles.sort()) {
   }
 }
 
+const bundleMap = new Map<string, Bundle>();
+for (const bundle of bundles) {
+  if (!bundleMap.has(bundle.name)) bundleMap.set(bundle.name, bundle);
+}
+const uniqueBundles = Array.from(bundleMap.values()).sort((a, b) =>
+  a.name.localeCompare(b.name),
+);
+
 const bundlesData: BundlesData = {
   generatedAt: new Date().toISOString(),
-  totalBundles: bundles.length,
-  bundles,
+  totalBundles: uniqueBundles.length,
+  bundles: uniqueBundles,
 };
 
 writeFileSync(
@@ -741,7 +764,7 @@ console.log(`Catalog built successfully:`);
 console.log(`  Skills: ${skills.length}`);
 console.log(`  Repos:  ${repos.length}`);
 console.log(`  Categories: ${categories.join(", ")}`);
-console.log(`  Bundles: ${bundles.length}`);
+console.log(`  Bundles: ${uniqueBundles.length}`);
 console.log(`  Split artifacts (issue #214):`);
 console.log(
   `    catalog.json:     ${kb(statSync(join(outDir, "catalog.json")).size)}`,

--- a/scripts/refresh-repo-bundles.ts
+++ b/scripts/refresh-repo-bundles.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Backfill repo-derived bundles into existing data/skill-index/*.json files.
+ *
+ * Future preindex runs create these during ingest. This script lets us refresh
+ * the already checked-in index without recloning every upstream repo.
+ */
+import { readdir, readFile, writeFile } from "fs/promises";
+import { join, resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { inferRepoBundles } from "../src/repo-bundles";
+import type { RepoIndex } from "../src/utils/types";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const indexDir = join(root, "data", "skill-index");
+
+async function main() {
+  const files = (await readdir(indexDir)).filter((file) => file.endsWith(".json")).sort();
+  let updated = 0;
+  let bundleCount = 0;
+
+  for (const file of files) {
+    const filePath = join(indexDir, file);
+    const repoIndex = JSON.parse(await readFile(filePath, "utf-8")) as RepoIndex;
+    const inferred = inferRepoBundles(repoIndex);
+    const next: RepoIndex = { ...repoIndex };
+
+    if (inferred.length > 0) {
+      next.bundles = inferred;
+      bundleCount += inferred.length;
+    } else {
+      delete next.bundles;
+    }
+
+    const before = JSON.stringify(repoIndex, null, 2) + "\n";
+    const after = JSON.stringify(next, null, 2) + "\n";
+    if (before !== after) {
+      await writeFile(filePath, after, "utf-8");
+      updated++;
+    }
+  }
+
+  console.log(`Refreshed repo-derived bundles: ${bundleCount} bundles across ${updated} index files`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -4,6 +4,8 @@ import { homedir } from "os";
 import { fileURLToPath } from "url";
 import { debug } from "./logger";
 import { readLock } from "./utils/lock";
+import { loadAllIndices } from "./skill-index";
+import { repoBundlesForIndex } from "./repo-bundles";
 import type {
   BundleManifest,
   BundleSkillRef,
@@ -242,6 +244,8 @@ export async function loadBundle(nameOrPath: string): Promise<BundleManifest> {
         return await readBundleFile(predefinedPath);
       } catch (predefinedErr: any) {
         if (predefinedErr?.message?.includes("Bundle file not found")) {
+          const repoBundle = await findRepoIndexBundle(nameOrPath);
+          if (repoBundle) return repoBundle;
           throw new Error(`Bundle file not found: ${filePath}`);
         }
         throw predefinedErr;
@@ -259,30 +263,56 @@ export async function listPredefinedBundles(): Promise<BundleManifest[]> {
 
   try {
     await access(PREDEFINED_BUNDLE_DIR);
-  } catch {
-    return bundles;
-  }
 
-  let entries: string[];
-  try {
-    entries = await readdir(PREDEFINED_BUNDLE_DIR);
-  } catch {
-    return bundles;
-  }
-
-  for (const entry of entries) {
-    if (!entry.endsWith(".json")) continue;
-    const filePath = join(PREDEFINED_BUNDLE_DIR, entry);
+    let entries: string[];
     try {
-      const bundle = await readBundleFile(filePath);
-      bundles.push(bundle);
+      entries = await readdir(PREDEFINED_BUNDLE_DIR);
     } catch {
-      debug(`bundle: skipping invalid predefined file ${filePath}`);
+      entries = [];
     }
+
+    for (const entry of entries) {
+      if (!entry.endsWith(".json")) continue;
+      const filePath = join(PREDEFINED_BUNDLE_DIR, entry);
+      try {
+        const bundle = await readBundleFile(filePath);
+        bundles.push(bundle);
+      } catch {
+        debug(`bundle: skipping invalid predefined file ${filePath}`);
+      }
+    }
+  } catch {
+    // No predefined bundle directory; repo-derived bundles below may still exist.
   }
 
-  bundles.sort((a, b) => a.name.localeCompare(b.name));
-  return bundles;
+  bundles.push(...(await listRepoIndexBundles()));
+
+  const byName = new Map<string, BundleManifest>();
+  for (const bundle of bundles) {
+    if (!byName.has(bundle.name)) byName.set(bundle.name, bundle);
+  }
+
+  return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function listRepoIndexBundles(): Promise<BundleManifest[]> {
+  try {
+    const indices = await loadAllIndices();
+    return indices.flatMap((index) => repoBundlesForIndex(index));
+  } catch (err) {
+    debug(`bundle: failed to load repo-derived bundles: ${err}`);
+    return [];
+  }
+}
+
+async function findRepoIndexBundle(name: string): Promise<BundleManifest | null> {
+  const sanitized = sanitizeBundleName(name);
+  const bundles = await listRepoIndexBundles();
+  return (
+    bundles.find((bundle) => bundle.name === name) ||
+    bundles.find((bundle) => sanitizeBundleName(bundle.name) === sanitized) ||
+    null
+  );
 }
 
 /**

--- a/src/ingester.ts
+++ b/src/ingester.ts
@@ -12,6 +12,7 @@ import { loadAllIndices } from "./skill-index";
 import { debug } from "./logger";
 import { dedupeSkillsByName } from "./skill-dedupe";
 import { verifySkill } from "./verifier";
+import { discoverExplicitRepoBundles, inferRepoBundles, mergeRepoBundles } from "./repo-bundles";
 import { estimateTokenCount } from "./utils/token-count";
 import { evaluateSkillContent } from "./evaluator";
 import { getEvalProviders } from "./eval/builtins";
@@ -205,6 +206,11 @@ export async function ingestRepo(sourceInput: string): Promise<IngestResult> {
       skillCount: skills.length,
       skills,
     };
+
+    repoIndex.bundles = mergeRepoBundles([
+      ...(await discoverExplicitRepoBundles(tempDir, repoIndex)),
+      ...inferRepoBundles(repoIndex),
+    ]);
 
     const indexDir = await ensureIndexDir();
     const outputFile = join(indexDir, `${source.owner}_${source.repo}.json`);

--- a/src/repo-bundles.test.ts
+++ b/src/repo-bundles.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { inferRepoBundles, mergeRepoBundles, repoBundlesForIndex } from "./repo-bundles";
+import type { IndexedSkill, RepoIndex } from "./utils/types";
+
+function skill(overrides: Partial<IndexedSkill>): IndexedSkill {
+  return {
+    name: "skill",
+    description: "",
+    version: "1.0.0",
+    license: "MIT",
+    creator: "tester",
+    compatibility: "",
+    allowedTools: [],
+    installUrl: "github:owner/repo:skills/skill",
+    relPath: "skills/skill",
+    ...overrides,
+  };
+}
+
+function repo(skills: IndexedSkill[]): RepoIndex {
+  return {
+    repoUrl: "https://github.com/owner/repo.git",
+    owner: "owner",
+    repo: "repo",
+    updatedAt: "2026-05-10T00:00:00.000Z",
+    skillCount: skills.length,
+    skills,
+  };
+}
+
+describe("repo-derived bundle inference", () => {
+  it("creates category bundles from indexed skills with provenance", () => {
+    const index = repo([
+      skill({
+        name: "seo-auditor",
+        description: "SEO marketing and growth audit",
+        installUrl: "github:owner/repo:skills/seo-auditor",
+        relPath: "skills/seo-auditor",
+      }),
+      skill({
+        name: "aso-marketing",
+        description: "ASO marketing workflow",
+        installUrl: "github:owner/repo:skills/aso-marketing",
+        relPath: "skills/aso-marketing",
+      }),
+      skill({
+        name: "unit-test-writer",
+        description: "Write tests for code",
+        installUrl: "github:owner/repo:skills/unit-test-writer",
+        relPath: "skills/unit-test-writer",
+      }),
+    ]);
+
+    const bundles = inferRepoBundles(index);
+    const marketing = bundles.find((bundle) => bundle.name === "owner-repo-marketing");
+
+    expect(marketing).toBeDefined();
+    expect(marketing!.inferred).toBe(true);
+    expect(marketing!.sourceRepo).toMatchObject({ owner: "owner", repo: "repo" });
+    expect(marketing!.skills.map((s) => s.name)).toEqual([
+      "aso-marketing",
+      "seo-auditor",
+    ]);
+    expect(marketing!.skills[0].installUrl).toContain("github:owner/repo:");
+  });
+
+  it("does not infer bundles from singleton categories", () => {
+    const bundles = inferRepoBundles(
+      repo([
+        skill({
+          name: "seo-auditor",
+          description: "SEO marketing audit",
+        }),
+      ]),
+    );
+
+    expect(bundles).toEqual([]);
+  });
+
+  it("keeps explicit bundles over inferred bundles with the same name", () => {
+    const index = repo([
+      skill({ name: "seo-auditor", description: "SEO marketing audit" }),
+      skill({ name: "aso-marketing", description: "ASO marketing workflow" }),
+    ]);
+    index.bundles = [
+      {
+        version: 1,
+        name: "owner-repo-marketing",
+        description: "Maintainer curated marketing bundle",
+        author: "owner",
+        createdAt: index.updatedAt,
+        tags: ["explicit"],
+        skills: [index.skills[0]],
+        sourceRepo: {
+          owner: index.owner,
+          repo: index.repo,
+          repoUrl: index.repoUrl,
+          relPath: ".asm/bundles.json",
+        },
+        explicit: true,
+      },
+    ];
+
+    const bundles = repoBundlesForIndex(index);
+    const marketing = bundles.find((bundle) => bundle.name === "owner-repo-marketing");
+
+    expect(marketing!.explicit).toBe(true);
+    expect(marketing!.description).toBe("Maintainer curated marketing bundle");
+  });
+
+  it("dedupes bundles by name", () => {
+    const merged = mergeRepoBundles([
+      {
+        version: 1,
+        name: "owner-repo-marketing",
+        description: "inferred",
+        author: "ASM",
+        createdAt: "2026-05-10T00:00:00.000Z",
+        tags: ["repo-derived"],
+        skills: [skill({ name: "seo" })],
+        sourceRepo: { owner: "owner", repo: "repo", repoUrl: "https://github.com/owner/repo.git" },
+        inferred: true,
+      },
+      {
+        version: 1,
+        name: "owner-repo-marketing",
+        description: "explicit",
+        author: "owner",
+        createdAt: "2026-05-10T00:00:00.000Z",
+        tags: ["repo-derived"],
+        skills: [skill({ name: "aso" })],
+        sourceRepo: { owner: "owner", repo: "repo", repoUrl: "https://github.com/owner/repo.git" },
+        explicit: true,
+      },
+    ]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].description).toBe("explicit");
+  });
+});

--- a/src/repo-bundles.test.ts
+++ b/src/repo-bundles.test.ts
@@ -1,5 +1,13 @@
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
 import { describe, expect, it } from "vitest";
-import { inferRepoBundles, mergeRepoBundles, repoBundlesForIndex } from "./repo-bundles";
+import {
+  discoverExplicitRepoBundles,
+  inferRepoBundles,
+  mergeRepoBundles,
+  repoBundlesForIndex,
+} from "./repo-bundles";
 import type { IndexedSkill, RepoIndex } from "./utils/types";
 
 function skill(overrides: Partial<IndexedSkill>): IndexedSkill {
@@ -106,6 +114,77 @@ describe("repo-derived bundle inference", () => {
 
     expect(marketing!.explicit).toBe(true);
     expect(marketing!.description).toBe("Maintainer curated marketing bundle");
+  });
+
+  it("normalizes explicit bundle skill install URLs to indexed repo skills", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "repo-bundles-test-"));
+    try {
+      const index = repo([
+        skill({
+          name: "seo-auditor",
+          description: "SEO marketing audit",
+          installUrl: "github:owner/repo:skills/seo-auditor",
+          relPath: "skills/seo-auditor",
+        }),
+      ]);
+      await writeFile(
+        join(tmpDir, "asm-bundles.json"),
+        JSON.stringify({
+          name: "marketing",
+          skills: [
+            {
+              name: "seo-auditor",
+              installUrl: "github:attacker/malicious:skills/seo-auditor",
+              description: "Curated SEO workflow",
+            },
+          ],
+        }),
+      );
+
+      const bundles = await discoverExplicitRepoBundles(tmpDir, index);
+
+      expect(bundles).toHaveLength(1);
+      expect(bundles[0].skills[0]).toMatchObject({
+        name: "seo-auditor",
+        installUrl: "github:owner/repo:skills/seo-auditor",
+        description: "Curated SEO workflow",
+      });
+      expect(bundles[0].sourceRepo).toMatchObject({
+        owner: "owner",
+        repo: "repo",
+        relPath: "asm-bundles.json",
+      });
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("drops explicit bundle entries that do not reference indexed skills", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "repo-bundles-test-"));
+    try {
+      const index = repo([
+        skill({
+          name: "seo-auditor",
+          description: "SEO marketing audit",
+          installUrl: "github:owner/repo:skills/seo-auditor",
+        }),
+      ]);
+      await writeFile(
+        join(tmpDir, "asm-bundles.json"),
+        JSON.stringify({
+          name: "marketing",
+          skills: [
+            { name: "not-in-this-repo", installUrl: "github:attacker/malicious" },
+          ],
+        }),
+      );
+
+      const bundles = await discoverExplicitRepoBundles(tmpDir, index);
+
+      expect(bundles).toEqual([]);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("dedupes bundles by name", () => {

--- a/src/repo-bundles.ts
+++ b/src/repo-bundles.ts
@@ -202,21 +202,18 @@ function normalizeExplicitBundle(
         const name = typeof skill.name === "string" ? skill.name : "";
         if (!name) return null;
         const match = byName.get(name);
-        const installUrl = typeof skill.installUrl === "string" && skill.installUrl
-          ? skill.installUrl
-          : match?.installUrl;
-        if (!installUrl) return null;
+        if (!match) return null;
         return {
-          name,
-          installUrl,
+          name: match.name,
+          installUrl: match.installUrl,
           description:
             typeof skill.description === "string" && skill.description
               ? skill.description
-              : match?.description || undefined,
+              : match.description || undefined,
           version:
             typeof skill.version === "string" && skill.version
               ? skill.version
-              : match?.version || undefined,
+              : match.version || undefined,
         };
       })
       .filter((skill): skill is BundleSkillRef => skill !== null),

--- a/src/repo-bundles.ts
+++ b/src/repo-bundles.ts
@@ -1,0 +1,344 @@
+import { readdir, readFile, stat } from "fs/promises";
+import { join } from "path";
+import type { BundleManifest, BundleSkillRef, IndexedSkill, RepoIndex } from "./utils/types";
+
+export interface RepoBundleSource {
+  owner: string;
+  repo: string;
+  repoUrl: string;
+  relPath?: string;
+}
+
+export type RepoBundleManifest = BundleManifest & {
+  sourceRepo: RepoBundleSource;
+  inferred?: boolean;
+  explicit?: boolean;
+};
+
+interface BundleGroup {
+  id: string;
+  title: string;
+  description: string;
+  tags: string[];
+  keywords: string[];
+}
+
+const GROUPS: BundleGroup[] = [
+  {
+    id: "marketing",
+    title: "Marketing Skills",
+    description: "Marketing, growth, SEO, ASO, affiliate, sales, and conversion skills.",
+    tags: ["marketing", "growth", "seo"],
+    keywords: ["marketing", "growth", "seo", "aso", "affiliate", "sales", "copy", "copywriting", "conversion", "cro", "brand", "social", "campaign"],
+  },
+  {
+    id: "writing",
+    title: "Writing Skills",
+    description: "Writing, editing, documentation, publishing, and content-production skills.",
+    tags: ["writing", "content", "docs"],
+    keywords: ["write", "writing", "writer", "blog", "article", "content", "docs", "documentation", "draft", "copy", "readme", "paper", "thesis", "proposal"],
+  },
+  {
+    id: "research",
+    title: "Research Skills",
+    description: "Research, academic, literature-review, citation, paper, and analysis skills.",
+    tags: ["research", "academic", "analysis"],
+    keywords: ["research", "academic", "scholar", "paper", "literature", "citation", "review", "analysis", "summar", "evaluate", "verify"],
+  },
+  {
+    id: "engineering",
+    title: "Engineering Skills",
+    description: "Coding, debugging, testing, architecture, review, and software engineering skills.",
+    tags: ["engineering", "coding", "testing"],
+    keywords: ["code", "coding", "debug", "test", "testing", "coverage", "review", "refactor", "architecture", "typescript", "python", "javascript", "build", "cli", "api"],
+  },
+  {
+    id: "frontend-design",
+    title: "Frontend & Design Skills",
+    description: "Frontend, UI, UX, visual design, component, theme, and landing-page skills.",
+    tags: ["frontend", "design", "ui"],
+    keywords: ["frontend", "ui", "ux", "design", "component", "react", "css", "html", "figma", "theme", "landing", "layout", "visual", "brand", "logo"],
+  },
+  {
+    id: "devops",
+    title: "DevOps Skills",
+    description: "Deployment, CI/CD, infrastructure, cloud, Docker, Kubernetes, and automation skills.",
+    tags: ["devops", "infra", "automation"],
+    keywords: ["devops", "deploy", "deployment", "ci", "cd", "pipeline", "docker", "kubernetes", "terraform", "ansible", "cloud", "infra", "infrastructure", "workflow", "release"],
+  },
+  {
+    id: "data-ai",
+    title: "Data & AI Skills",
+    description: "Data, analytics, AI, model, prompt, agent, and automation skills.",
+    tags: ["data", "ai", "agents"],
+    keywords: ["data", "analytics", "analysis", "ai", "agent", "llm", "model", "prompt", "openai", "claude", "gemini", "automation", "dataset", "sql"],
+  },
+  {
+    id: "product-business",
+    title: "Product & Business Skills",
+    description: "Product, strategy, PRD, planning, finance, resume, and business workflow skills.",
+    tags: ["product", "business", "planning"],
+    keywords: ["product", "prd", "strategy", "planning", "business", "finance", "resume", "career", "startup", "market", "competitor", "customer", "sales"],
+  },
+];
+
+const MIN_SKILLS_PER_INFERRED_BUNDLE = 2;
+const MAX_SKILLS_PER_INFERRED_BUNDLE = 80;
+const EXPLICIT_BUNDLE_FILES = [
+  "asm-bundles.json",
+  "asm.bundle.json",
+  ".asm/bundles.json",
+  ".asm/bundle.json",
+];
+const EXPLICIT_BUNDLE_DIRS = ["bundles", "data/bundles", ".asm/bundles"];
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function repoScopedName(owner: string, repo: string, name: string): string {
+  const ownerSlug = slugify(owner);
+  const repoSlug = slugify(repo);
+  const nameSlug = slugify(name);
+  const prefix = `${ownerSlug}-${repoSlug}`;
+  return nameSlug.startsWith(prefix) ? nameSlug : `${prefix}-${nameSlug}`;
+}
+
+function skillText(skill: IndexedSkill): string {
+  return [skill.name, skill.description, skill.relPath, skill.installUrl]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function matchesGroup(skill: IndexedSkill, group: BundleGroup): boolean {
+  const text = skillText(skill);
+  return group.keywords.some((keyword) => text.includes(keyword));
+}
+
+function toBundleSkillRef(skill: IndexedSkill): BundleSkillRef {
+  return {
+    name: skill.name,
+    installUrl: skill.installUrl,
+    description: skill.description || undefined,
+    version: skill.version || undefined,
+  };
+}
+
+function dedupeSkillRefs(skills: BundleSkillRef[]): BundleSkillRef[] {
+  const seen = new Set<string>();
+  const deduped: BundleSkillRef[] = [];
+  for (const skill of skills) {
+    const key = `${skill.installUrl || ""}\u0000${skill.name}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(skill);
+  }
+  return deduped;
+}
+
+function sortSkills(skills: BundleSkillRef[]): BundleSkillRef[] {
+  return [...skills].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function inferRepoBundles(repoIndex: RepoIndex): RepoBundleManifest[] {
+  const bundles: RepoBundleManifest[] = [];
+  if (!repoIndex.skills || repoIndex.skills.length < MIN_SKILLS_PER_INFERRED_BUNDLE) {
+    return bundles;
+  }
+
+  for (const group of GROUPS) {
+    const matchingSkills = repoIndex.skills
+      .filter((skill) => matchesGroup(skill, group))
+      .slice(0, MAX_SKILLS_PER_INFERRED_BUNDLE);
+
+    if (matchingSkills.length < MIN_SKILLS_PER_INFERRED_BUNDLE) continue;
+
+    const name = repoScopedName(repoIndex.owner, repoIndex.repo, group.id);
+    bundles.push({
+      version: 1,
+      name,
+      description: `${group.description} Derived from ${repoIndex.owner}/${repoIndex.repo}.`,
+      author: `ASM (${repoIndex.owner}/${repoIndex.repo})`,
+      createdAt: repoIndex.updatedAt,
+      tags: ["repo-derived", "inferred", ...group.tags, slugify(repoIndex.owner), slugify(repoIndex.repo)],
+      skills: sortSkills(matchingSkills.map(toBundleSkillRef)),
+      sourceRepo: {
+        owner: repoIndex.owner,
+        repo: repoIndex.repo,
+        repoUrl: repoIndex.repoUrl,
+      },
+      inferred: true,
+    });
+  }
+
+  return bundles;
+}
+
+function normalizeExplicitBundle(
+  raw: unknown,
+  repoIndex: Pick<RepoIndex, "owner" | "repo" | "repoUrl" | "updatedAt" | "skills">,
+  relPath: string,
+): RepoBundleManifest | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const obj = raw as Record<string, any>;
+  const rawSkills = Array.isArray(obj.skills) ? obj.skills : [];
+  if (rawSkills.length === 0) return null;
+
+  const byName = new Map(repoIndex.skills.map((skill) => [skill.name, skill]));
+  const skillRefs = dedupeSkillRefs(
+    rawSkills
+      .map((entry: unknown): BundleSkillRef | null => {
+        if (typeof entry === "string") {
+          const match = byName.get(entry);
+          return match ? toBundleSkillRef(match) : null;
+        }
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+        const skill = entry as Record<string, any>;
+        const name = typeof skill.name === "string" ? skill.name : "";
+        if (!name) return null;
+        const match = byName.get(name);
+        const installUrl = typeof skill.installUrl === "string" && skill.installUrl
+          ? skill.installUrl
+          : match?.installUrl;
+        if (!installUrl) return null;
+        return {
+          name,
+          installUrl,
+          description:
+            typeof skill.description === "string" && skill.description
+              ? skill.description
+              : match?.description || undefined,
+          version:
+            typeof skill.version === "string" && skill.version
+              ? skill.version
+              : match?.version || undefined,
+        };
+      })
+      .filter((skill): skill is BundleSkillRef => skill !== null),
+  );
+
+  if (skillRefs.length === 0) return null;
+
+  const baseName = typeof obj.name === "string" && obj.name ? obj.name : relPath.replace(/\.json$/, "");
+  return {
+    version: 1,
+    name: repoScopedName(repoIndex.owner, repoIndex.repo, baseName),
+    description:
+      typeof obj.description === "string" && obj.description
+        ? obj.description
+        : `Bundle from ${repoIndex.owner}/${repoIndex.repo}.`,
+    author:
+      typeof obj.author === "string" && obj.author
+        ? obj.author
+        : `ASM (${repoIndex.owner}/${repoIndex.repo})`,
+    createdAt:
+      typeof obj.createdAt === "string" && obj.createdAt
+        ? obj.createdAt
+        : repoIndex.updatedAt,
+    tags: Array.isArray(obj.tags)
+      ? ["repo-derived", "explicit", ...obj.tags.filter((tag: unknown) => typeof tag === "string")]
+      : ["repo-derived", "explicit"],
+    skills: sortSkills(skillRefs),
+    sourceRepo: {
+      owner: repoIndex.owner,
+      repo: repoIndex.repo,
+      repoUrl: repoIndex.repoUrl,
+      relPath,
+    },
+    explicit: true,
+  };
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    const s = await stat(path);
+    return s.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function dirExists(path: string): Promise<boolean> {
+  try {
+    const s = await stat(path);
+    return s.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function readBundleCandidates(repoRoot: string): Promise<Array<{ relPath: string; data: unknown }>> {
+  const candidates: Array<{ relPath: string; data: unknown }> = [];
+
+  for (const relPath of EXPLICIT_BUNDLE_FILES) {
+    const absPath = join(repoRoot, relPath);
+    if (!(await fileExists(absPath))) continue;
+    try {
+      candidates.push({ relPath, data: JSON.parse(await readFile(absPath, "utf-8")) });
+    } catch {
+      // Ignore malformed explicit bundle metadata. Indexing must remain best-effort.
+    }
+  }
+
+  for (const relDir of EXPLICIT_BUNDLE_DIRS) {
+    const absDir = join(repoRoot, relDir);
+    if (!(await dirExists(absDir))) continue;
+    let entries: string[] = [];
+    try {
+      entries = await readdir(absDir);
+    } catch {
+      continue;
+    }
+    for (const entry of entries.filter((name) => name.endsWith(".json")).sort()) {
+      const relPath = `${relDir}/${entry}`;
+      try {
+        candidates.push({ relPath, data: JSON.parse(await readFile(join(absDir, entry), "utf-8")) });
+      } catch {
+        // Ignore malformed explicit bundle metadata. Indexing must remain best-effort.
+      }
+    }
+  }
+
+  return candidates;
+}
+
+export async function discoverExplicitRepoBundles(
+  repoRoot: string,
+  repoIndex: Pick<RepoIndex, "owner" | "repo" | "repoUrl" | "updatedAt" | "skills">,
+): Promise<RepoBundleManifest[]> {
+  const bundles: RepoBundleManifest[] = [];
+  const candidates = await readBundleCandidates(repoRoot);
+
+  for (const candidate of candidates) {
+    const data = candidate.data as any;
+    const bundleInputs = Array.isArray(data?.bundles) ? data.bundles : [data];
+    for (const input of bundleInputs) {
+      const bundle = normalizeExplicitBundle(input, repoIndex, candidate.relPath);
+      if (bundle) bundles.push(bundle);
+    }
+  }
+
+  return mergeRepoBundles(bundles);
+}
+
+export function mergeRepoBundles(bundles: RepoBundleManifest[]): RepoBundleManifest[] {
+  const byName = new Map<string, RepoBundleManifest>();
+  for (const bundle of bundles) {
+    const existing = byName.get(bundle.name);
+    if (!existing || (bundle.explicit && !existing.explicit)) {
+      byName.set(bundle.name, bundle);
+    }
+  }
+  return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function repoBundlesForIndex(repoIndex: RepoIndex): RepoBundleManifest[] {
+  const explicit = (repoIndex.bundles || []) as RepoBundleManifest[];
+  const inferred = inferRepoBundles(repoIndex);
+  return mergeRepoBundles([...explicit, ...inferred]);
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -336,6 +336,19 @@ export interface IndexedSkill {
   evalSummaries?: Record<string, SkillEvalSummary>;
 }
 
+export interface RepoBundleSource {
+  owner: string;
+  repo: string;
+  repoUrl: string;
+  relPath?: string;
+}
+
+export interface RepoIndexBundle extends BundleManifest {
+  sourceRepo: RepoBundleSource;
+  inferred?: boolean;
+  explicit?: boolean;
+}
+
 export interface RepoIndex {
   repoUrl: string;
   owner: string;
@@ -343,6 +356,8 @@ export interface RepoIndex {
   updatedAt: string;
   skillCount: number;
   skills: IndexedSkill[];
+  /** Repo-derived bundles created from explicit bundle metadata or inference. */
+  bundles?: RepoIndexBundle[];
 }
 
 // ─── Security Audit Types ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add repo-derived bundle inference and explicit bundle metadata support during repo indexing
- expose indexed bundles through bundle load/list and website bundle catalog
- refresh existing checked-in skill indexes with 196 inferred bundles across 28 repos
- preserve repo-derived bundle provenance by normalizing explicit bundle skill install URLs to indexed repo skills

## Validation
- npx vitest run src/repo-bundles.test.ts src/bundler.test.ts src/ingester.test.ts --pool=forks --poolOptions.forks.singleFork=true
- npm run typecheck -- --pretty false
- npm run refresh:repo-bundles
- npm run build:website
- npm run build
- verified website/bundles.json has 200 bundles
- verified dist CLI lists 200 pre-defined bundles

## Decision Record

**Root cause:** ASM indexed repository skills but did not create or expose repo-level bundle records, so users had to discover and install related skills individually. During review, explicit bundle metadata also allowed caller-provided skill install URLs to override indexed skill provenance.

**Options considered:**
- Keep only individual skill indexing and document manual bundle creation.
- Infer bundles only from existing indexed skill metadata.
- Support explicit bundle metadata plus best-effort inference during repo indexing.

**Options rejected:**
- Manual-only bundles were rejected because they do not satisfy repo-derived bundle discovery/install workflows.
- Inference-only bundles were rejected because maintainers need a way to curate precise bundle contents when repo structure alone is insufficient.

**Selected option:** Support explicit repo bundle metadata, infer suggested bundles from indexed skills, merge/dedupe explicit and inferred records, expose repo-derived bundles in CLI/website bundle listing, and normalize explicit bundle skills back to indexed repo skills so source provenance remains authoritative.

**Residual risk:** Inferred categories are heuristic and may over/under-group some repositories; explicit metadata can refine this. Malformed explicit bundle metadata is ignored to keep indexing best-effort.

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|---|---|---|
| Repo indexing can emit zero, one, or multiple bundle records for a repository. | pass | `src/ingester.ts` assigns merged explicit + inferred bundles; `src/repo-bundles.ts` returns empty arrays for no matches and multiple group matches. |
| Bundle records preserve provenance back to the source repo and included skill paths. | pass | `src/repo-bundles.ts` writes `sourceRepo`; explicit object skill refs are normalized to indexed skills; regression tests cover mismatched external install URLs. |
| ASM supports explicit bundle metadata when present in the repo, rather than relying only on inference. | pass | `discoverExplicitRepoBundles()` scans `asm-bundles.json`, `asm.bundle.json`, `.asm/*`, and bundle directories. |
| ASM can optionally infer suggested bundles from repo structure, tags, skill metadata, or naming conventions. | pass | `inferRepoBundles()` groups indexed skills by keyword/category heuristics. |
| Search/list output makes repo-derived bundles discoverable separately from individual skills. | pass | `listPredefinedBundles()` and website catalog generation include repo-derived bundles separately from skill search results. |
| Installing a repo-derived bundle installs all included skills using the existing bundle install path. | pass | `loadBundle()` can resolve repo index bundles; `asm bundle install` reuses the existing bundle skill install loop. |
| Existing repo indexing behavior for individual skills remains backward compatible. | pass | Existing `skills` records are preserved; focused ingester/bundler/repo-bundles tests pass. |

Closes #275
