### PR TITLE
docs(readme): document asm bundle command (#202)

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,13 @@ asm
 | `asm index search <query>`      | Search indexed skills                                 |
 | `asm index list`                | List indexed repositories                             |
 | `asm index remove <owner/repo>` | Remove a repo from the index                          |
+| `asm bundle list`               | List saved or pre-defined bundles (`--predefined`)    |
+| `asm bundle install <name>`     | Install every skill in a bundle in one pass           |
+| `asm bundle create <name>`      | Create a bundle from installed skills                 |
+| `asm bundle show <name>`        | Show bundle details and skill list                    |
+| `asm bundle modify <name>`      | Add/remove skills or update bundle metadata           |
+| `asm bundle export <name>`      | Export a bundle to a JSON file                        |
+| `asm bundle remove <name>`      | Remove a saved bundle                                 |
 | `asm config show`               | Print current config                                  |
 | `asm config path`               | Print config file path                                |
 | `asm config reset`              | Reset config to defaults                              |
@@ -698,6 +705,33 @@ asm index ingest github:anthropics/skills
 ```bash
 asm index search "frontend design" --json
 ```
+
+**Skill bundles** — install a curated set of skills in one command. Pre-defined bundles ship with ASM for common workflows (frontend, devops, iOS release, content writing). Browse them at [luongnv.com/asm/bundles](https://luongnv.com/asm/bundles/) or list them locally:
+
+```bash
+asm bundle list --predefined
+```
+
+Install every skill in a pre-defined bundle:
+
+```bash
+asm bundle install frontend-dev
+```
+
+Install from a bundle file (custom or shared):
+
+```bash
+asm bundle install ./my-bundle.json
+```
+
+Build a custom bundle from your installed skills, then export it to share:
+
+```bash
+asm bundle create my-workflow
+asm bundle export my-workflow ./my-workflow.json
+```
+
+A bundle is a JSON file with a `name`, `description`, `author`, and a list of `skills` (each with `name` + `installUrl`). The schema is validated on install — see `src/utils/types.ts` (`BundleManifest`). You can also assemble a custom bundle visually on the website's [/bundles](https://luongnv.com/asm/bundles/) page and export it as JSON.
 
 </details>
 


### PR DESCRIPTION
## Summary

- Documents the existing `asm bundle` command in `README.md` — the seven subcommands (`list`, `install`, `create`, `show`, `modify`, `export`, `remove`) and the `/bundles` website page.
- Closes the discovery gap that left issue #202 open even though the feature itself shipped across PRs #130, #208, #211, #215, #231, #240, and #276.

## Approach

`README.md` previously mentioned "bundle" only in the dist-bundling sense. After confirming via `node dist/agent-skill-manager.js bundle list --predefined --json` that the CLI is fully wired and 4 curated bundles ship in `data/bundles/`, this PR adds:

- 7 rows to the Commands table for the bundle subcommands.
- A "Skill bundles" example block in the Examples section showing pre-defined install, custom-bundle create/export, file install, and links to [`/bundles`](https://luongnv.com/asm/bundles/).
- A pointer to the `BundleManifest` type in `src/utils/types.ts` for the JSON schema.

## Decision Record

**Why a docs-only PR closes issue #202:** Research showed all 7 acceptance criteria are already satisfied in `main` — the CLI subcommand exists (`src/cli.ts:4210`), `bundle install` is one-pass with per-skill progress (`cli.ts:4332-4511`), custom bundles can be built from CLI (`create` + `export`) or the website (`BundleBuilderDialog.jsx`), the JSON schema is enforced via `validateBundle()` (`src/bundler.ts:32-96`), 4 bundles ship in `data/bundles/`, the `/bundles` route is wired in `website-src/src/App.jsx:46-47`, and `bundle install` reuses `parseSource` / `cloneToTemp` / `validateSkill` / `executeInstall` from `installer.ts` without duplication. The only remaining gap was discoverability from the README — addressed here.

**What was rejected:** adding a `delete` alias for `remove` (semantic equivalent, would just inflate the API surface), a standalone `docs/bundle-schema.md` (the TypeScript types in `src/utils/types.ts` and the validator in `src/bundler.ts` are the source of truth; a separate markdown file would rot), and a new e2e test (`src/bundler.test.ts` already has 25+ unit tests covering schema validation, load fallbacks, and CRUD).

## Changes

| File | Change |
| --- | --- |
| `README.md` | +34 lines — Commands table rows + Skill bundles example block |

## Test Results

- `npm run typecheck` — pass (no files to check; markdown only).
- Pre-commit hooks: trailing whitespace, line endings, large files, local security scan, prettier, typecheck, unit tests — all pass.
- Pre-push hooks: build + node e2e tests — pass.

## Acceptance Criteria Verification

| AC | Status | Evidence |
| --- | --- | --- |
| `asm bundle` CLI with create/list/show/modify/delete/install/export | already shipped | `src/cli.ts:4210` (PR #130, #208); README now lists each operation |
| `asm bundle install <name-or-file>` one-pass with progress/per-skill reporting | already shipped | `src/cli.ts:4332-4511` (PR #130); README documents both name and file forms |
| Custom bundle from catalog + export to `.json` | already shipped | CLI: `create` + `export` (PR #208); Website: `BundleBuilderDialog.jsx` (PR #240); README documents the CLI path and links the website builder |
| JSON schema documented and validated on install | already shipped | `src/utils/types.ts:412-432` + `src/bundler.ts:32-96` (PR #130); README points readers to `BundleManifest` |
| ≥3 pre-defined bundles | already shipped | 4 bundles in `data/bundles/` (PR #211); README lists workflow names |
| `/bundles` website page | already shipped | `website-src/src/App.jsx:46-47` + `BundlesPage.jsx` (PR #215, #231); README links twice |
| Bundle install reuses single-skill installer | already shipped | `src/cli.ts:4395-4475` reuses `parseSource`/`cloneToTemp`/`validateSkill`/`executeInstall` from `installer.ts` (PR #130) |

Closes #202