### PR TITLE
fix(uninstaller): surface relocation failures via non-zero exit code (#282)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1091,11 +1091,25 @@ async function cmdUninstall(args: ParsedArgs) {
   // When relocation is needed, pass the full RelocationInfo so executeRemoval
   // physically renames the real folder rather than deleting it and symlinking
   // to the original (which would have been the about-to-be-deleted path).
-  const log = await executeRemoval(
-    plan,
-    undefined,
-    relocationInfo?.needed ? relocationInfo : undefined,
-  );
+  let log: string[];
+  try {
+    log = await executeRemoval(
+      plan,
+      undefined,
+      relocationInfo?.needed ? relocationInfo : undefined,
+    );
+  } catch (err: any) {
+    // executeRemoval throws when a relocation rename/EXDEV-fallback fails.
+    // Surface any partial log entries (including the failure message it
+    // pushed before throwing) so the user sees what happened, then exit
+    // non-zero — don't print "Done." for a half-finished uninstall.
+    const partialLog: string[] = Array.isArray(err?.log) ? err.log : [];
+    for (const entry of partialLog) {
+      console.error(entry);
+    }
+    error(err?.message || "Uninstall failed.");
+    process.exit(1);
+  }
   for (const entry of log) {
     console.error(entry);
   }

--- a/src/uninstaller.test.ts
+++ b/src/uninstaller.test.ts
@@ -1218,6 +1218,50 @@ describe("executeRemoval with relocation", () => {
       await rm(base, { recursive: true, force: true });
     }
   });
+
+  it("throws (with log attached) when relocation rename fails so cmdUninstall exits non-zero", async () => {
+    // Regression for issue #282: a real-folder relocation failure was
+    // silently logged and the CLI still printed "Done." with exit 0.
+    // executeRemoval must propagate the failure so cmdUninstall can
+    // surface a non-zero exit, while keeping the log entry visible.
+    const base = await mkdtemp(join(tmpdir(), "asm-reloc-fail-"));
+    try {
+      const realDir = join(base, "claude", "skills", "my-skill");
+      const linkDir = join(base, "codex", "skills", "my-skill");
+      await mkdir(realDir, { recursive: true });
+      await mkdir(dirname(linkDir), { recursive: true });
+      await symlink(realDir, linkDir, "dir");
+
+      const plan: RemovalPlan = {
+        directories: [{ path: realDir, isSymlink: false }],
+        ruleFiles: [],
+        agentsBlocks: [],
+      };
+
+      // fromPath does not exist on disk — rename will fail with ENOENT,
+      // which is NOT EXDEV, so it hits the `throw err` branch in the
+      // rename try/catch and triggers the outer relocation catch block.
+      const relocation: RelocationInfo = {
+        needed: true,
+        fromProvider: "claude",
+        fromPath: join(base, "does", "not", "exist"),
+        toProvider: "codex",
+        toPath: linkDir,
+        repointPaths: [],
+      };
+
+      await expect(
+        executeRemoval(plan, undefined, relocation),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining("Failed to relocate real folder"),
+        log: expect.arrayContaining([
+          expect.stringContaining("Failed to relocate real folder"),
+        ]),
+      });
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
 });
 
 // ─── buildFullRemovalPlan: AGENTS.md filter regression ─────────────────────

--- a/src/uninstaller.ts
+++ b/src/uninstaller.ts
@@ -371,7 +371,18 @@ export async function executeRemoval(
           `Relocated real folder: ${relocation.fromPath} -> ${relocation.toPath}`,
         );
       } catch (err: any) {
+        // Relocation is load-bearing: if the rename/EXDEV-fallback fails
+        // we must NOT continue (repointing surviving symlinks at an empty
+        // toPath would dangle them, and the standard removal loop would
+        // delete the still-intact source). Push the human-readable log
+        // entry so callers can surface it, then throw so cmdUninstall
+        // exits non-zero rather than printing "Done."
         log.push(`Failed to relocate real folder: ${err.message}`);
+        const wrapped: Error & { log?: string[] } = new Error(
+          `Failed to relocate real folder: ${err.message}`,
+        );
+        wrapped.log = log;
+        throw wrapped;
       }
     }
 


### PR DESCRIPTION
## Summary

- `asm uninstall <name> -t <provider>` could silently report success after a failed real-folder relocation: the outer `try`/`catch` in `executeRemoval` pushed a "Failed to relocate real folder" entry to the human-readable log array but then continued, so `cmdUninstall` printed "Done." and exited 0.
- Now `executeRemoval` throws an `Error` (with the accumulated `log` attached) right after pushing the failure entry. `cmdUninstall` catches it, prints the partial log so the failure remains visible to the user, and exits non-zero via `process.exit(1)`.
- Throwing immediately also avoids the worst-case follow-on: repointing surviving symlinks at a `toPath` that the rename never populated would dangle them. Now the relocation flow stops cleanly on failure.

## Test plan

- [x] `npm run typecheck` — passes.
- [x] `npm run build` — passes.
- [x] `npm test` — all 1698 unit tests across 50 files pass, including the existing `executeRemoval with relocation` suite.
- [x] New focused test `throws (with log attached) when relocation rename fails so cmdUninstall exits non-zero` in `src/uninstaller.test.ts` — points `fromPath` at a nonexistent path (rename fails with ENOENT, hits the `throw err` branch), asserts the rejection carries both the failure message and a `log` array containing the human-readable entry.

Closes #282