### PR TITLE
chore(security): supply-chain hardening across npm + GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 # Pre-commit runs format, lint, typecheck, unit tests, build, and e2e
 # locally before every push. CI is a thin safety net for things that need
 # a clean VM or a version matrix.
@@ -13,14 +16,15 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         node-version: [18, 20, 22]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -28,16 +32,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit dependencies
+        run: npm audit --audit-level=high --omit=dev
+
       - name: Run unit tests
         run: npx vitest run src/
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -60,13 +68,13 @@ jobs:
         run: npm pack
 
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist
           path: dist/
 
       - name: Upload npm tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: npm-tarball
           path: "*.tgz"
@@ -74,14 +82,15 @@ jobs:
   e2e-node:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         node-version: [18, 20, 22]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -90,7 +99,7 @@ jobs:
         run: npm ci
 
       - name: Download dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist/
@@ -107,14 +116,15 @@ jobs:
   e2e-npm-install:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         node-version: [18, 20, 22]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -123,7 +133,7 @@ jobs:
         run: npm ci
 
       - name: Download npm tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: npm-tarball
           path: ./

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -28,8 +28,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -38,11 +36,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -55,7 +56,7 @@ jobs:
 
       - name: Upload website artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: website/
 
@@ -63,14 +64,19 @@ jobs:
     needs: build
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
 
     steps:
       - name: Setup GitHub Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4.0.0
 
       - id: deploy
         name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,10 +16,11 @@ permissions:
 jobs:
   local-security:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.x"
 
@@ -46,7 +47,7 @@ jobs:
         run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
 
       - name: Cache trivy vulnerability DB
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/trivy
           key: trivy-db-${{ runner.os }}-${{ steps.trivy-cache-key.outputs.week }}
@@ -67,7 +68,7 @@ jobs:
 
       - name: Upload security reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: security-reports
           path: |

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,9 @@ website/assets/index-*.js
 website/assets/index-*.css
 
 
-# dev tools
+# dev tools — per-developer AI agent sidecars, intentionally not tracked.
+# Each may contain its own package-lock.json / config; reproducibility is
+# the contributor's responsibility, not the repo's.
 .claude
 .claude/
 .codex

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,17 @@
+# Supply chain controls. See: scripts/security_check.py + supply-chain-audit
+# notes in repo. Applies to this repo's installs only — does NOT affect
+# downstream consumers of the published `agent-skill-manager` tarball
+# (their own .npmrc/lifecycle settings govern that install).
+
+# Block installs of versions published in the last 7 days. Most malicious
+# npm versions are detected and yanked within 24–72h.
+min-release-age=7d
+
+# Disable lifecycle scripts (preinstall/install/postinstall) of dependencies
+# at install time. This repo's own `postinstall` in package.json is NOT
+# triggered during `npm ci` of a checked-out repo, so this is safe for
+# dev + CI.  Downstream `npm i -g agent-skill-manager` is unaffected.
+ignore-scripts=true
+
+# Fail CI installs on disclosed high-severity advisories.
+audit-level=high

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "yaml": "^2.8.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=18 <23",
+    "npm": ">=9"
   },
   "keywords": [
     "agent-skill-manager",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    "security:openssf-scorecard"
+  ],
+  "minimumReleaseAge": "7 days",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days",
+    "labels": ["security"]
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Layered supply-chain defenses against the 2024–2025 wave of registry / Actions attacks (Axios, TanStack, ultralytics, tj-actions/changed-files). Produced by `/supply-chain-audit` after a four-phase detect → audit → plan → apply cycle.

**npm**
- New `.npmrc`: `min-release-age=7d`, `ignore-scripts=true`, `audit-level=high`. Repo-only — does **not** affect downstream `npm i -g agent-skill-manager`; `scripts/postinstall.cjs` still runs for global installs of the published tarball (gated on `npm_config_global`).
- `ci.yml`: new `npm audit --audit-level=high --omit=dev` step in `unit-tests`.
- `package.json`: tighten `engines` to `node >=18 <23`, `npm >=9`.
- `.gitignore`: documenting comment explaining the per-developer `.opencode/` policy.

**GitHub Actions**
- Pinned every `uses:` line across `ci.yml`, `deploy-website.yml`, `security.yml` to a 40-char SHA + trailing version comment (9 distinct Actions). SHAs resolved live from the GitHub API at apply time.
- `ci.yml`: top-level `permissions: contents: read` (was inherited / write-capable).
- `deploy-website.yml`: scope `pages: write` + `id-token: write` to the `deploy` job only; `build` is now `contents: read`.
- Every job has `timeout-minutes` (10–20) — bounds the exfil window vs the 6-hour default.

**Renovate**
- New `renovate.json`: `pinDigests: true` for github-actions, `minimumReleaseAge: 7 days` for npm (acts as the real cooldown gate today — `.npmrc min-release-age` requires npm 11.10+, CI matrix runs 18/20/22 with older npm).
- Security advisories bypass cooldown (`vulnerabilityAlerts.minimumReleaseAge: 0 days`).

## Caveats called out during apply

- **`.opencode/package-lock.json` not committed.** The audit plan defaulted to commit, but `.gitignore` already excludes `.opencode/` alongside `.claude/`, `.codex/`, `.gemini/` — clearly intentional per-developer AI-tool sidecars. Switched to documenting the policy in `.gitignore` instead of force-adding.
- **`min-release-age` warns "Unknown project config" on npm < 11.10.** Forward-compatible; Renovate enforces today.
- **`engines.node: >=18 <23`** warns on Node 25 local dev (warn, not block). Widen if you regularly dev on Node 25.

## Audit findings closed

| ID     | Severity  | Closed by |
|--------|-----------|-----------|
| npm-1  | Critical  | `.npmrc` `min-release-age=7d` + Renovate `minimumReleaseAge` |
| npm-2  | High      | `.npmrc` `ignore-scripts=true` |
| npm-3  | Medium    | `npm audit` step in `ci.yml` |
| npm-4  | Low       | `engines` tightened in `package.json` |
| npm-5  | Low       | `.gitignore` comment documenting `.opencode/` policy |
| gha-1  | Critical  | SHA-pinned all 9 Actions + `renovate.json` |
| gha-2  | High      | `permissions: contents: read` top of `ci.yml` |
| gha-3  | Medium    | `timeout-minutes` on every job |
| gha-4  | Low       | `pages:`/`id-token:` scoped to `deploy` job |

## Test plan

- [x] Pre-commit hooks passed locally (lint, prettier, typecheck, unit tests, security check, build, e2e)
- [x] Pre-push hooks passed (build + e2e)
- [x] YAML parses for all three workflows
- [x] JSON parses for `renovate.json` and `package.json`
- [x] `npm ci --dry-run` succeeds with new `.npmrc`
- [ ] CI green on this PR across the Node 18/20/22 matrix
- [ ] `Deploy Skill Catalog` workflow still produces a Pages artifact (only runs on `main` push, will verify after merge)

## Not in this PR

- Installing Renovate App on the repo — `renovate.json` is inert without it. Dependabot users can substitute `.github/dependabot.yml`.
- Moving npm publish to OIDC / Trusted Publishing — out of scope; no publish step exists in CI today.