### PR TITLE
fix(test): stop bundle tests leaking installed skills to ~/.claude/skills/ (#288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - `asm uninstall <name> -t <provider>` now preserves the `.skill-lock.json` entry (source-tracking metadata: `source`, `commitHash`, `ref`) when other providers still have the skill installed, so subsequent `asm list`/`asm update` keep working on the survivors. Implemented as a hybrid of the issue's option 2 + option 1: when a real-folder relocation moves the canonical home to a kept provider the lock entry's `provider` field is repointed at the new home; when no relocation happened (two-real-folders or repoint-only topology) the entry is left intact. The full-uninstall path (no `-t`) still drops the entry as before. Known caveat in the two-real-folders case: the lock points at one surviving provider; per-provider lock entries remain the long-term fix ([#284](https://github.com/luongnv89/asm/issues/284)) — @luongnv89
+- `fix(test):` Stop bundle modify/export tests from leaking installed skill copies into the user's real `~/.claude/skills/`. Each test now creates its source dir as `<tmpRoot>/<frontmatter-name>/` so the installer's destination basename matches the name the `uninstall` cleanup uses for lookup; a per-test `assertSkillUninstalled` guard fails the test if the install survives, and a one-shot `beforeAll` sweep removes any `cli-skill-for-*` leftovers accumulated by prior runs ([#288](https://github.com/luongnv89/asm/issues/288)) — @luongnv89
 
 ## v2.7.0 — 2026-05-10
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -16,6 +16,7 @@ import {
   rm,
   writeFile,
   mkdir,
+  readdir,
   readFile,
   lstat,
   readlink,
@@ -44,6 +45,29 @@ async function runCLI(
     stderr: res.stderr.trim(),
     exitCode: res.exitCode,
   };
+}
+
+// Helper: assert that a globally installed skill directory was actually removed.
+// `asm install <dir>` installs to ~/.claude/skills/<basename(dir)>, and the
+// uninstaller looks up by that same basename. When a test's source directory
+// basename does not match the skill's frontmatter `name`, the uninstall step
+// silently fails to match and leaks the install (issue #288). This helper, run
+// in each test's `finally`, catches regressions of that bug class.
+async function assertSkillUninstalled(installedDirName: string): Promise<void> {
+  const installedPath = join(homedir(), ".claude", "skills", installedDirName);
+  let leaked = false;
+  try {
+    await lstat(installedPath);
+    leaked = true;
+  } catch {
+    // ENOENT — expected: uninstall removed it.
+  }
+  if (leaked) {
+    await rm(installedPath, { recursive: true, force: true });
+    throw new Error(
+      `Test leaked installed skill at ${installedPath} — uninstall did not remove it.`,
+    );
+  }
 }
 
 // ─── parseArgs unit tests ───────────────────────────────────────────────────
@@ -3764,6 +3788,26 @@ describe("parseArgs: bundle modify and export", () => {
 // ─── CLI integration: bundle modify ──────────────────────────────────────────
 
 describe("CLI integration: bundle modify", () => {
+  // One-shot cleanup of historical leftovers from #288: prior versions of these
+  // tests used `mkdtemp` prefixes that did not match the frontmatter name, so
+  // `asm uninstall` could not find the installed copy and ~/.claude/skills/
+  // accumulated hundreds of `cli-skill-for-*` directories. Sweep any that
+  // remain on developer machines on the next test run.
+  beforeAll(async () => {
+    const skillsDir = join(homedir(), ".claude", "skills");
+    let entries: string[] = [];
+    try {
+      entries = await readdir(skillsDir);
+    } catch {
+      return; // no skills dir — nothing to sweep
+    }
+    await Promise.all(
+      entries
+        .filter((e) => e.startsWith("cli-skill-for-"))
+        .map((e) => rm(join(skillsDir, e), { recursive: true, force: true })),
+    );
+  });
+
   test("bundle modify without name exits 2", async () => {
     const { stderr, exitCode } = await runCLI("bundle", "modify");
     expect(exitCode).toBe(2);
@@ -3821,10 +3865,15 @@ describe("CLI integration: bundle modify", () => {
   });
 
   test("bundle modify --add and --description updates saved bundle", async () => {
-    // Create a real bundle in the bundles directory first
-    const tmpSkillDir = await mkdtemp(join(tmpdir(), "cli-skill-for-modify-"));
+    // Source dir basename must equal the skill's frontmatter `name` so the
+    // installer's destination directory matches the name the uninstall call
+    // uses for lookup — see #288.
+    const tmpRoot = await mkdtemp(join(tmpdir(), "cli-bundle-modify-"));
+    const skillName = "modify-test-skill";
+    const tmpSkillDir = join(tmpRoot, skillName);
+    await mkdir(tmpSkillDir, { recursive: true });
     const skillMd = `---
-name: modify-test-skill
+name: ${skillName}
 description: A test skill for modify
 version: 1.0.0
 ---
@@ -3869,15 +3918,19 @@ version: 1.0.0
       expect(parsed.tags).toEqual(["foo", "bar"]);
     } finally {
       await runCLI("bundle", "remove", bundleName, "--yes");
-      await runCLI("uninstall", "modify-test-skill", "--yes");
-      await rm(tmpSkillDir, { recursive: true, force: true });
+      await runCLI("uninstall", skillName, "--yes");
+      await rm(tmpRoot, { recursive: true, force: true });
+      await assertSkillUninstalled(skillName);
     }
   });
 
   test("bundle modify --remove on nonexistent skill reports no change", async () => {
-    const tmpSkillDir = await mkdtemp(join(tmpdir(), "cli-skill-for-remove-"));
+    const tmpRoot = await mkdtemp(join(tmpdir(), "cli-bundle-remove-"));
+    const skillName = "rm-skill-a";
+    const tmpSkillDir = join(tmpRoot, skillName);
+    await mkdir(tmpSkillDir, { recursive: true });
     const skillMd = `---
-name: rm-skill-a
+name: ${skillName}
 description: A test skill
 version: 1.0.0
 ---
@@ -3911,16 +3964,20 @@ version: 1.0.0
       expect(stderr).toContain("not found in bundle");
     } finally {
       await runCLI("bundle", "remove", bundleName, "--yes");
-      await runCLI("uninstall", "rm-skill-a", "--yes");
-      await rm(tmpSkillDir, { recursive: true, force: true });
+      await runCLI("uninstall", skillName, "--yes");
+      await rm(tmpRoot, { recursive: true, force: true });
+      await assertSkillUninstalled(skillName);
     }
   });
 
   test("bundle modify --remove all skills exits 1 with at-least-one-skill error", async () => {
     // Create a bundle file directly with one skill, then try to remove it
-    const tmpSkillDir = await mkdtemp(join(tmpdir(), "cli-skill-for-remove2-"));
+    const tmpRoot = await mkdtemp(join(tmpdir(), "cli-bundle-remove2-"));
+    const skillName = "rm-only-skill";
+    const tmpSkillDir = join(tmpRoot, skillName);
+    await mkdir(tmpSkillDir, { recursive: true });
     const skillMd = `---
-name: rm-only-skill
+name: ${skillName}
 description: Only skill
 version: 1.0.0
 ---
@@ -3949,7 +4006,7 @@ version: 1.0.0
     );
     const bundleData = JSON.parse(showOut);
     const hasSkill = bundleData.skills.some(
-      (s: { name: string }) => s.name === "rm-only-skill",
+      (s: { name: string }) => s.name === skillName,
     );
 
     try {
@@ -3960,7 +4017,7 @@ version: 1.0.0
           "modify",
           bundleName,
           "--remove",
-          "rm-only-skill",
+          skillName,
         );
         expect(exitCode).toBe(1);
         expect(stderr).toContain("at least one skill");
@@ -3970,8 +4027,9 @@ version: 1.0.0
       }
     } finally {
       await runCLI("bundle", "remove", bundleName, "--yes");
-      await runCLI("uninstall", "rm-only-skill", "--yes");
-      await rm(tmpSkillDir, { recursive: true, force: true });
+      await runCLI("uninstall", skillName, "--yes");
+      await rm(tmpRoot, { recursive: true, force: true });
+      await assertSkillUninstalled(skillName);
     }
   });
 
@@ -4003,9 +4061,12 @@ describe("CLI integration: bundle export", () => {
   });
 
   test("bundle export writes bundle JSON to specified file", async () => {
-    const tmpSkillDir = await mkdtemp(join(tmpdir(), "cli-skill-for-export-"));
+    const tmpRoot = await mkdtemp(join(tmpdir(), "cli-bundle-export-"));
+    const skillName = "export-test-skill";
+    const tmpSkillDir = join(tmpRoot, skillName);
+    await mkdir(tmpSkillDir, { recursive: true });
     const skillMd = `---
-name: export-test-skill
+name: ${skillName}
 description: A test skill for export
 version: 1.0.0
 ---
@@ -4048,16 +4109,20 @@ version: 1.0.0
       expect(Array.isArray(parsed.skills)).toBe(true);
     } finally {
       await runCLI("bundle", "remove", bundleName, "--yes");
-      await runCLI("uninstall", "export-test-skill", "--yes");
-      await rm(tmpSkillDir, { recursive: true, force: true });
+      await runCLI("uninstall", skillName, "--yes");
+      await rm(tmpRoot, { recursive: true, force: true });
       await rm(outputDir, { recursive: true, force: true });
+      await assertSkillUninstalled(skillName);
     }
   });
 
   test("bundle export defaults to ./<name>.json when no output file given", async () => {
-    const tmpSkillDir = await mkdtemp(join(tmpdir(), "cli-skill-for-export2-"));
+    const tmpRoot = await mkdtemp(join(tmpdir(), "cli-bundle-export2-"));
+    const skillName = "export-default-skill";
+    const tmpSkillDir = join(tmpRoot, skillName);
+    await mkdir(tmpSkillDir, { recursive: true });
     const skillMd = `---
-name: export-default-skill
+name: ${skillName}
 description: A test skill
 version: 1.0.0
 ---
@@ -4096,15 +4161,19 @@ version: 1.0.0
       }
     } finally {
       await runCLI("bundle", "remove", bundleName, "--yes");
-      await runCLI("uninstall", "export-default-skill", "--yes");
-      await rm(tmpSkillDir, { recursive: true, force: true });
+      await runCLI("uninstall", skillName, "--yes");
+      await rm(tmpRoot, { recursive: true, force: true });
+      await assertSkillUninstalled(skillName);
     }
   });
 
   test("bundle export does not overwrite existing file without --force", async () => {
-    const tmpSkillDir = await mkdtemp(join(tmpdir(), "cli-skill-for-noover-"));
+    const tmpRoot = await mkdtemp(join(tmpdir(), "cli-bundle-noover-"));
+    const skillName = "export-nooverwrite-skill";
+    const tmpSkillDir = join(tmpRoot, skillName);
+    await mkdir(tmpSkillDir, { recursive: true });
     const skillMd = `---
-name: export-nooverwrite-skill
+name: ${skillName}
 description: A test skill
 version: 1.0.0
 ---
@@ -4147,16 +4216,20 @@ version: 1.0.0
       expect(content).toBe("existing content");
     } finally {
       await runCLI("bundle", "remove", bundleName, "--yes");
-      await runCLI("uninstall", "export-nooverwrite-skill", "--yes");
-      await rm(tmpSkillDir, { recursive: true, force: true });
+      await runCLI("uninstall", skillName, "--yes");
+      await rm(tmpRoot, { recursive: true, force: true });
       await rm(outputDir, { recursive: true, force: true });
+      await assertSkillUninstalled(skillName);
     }
   });
 
   test("bundle export --force overwrites existing file", async () => {
-    const tmpSkillDir = await mkdtemp(join(tmpdir(), "cli-skill-for-force-"));
+    const tmpRoot = await mkdtemp(join(tmpdir(), "cli-bundle-force-"));
+    const skillName = "export-force-skill";
+    const tmpSkillDir = join(tmpRoot, skillName);
+    await mkdir(tmpSkillDir, { recursive: true });
     const skillMd = `---
-name: export-force-skill
+name: ${skillName}
 description: A test skill
 version: 1.0.0
 ---
@@ -4201,16 +4274,20 @@ version: 1.0.0
       expect(parsed.name).toBe(bundleName);
     } finally {
       await runCLI("bundle", "remove", bundleName, "--yes");
-      await runCLI("uninstall", "export-force-skill", "--yes");
-      await rm(tmpSkillDir, { recursive: true, force: true });
+      await runCLI("uninstall", skillName, "--yes");
+      await rm(tmpRoot, { recursive: true, force: true });
       await rm(outputDir, { recursive: true, force: true });
+      await assertSkillUninstalled(skillName);
     }
   });
 
   test("bundle export --json outputs structured JSON result", async () => {
-    const tmpSkillDir = await mkdtemp(join(tmpdir(), "cli-skill-for-json-"));
+    const tmpRoot = await mkdtemp(join(tmpdir(), "cli-bundle-json-"));
+    const skillName = "export-json-skill";
+    const tmpSkillDir = join(tmpRoot, skillName);
+    await mkdir(tmpSkillDir, { recursive: true });
     const skillMd = `---
-name: export-json-skill
+name: ${skillName}
 description: A test skill
 version: 1.0.0
 ---
@@ -4249,9 +4326,10 @@ version: 1.0.0
       expect(result.bundle.name).toBe(bundleName);
     } finally {
       await runCLI("bundle", "remove", bundleName, "--yes");
-      await runCLI("uninstall", "export-json-skill", "--yes");
-      await rm(tmpSkillDir, { recursive: true, force: true });
+      await runCLI("uninstall", skillName, "--yes");
+      await rm(tmpRoot, { recursive: true, force: true });
       await rm(outputDir, { recursive: true, force: true });
+      await assertSkillUninstalled(skillName);
     }
   });
 });


### PR DESCRIPTION
## Summary

- Eight bundle modify/export tests in `src/cli.test.ts` were installing skills from `mkdtemp` temp dirs whose basename did not match the skill's frontmatter `name`. The installer keeps the source basename for the destination, so `~/.claude/skills/cli-skill-for-modify-XXXXXX/` was created — and the test's cleanup `runCLI("uninstall", "modify-test-skill")` never matched, leaking the install copy forever.
- This PR makes each test's source dir basename equal to the frontmatter `name`, adds a per-test `assertSkillUninstalled` regression guard, and sweeps any pre-existing `cli-skill-for-*` leftovers via a one-shot `beforeAll`.

## Approach

**Decision: fix the leak at the test layer, not the installer.**

The alternative root-cause fix — making `asm install` derive the destination directory from the SKILL.md frontmatter `name` — would change user-visible installer behavior and is out of scope for this cleanup. The test-side fix follows the working pattern already in use at \`src/cli.test.ts:3499\`/\`3543\`/\`3598\` (bundle install tests use \`mkdtemp + mkdir(skillName)\`).

## Decision Record

- **Option A — change installer to use frontmatter name for destination:** rejected (user-visible behavior change, scope creep, separate PR-worthy discussion)
- **Option B — sandbox HOME for the 8 tests via `runCLIWithHome`:** considered, would also work; deferred in favor of B' because it requires migrating 8 multi-step tests to a new runner pattern
- **Option B' (selected) — match source basename to frontmatter name:** matches the existing convention in the same file, minimal diff, makes the leak structurally impossible
- **AC1 cleanup of historical leftovers:** `beforeAll` sweep of `cli-skill-for-*` in each affected suite. Self-heals dev machines on next run without requiring a separate one-off script.
- **AC3 regression guard:** per-test `assertSkillUninstalled(skillName)` in each `finally`. Fires per-test (loud failure) rather than once at file end. The advisor noted that asserting on `cli-skill-for-*` post-fix would test the wrong invariant — the bug class is "uninstall claims success but the dir survives," so the guard checks the install directory itself.

## Changes

| File | Change |
|---|---|
| `src/cli.test.ts` | New `assertSkillUninstalled` helper; 8 tests refactored to use `<tmpRoot>/<skillName>/` source layout; `beforeAll` sweep in `bundle modify` suite; added `readdir` to the static imports |
| `CHANGELOG.md` | Unreleased Bug Fixes entry citing #288 |

Total: 2 files, +114 / -35 lines.

## Test Results

| Check | Result |
|---|---|
| `npm run typecheck` | ✓ pass |
| Bundle suites (48 tests) | ✓ all pass |
| Full test suite (1706 tests, 50 files) | ✓ all pass |
| `~/.claude/skills/cli-skill-for-*` after run | 0 (was 296 before) |
| `~/.claude/skills/<test-skill-names>` after run | 0 of 8 |

## Acceptance Criteria Verification

| AC | How verified |
|---|---|
| One-shot cleanup of existing leak | `beforeAll` in `bundle modify` suite removes any `cli-skill-for-*` leftovers — verified that 296 leftovers disappeared on the first run of the modified suite |
| Tests no longer leak | Per-test `assertSkillUninstalled` runs in `finally`; full suite passes with 0 leftover directories in `~/.claude/skills/` |
| Regression guard | `assertSkillUninstalled` throws if the installed dir survives the uninstall call, failing the specific test rather than the silent leak the original tests had |
| Root cause addressed (with explanation) | Test-side fix chosen over installer change — explained inline in the test comment and in this PR's Decision Record |

## Test plan

- [ ] CI passes
- [ ] Reviewer verifies `~/.claude/skills/` is unchanged before vs. after running the suite on their machine
- [ ] Spot-check that the new `assertSkillUninstalled` actually fails when the install survives (e.g., temporarily revert one of the basename fixes — the matching test should fail loudly)

Closes #288