### PR TITLE
fix(uninstaller): preserve lock entry on partial -t uninstall (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- `asm uninstall <name> -t <provider>` now preserves the `.skill-lock.json` entry (source-tracking metadata: `source`, `commitHash`, `ref`) when other providers still have the skill installed, so subsequent `asm list`/`asm update` keep working on the survivors. Implemented as a hybrid of the issue's option 2 + option 1: when a real-folder relocation moves the canonical home to a kept provider the lock entry's `provider` field is repointed at the new home; when no relocation happened (two-real-folders or repoint-only topology) the entry is left intact. The full-uninstall path (no `-t`) still drops the entry as before. Known caveat in the two-real-folders case: the lock points at one surviving provider; per-provider lock entries remain the long-term fix ([#284](https://github.com/luongnv89/asm/issues/284)) — @luongnv89
+
 ## v2.7.0 — 2026-05-10
 
 ### Features

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -846,6 +846,163 @@ describe("CLI integration: uninstall", () => {
   });
 });
 
+// ─── CLI integration: uninstall lock-entry cleanup (issue #284) ─────────────
+//
+// Partial uninstall via `-t <provider>` must preserve `.skill-lock.json`
+// source-tracking metadata (source, commitHash, ref) when other providers
+// still have the skill installed. Full uninstall (no `-t`) still drops the
+// entry. The lock entry's `provider` field is repointed when a real-folder
+// relocation moved the canonical home, and left as-is otherwise.
+
+describe("CLI integration: uninstall lock-entry cleanup", () => {
+  let lockPath: string;
+
+  beforeAll(async () => {
+    const { stdout } = await runCLI("config", "path");
+    // config path looks like /<home>/.config/agent-skill-manager/config.json
+    lockPath = join(dirname(stdout.trim()), ".skill-lock.json");
+  });
+
+  async function readLockSkill(name: string) {
+    try {
+      const raw = await readFile(lockPath, "utf-8");
+      const lock = JSON.parse(raw);
+      return lock.skills?.[name] ?? null;
+    } catch (err: any) {
+      if (err.code === "ENOENT") return null;
+      throw err;
+    }
+  }
+
+  test("partial uninstall with -t preserves lock entry when other provider survives", async () => {
+    const tmpDir = await mkdtemp(
+      join(tmpdir(), "cli-uninstall-lock-preserve-"),
+    );
+    const skillDir = join(tmpDir, "lock-preserve-skill");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      `---\nname: lock-preserve-skill\ndescription: A test skill\nversion: 1.0.0\n---\n# lock-preserve-skill\n`,
+    );
+
+    try {
+      // Install into both providers (two separate real-folder installs)
+      const r1 = await runCLI(
+        "install",
+        skillDir,
+        "--yes",
+        "--force",
+        "--tool",
+        "claude",
+      );
+      expect(r1.exitCode).toBe(0);
+      const r2 = await runCLI(
+        "install",
+        skillDir,
+        "--yes",
+        "--force",
+        "--tool",
+        "codex",
+      );
+      expect(r2.exitCode).toBe(0);
+
+      // Lock entry exists after the second install
+      const before = await readLockSkill("lock-preserve-skill");
+      expect(before).not.toBeNull();
+      const sourceBefore = before.source;
+      const installedAtBefore = before.installedAt;
+
+      // Partial uninstall of claude only; codex still installed
+      const u = await runCLI(
+        "uninstall",
+        "lock-preserve-skill",
+        "--yes",
+        "--tool",
+        "claude",
+      );
+      expect(u.exitCode).toBe(0);
+
+      // Lock entry must still exist and retain source-tracking metadata
+      const after = await readLockSkill("lock-preserve-skill");
+      expect(after).not.toBeNull();
+      expect(after.source).toBe(sourceBefore);
+      expect(after.installedAt).toBe(installedAtBefore);
+    } finally {
+      // Clean up remaining install (codex) — full uninstall drops the entry
+      await runCLI("uninstall", "lock-preserve-skill", "--yes");
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("full uninstall (no -t) removes the lock entry", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "cli-uninstall-lock-full-"));
+    const skillDir = join(tmpDir, "lock-full-uninstall-skill");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      `---\nname: lock-full-uninstall-skill\ndescription: A test skill\nversion: 1.0.0\n---\n# lock-full-uninstall-skill\n`,
+    );
+
+    try {
+      const r = await runCLI(
+        "install",
+        skillDir,
+        "--yes",
+        "--force",
+        "--tool",
+        "claude",
+      );
+      expect(r.exitCode).toBe(0);
+      expect(await readLockSkill("lock-full-uninstall-skill")).not.toBeNull();
+
+      const u = await runCLI("uninstall", "lock-full-uninstall-skill", "--yes");
+      expect(u.exitCode).toBe(0);
+
+      expect(await readLockSkill("lock-full-uninstall-skill")).toBeNull();
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("partial uninstall with -t removes lock entry when no other providers survive", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "cli-uninstall-lock-tonly-"));
+    const skillDir = join(tmpDir, "lock-tonly-skill");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      `---\nname: lock-tonly-skill\ndescription: A test skill\nversion: 1.0.0\n---\n# lock-tonly-skill\n`,
+    );
+
+    try {
+      // Install only into claude
+      const r = await runCLI(
+        "install",
+        skillDir,
+        "--yes",
+        "--force",
+        "--tool",
+        "claude",
+      );
+      expect(r.exitCode).toBe(0);
+      expect(await readLockSkill("lock-tonly-skill")).not.toBeNull();
+
+      // Partial uninstall via -t claude, no other providers — entry must drop
+      const u = await runCLI(
+        "uninstall",
+        "lock-tonly-skill",
+        "--yes",
+        "--tool",
+        "claude",
+      );
+      expect(u.exitCode).toBe(0);
+
+      expect(await readLockSkill("lock-tonly-skill")).toBeNull();
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("CLI integration: audit", () => {
   test("audit runs and exits 0", async () => {
     const { exitCode } = await runCLI("audit");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,7 +98,12 @@ import {
   formatSecurityReport,
   formatSecurityReportJSON,
 } from "./security-auditor";
-import { writeLockEntry, removeLockEntry, getCommitHash } from "./utils/lock";
+import {
+  writeLockEntry,
+  removeLockEntry,
+  setLockEntryProvider,
+  getCommitHash,
+} from "./utils/lock";
 import {
   checkOutdated,
   updateSkills,
@@ -151,7 +156,7 @@ import { VERSION_STRING } from "./utils/version";
 import { buildShadowingReport } from "./utils/path-shadowing";
 import { parseEditorCommand } from "./utils/editor";
 import { setVerbose } from "./logger";
-import { join as joinPath } from "path";
+import { join as joinPath, resolve } from "path";
 import type {
   Scope,
   SortBy,
@@ -1100,11 +1105,40 @@ async function cmdUninstall(args: ParsedArgs) {
     console.error(entry);
   }
 
-  // Remove lock entry for tracking
+  // Lock-entry cleanup. The lock schema stores one entry per skill name,
+  // keyed on a single provider field. On a full uninstall (no `-t`) we
+  // drop the entry. On a partial uninstall (`-t <provider>`) with other
+  // providers' instances still present, we MUST keep source-tracking
+  // metadata (`source`, `commitHash`, `ref`) alive for the survivors:
+  //
+  //   • Real-folder relocation (a real folder was moved to a kept
+  //     provider's slot) — repoint the lock entry's `provider` field at
+  //     the new home so `asm list`/`asm update` use the right path.
+  //   • Two-real-folders or repoint-only — at least one surviving
+  //     provider has a real folder, so source-tracking metadata stays
+  //     useful even if the entry's `provider` field is now stale
+  //     relative to which install survived.
+  //
+  // Known limitation: in the two-real-folders case the lock points at
+  // ONE provider only; that provider may not be the one that survived.
+  // Per-provider lock entries are the long-term fix (tracked separately).
+  const removedDirSet = new Set(plan.directories.map((d) => resolve(d.path)));
+  const survivingInstances = matchingSkills.filter(
+    (s) => !removedDirSet.has(resolve(s.originalPath)),
+  );
   try {
-    await removeLockEntry(skillName);
+    if (targetProvider && survivingInstances.length > 0) {
+      if (relocationInfo?.needed && !relocationInfo.repointOnly) {
+        await setLockEntryProvider(skillName, relocationInfo.toProvider);
+      }
+      // else: keep the lock entry as-is — two-real-folders or
+      // repoint-only, both leave the original provider's real folder
+      // intact, so source-tracking metadata stays accurate.
+    } else {
+      await removeLockEntry(skillName);
+    }
   } catch {
-    // Lock removal failure is non-fatal
+    // Lock cleanup failure is non-fatal
   }
 
   console.error(ansi.green("\nDone."));

--- a/src/utils/lock.test.ts
+++ b/src/utils/lock.test.ts
@@ -14,6 +14,7 @@ import {
   readLock,
   writeLockEntry,
   removeLockEntry,
+  setLockEntryProvider,
   getCommitHash,
 } from "./lock";
 
@@ -234,6 +235,89 @@ describe("removeLockEntry", () => {
   test("no-op when lock file does not exist", async () => {
     // Should not throw
     await removeLockEntry("anything");
+  });
+});
+
+// ─── setLockEntryProvider tests ──────────────────────────────────────────────
+
+describe("setLockEntryProvider", () => {
+  test("updates provider while preserving all other fields", async () => {
+    const data = {
+      version: 1,
+      skills: {
+        "my-skill": {
+          source: "github:owner/repo",
+          commitHash: "abc123",
+          ref: "v1.0",
+          installedAt: "2026-05-10T12:00:00Z",
+          provider: "claude",
+          sourceType: "github" as const,
+        },
+      },
+    };
+    await writeFile(mockState.lockPath, JSON.stringify(data), "utf-8");
+
+    await setLockEntryProvider("my-skill", "codex");
+
+    const lock = await readLock();
+    expect(lock.skills["my-skill"].provider).toBe("codex");
+    expect(lock.skills["my-skill"].source).toBe("github:owner/repo");
+    expect(lock.skills["my-skill"].commitHash).toBe("abc123");
+    expect(lock.skills["my-skill"].ref).toBe("v1.0");
+    expect(lock.skills["my-skill"].installedAt).toBe("2026-05-10T12:00:00Z");
+    expect(lock.skills["my-skill"].sourceType).toBe("github");
+  });
+
+  test("no-op when entry does not exist", async () => {
+    const data = {
+      version: 1,
+      skills: {
+        "skill-a": {
+          source: "github:owner/a",
+          commitHash: "aaa",
+          ref: "main",
+          installedAt: "2026-05-10T12:00:00Z",
+          provider: "claude",
+        },
+      },
+    };
+    await writeFile(mockState.lockPath, JSON.stringify(data), "utf-8");
+
+    await setLockEntryProvider("nonexistent", "codex");
+
+    const lock = await readLock();
+    expect(Object.keys(lock.skills)).toHaveLength(1);
+    expect(lock.skills["skill-a"].provider).toBe("claude");
+  });
+
+  test("no-op when lock file does not exist", async () => {
+    // Should not throw and should not create the lock file
+    await setLockEntryProvider("anything", "codex");
+    const lock = await readLock();
+    expect(lock.skills).toEqual({});
+  });
+
+  test("no-op when provider already matches", async () => {
+    const data = {
+      version: 1,
+      skills: {
+        "skill-a": {
+          source: "github:owner/a",
+          commitHash: "aaa",
+          ref: "main",
+          installedAt: "2026-05-10T12:00:00Z",
+          provider: "claude",
+        },
+      },
+    };
+    await writeFile(mockState.lockPath, JSON.stringify(data), "utf-8");
+    // Capture the on-disk bytes — no write should occur on a no-op match
+    const before = await readFile(mockState.lockPath, "utf-8");
+
+    await setLockEntryProvider("skill-a", "claude");
+
+    const after = await readFile(mockState.lockPath, "utf-8");
+    expect(after).toBe(before);
   });
 });
 

--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -73,6 +73,32 @@ export async function removeLockEntry(name: string): Promise<void> {
   debug(`lock: removed entry for "${name}"`);
 }
 
+/**
+ * Rewrite an existing entry's provider field while preserving every other
+ * field (source, commitHash, ref, installedAt, sourceType, registryName).
+ * No-op when the entry doesn't exist. Used by partial-uninstall (`-t`) when
+ * a real-folder relocation moves the canonical home from one provider to
+ * another and source-tracking metadata must follow the surviving instance.
+ */
+export async function setLockEntryProvider(
+  name: string,
+  provider: string,
+): Promise<void> {
+  const lock = await readLock();
+  const entry = lock.skills[name];
+  if (!entry) {
+    debug(`lock: no entry for "${name}", cannot update provider`);
+    return;
+  }
+  if (entry.provider === provider) {
+    debug(`lock: entry for "${name}" already points at "${provider}"`);
+    return;
+  }
+  lock.skills[name] = { ...entry, provider };
+  await writeLock(lock);
+  debug(`lock: updated provider for "${name}" -> "${provider}"`);
+}
+
 async function writeLock(lock: LockFile): Promise<void> {
   const lockPath = getLockPath();
   await mkdir(dirname(lockPath), { recursive: true });


### PR DESCRIPTION
## Summary

- Closes #284. `asm uninstall <name> -t <provider>` was unconditionally dropping the `.skill-lock.json` entry, so when other providers' instances survived, source-tracking metadata (`source`, `commitHash`, `ref`) was lost and `asm list` / `asm update` could no longer trace the survivors back to their install.
- Implements the **option-2 + option-1 hybrid** suggested in the issue:
  - `-t <provider>` AND at least one other instance survives:
    - real-folder relocation moved the canonical home → repoint the lock entry's `provider` field at the new home (`setLockEntryProvider`)
    - two-real-folders or repoint-only → keep the entry as-is
  - Otherwise (full uninstall, or `-t` with no survivors): drop the entry as before.
- New helper `setLockEntryProvider(name, provider)` in `src/utils/lock.ts` — no-op on missing entry, preserves every other field.
- Decision documented in [CHANGELOG.md](../blob/fix/284-uninstaller-preserve-lock-entry/CHANGELOG.md) under a new `## Unreleased` section, including the known limitation that drives the per-provider lock schema follow-up.

## Test plan

- [x] `npm test` (1704 tests, 50 files — all passing)
- [x] `npm run build` clean
- [x] Unit tests for `setLockEntryProvider` (`src/utils/lock.test.ts`): updates provider while preserving all fields, no-op when entry missing, no-op when lock file missing, no-op when provider already matches.
- [x] CLI integration tests (`src/cli.test.ts`, new `CLI integration: uninstall lock-entry cleanup` group):
  - `asm uninstall foo -t claude` with codex also installed → lock entry preserved, source-tracking metadata intact.
  - `asm uninstall foo` (no `-t`) → lock entry removed.
  - `asm uninstall foo -t claude` with no other providers installed → lock entry removed.