### PR TITLE
fix(uninstaller): clean up partial state on EXDEV cp fallback failure (#283)

### DIFF
--- a/src/uninstaller.test.ts
+++ b/src/uninstaller.test.ts
@@ -1,4 +1,26 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+// ─── Module mocks for EXDEV cp fallback test (issue #283) ────────────────────
+// `vi.mock` is hoisted and file-level, so route through `vi.hoisted` so we can
+// swap rename/cp behaviour per test. All other tests fall through to the real
+// implementations.
+const fspMocks = vi.hoisted(() => ({
+  renameOverride: null as null | ((...args: any[]) => Promise<void>),
+  cpOverride: null as null | ((...args: any[]) => Promise<void>),
+}));
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+  return {
+    ...actual,
+    rename: (...args: Parameters<typeof actual.rename>) =>
+      fspMocks.renameOverride
+        ? fspMocks.renameOverride(...args)
+        : actual.rename(...args),
+    cp: (...args: Parameters<typeof actual.cp>) =>
+      fspMocks.cpOverride ? fspMocks.cpOverride(...args) : actual.cp(...args),
+  };
+});
+
 import {
   buildRemovalPlan,
   buildFullRemovalPlan,
@@ -1259,6 +1281,82 @@ describe("executeRemoval with relocation", () => {
         ]),
       });
     } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("cleans up partial copy at toPath when EXDEV cp fallback fails mid-copy", async () => {
+    // Regression for issue #283: when rename returns EXDEV and the cp
+    // fallback throws partway through (e.g. ENOSPC), the partial copy at
+    // toPath was left behind, the source at fromPath was untouched, and
+    // the failure was swallowed by the outer catch as a generic log line —
+    // leaving a half-migrated skill with no surfaced error. executeRemoval
+    // must clean up toPath before re-raising so re-running uninstall starts
+    // from a clean slate.
+    const base = await mkdtemp(join(tmpdir(), "asm-reloc-exdev-"));
+    let cpCalls = 0;
+    let renameCalls = 0;
+    try {
+      const realDir = join(base, "claude", "skills", "my-skill");
+      const linkDir = join(base, "codex", "skills", "my-skill");
+      await mkdir(realDir, { recursive: true });
+      await writeFile(join(realDir, "SKILL.md"), "source content");
+      await mkdir(dirname(linkDir), { recursive: true });
+      await symlink(realDir, linkDir, "dir");
+
+      // Force rename to report EXDEV so the cp fallback is exercised, then
+      // have cp create a partial copy at toPath before throwing — this
+      // mirrors a real mid-copy failure (e.g. disk full after some files
+      // have already been written).
+      fspMocks.renameOverride = async () => {
+        renameCalls += 1;
+        throw Object.assign(new Error("cross-device link"), { code: "EXDEV" });
+      };
+      fspMocks.cpOverride = async (_src: string, dest: string) => {
+        cpCalls += 1;
+        await mkdir(dest, { recursive: true });
+        await writeFile(join(dest, "SKILL.md"), "partial");
+        throw Object.assign(new Error("no space left on device"), {
+          code: "ENOSPC",
+        });
+      };
+
+      const plan: RemovalPlan = {
+        directories: [{ path: realDir, isSymlink: false }],
+        ruleFiles: [],
+        agentsBlocks: [],
+      };
+      const relocation: RelocationInfo = {
+        needed: true,
+        fromProvider: "claude",
+        fromPath: realDir,
+        toProvider: "codex",
+        toPath: linkDir,
+        repointPaths: [],
+      };
+
+      await expect(
+        executeRemoval(plan, undefined, relocation),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining("no space left on device"),
+        log: expect.arrayContaining([
+          expect.stringContaining("Failed to relocate real folder"),
+        ]),
+      });
+
+      // Partial copy at toPath was cleaned up.
+      await expect(lstat(linkDir)).rejects.toMatchObject({ code: "ENOENT" });
+      // Source at fromPath is intact so the user can re-run uninstall.
+      const sourceStats = await lstat(realDir);
+      expect(sourceStats.isDirectory()).toBe(true);
+      const sourceFile = await lstat(join(realDir, "SKILL.md"));
+      expect(sourceFile.isFile()).toBe(true);
+
+      expect(cpCalls).toBe(1);
+      expect(renameCalls).toBe(1);
+    } finally {
+      fspMocks.renameOverride = null;
+      fspMocks.cpOverride = null;
       await rm(base, { recursive: true, force: true });
     }
   });

--- a/src/uninstaller.ts
+++ b/src/uninstaller.ts
@@ -358,10 +358,27 @@ export async function executeRemoval(
             // Rare on a single-user machine but possible when ~/.claude and
             // ~/.codex live on different mounts (NFS, encrypted volumes).
             const { cp } = await import("fs/promises");
-            await cp(relocation.fromPath, relocation.toPath, {
-              recursive: true,
-              preserveTimestamps: true,
-            });
+            try {
+              await cp(relocation.fromPath, relocation.toPath, {
+                recursive: true,
+                preserveTimestamps: true,
+              });
+            } catch (cpErr: any) {
+              // Partial copy at toPath if cp threw mid-way (disk full, perm
+              // error on a specific file). Best-effort clean it up so the
+              // user isn't left with a half-migrated skill; fromPath is still
+              // intact because the rm below only runs after a successful cp,
+              // so re-running uninstall remains safe. Surface the original
+              // cp error so the outer catch wraps it as a relocation failure.
+              try {
+                await rm(relocation.toPath, { recursive: true, force: true });
+              } catch (cleanupErr: any) {
+                log.push(
+                  `Failed to clean up partial copy at ${relocation.toPath}: ${cleanupErr.message}`,
+                );
+              }
+              throw cpErr;
+            }
             await rm(relocation.fromPath, { recursive: true, force: true });
           } else {
             throw err;


### PR DESCRIPTION
Closes #283

## Summary

When the EXDEV fallback's recursive `cp` threw mid-copy (e.g. `ENOSPC`, perm error on a specific file), the uninstaller was left with:

- A partial copy at `toPath`
- The full source still at `fromPath`
- No clear error surfaced to the user

This wraps the `cp` call in a focused `try/catch` so the partial `toPath` is best-effort removed before the original `cp` error propagates. The `rm` of `fromPath` moves inside the success path, so the source naturally survives any `cp` failure and the user can safely re-run uninstall.

## Approach

- Inner `try/catch` only around the `cp` invocation inside the existing `EXDEV` branch.
- On `cp` failure: `fs.rm(toPath, { recursive: true, force: true })` then re-throw the original error.
- Cleanup errors are pushed onto the existing `log` array (same pattern as repoint failures) so the root cause stays the thrown error.
- Outer relocation `catch` (issue #282) still wraps the propagated error with the human-readable "Failed to relocate real folder" log entry — no double-wrapping.

## Test

Added `cleans up partial copy at toPath when EXDEV cp fallback fails mid-copy` in the existing `executeRemoval with relocation` describe block. The test:

- Mocks `rename` to throw `EXDEV` and `cp` to write a partial file then throw `ENOSPC`.
- Asserts `executeRemoval` rejects with the original `ENOSPC` message and the log line.
- Asserts `toPath` was cleaned up (`lstat` ENOENT) and `fromPath` (with its `SKILL.md`) is intact.

`fs/promises` is mocked at module level via `vi.hoisted` + `vi.mock` with a per-test override toggle, so all 52 existing tests continue to use the real filesystem implementations.

## Dependency

Depends on PR #285 (issue #282, branch `fix/282-uninstaller-relocation-exit-code`). The diff is opened against `main`, but the EXDEV cleanup is built on top of #282's "throw and propagate" contract. The PR will look cleaner once #285 lands.

## Test plan

- [x] `npm test` (1699/1699 pass)
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] New test covers all three acceptance criteria (cleanup of toPath, source intact, error propagates)