### PR TITLE
feat(website): fetch live GitHub star count in catalog header (#308)

### DIFF
--- a/website-src/src/__tests__/header-live-stars.test.jsx
+++ b/website-src/src/__tests__/header-live-stars.test.jsx
@@ -1,0 +1,94 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { HashRouter } from "react-router-dom";
+
+/**
+ * Tests for issue #308 — the catalog header shows the GitHub star count.
+ * It now fetches the live count from the GitHub API on mount and only
+ * falls back to the static `catalog.stars` value when that fetch does not
+ * yield a usable number. These tests pin the two behaviours that matter:
+ * the page always renders the static value first, and a successful live
+ * fetch replaces it while a failed one leaves it untouched.
+ */
+
+// Control the catalog the header reads from without standing up the real
+// CatalogProvider (which fetches skills.min.json / search.idx.json).
+const mockCatalog = { stars: 552, version: "2.11.0" };
+vi.mock("../hooks/useCatalog.jsx", () => ({
+  useCatalog: () => ({ catalog: mockCatalog }),
+}));
+
+import Header from "../components/Header.jsx";
+
+function renderHeader() {
+  return render(
+    <HashRouter
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <Header />
+    </HashRouter>,
+  );
+}
+
+describe("Header — live GitHub star count (issue #308)", () => {
+  beforeEach(() => {
+    mockCatalog.stars = 552;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the static catalog star count immediately on mount", () => {
+    // fetch never resolves — the static value must already be on screen.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise(() => {})),
+    );
+    renderHeader();
+    expect(screen.getByText("★ 552")).toBeTruthy();
+  });
+
+  it("updates to the live star count once the GitHub API responds", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ stargazers_count: 1234 }),
+        }),
+      ),
+    );
+    renderHeader();
+    // 1234 -> "1.2k" via formatStars.
+    await waitFor(() => expect(screen.getByText("★ 1.2k")).toBeTruthy());
+  });
+
+  it("falls back to the static count when the API call fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("network down"))),
+    );
+    renderHeader();
+    // The rejected fetch is swallowed; the static value stays put.
+    await waitFor(() => expect(screen.getByText("★ 552")).toBeTruthy());
+    expect(screen.queryByText(/1\.2k/)).toBeNull();
+  });
+
+  it("falls back to the static count on a non-OK API response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 403,
+          json: () => Promise.resolve({}),
+        }),
+      ),
+    );
+    renderHeader();
+    await waitFor(() => expect(screen.getByText("★ 552")).toBeTruthy());
+  });
+});

--- a/website-src/src/components/Header.jsx
+++ b/website-src/src/components/Header.jsx
@@ -3,6 +3,23 @@ import { Link, NavLink } from "react-router-dom";
 import { useCatalog } from "../hooks/useCatalog.jsx";
 import BundleCartButton from "./BundleCartButton.jsx";
 
+/**
+ * Fetch live GitHub star count for the ASM repo.
+ * Falls back to the static catalog value if the API call fails.
+ */
+const REPO_API = "https://api.github.com/repos/luongnv89/asm";
+
+async function fetchLiveStars(signal) {
+  try {
+    const res = await fetch(REPO_API, { signal });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.stargazers_count ?? null;
+  } catch {
+    return null;
+  }
+}
+
 function applyTheme(next) {
   document.documentElement.setAttribute("data-theme", next);
   localStorage.setItem("asm-theme", next);
@@ -25,7 +42,18 @@ function formatStars(n) {
 export default function Header({ onOpenBundleBuilder }) {
   const { catalog } = useCatalog();
   const version = catalog?.version;
-  const stars = formatStars(catalog?.stars);
+  const [liveStars, setLiveStars] = useState(null);
+
+  // Fetch live GitHub stars on mount, fall back to static catalog value
+  useEffect(() => {
+    const ctrl = new AbortController();
+    fetchLiveStars(ctrl.signal).then((n) => {
+      if (n != null) setLiveStars(n);
+    });
+    return () => ctrl.abort();
+  }, []);
+
+  const stars = formatStars(liveStars ?? catalog?.stars);
   const [theme, setTheme] = useState(() =>
     typeof document === "undefined"
       ? "dark"


### PR DESCRIPTION
Closes #308

## Summary

The catalog website header displayed the GitHub star count from the build-time catalog (`skills.min.json`), so it only refreshed on a full `npm run build:website` and could drift from the real value. This change fetches the live star count from the GitHub API on mount and falls back to the static catalog value when the request fails or rate-limits, keeping the header current without a rebuild.

## Approach

A complete, sound implementation already existed as uncommitted work in the working tree (`Header.jsx`). Rather than re-implement from scratch and risk a second, conflicting version, the work here was to **verify and deliver** it: confirm build/lint/tests, add a focused test for the fallback behaviour, and ship as an atomic PR. The implementation adds `fetchLiveStars(signal)` (a `fetch` of `https://api.github.com/repos/luongnv89/asm` returning `stargazers_count` or `null`), a mount `useEffect` with an `AbortController`, and a render-time fallback `formatStars(liveStars ?? catalog?.stars)`.

## Decision Record

- **Root cause:** The header's star count was sourced from the static build artifact (`catalog.stars`), refreshed only on a full website rebuild, so it lagged the real GitHub value.
- **Options considered:** Option 1 — keep static, refresh only at build time (status quo); Option 2 — client-side live fetch on mount with static fallback (balanced); Option 3 — server/edge-cached proxy endpoint that refreshes the count out of band.
- **Options rejected:** Option 1 — does not solve staleness, which is the whole point of the issue. Option 3 — needs new server/edge infrastructure and a caching layer, disproportionate for an XS cosmetic value and outside the static-site deployment model.
- **Selected option:** Option 2 — client-side live fetch on mount with graceful fallback to the static catalog value. Matches the acceptance criteria, requires no backend, and degrades cleanly under GitHub API rate limits.
- **Residual risk:** Unauthenticated GitHub API calls are rate-limited (60/hr per IP); on a rate-limited response the header silently keeps the static value (the intended fallback). The live fetch fires once per page load with no client-side cache — acceptable for a low-traffic catalog header.

Analyzed at: `feature/308-live-github-stars @ 39b5c34` (2026-06-11)

## Changes

| File | Change |
|------|--------|
| `website-src/src/components/Header.jsx` | Add `fetchLiveStars(signal)` + `REPO_API` const; fetch live stars in a mount `useEffect` with an `AbortController`; render `formatStars(liveStars ?? catalog?.stars)` so the static value shows first and the live value swaps in once fetched. |
| `website-src/src/__tests__/header-live-stars.test.jsx` | New test file (4 tests): static-first render, live update on a successful response, and graceful fallback on both a rejected fetch and a non-OK (403/rate-limit) response. |

## Test Results

- Unit tests: 57 passed (53 baseline + 4 new in `header-live-stars.test.jsx`)
- Integration tests: n/a
- E2e tests: not run (XS client-side change, no e2e surface)
- Build: passed (`npm run build:site` — 1621 modules transformed)
- Lint: clean on both changed files (`npm run lint:site`; pre-existing errors in `ChangelogPage.jsx`/`SkillDetail.jsx` are unrelated and out of scope)
- QA cycles: 1 (code review returned PASS, 0 fixable issues)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Header fetches live GitHub star count from the API on page load | pass | `useEffect(..., [])` calls `fetchLiveStars` on mount (`Header.jsx:48`); test "updates to the live star count once the GitHub API responds" |
| API call is non-blocking — static value renders first, then updates to live | pass | Initial `liveStars=null` ⇒ first render shows `catalog?.stars`; test "renders the static catalog star count immediately on mount" |
| Graceful fallback to the static count if the API fails or rate-limits | pass | `fetchLiveStars` returns `null` on both `!res.ok` and thrown errors; render coalesces `liveStars ?? catalog?.stars`; tests "falls back ... when the API call fails" and "falls back ... on a non-OK API response" |
| Abort signal avoids state updates on unmounted components | pass | `AbortController` aborted in the effect cleanup (`Header.jsx:53`). Verified by code-trace + independent code review: an aborted fetch is caught inside `fetchLiveStars` and resolves to `null`, so the `if (n != null)` guard skips `setLiveStars` — no setState on an unmounted component. Not pinned by a dedicated test: the visible output is identical with or without the guard (render-time nullish coalescing collapses `null` to the static value), and a `useState`-spy test proved brittle against React's non-configurable ESM export, so it was not added. |
