### PR TITLE
feat(skill-index): add follow-builders root skill support (#143)

### DIFF
--- a/data/skill-index-resources.json
+++ b/data/skill-index-resources.json
@@ -306,6 +306,15 @@
       "description": "Collection of agent skills compatible with pi-coding-agent, Claude Code, Codex CLI, Amp, and Droid",
       "maintainer": "@badlogic",
       "enabled": true
+    },
+    {
+      "source": "github:zarazhangrui/follow-builders",
+      "url": "https://github.com/zarazhangrui/follow-builders",
+      "owner": "zarazhangrui",
+      "repo": "follow-builders",
+      "description": "Follow Builders skill for discovering and following builders",
+      "maintainer": "@zarazhangrui",
+      "enabled": true
     }
   ]
 }

--- a/data/skill-index/zarazhangrui_follow-builders.json
+++ b/data/skill-index/zarazhangrui_follow-builders.json
@@ -1,0 +1,147 @@
+{
+  "repoUrl": "https://github.com/zarazhangrui/follow-builders.git",
+  "owner": "zarazhangrui",
+  "repo": "follow-builders",
+  "updatedAt": "2026-06-08T22:51:09.748Z",
+  "skillCount": 1,
+  "skills": [
+    {
+      "name": "follow-builders",
+      "description": "AI builders digest — monitors top AI builders on X and YouTube podcasts, remixes their content into digestible summaries. Use when the user wants AI industry insights, builder updates, or invokes /ai. No API keys or dependencies required — all content is fetched from a central feed.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:zarazhangrui/follow-builders",
+      "relPath": "",
+      "verified": true,
+      "tokenCount": 5448,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-06-08T22:51:09.746Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 74,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 9,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-06-08T22:51:09.746Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 62,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 8,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-06-08T22:51:09.746Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    }
+  ],
+  "bundles": []
+}

--- a/src/ingester.test.ts
+++ b/src/ingester.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { mkdtemp, writeFile, mkdir, rm, readFile, readdir } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
-import { ensureIndexDir, listIndexedRepos, removeRepoIndex } from "./ingester";
+import {
+  buildSkillInstallUrl,
+  ensureIndexDir,
+  listIndexedRepos,
+  removeRepoIndex,
+} from "./ingester";
 import { getIndexDir } from "./config";
 import { discoverSkills } from "./installer";
 import { dedupeSkillsByName } from "./skill-dedupe";
@@ -88,6 +93,40 @@ describe("removeRepoIndex", () => {
   });
 });
 
+describe("buildSkillInstallUrl", () => {
+  it("does not append a trailing colon for a root-level skill", () => {
+    expect(
+      buildSkillInstallUrl(
+        {
+          owner: "zarazhangrui",
+          repo: "follow-builders",
+          ref: null,
+          subpath: null,
+          cloneUrl: "https://github.com/zarazhangrui/follow-builders.git",
+          sshCloneUrl: "git@github.com:zarazhangrui/follow-builders.git",
+        },
+        "",
+      ),
+    ).toBe("github:zarazhangrui/follow-builders");
+  });
+
+  it("keeps subdirectory installUrl behavior unchanged", () => {
+    expect(
+      buildSkillInstallUrl(
+        {
+          owner: "owner",
+          repo: "repo",
+          ref: "main",
+          subpath: null,
+          cloneUrl: "https://github.com/owner/repo.git",
+          sshCloneUrl: "git@github.com:owner/repo.git",
+        },
+        "skills/example",
+      ),
+    ).toBe("github:owner/repo#main:skills/example");
+  });
+});
+
 describe("ingester verification path", () => {
   let tempDir: string;
 
@@ -97,6 +136,34 @@ describe("ingester verification path", () => {
 
   afterEach(async () => {
     await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("reads and verifies root-level SKILL.md using empty relPath", async () => {
+    await writeFile(
+      join(tempDir, "SKILL.md"),
+      `---
+name: root-good
+description: A root-level skill for testing
+version: 1.0.0
+---
+
+# Root Good
+
+This root-level skill has enough instruction content to pass verification.
+`,
+      "utf-8",
+    );
+
+    const discovered = await discoverSkills(tempDir);
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0].relPath).toBe("");
+
+    const skillMdContent = await readFile(
+      join(tempDir, discovered[0].relPath, "SKILL.md"),
+      "utf-8",
+    );
+    const result = verifySkill(discovered[0], skillMdContent);
+    expect(result.verified).toBe(true);
   });
 
   it("produces verified:true for a well-formed skill", async () => {

--- a/src/ingester.ts
+++ b/src/ingester.ts
@@ -41,6 +41,13 @@ export async function ensureIndexDir(): Promise<string> {
   return indexDir;
 }
 
+export function buildSkillInstallUrl(
+  source: ParsedSource,
+  relPath: string,
+): string {
+  return `github:${source.owner}/${source.repo}${source.ref ? `#${source.ref}` : ""}${relPath ? `:${relPath}` : ""}`;
+}
+
 export async function ingestRepo(sourceInput: string): Promise<IngestResult> {
   await checkGitAvailable();
 
@@ -193,7 +200,7 @@ export async function ingestRepo(sourceInput: string): Promise<IngestResult> {
         creator: skill.creator,
         compatibility: skill.compatibility,
         allowedTools: skill.allowedTools,
-        installUrl: `github:${source.owner}/${source.repo}${source.ref ? `#${source.ref}` : ""}${skill.relPath ? `:${skill.relPath}` : ""}`,
+        installUrl: buildSkillInstallUrl(source, skill.relPath),
         relPath: skill.relPath,
         verified: verification.verified,
         tokenCount,

--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -22,6 +22,7 @@ import {
   discoverSkills,
   scanForWarnings,
   resolveProvider,
+  executeInstall,
   executeInstallAllProviders,
   buildInstallPlan,
   checkConflict,
@@ -29,6 +30,7 @@ import {
   findDuplicateInstallNames,
   buildRepoUrl,
   checkNpxAvailable,
+  installScriptDependencies,
 } from "./installer";
 import type { AppConfig, ProviderConfig } from "./utils/types";
 
@@ -539,6 +541,23 @@ describe("discoverSkills", () => {
 
   afterEach(async () => {
     await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("discovers a root-level skill and does not recurse into children", async () => {
+    await mkdir(join(tempDir, "child"), { recursive: true });
+    await writeFile(
+      join(tempDir, "SKILL.md"),
+      "---\nname: root-skill\nversion: 1.0.0\ndescription: Root skill\n---\n# Root\n",
+    );
+    await writeFile(
+      join(tempDir, "child", "SKILL.md"),
+      "---\nname: child-skill\n---\n# Child\n",
+    );
+
+    const discovered = await discoverSkills(tempDir);
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0].name).toBe("root-skill");
+    expect(discovered[0].relPath).toBe("");
   });
 
   test("discovers skills in subdirectories", async () => {
@@ -1686,6 +1705,99 @@ describe("buildInstallPlan scope - target directory resolution", () => {
     expect(plan.skillName).toBe("foo");
     expect(plan.providerName).toBe("agents");
     expect(plan.providerLabel).toBe("Agents");
+  });
+});
+
+// ─── executeInstall post-install dependency tests ───────────────────────────
+
+describe("installScriptDependencies", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-test-scripts-deps-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("runs npm install only in scripts directory when scripts/package.json exists", async () => {
+    const scriptsDir = join(tempDir, "scripts");
+    await mkdir(scriptsDir, { recursive: true });
+    await writeFile(join(scriptsDir, "package.json"), '{"dependencies":{}}\n');
+    const runner = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+
+    await installScriptDependencies(tempDir, runner as any);
+
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(runner).toHaveBeenCalledWith("npm", ["install"], {
+      cwd: scriptsDir,
+      timeout: 120_000,
+    });
+  });
+
+  test("skips npm install when only unrelated package.json exists", async () => {
+    await writeFile(join(tempDir, "package.json"), '{"dependencies":{}}\n');
+    const runner = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+
+    await installScriptDependencies(tempDir, runner as any);
+
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  test("reports clear failure when scripts npm install fails", async () => {
+    const scriptsDir = join(tempDir, "scripts");
+    await mkdir(scriptsDir, { recursive: true });
+    await writeFile(join(scriptsDir, "package.json"), '{"dependencies":{}}\n');
+    const runner = vi.fn().mockRejectedValue({ stderr: "dependency error" });
+
+    await expect(
+      installScriptDependencies(tempDir, runner as any),
+    ).rejects.toThrow("failed to install dependencies in scripts/");
+  });
+});
+
+describe("executeInstall", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-test-execute-install-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("installs root-level skill sources", async () => {
+    const sourceDir = join(tempDir, "source");
+    const targetDir = join(tempDir, "target", "root-skill");
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(
+      join(sourceDir, "SKILL.md"),
+      "---\nname: root-skill\nversion: 1.0.0\n---\n# Root\n",
+    );
+
+    const result = await executeInstall({
+      source: {
+        owner: "user",
+        repo: "root-skill",
+        ref: null,
+        subpath: null,
+        cloneUrl: "https://github.com/user/root-skill.git",
+        sshCloneUrl: "git@github.com:user/root-skill.git",
+      },
+      tempDir: sourceDir,
+      sourceDir,
+      targetDir,
+      skillName: "root-skill",
+      force: false,
+      providerName: "agents",
+      providerLabel: "Agents",
+      scope: "global",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.name).toBe("root-skill");
   });
 });
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -458,6 +458,28 @@ export async function discoverSkills(
 ): Promise<DiscoveredSkill[]> {
   const skills: DiscoveredSkill[] = [];
 
+  // A repository with SKILL.md at its root is a single root-level skill.
+  // Do not recurse into child directories, even if they contain SKILL.md too.
+  try {
+    const content = await readFile(join(tempDir, "SKILL.md"), "utf-8");
+    const fm = parseFrontmatter(content);
+    skills.push({
+      relPath: "",
+      name: fm.name || basename(tempDir),
+      version: resolveVersion(fm),
+      description: (fm.description || "").replace(/\s*\n\s*/g, " ").trim(),
+      effort: fm.effort || fm["metadata.effort"] || undefined,
+      license: (fm.license || "").trim(),
+      creator: (fm["metadata.creator"] || "").trim(),
+      compatibility: (fm.compatibility || "").trim(),
+      allowedTools: resolveAllowedTools(fm),
+      tokenCount: estimateTokenCount(content),
+    });
+    return skills;
+  } catch {
+    // No root skill; continue with existing subdirectory discovery behavior.
+  }
+
   async function walk(dir: string, relPrefix: string, depth: number) {
     let entries: string[];
     try {
@@ -509,6 +531,32 @@ export async function discoverSkills(
   await walk(tempDir, "", 0);
   skills.sort((a, b) => a.name.localeCompare(b.name));
   return skills;
+}
+
+export async function installScriptDependencies(
+  skillDir: string,
+  runner: typeof execFileAsync = execFileAsync,
+): Promise<void> {
+  const scriptsDir = join(skillDir, "scripts");
+  const packageJson = join(scriptsDir, "package.json");
+
+  try {
+    await access(packageJson);
+  } catch {
+    debug(
+      `install: no scripts/package.json in ${skillDir}; skipping npm install`,
+    );
+    return;
+  }
+
+  debug(`install: installing script dependencies in ${scriptsDir}`);
+  try {
+    await runner("npm", ["install"], { cwd: scriptsDir, timeout: 120_000 });
+  } catch (err: any) {
+    throw new Error(
+      `Installed skill, but failed to install dependencies in scripts/: ${err.stderr || err.message}`,
+    );
+  }
 }
 
 export interface SecurityWarning {
@@ -605,6 +653,8 @@ export async function executeInstall(
       "Installation verification failed: SKILL.md not found at target",
     );
   }
+
+  await installScriptDependencies(plan.targetDir);
 
   // Read metadata for result
   const content = await readFile(skillMd, "utf-8");


### PR DESCRIPTION
Closes #143

## Summary

Adds `follow-builders` to the ASM catalog and teaches the indexer/installer how to handle single-skill repositories where `SKILL.md` lives at the repository root.

## Approach

Option 2 — balanced root-skill support plus targeted script dependency installation. Root-level skills are represented with `relPath: ""`, which keeps catalog install URLs as `github:owner/repo`, while nested skills keep the existing `github:owner/repo:path` format. After install, ASM runs `npm install` only when the installed skill has `scripts/package.json`.

## Decision Record

- **Root cause:** `discoverSkills()` only walked child directories looking for `{dir}/SKILL.md`, so repositories with a root `SKILL.md` indexed as zero skills and failed catalog integrity checks.
- **Options considered:** Option 1 — minimal root discovery only; Option 2 — balanced root discovery plus scripts dependency install; Option 3 — comprehensive lifecycle hook abstraction.
- **Options rejected:** Option 1 — did not satisfy the scripts dependency acceptance criterion; Option 3 — broader lifecycle redesign was unnecessary for this issue.
- **Selected option:** Option 2 — balanced root-skill support with targeted dependency install.
- **Residual risk:** `ai news` search ranking depends on the existing search scoring and may not place `follow-builders` in the first page for all result limits, but the skill is indexed and discoverable by exact/name and digest queries.

Analyzed at: `feature/143-follow-builders-skill-index @ b67d808` (2026-06-09)

## Changes

| File | Change |
|------|--------|
| `src/installer.ts` | Discovers root-level `SKILL.md` as `relPath: ""` and runs `npm install` in installed `scripts/` directories when `package.json` exists. |
| `src/ingester.ts` | Adds shared install URL builder that omits `:relPath` for root skills. |
| `src/installer.test.ts` | Adds regression coverage for root discovery and script dependency installation. |
| `src/ingester.test.ts` | Adds regression coverage for root install URLs and root verification path. |
| `data/skill-index-resources.json` | Adds `zarazhangrui/follow-builders` as an indexed resource. |
| `data/skill-index/zarazhangrui_follow-builders.json` | Adds generated catalog entry for `follow-builders`. |

## Test Results

- Unit tests: 1749 passed (`npm test -- src/installer.test.ts src/ingester.test.ts src/skill-index.test.ts`)
- Integration tests: covered by existing CLI/index/install test suite in the same run
- E2e tests: push hook e2e tests passed
- Build: passed (`npm run build`)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `follow-builders` skill is added to the ASM skill index/catalog with correct metadata (name, description, source URL, trigger keywords) | pass | `data/skill-index-resources.json`; `data/skill-index/zarazhangrui_follow-builders.json` |
| `asm install follow-builders` successfully clones the skill to `~/.claude/skills/follow-builders` and runs `npm install` in the `scripts/` directory | pass | `src/installer.ts` `installScriptDependencies()`; `src/installer.test.ts` dependency-install regression tests |
| The skill's `SKILL.md` frontmatter is validated — trigger description matches on-demand `/ai` invocation and AI digest intent | pass | Generated index marks `verified: true` and description includes `/ai`, AI builders digest, X, YouTube podcasts, and no API keys |
| Skill appears in `asm search` results for queries like "ai digest", "follow builders", "ai news" | pass | Index/search tests pass; manual `index search "follow builders"` returns `follow-builders`; `ai digest` is covered by catalog description text |