### PR TITLE
feat(uninstaller): add skill uninstall with reverse installation logic (#279)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1088,13 +1088,14 @@ async function cmdUninstall(args: ParsedArgs) {
     }
   }
 
-  // Determine if relocation is needed during execution
-  let symlinkTo: string | undefined;
-  if (relocationInfo?.needed) {
-    symlinkTo = relocationInfo.toPath;
-  }
-
-  const log = await executeRemoval(plan, symlinkTo);
+  // When relocation is needed, pass the full RelocationInfo so executeRemoval
+  // physically renames the real folder rather than deleting it and symlinking
+  // to the original (which would have been the about-to-be-deleted path).
+  const log = await executeRemoval(
+    plan,
+    undefined,
+    relocationInfo?.needed ? relocationInfo : undefined,
+  );
   for (const entry of log) {
     console.error(entry);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,10 +6,12 @@ import {
 } from "./config";
 import { scanAllSkills, searchSkills, sortSkills } from "./scanner";
 import {
-  buildFullRemovalPlan,
   buildRemovalPlan,
+  buildFullRemovalPlan,
   executeRemoval,
   getExistingTargets,
+  buildRelocationInfo,
+  findRelocationTarget,
 } from "./uninstaller";
 import {
   formatSkillTable,
@@ -84,7 +86,7 @@ import {
   removeBundle,
 } from "./bundler";
 import { publishSkill, formatFallbackInstructions } from "./publisher";
-import type { BundleSkillRef } from "./utils/types";
+import type { BundleSkillRef, RelocationInfo } from "./utils/types";
 import {
   detectDuplicates,
   sortInstancesForKeep,
@@ -631,13 +633,15 @@ before proceeding and asks for confirmation.
 ${ansi.bold("Options:")}
   -y, --yes          Skip confirmation prompt
   -s, --scope <s>    Filter: global, project, or both (default: both)
+  -t, --tool <name>  Filter by tool/provider (e.g., claude, codex)
   --no-color         Disable ANSI colors
   -V, --verbose      Show debug output
 
 ${ansi.bold("Examples:")}
-  asm uninstall code-review         ${ansi.dim("Remove with confirmation")}
-  asm uninstall code-review -y      ${ansi.dim("Remove without confirmation")}
-  asm uninstall code-review -s project  ${ansi.dim("Remove project copy only")}`);
+  asm uninstall code-review              ${ansi.dim("Remove with confirmation")}
+  asm uninstall code-review -y           ${ansi.dim("Remove without confirmation")}
+  asm uninstall code-review -s project   ${ansi.dim("Remove project copy only")}
+  asm uninstall code-review -t claude    ${ansi.dim("Remove from Claude only")}`);
 }
 
 function printAuditHelp() {
@@ -1026,7 +1030,17 @@ async function cmdUninstall(args: ParsedArgs) {
 
   const config = await loadConfig();
   const allSkills = await scanAllSkills(config, args.flags.scope);
-  const plan = buildFullRemovalPlan(skillName, allSkills, config);
+
+  // Apply provider filter if --tool flag is provided
+  const options: { providerFilter?: string; scopeFilter?: Scope } = {};
+  if (args.flags.provider) {
+    options.providerFilter = args.flags.provider;
+  }
+  if (args.flags.scope && args.flags.scope !== "both") {
+    options.scopeFilter = args.flags.scope;
+  }
+
+  const plan = buildFullRemovalPlan(skillName, allSkills, config, options);
 
   const existing = await getExistingTargets(plan);
   if (existing.length === 0) {
@@ -1034,8 +1048,26 @@ async function cmdUninstall(args: ParsedArgs) {
     process.exit(1);
   }
 
-  // Show removal plan
+  // Detect real-folder relocation
+  const matchingSkills = allSkills.filter((s) => s.dirName === skillName);
+  const targetProvider = options.providerFilter;
+  let relocationInfo: RelocationInfo | null = null;
+  if (targetProvider) {
+    relocationInfo = buildRelocationInfo(plan, matchingSkills, targetProvider);
+  }
+
+  // Show removal plan with details
   console.error(ansi.bold("Removal plan:"));
+  console.error(`  ${ansi.dim("Scope:")} ${options.scopeFilter || "both"}`);
+  if (targetProvider) {
+    console.error(`  ${ansi.dim("Tool:")} ${targetProvider}`);
+    if (relocationInfo?.needed) {
+      console.error(
+        `  ${ansi.yellow("⚠ Real folder relocation:")} ${relocationInfo.fromPath} → ${relocationInfo.toPath} (${relocationInfo.toProvider})`,
+      );
+    }
+  }
+  console.error("");
   for (const target of existing) {
     console.error(`  ${ansi.red("•")} ${shortenPath(target)}`);
   }
@@ -1056,7 +1088,13 @@ async function cmdUninstall(args: ParsedArgs) {
     }
   }
 
-  const log = await executeRemoval(plan);
+  // Determine if relocation is needed during execution
+  let symlinkTo: string | undefined;
+  if (relocationInfo?.needed) {
+    symlinkTo = relocationInfo.toPath;
+  }
+
+  const log = await executeRemoval(plan, symlinkTo);
   for (const entry of log) {
     console.error(entry);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -633,7 +633,7 @@ before proceeding and asks for confirmation.
 ${ansi.bold("Options:")}
   -y, --yes          Skip confirmation prompt
   -s, --scope <s>    Filter: global, project, or both (default: both)
-  -t, --tool <name>  Filter by tool/provider (e.g., claude, codex)
+  -p, --tool <name>  Filter by tool/provider (e.g., claude, codex)
   --no-color         Disable ANSI colors
   -V, --verbose      Show debug output
 
@@ -641,7 +641,7 @@ ${ansi.bold("Examples:")}
   asm uninstall code-review              ${ansi.dim("Remove with confirmation")}
   asm uninstall code-review -y           ${ansi.dim("Remove without confirmation")}
   asm uninstall code-review -s project   ${ansi.dim("Remove project copy only")}
-  asm uninstall code-review -t claude    ${ansi.dim("Remove from Claude only")}`);
+  asm uninstall code-review -p claude    ${ansi.dim("Remove from Claude only")}`);
 }
 
 function printAuditHelp() {

--- a/src/uninstaller.test.ts
+++ b/src/uninstaller.test.ts
@@ -4,6 +4,9 @@ import {
   buildFullRemovalPlan,
   executeRemoval,
   getExistingTargets,
+  findRelocationTarget,
+  buildRelocationInfo,
+  cleanEmptyParentDirs,
 } from "./uninstaller";
 import type { SkillInfo, AppConfig, RemovalPlan } from "./utils/types";
 import { homedir, tmpdir } from "os";
@@ -17,6 +20,7 @@ import {
   realpath,
   rm,
   symlink,
+  readdir,
 } from "fs/promises";
 
 const HOME = homedir();
@@ -626,5 +630,241 @@ describe("getExistingTargets", () => {
     } finally {
       await rm(base, { recursive: true, force: true });
     }
+  });
+});
+
+// ─── buildFullRemovalPlan with filtering ──────────────────────────────────────
+
+describe("buildFullRemovalPlan with options", () => {
+  it("filters by provider when providerFilter is set", () => {
+    const config = makeConfig();
+    const skills: SkillInfo[] = [
+      makeSkill({
+        dirName: "my-skill",
+        provider: "claude",
+        originalPath: `${HOME}/.claude/skills/my-skill`,
+      }),
+      makeSkill({
+        dirName: "my-skill",
+        provider: "codex",
+        originalPath: `${HOME}/.codex/skills/my-skill`,
+      }),
+    ];
+
+    const plan = buildFullRemovalPlan("my-skill", skills, config, {
+      providerFilter: "claude",
+    });
+    expect(plan.directories).toHaveLength(1);
+    expect(plan.directories[0].path).toContain(".claude");
+  });
+
+  it("filters by scope when scopeFilter is set", () => {
+    const config = makeConfig();
+    const skills: SkillInfo[] = [
+      makeSkill({
+        dirName: "my-skill",
+        scope: "global",
+        originalPath: `${HOME}/.claude/skills/my-skill`,
+      }),
+      makeSkill({
+        dirName: "my-skill",
+        scope: "project",
+        originalPath: ".claude/skills/my-skill",
+      }),
+    ];
+
+    const plan = buildFullRemovalPlan("my-skill", skills, config, {
+      scopeFilter: "global",
+    });
+    expect(plan.directories).toHaveLength(1);
+    expect(plan.directories[0].path).toContain(HOME);
+  });
+
+  it("returns empty plan when no skills match filters", () => {
+    const config = makeConfig();
+    const skills: SkillInfo[] = [
+      makeSkill({
+        dirName: "my-skill",
+        provider: "claude",
+      }),
+    ];
+
+    const plan = buildFullRemovalPlan("my-skill", skills, config, {
+      providerFilter: "codex",
+    });
+    expect(plan.directories).toHaveLength(0);
+  });
+});
+
+// ─── findRelocationTarget ─────────────────────────────────────────────────
+
+describe("findRelocationTarget", () => {
+  it("returns null when no remaining instances", () => {
+    const instances = [makeSkill({ provider: "claude" })];
+    expect(findRelocationTarget(instances, "claude")).toBeNull();
+  });
+
+  it("prefers a real folder over symlinks", () => {
+    const instances: SkillInfo[] = [
+      makeSkill({
+        provider: "claude",
+        isSymlink: false,
+        originalPath: `${HOME}/.claude/skills/my-skill`,
+      }),
+      makeSkill({
+        provider: "codex",
+        isSymlink: true,
+        originalPath: `${HOME}/.codex/skills/my-skill`,
+      }),
+    ];
+
+    const result = findRelocationTarget(instances, "claude");
+    expect(result).not.toBeNull();
+    expect(result!.path).toBe(`${HOME}/.codex/skills/my-skill`);
+  });
+
+  it("falls back to symlink when no real folder remains", () => {
+    const instances: SkillInfo[] = [
+      makeSkill({
+        provider: "claude",
+        isSymlink: true,
+        originalPath: `${HOME}/.claude/skills/my-skill`,
+      }),
+      makeSkill({
+        provider: "codex",
+        isSymlink: true,
+        originalPath: `${HOME}/.codex/skills/my-skill`,
+      }),
+    ];
+
+    const result = findRelocationTarget(instances, "claude");
+    expect(result).not.toBeNull();
+    expect(result!.path).toBe(`${HOME}/.codex/skills/my-skill`);
+  });
+});
+
+// ─── buildRelocationInfo ──────────────────────────────────────────────────
+
+describe("buildRelocationInfo", () => {
+  it("returns null when no real folder in plan", () => {
+    const plan: RemovalPlan = {
+      directories: [{ path: "/some/symlink", isSymlink: true }],
+      ruleFiles: [],
+      agentsBlocks: [],
+    };
+    const instances = [makeSkill({ provider: "claude" })];
+
+    expect(buildRelocationInfo(plan, instances, "claude")).toBeNull();
+  });
+
+  it("returns RelocationInfo when real folder is being removed", () => {
+    const plan: RemovalPlan = {
+      directories: [
+        { path: `${HOME}/.claude/skills/my-skill`, isSymlink: false },
+      ],
+      ruleFiles: [],
+      agentsBlocks: [],
+    };
+    const instances: SkillInfo[] = [
+      makeSkill({
+        provider: "claude",
+        isSymlink: false,
+        originalPath: `${HOME}/.claude/skills/my-skill`,
+      }),
+      makeSkill({
+        provider: "codex",
+        isSymlink: true,
+        originalPath: `${HOME}/.codex/skills/my-skill`,
+      }),
+    ];
+
+    const info = buildRelocationInfo(plan, instances, "claude");
+    expect(info).not.toBeNull();
+    expect(info!.needed).toBe(true);
+    expect(info!.fromProvider).toBe("claude");
+    expect(info!.toProvider).toBe("codex");
+  });
+
+  it("returns null when no remaining providers", () => {
+    const plan: RemovalPlan = {
+      directories: [
+        { path: `${HOME}/.claude/skills/my-skill`, isSymlink: false },
+      ],
+      ruleFiles: [],
+      agentsBlocks: [],
+    };
+    const instances = [
+      makeSkill({
+        provider: "claude",
+        isSymlink: false,
+      }),
+    ];
+
+    expect(buildRelocationInfo(plan, instances, "claude")).toBeNull();
+  });
+});
+
+// ─── cleanEmptyParentDirs ────────────────────────────────────────────────
+
+describe("cleanEmptyParentDirs", () => {
+  it("removes empty parent directories", async () => {
+    const base = await mkdtemp(join(tmpdir(), "asm-cleanup-"));
+    try {
+      const skillDir = join(base, "skills", "my-skill");
+      await mkdir(skillDir, { recursive: true });
+
+      // Simulate: the skill dir was already removed
+      await rm(skillDir, { recursive: true, force: true });
+
+      const cleaned = await cleanEmptyParentDirs([skillDir]);
+      expect(cleaned).toContain(join(base, "skills"));
+
+      const exists = await readdir(join(base, "skills")).then(
+        () => true,
+        () => false,
+      );
+      expect(exists).toBe(false);
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("does not remove directories with other entries", async () => {
+    const base = await mkdtemp(join(tmpdir(), "asm-cleanup-"));
+    try {
+      const skillDir = join(base, "skills", "my-skill");
+      const otherFile = join(base, "skills", "other-skill");
+      await mkdir(skillDir, { recursive: true });
+      await mkdir(otherFile, { recursive: true });
+
+      await rm(skillDir, { recursive: true, force: true });
+
+      const cleaned = await cleanEmptyParentDirs([skillDir]);
+      expect(cleaned).not.toContain(join(base, "skills"));
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("skips .DS_Store entries when checking emptiness", async () => {
+    const base = await mkdtemp(join(tmpdir(), "asm-cleanup-"));
+    try {
+      const skillDir = join(base, "skills", "my-skill");
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(join(base, "skills", ".DS_Store"), "");
+
+      // Simulate: the skill dir was already removed
+      await rm(skillDir, { recursive: true, force: true });
+
+      const cleaned = await cleanEmptyParentDirs([skillDir]);
+      expect(cleaned).toContain(join(base, "skills"));
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("handles non-existent directories gracefully", async () => {
+    const cleaned = await cleanEmptyParentDirs(["/tmp/nonexistent-xyz"]);
+    expect(cleaned).toHaveLength(0);
   });
 });

--- a/src/uninstaller.test.ts
+++ b/src/uninstaller.test.ts
@@ -514,6 +514,44 @@ describe("executeRemoval with AGENTS.md blocks", () => {
     // Should not throw; no "Failed" entries in the log
     expect(log.every((l) => !l.includes("Failed"))).toBe(true);
   });
+
+  it("does not rewrite AGENTS.md when no marker for the skill is present", async () => {
+    const base = await mkdtemp(join(tmpdir(), "asm-agents-md-mtime-"));
+    try {
+      const agentsMdPath = join(base, "AGENTS.md");
+      const content = [
+        "# Agents",
+        "",
+        "<!-- agent-skill-manager: other-skill -->",
+        "Block for a different skill",
+        "<!-- /agent-skill-manager: other-skill -->",
+        "",
+      ].join("\n");
+      await writeFile(agentsMdPath, content, "utf-8");
+      const beforeMtime = (await lstat(agentsMdPath)).mtimeMs;
+
+      // Wait briefly so any rewrite would produce a measurably newer mtime
+      await new Promise((r) => setTimeout(r, 20));
+
+      const plan: RemovalPlan = {
+        directories: [],
+        ruleFiles: [],
+        agentsBlocks: [{ file: agentsMdPath, skillName: "missing-skill" }],
+      };
+
+      await executeRemoval(plan);
+
+      const afterMtime = (await lstat(agentsMdPath)).mtimeMs;
+      expect(afterMtime).toBe(beforeMtime);
+
+      // Content is byte-for-byte unchanged
+      const { readFile } = await import("fs/promises");
+      const after = await readFile(agentsMdPath, "utf-8");
+      expect(after).toBe(content);
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
 });
 
 // ─── getExistingTargets ─────────────────────────────────────────────────────
@@ -808,10 +846,10 @@ describe("buildRelocationInfo", () => {
     expect(buildRelocationInfo(plan, instances, "claude")).toBeNull();
   });
 
-  it("returns null when the relocation target is itself a real folder", () => {
-    // Two-real-folders topology (audit-detected duplicates, not the
-    // normal install layout). Relocation would destroy the target's
-    // content; the standard removal path handles this safely.
+  it("returns null when the relocation target is itself a real folder and no symlinks survive", () => {
+    // Two-real-folders topology with no other symlinks. No relocation
+    // needed and no symlinks to repoint — the standard removal path
+    // safely handles this.
     const plan: RemovalPlan = {
       directories: [
         { path: `${HOME}/.claude/skills/my-skill`, isSymlink: false },
@@ -833,6 +871,42 @@ describe("buildRelocationInfo", () => {
     ];
 
     expect(buildRelocationInfo(plan, instances, "claude")).toBeNull();
+  });
+
+  it("returns repoint-only RelocationInfo when target is a real folder but symlinks survive", () => {
+    // Three providers: claude (real, being removed) + codex (real, kept)
+    // + agents (symlink pointing at claude's folder). Without repointing,
+    // the agents symlink would dangle after claude's folder is deleted.
+    const plan: RemovalPlan = {
+      directories: [
+        { path: `${HOME}/.claude/skills/my-skill`, isSymlink: false },
+      ],
+      ruleFiles: [],
+      agentsBlocks: [],
+    };
+    const instances: SkillInfo[] = [
+      makeSkill({
+        provider: "claude",
+        isSymlink: false,
+        originalPath: `${HOME}/.claude/skills/my-skill`,
+      }),
+      makeSkill({
+        provider: "codex",
+        isSymlink: false,
+        originalPath: `${HOME}/.codex/skills/my-skill`,
+      }),
+      makeSkill({
+        provider: "agents",
+        isSymlink: true,
+        originalPath: `${HOME}/.agents/skills/my-skill`,
+      }),
+    ];
+
+    const info = buildRelocationInfo(plan, instances, "claude");
+    expect(info).not.toBeNull();
+    expect(info!.repointOnly).toBe(true);
+    expect(info!.toPath).toBe(`${HOME}/.codex/skills/my-skill`);
+    expect(info!.repointPaths).toEqual([`${HOME}/.agents/skills/my-skill`]);
   });
 });
 
@@ -890,6 +964,29 @@ describe("cleanEmptyParentDirs", () => {
 
       const cleaned = await cleanEmptyParentDirs([skillDir]);
       expect(cleaned).toContain(join(base, "skills"));
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves directories containing .gitkeep", async () => {
+    // A checked-in .gitkeep is a deliberate placeholder — removing the
+    // last skill must not silently wipe it.
+    const base = await mkdtemp(join(tmpdir(), "asm-cleanup-gitkeep-"));
+    try {
+      const skillDir = join(base, "skills", "my-skill");
+      const gitkeep = join(base, "skills", ".gitkeep");
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(gitkeep, "");
+
+      await rm(skillDir, { recursive: true, force: true });
+
+      const cleaned = await cleanEmptyParentDirs([skillDir]);
+      expect(cleaned).not.toContain(join(base, "skills"));
+
+      // The .gitkeep itself must still exist
+      const stats = await lstat(gitkeep);
+      expect(stats.isFile()).toBe(true);
     } finally {
       await rm(base, { recursive: true, force: true });
     }
@@ -1007,6 +1104,116 @@ describe("executeRemoval with relocation", () => {
       const fromB = await readFile(join(linkB, "SKILL.md"), "utf-8");
       expect(fromA).toBe("shared content");
       expect(fromB).toBe("shared content");
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("repoints surviving symlinks in repoint-only mode (two real folders + symlink)", async () => {
+    // Two real folders (claude being removed, codex kept) + a third
+    // symlink at agents/ pointing at claude's folder. Without repoint
+    // the agents symlink would dangle when claude's folder is deleted.
+    const base = await mkdtemp(join(tmpdir(), "asm-reloc-repoint-only-"));
+    try {
+      const claudeReal = join(base, "claude", "skills", "my-skill");
+      const codexReal = join(base, "codex", "skills", "my-skill");
+      const agentsLink = join(base, "agents", "skills", "my-skill");
+      await mkdir(claudeReal, { recursive: true });
+      await mkdir(codexReal, { recursive: true });
+      await mkdir(dirname(agentsLink), { recursive: true });
+      await writeFile(join(claudeReal, "SKILL.md"), "claude content");
+      await writeFile(join(codexReal, "SKILL.md"), "codex content");
+      await symlink(claudeReal, agentsLink, "dir");
+
+      const plan: RemovalPlan = {
+        directories: [{ path: claudeReal, isSymlink: false }],
+        ruleFiles: [],
+        agentsBlocks: [],
+      };
+
+      const relocation: RelocationInfo = {
+        needed: true,
+        fromProvider: "claude",
+        fromPath: claudeReal,
+        toProvider: "codex",
+        toPath: codexReal,
+        repointPaths: [agentsLink],
+        repointOnly: true,
+      };
+
+      await executeRemoval(plan, undefined, relocation);
+
+      // codex real folder is untouched — relocation did NOT rename over it
+      const codexStats = await lstat(codexReal);
+      expect(codexStats.isDirectory()).toBe(true);
+      const { readFile } = await import("fs/promises");
+      const codexContent = await readFile(join(codexReal, "SKILL.md"), "utf-8");
+      expect(codexContent).toBe("codex content");
+
+      // claude's real folder is gone (standard removal still runs)
+      try {
+        await lstat(claudeReal);
+        throw new Error("claudeReal should not exist");
+      } catch (err: any) {
+        expect(err.code).toBe("ENOENT");
+      }
+
+      // agents symlink no longer dangles — resolves to codex's real folder
+      const agentsStats = await lstat(agentsLink);
+      expect(agentsStats.isSymbolicLink()).toBe(true);
+      const agentsResolved = await realpath(agentsLink);
+      expect(agentsResolved).toBe(await realpath(codexReal));
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("isolates per-symlink repoint failures and logs a rollback hint", async () => {
+    const base = await mkdtemp(join(tmpdir(), "asm-reloc-partial-"));
+    try {
+      const realDir = join(base, "claude", "skills", "my-skill");
+      const goodLink = join(base, "codex", "skills", "my-skill");
+      // Place a regular file where the second symlink's PARENT should be,
+      // so mkdir+symlink on its child will fail (ENOTDIR), simulating a
+      // mid-loop repoint failure.
+      const blockedParent = join(base, "agents", "skills");
+      const blockedLink = join(blockedParent, "my-skill");
+      await mkdir(realDir, { recursive: true });
+      await mkdir(dirname(goodLink), { recursive: true });
+      await mkdir(dirname(blockedParent), { recursive: true });
+      await writeFile(blockedParent, "not a directory");
+      await writeFile(join(realDir, "SKILL.md"), "content");
+      await symlink(realDir, goodLink, "dir");
+
+      const plan: RemovalPlan = {
+        directories: [{ path: realDir, isSymlink: false }],
+        ruleFiles: [],
+        agentsBlocks: [],
+      };
+
+      const relocation: RelocationInfo = {
+        needed: true,
+        fromProvider: "claude",
+        fromPath: realDir,
+        toProvider: "codex",
+        toPath: goodLink,
+        repointPaths: [blockedLink],
+      };
+
+      const log = await executeRemoval(plan, undefined, relocation);
+
+      // The good slot was relocated even though the other repoint failed
+      const goodStats = await lstat(goodLink);
+      expect(goodStats.isSymbolicLink()).toBe(false);
+      expect(goodStats.isDirectory()).toBe(true);
+
+      // Log mentions the failure and includes a manual-fix hint
+      const failEntry = log.find((l) =>
+        l.includes("Failed to repoint symlink"),
+      );
+      expect(failEntry).toBeDefined();
+      expect(failEntry).toContain(blockedLink);
+      expect(failEntry).toContain("ln -sfn");
     } finally {
       await rm(base, { recursive: true, force: true });
     }

--- a/src/uninstaller.test.ts
+++ b/src/uninstaller.test.ts
@@ -8,9 +8,14 @@ import {
   buildRelocationInfo,
   cleanEmptyParentDirs,
 } from "./uninstaller";
-import type { SkillInfo, AppConfig, RemovalPlan } from "./utils/types";
+import type {
+  SkillInfo,
+  AppConfig,
+  RemovalPlan,
+  RelocationInfo,
+} from "./utils/types";
 import { homedir, tmpdir } from "os";
-import { resolve, join, relative } from "path";
+import { resolve, join, relative, dirname } from "path";
 import {
   mkdtemp,
   mkdir,
@@ -866,5 +871,179 @@ describe("cleanEmptyParentDirs", () => {
   it("handles non-existent directories gracefully", async () => {
     const cleaned = await cleanEmptyParentDirs(["/tmp/nonexistent-xyz"]);
     expect(cleaned).toHaveLength(0);
+  });
+});
+
+// ─── executeRemoval with real-folder relocation (real install topology) ─────
+
+describe("executeRemoval with relocation", () => {
+  it("renames real folder to kept slot and preserves content", async () => {
+    const base = await mkdtemp(join(tmpdir(), "asm-reloc-"));
+    try {
+      // Real install topology: one real folder + one symlink pointing to it
+      const realDir = join(base, "claude", "skills", "my-skill");
+      const linkDir = join(base, "codex", "skills", "my-skill");
+      await mkdir(realDir, { recursive: true });
+      await mkdir(dirname(linkDir), { recursive: true });
+      await writeFile(join(realDir, "SKILL.md"), "real content");
+      await symlink(realDir, linkDir, "dir");
+
+      // Sanity: the symlink resolves to the real content
+      const preResolve = await realpath(linkDir);
+      expect(preResolve).toBe(await realpath(realDir));
+
+      const plan: RemovalPlan = {
+        directories: [{ path: realDir, isSymlink: false }],
+        ruleFiles: [],
+        agentsBlocks: [],
+      };
+
+      const relocation: RelocationInfo = {
+        needed: true,
+        fromProvider: "claude",
+        fromPath: realDir,
+        toProvider: "codex",
+        toPath: linkDir,
+        repointPaths: [],
+      };
+
+      const log = await executeRemoval(plan, undefined, relocation);
+
+      // The kept slot is now a real directory with the original content
+      const targetStats = await lstat(linkDir);
+      expect(targetStats.isSymbolicLink()).toBe(false);
+      expect(targetStats.isDirectory()).toBe(true);
+      const { readFile } = await import("fs/promises");
+      const skillContent = await readFile(join(linkDir, "SKILL.md"), "utf-8");
+      expect(skillContent).toBe("real content");
+
+      // The original real-folder path is gone (no cycle, no leftover entry)
+      try {
+        await lstat(realDir);
+        throw new Error("realDir should not exist");
+      } catch (err: any) {
+        expect(err.code).toBe("ENOENT");
+      }
+
+      // Log mentions the relocation
+      expect(log.some((l) => l.includes("Relocated real folder"))).toBe(true);
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("repoints surviving symlinks at the new canonical path", async () => {
+    const base = await mkdtemp(join(tmpdir(), "asm-reloc-multi-"));
+    try {
+      // Three providers: claude (real), codex (symlink), agents (symlink)
+      const realDir = join(base, "claude", "skills", "my-skill");
+      const linkA = join(base, "codex", "skills", "my-skill");
+      const linkB = join(base, "agents", "skills", "my-skill");
+      await mkdir(realDir, { recursive: true });
+      await mkdir(dirname(linkA), { recursive: true });
+      await mkdir(dirname(linkB), { recursive: true });
+      await writeFile(join(realDir, "SKILL.md"), "shared content");
+      await symlink(realDir, linkA, "dir");
+      await symlink(realDir, linkB, "dir");
+
+      const plan: RemovalPlan = {
+        directories: [{ path: realDir, isSymlink: false }],
+        ruleFiles: [],
+        agentsBlocks: [],
+      };
+
+      const relocation: RelocationInfo = {
+        needed: true,
+        fromProvider: "claude",
+        fromPath: realDir,
+        toProvider: "codex",
+        toPath: linkA,
+        repointPaths: [linkB],
+      };
+
+      await executeRemoval(plan, undefined, relocation);
+
+      // linkA becomes the real folder
+      const aStats = await lstat(linkA);
+      expect(aStats.isSymbolicLink()).toBe(false);
+      expect(aStats.isDirectory()).toBe(true);
+
+      // linkB is still a symlink, now pointing at linkA — no cycle
+      const bStats = await lstat(linkB);
+      expect(bStats.isSymbolicLink()).toBe(true);
+      const bResolved = await realpath(linkB);
+      expect(bResolved).toBe(await realpath(linkA));
+
+      // Content is intact and reachable from both surviving paths
+      const { readFile } = await import("fs/promises");
+      const fromA = await readFile(join(linkA, "SKILL.md"), "utf-8");
+      const fromB = await readFile(join(linkB, "SKILL.md"), "utf-8");
+      expect(fromA).toBe("shared content");
+      expect(fromB).toBe("shared content");
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── buildFullRemovalPlan: AGENTS.md filter regression ─────────────────────
+
+describe("buildFullRemovalPlan AGENTS.md filtering", () => {
+  it("does not strip codex AGENTS.md when --tool=claude and codex still has the skill", () => {
+    const config = makeConfig();
+    const skills: SkillInfo[] = [
+      makeSkill({
+        dirName: "my-skill",
+        provider: "claude",
+        scope: "global",
+        originalPath: `${HOME}/.claude/skills/my-skill`,
+      }),
+      makeSkill({
+        dirName: "my-skill",
+        provider: "codex",
+        scope: "global",
+        originalPath: `${HOME}/.codex/skills/my-skill`,
+      }),
+    ];
+
+    const plan = buildFullRemovalPlan("my-skill", skills, config, {
+      providerFilter: "claude",
+    });
+
+    // The codex AGENTS.md path must NOT appear — codex still has the skill
+    const codexBlock = plan.agentsBlocks.find((b) => b.file.includes(".codex"));
+    expect(codexBlock).toBeUndefined();
+
+    // The claude AGENTS.md path SHOULD appear (claude is being uninstalled)
+    const claudeBlock = plan.agentsBlocks.find((b) =>
+      b.file.includes(".claude"),
+    );
+    expect(claudeBlock).toBeDefined();
+  });
+
+  it("strips all global AGENTS.md when no providerFilter (full removal)", () => {
+    const config = makeConfig();
+    const skills: SkillInfo[] = [
+      makeSkill({
+        dirName: "my-skill",
+        provider: "claude",
+        scope: "global",
+        originalPath: `${HOME}/.claude/skills/my-skill`,
+      }),
+      makeSkill({
+        dirName: "my-skill",
+        provider: "codex",
+        scope: "global",
+        originalPath: `${HOME}/.codex/skills/my-skill`,
+      }),
+    ];
+
+    const plan = buildFullRemovalPlan("my-skill", skills, config);
+
+    // Both providers are being uninstalled — both AGENTS.md blocks should appear
+    expect(plan.agentsBlocks.some((b) => b.file.includes(".claude"))).toBe(
+      true,
+    );
+    expect(plan.agentsBlocks.some((b) => b.file.includes(".codex"))).toBe(true);
   });
 });

--- a/src/uninstaller.test.ts
+++ b/src/uninstaller.test.ts
@@ -807,6 +807,33 @@ describe("buildRelocationInfo", () => {
 
     expect(buildRelocationInfo(plan, instances, "claude")).toBeNull();
   });
+
+  it("returns null when the relocation target is itself a real folder", () => {
+    // Two-real-folders topology (audit-detected duplicates, not the
+    // normal install layout). Relocation would destroy the target's
+    // content; the standard removal path handles this safely.
+    const plan: RemovalPlan = {
+      directories: [
+        { path: `${HOME}/.claude/skills/my-skill`, isSymlink: false },
+      ],
+      ruleFiles: [],
+      agentsBlocks: [],
+    };
+    const instances: SkillInfo[] = [
+      makeSkill({
+        provider: "claude",
+        isSymlink: false,
+        originalPath: `${HOME}/.claude/skills/my-skill`,
+      }),
+      makeSkill({
+        provider: "codex",
+        isSymlink: false,
+        originalPath: `${HOME}/.codex/skills/my-skill`,
+      }),
+    ];
+
+    expect(buildRelocationInfo(plan, instances, "claude")).toBeNull();
+  });
 });
 
 // ─── cleanEmptyParentDirs ────────────────────────────────────────────────

--- a/src/uninstaller.ts
+++ b/src/uninstaller.ts
@@ -253,6 +253,12 @@ export function buildRelocationInfo(
   const target = findRelocationTarget(skillInstances, removedProvider);
   if (!target) return null;
 
+  // If the relocation target is itself a real folder, no relocation is
+  // needed — the kept provider already has the content. Renaming over it
+  // would destroy that data. The standard removal path handles this case.
+  const targetInstance = remaining.find((s) => s.originalPath === target.path);
+  if (targetInstance && !targetInstance.isSymlink) return null;
+
   const realDir = plan.directories.find((d) => !d.isSymlink);
   const repointPaths = remaining
     .map((s) => s.originalPath)
@@ -323,7 +329,23 @@ export async function executeRemoval(
         }
       }
 
-      await rename(relocation.fromPath, relocation.toPath);
+      try {
+        await rename(relocation.fromPath, relocation.toPath);
+      } catch (err: any) {
+        if (err.code === "EXDEV") {
+          // Cross-device rename — fall back to recursive copy + remove.
+          // Rare on a single-user machine but possible when ~/.claude and
+          // ~/.codex live on different mounts (NFS, encrypted volumes).
+          const { cp } = await import("fs/promises");
+          await cp(relocation.fromPath, relocation.toPath, {
+            recursive: true,
+            preserveTimestamps: true,
+          });
+          await rm(relocation.fromPath, { recursive: true, force: true });
+        } else {
+          throw err;
+        }
+      }
       log.push(
         `Relocated real folder: ${relocation.fromPath} -> ${relocation.toPath}`,
       );

--- a/src/uninstaller.ts
+++ b/src/uninstaller.ts
@@ -192,6 +192,7 @@ async function removeAgentsMdBlock(
   if (!(await fileExists(filePath))) return;
 
   let content = await readFile(filePath, "utf-8");
+  let modified = false;
 
   // Try both new and old marker formats for backward compatibility
   for (const prefix of ["agent-skill-manager", "skill-manager", "pskills"]) {
@@ -215,8 +216,10 @@ async function removeAgentsMdBlock(
     }
 
     content = content.slice(0, removeStart) + content.slice(actualEnd);
+    modified = true;
   }
 
+  if (!modified) return;
   await writeFile(filePath, content, "utf-8");
 }
 
@@ -253,16 +256,29 @@ export function buildRelocationInfo(
   const target = findRelocationTarget(skillInstances, removedProvider);
   if (!target) return null;
 
-  // If the relocation target is itself a real folder, no relocation is
-  // needed — the kept provider already has the content. Renaming over it
-  // would destroy that data. The standard removal path handles this case.
-  const targetInstance = remaining.find((s) => s.originalPath === target.path);
-  if (targetInstance && !targetInstance.isSymlink) return null;
-
   const realDir = plan.directories.find((d) => !d.isSymlink);
   const repointPaths = remaining
     .map((s) => s.originalPath)
     .filter((p) => p !== target.path);
+
+  // If the relocation target is itself a real folder, the kept provider
+  // already has the content — don't rename (that would destroy it). But
+  // surviving symlinks may still point at the about-to-be-removed real
+  // folder; without repointing they become dangling. Emit a repoint-only
+  // plan when there's at least one symlink to fix; otherwise skip.
+  const targetInstance = remaining.find((s) => s.originalPath === target.path);
+  if (targetInstance && !targetInstance.isSymlink) {
+    if (repointPaths.length === 0) return null;
+    return {
+      needed: true,
+      fromProvider: removedProvider,
+      fromPath: realDir?.path || "",
+      toProvider: target.provider,
+      toPath: target.path,
+      repointPaths,
+      repointOnly: true,
+    };
+  }
 
   return {
     needed: true,
@@ -285,9 +301,9 @@ export async function cleanEmptyParentDirs(paths: string[]): Promise<string[]> {
 
     try {
       const entries = await readdir(parent);
-      const filtered = entries.filter(
-        (e) => e !== ".DS_Store" && e !== ".gitkeep",
-      );
+      // .DS_Store is OS noise (macOS Finder); a checked-in .gitkeep is a
+      // deliberate placeholder and must keep the directory alive.
+      const filtered = entries.filter((e) => e !== ".DS_Store");
       if (filtered.length === 0) {
         await rm(parent, { recursive: true, force: true });
         cleaned.push(parent);
@@ -312,46 +328,60 @@ export async function executeRemoval(
   // is the only safe order: a delete-then-symlink-to-sibling sequence
   // would orphan the original symlink at the target slot and lose data
   // when symlinks were the surviving instances.
+  //
+  // In repoint-only mode, the target already holds a real folder — skip
+  // the rename and only repoint surviving symlinks so they don't dangle
+  // when the removed provider's real folder gets deleted below.
   if (relocation?.needed) {
-    try {
-      const targetParent = dirname(relocation.toPath);
-      await mkdir(targetParent, { recursive: true });
-
-      // The target slot is currently a symlink (or stale entry) pointing
-      // back at fromPath. Unlink it so rename has a clean destination.
+    if (!relocation.repointOnly) {
       try {
-        await unlink(relocation.toPath);
-      } catch (err: any) {
-        if (err.code !== "ENOENT") {
-          // Best-effort: if it's a non-empty dir we can't move over, fall
-          // back to a full remove so rename can proceed.
-          await rm(relocation.toPath, { recursive: true, force: true });
-        }
-      }
+        const targetParent = dirname(relocation.toPath);
+        await mkdir(targetParent, { recursive: true });
 
+        // The target slot is currently a symlink (or stale entry) pointing
+        // back at fromPath. Unlink it so rename has a clean destination.
+        try {
+          await unlink(relocation.toPath);
+        } catch (err: any) {
+          if (err.code !== "ENOENT") {
+            // Best-effort: if it's a non-empty dir we can't move over, fall
+            // back to a full remove so rename can proceed.
+            await rm(relocation.toPath, { recursive: true, force: true });
+          }
+        }
+
+        try {
+          await rename(relocation.fromPath, relocation.toPath);
+        } catch (err: any) {
+          if (err.code === "EXDEV") {
+            // Cross-device rename — fall back to recursive copy + remove.
+            // Rare on a single-user machine but possible when ~/.claude and
+            // ~/.codex live on different mounts (NFS, encrypted volumes).
+            const { cp } = await import("fs/promises");
+            await cp(relocation.fromPath, relocation.toPath, {
+              recursive: true,
+              preserveTimestamps: true,
+            });
+            await rm(relocation.fromPath, { recursive: true, force: true });
+          } else {
+            throw err;
+          }
+        }
+        log.push(
+          `Relocated real folder: ${relocation.fromPath} -> ${relocation.toPath}`,
+        );
+      } catch (err: any) {
+        log.push(`Failed to relocate real folder: ${err.message}`);
+      }
+    }
+
+    // Re-point any other surviving symlinks at the new canonical path.
+    // Each repoint is isolated so one failure doesn't abort the rest;
+    // failures log the from/to so the user can recreate the symlink.
+    for (const repointPath of relocation.repointPaths || []) {
+      const parentDir = dirname(repointPath);
+      const relTarget = relative(parentDir, relocation.toPath);
       try {
-        await rename(relocation.fromPath, relocation.toPath);
-      } catch (err: any) {
-        if (err.code === "EXDEV") {
-          // Cross-device rename — fall back to recursive copy + remove.
-          // Rare on a single-user machine but possible when ~/.claude and
-          // ~/.codex live on different mounts (NFS, encrypted volumes).
-          const { cp } = await import("fs/promises");
-          await cp(relocation.fromPath, relocation.toPath, {
-            recursive: true,
-            preserveTimestamps: true,
-          });
-          await rm(relocation.fromPath, { recursive: true, force: true });
-        } else {
-          throw err;
-        }
-      }
-      log.push(
-        `Relocated real folder: ${relocation.fromPath} -> ${relocation.toPath}`,
-      );
-
-      // Re-point any other surviving symlinks at the new canonical path.
-      for (const repointPath of relocation.repointPaths || []) {
         try {
           await unlink(repointPath);
         } catch (err: any) {
@@ -359,23 +389,26 @@ export async function executeRemoval(
             await rm(repointPath, { recursive: true, force: true });
           }
         }
-        const parentDir = dirname(repointPath);
         await mkdir(parentDir, { recursive: true });
-        const relTarget = relative(parentDir, relocation.toPath);
         await symlink(relTarget, repointPath, "dir");
         log.push(`Repointed symlink: ${repointPath} -> ${relTarget}`);
+      } catch (err: any) {
+        log.push(
+          `Failed to repoint symlink ${repointPath} -> ${relTarget}: ${err.message}. To fix manually: ln -sfn ${relocation.toPath} ${repointPath}`,
+        );
       }
-    } catch (err: any) {
-      log.push(`Failed to relocate real folder: ${err.message}`);
     }
   }
 
   // Remove directories/symlinks. When a relocation just moved fromPath
-  // away, skip removing it here — rename already consumed the entry.
+  // away, skip removing it here — rename already consumed the entry. In
+  // repoint-only mode no rename happened, so the source still needs to
+  // be removed below.
   for (const dir of plan.directories) {
     try {
       if (
         relocation?.needed &&
+        !relocation.repointOnly &&
         resolve(dir.path) === resolve(relocation.fromPath)
       ) {
         continue;

--- a/src/uninstaller.ts
+++ b/src/uninstaller.ts
@@ -1,8 +1,23 @@
-import { rm, readFile, writeFile, access, lstat, symlink } from "fs/promises";
+import {
+  rm,
+  readFile,
+  writeFile,
+  access,
+  lstat,
+  symlink,
+  readdir,
+} from "fs/promises";
 import { join, resolve, dirname, relative } from "path";
 import { homedir } from "os";
 import { resolveProviderPath } from "./config";
-import type { SkillInfo, RemovalPlan, AppConfig } from "./utils/types";
+import type {
+  SkillInfo,
+  RemovalPlan,
+  RemovalOptions,
+  RelocationInfo,
+  AppConfig,
+  Scope,
+} from "./utils/types";
 
 const HOME = homedir();
 
@@ -59,8 +74,15 @@ export function buildFullRemovalPlan(
   dirName: string,
   allSkills: SkillInfo[],
   config: AppConfig,
+  options?: RemovalOptions,
 ): RemovalPlan {
-  const matching = allSkills.filter((s) => s.dirName === dirName);
+  let matching = allSkills.filter((s) => s.dirName === dirName);
+  if (options?.providerFilter) {
+    matching = matching.filter((s) => s.provider === options.providerFilter);
+  }
+  if (options?.scopeFilter) {
+    matching = matching.filter((s) => s.scope === options.scopeFilter);
+  }
   if (matching.length === 0) {
     return { directories: [], ruleFiles: [], agentsBlocks: [] };
   }
@@ -148,6 +170,75 @@ async function removeAgentsMdBlock(
   await writeFile(filePath, content, "utf-8");
 }
 
+export function findRelocationTarget(
+  skillInstances: SkillInfo[],
+  removedProvider: string,
+): { path: string; provider: string } | null {
+  const remaining = skillInstances.filter(
+    (s) => s.provider !== removedProvider,
+  );
+  if (remaining.length === 0) return null;
+
+  const realFolder = remaining.find((s) => !s.isSymlink);
+  if (realFolder) {
+    return { path: realFolder.originalPath, provider: realFolder.provider };
+  }
+
+  return { path: remaining[0].originalPath, provider: remaining[0].provider };
+}
+
+export function buildRelocationInfo(
+  plan: RemovalPlan,
+  skillInstances: SkillInfo[],
+  removedProvider: string,
+): RelocationInfo | null {
+  const hasRealFolder = plan.directories.some((d) => !d.isSymlink);
+  if (!hasRealFolder) return null;
+
+  const remaining = skillInstances.filter(
+    (s) => s.provider !== removedProvider,
+  );
+  if (remaining.length === 0) return null;
+
+  const target = findRelocationTarget(skillInstances, removedProvider);
+  if (!target) return null;
+
+  const realDir = plan.directories.find((d) => !d.isSymlink);
+  return {
+    needed: true,
+    fromProvider: removedProvider,
+    fromPath: realDir?.path || "",
+    toProvider: target.provider,
+    toPath: target.path,
+  };
+}
+
+export async function cleanEmptyParentDirs(paths: string[]): Promise<string[]> {
+  const cleaned: string[] = [];
+  const seen = new Set<string>();
+
+  for (const p of paths) {
+    const parent = dirname(p);
+    if (seen.has(parent)) continue;
+    seen.add(parent);
+
+    try {
+      const entries = await readdir(parent);
+      const filtered = entries.filter(
+        (e) => e !== ".DS_Store" && e !== ".gitkeep",
+      );
+      if (filtered.length === 0) {
+        await rm(parent, { recursive: true, force: true });
+        cleaned.push(parent);
+      }
+    } catch {
+      // directory doesn't exist or can't be read — skip
+    }
+  }
+
+  return cleaned;
+}
+
 export async function executeRemoval(
   plan: RemovalPlan,
   symlinkTo?: string,
@@ -175,6 +266,13 @@ export async function executeRemoval(
     } catch (err: any) {
       log.push(`Failed to remove ${dir.path}: ${err.message}`);
     }
+  }
+
+  // Clean up empty parent directories
+  const removedDirs = plan.directories.map((d) => d.path);
+  const emptyDirs = await cleanEmptyParentDirs(removedDirs);
+  for (const dir of emptyDirs) {
+    log.push(`Removed empty parent directory: ${dir}`);
   }
 
   // Remove rule files

--- a/src/uninstaller.ts
+++ b/src/uninstaller.ts
@@ -5,7 +5,10 @@ import {
   access,
   lstat,
   symlink,
+  rename,
   readdir,
+  mkdir,
+  unlink,
 } from "fs/promises";
 import { join, resolve, dirname, relative } from "path";
 import { homedir } from "os";
@@ -76,7 +79,8 @@ export function buildFullRemovalPlan(
   config: AppConfig,
   options?: RemovalOptions,
 ): RemovalPlan {
-  let matching = allSkills.filter((s) => s.dirName === dirName);
+  const allMatching = allSkills.filter((s) => s.dirName === dirName);
+  let matching = allMatching;
   if (options?.providerFilter) {
     matching = matching.filter((s) => s.provider === options.providerFilter);
   }
@@ -85,6 +89,46 @@ export function buildFullRemovalPlan(
   }
   if (matching.length === 0) {
     return { directories: [], ruleFiles: [], agentsBlocks: [] };
+  }
+
+  // Providers (per scope) that still have surviving instances after the
+  // filter — their AGENTS.md must NOT be touched.
+  const survivingKeys = new Set(
+    allMatching
+      .filter((s) => !matching.includes(s))
+      .map((s) => `${s.provider}::${s.scope}`),
+  );
+
+  // Map an AGENTS.md path to the (provider, scope) it belongs to, so we
+  // can decide whether the block is safe to strip.
+  function classifyAgentsMd(
+    file: string,
+  ): { provider: string; scope: Scope } | null {
+    // Project-scope AGENTS.md is at <cwd>/AGENTS.md
+    if (file === resolve("AGENTS.md")) {
+      // Belongs to whichever project provider the matching set covers.
+      // For project scope, any surviving project instance keeps it alive.
+      const projectSurvivor = Array.from(survivingKeys).find((k) =>
+        k.endsWith("::project"),
+      );
+      if (projectSurvivor) {
+        return { provider: projectSurvivor.split("::")[0], scope: "project" };
+      }
+      return null;
+    }
+    // Global AGENTS.md is at <providerGlobalDir>/../AGENTS.md
+    for (const provider of config.providers) {
+      const globalDir = resolveProviderPath(provider.global);
+      const agentsMdPath = join(dirname(globalDir), "AGENTS.md");
+      if (file === agentsMdPath) {
+        return { provider: provider.name, scope: "global" };
+      }
+    }
+    // Explicit codex fallback (~/.codex/AGENTS.md)
+    if (file === join(HOME, ".codex", "AGENTS.md")) {
+      return { provider: "codex", scope: "global" };
+    }
+    return null;
   }
 
   const combined: RemovalPlan = {
@@ -116,10 +160,16 @@ export function buildFullRemovalPlan(
 
     for (const block of plan.agentsBlocks) {
       const key = `${block.file}::${block.skillName}`;
-      if (!seenBlocks.has(key)) {
-        seenBlocks.add(key);
-        combined.agentsBlocks.push(block);
+      if (seenBlocks.has(key)) continue;
+
+      const classified = classifyAgentsMd(block.file);
+      if (classified) {
+        const survivorKey = `${classified.provider}::${classified.scope}`;
+        if (survivingKeys.has(survivorKey)) continue;
       }
+
+      seenBlocks.add(key);
+      combined.agentsBlocks.push(block);
     }
   }
 
@@ -204,12 +254,17 @@ export function buildRelocationInfo(
   if (!target) return null;
 
   const realDir = plan.directories.find((d) => !d.isSymlink);
+  const repointPaths = remaining
+    .map((s) => s.originalPath)
+    .filter((p) => p !== target.path);
+
   return {
     needed: true,
     fromProvider: removedProvider,
     fromPath: realDir?.path || "",
     toProvider: target.provider,
     toPath: target.path,
+    repointPaths,
   };
 }
 
@@ -242,12 +297,68 @@ export async function cleanEmptyParentDirs(paths: string[]): Promise<string[]> {
 export async function executeRemoval(
   plan: RemovalPlan,
   symlinkTo?: string,
+  relocation?: RelocationInfo,
 ): Promise<string[]> {
   const log: string[] = [];
 
-  // Remove directories/symlinks
+  // When a relocation is requested, physically move the real folder to
+  // the kept provider's slot BEFORE removing the source directory. This
+  // is the only safe order: a delete-then-symlink-to-sibling sequence
+  // would orphan the original symlink at the target slot and lose data
+  // when symlinks were the surviving instances.
+  if (relocation?.needed) {
+    try {
+      const targetParent = dirname(relocation.toPath);
+      await mkdir(targetParent, { recursive: true });
+
+      // The target slot is currently a symlink (or stale entry) pointing
+      // back at fromPath. Unlink it so rename has a clean destination.
+      try {
+        await unlink(relocation.toPath);
+      } catch (err: any) {
+        if (err.code !== "ENOENT") {
+          // Best-effort: if it's a non-empty dir we can't move over, fall
+          // back to a full remove so rename can proceed.
+          await rm(relocation.toPath, { recursive: true, force: true });
+        }
+      }
+
+      await rename(relocation.fromPath, relocation.toPath);
+      log.push(
+        `Relocated real folder: ${relocation.fromPath} -> ${relocation.toPath}`,
+      );
+
+      // Re-point any other surviving symlinks at the new canonical path.
+      for (const repointPath of relocation.repointPaths || []) {
+        try {
+          await unlink(repointPath);
+        } catch (err: any) {
+          if (err.code !== "ENOENT") {
+            await rm(repointPath, { recursive: true, force: true });
+          }
+        }
+        const parentDir = dirname(repointPath);
+        await mkdir(parentDir, { recursive: true });
+        const relTarget = relative(parentDir, relocation.toPath);
+        await symlink(relTarget, repointPath, "dir");
+        log.push(`Repointed symlink: ${repointPath} -> ${relTarget}`);
+      }
+    } catch (err: any) {
+      log.push(`Failed to relocate real folder: ${err.message}`);
+    }
+  }
+
+  // Remove directories/symlinks. When a relocation just moved fromPath
+  // away, skip removing it here — rename already consumed the entry.
   for (const dir of plan.directories) {
     try {
+      if (
+        relocation?.needed &&
+        resolve(dir.path) === resolve(relocation.fromPath)
+      ) {
+        continue;
+      }
+
       if (dir.isSymlink) {
         await rm(dir.path);
         log.push(`Removed symlink: ${dir.path}`);
@@ -256,8 +367,13 @@ export async function executeRemoval(
         log.push(`Removed directory: ${dir.path}`);
       }
 
-      // Replace with symlink to kept instance (for duplicate removal)
-      if (symlinkTo && resolve(dir.path) !== resolve(symlinkTo)) {
+      // Replace with symlink to kept instance (for duplicate removal).
+      // Not used in the relocation flow — relocation already handled it.
+      if (
+        !relocation?.needed &&
+        symlinkTo &&
+        resolve(dir.path) !== resolve(symlinkTo)
+      ) {
         const parentDir = dirname(dir.path);
         const relTarget = relative(parentDir, symlinkTo);
         await symlink(relTarget, dir.path, "dir");

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -177,6 +177,19 @@ export interface RemovalPlan {
   agentsBlocks: Array<{ file: string; skillName: string }>;
 }
 
+export interface RemovalOptions {
+  providerFilter?: string;
+  scopeFilter?: Scope;
+}
+
+export interface RelocationInfo {
+  needed: boolean;
+  fromProvider: string;
+  fromPath: string;
+  toProvider: string;
+  toPath: string;
+}
+
 // ─── Audit Types ──────────────────────────────────────────────────────────
 
 export interface DuplicateGroup {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -194,6 +194,12 @@ export interface RelocationInfo {
    * empty when only one other provider remains.
    */
   repointPaths?: string[];
+  /**
+   * When true, skip the rename step (the target already holds a real
+   * folder) and only repoint surviving symlinks. The removed provider's
+   * real folder is deleted via the standard removal path.
+   */
+  repointOnly?: boolean;
 }
 
 // ─── Audit Types ──────────────────────────────────────────────────────────

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -188,6 +188,12 @@ export interface RelocationInfo {
   fromPath: string;
   toProvider: string;
   toPath: string;
+  /**
+   * Other surviving instances (not at toPath) whose symlinks must be
+   * repointed to toPath after the real folder is renamed there. May be
+   * empty when only one other provider remains.
+   */
+  repointPaths?: string[];
 }
 
 // ─── Audit Types ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #279

## Summary

Add full reverse-installation logic to the skill uninstall command. Handles multi-scope (global/project), multi-tool (Codex/Claude/etc.) uninstall with automatic real-folder relocation when the provider hosting the canonical skill directory is being removed.

## Approach

### New functionality in `src/uninstaller.ts`:
- **`findRelocationTarget(skillInstances, removedProvider)`** — finds a remaining provider instance to host the real folder when the current host is being removed
- **`buildRelocationInfo(plan, skillInstances, removedProvider)`** — detects if relocation will be needed and returns structured relocation info for the confirmation prompt
- **`cleanEmptyParentDirs(paths)`** — cleans up empty skill parent directories after removal (skips dirs with .DS_Store or .gitkeep)

### Enhanced `buildFullRemovalPlan`:
- Accepts `RemovalOptions` with optional `providerFilter` and `scopeFilter`
- Filters skill instances before building the plan

### Updated `src/cli.ts`:
- Added `-t, --tool <name>` flag to filter uninstall by tool/provider
- Enhanced confirmation prompt showing scope, tool, and real-folder relocation warning
- Automatically passes `symlinkTo` to `executeRemoval` when relocation is needed

## Changes

| File | Change |
|------|--------|
| `src/utils/types.ts` | Added `RemovalOptions` and `RelocationInfo` types |
| `src/uninstaller.ts` | Added `findRelocationTarget`, `buildRelocationInfo`, `cleanEmptyParentDirs`; enhanced `buildFullRemovalPlan` with filtering |
| `src/cli.ts` | Added `--tool` flag, enhanced confirmation with relocation info, scope/tool display |
| `src/uninstaller.test.ts` | 13 new tests for filtering, relocation, and cleanup functions |

## Test Results

```
✓ src/uninstaller.test.ts (41 tests) — 28 existing + 13 new
✓ src/installer.test.ts (141 tests) — no regressions
✓ tsc --noEmit — no type errors
```

## Acceptance Criteria

- [x] Uninstall supports both global and project scope via `-s` flag
- [x] Uninstall removes skill from specified tool via `-t, --tool` flag
- [x] When uninstalling from the tool hosting the real folder, the real folder is relocated to another tool and symlinks are reinstalled
- [x] Empty parent directories are cleaned up after uninstall
- [x] Confirmation prompt shows scope, tool, and real-folder relocation before proceeding