### PR TITLE
feat(website): add marketing landing page, move catalog to /skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@
 <p align="center">
   <a href="#get-started-in-30-seconds"><strong>Get Started in 30 Seconds &rarr;</strong></a>
   &nbsp;&nbsp;|&nbsp;&nbsp;
-  <a href="https://luongnv.com/asm/"><strong>Browse 2,800+ Skills Online &rarr;</strong></a>
+  <a href="https://luongnv.com/asm/#/skills"><strong>Browse 3,800+ Skills Online &rarr;</strong></a>
 </p>
 
 ---
 
 ### 🌐 ASM Catalog — Browse Skills in Your Browser
 
-Don't want to install anything yet? **[Explore the full skill catalog online &rarr;](https://luongnv.com/asm/)**
+Don't want to install anything yet? **[Explore the full skill catalog online &rarr;](https://luongnv.com/asm/#/skills)**
 
-Search, filter by category or repo, and copy install commands — all from a single page. No signup, no backend, no tracking. Share filtered views via URL (e.g. `?q=code-review&cat=development`).
+Search, filter by category or repo, and copy install commands — all from a single page. No signup, no backend, no tracking. Share filtered views via URL (e.g. `#/skills?q=code-review&cat=development`).
 
 ---
 
@@ -707,7 +707,7 @@ asm index ingest github:anthropics/skills
 asm index search "frontend design" --json
 ```
 
-**Skill bundles** — install a curated set of skills in one command. Pre-defined bundles ship with ASM for common workflows (frontend, devops, iOS release, content writing). Browse them at [luongnv.com/asm/bundles](https://luongnv.com/asm/bundles/) or list them locally:
+**Skill bundles** — install a curated set of skills in one command. Pre-defined bundles ship with ASM for common workflows (frontend, devops, iOS release, content writing). Browse them at [luongnv.com/asm/#/bundles](https://luongnv.com/asm/#/bundles) or list them locally:
 
 ```bash
 asm bundle list --predefined
@@ -732,7 +732,7 @@ asm bundle create my-workflow
 asm bundle export my-workflow ./my-workflow.json
 ```
 
-A bundle is a JSON file with a `name`, `description`, `author`, and a list of `skills` (each with `name` + `installUrl`). The schema is validated on install — see `src/utils/types.ts` (`BundleManifest`). You can also assemble a custom bundle visually on the website's [/bundles](https://luongnv.com/asm/bundles/) page and export it as JSON.
+A bundle is a JSON file with a `name`, `description`, `author`, and a list of `skills` (each with `name` + `installUrl`). The schema is validated on install — see `src/utils/types.ts` (`BundleManifest`). You can also assemble a custom bundle visually on the website's [/bundles](https://luongnv.com/asm/#/bundles) page and export it as JSON.
 
 </details>
 

--- a/website-src/assets/og-image.svg
+++ b/website-src/assets/og-image.svg
@@ -37,9 +37,9 @@
     <circle cx="2.6" cy="3.2" r="1.3" fill="#00ff41" opacity="0.7"/>
   </g>
   <!-- Title -->
-  <text x="600" y="350" text-anchor="middle" fill="#e0e0e8" font-family="monospace" font-size="52" font-weight="700">asm <tspan fill="#00ff41">catalog</tspan></text>
+  <text x="600" y="350" text-anchor="middle" fill="#e0e0e8" font-family="monospace" font-size="46" font-weight="700">asm <tspan fill="#00ff41">agent-skill-manager</tspan></text>
   <!-- Subtitle -->
-  <text x="600" y="400" text-anchor="middle" fill="#8888a0" font-family="sans-serif" font-size="24">Browse &amp; install {{SKILL_COUNT}}+ agent skills for AI coding agents</text>
+  <text x="600" y="400" text-anchor="middle" fill="#8888a0" font-family="sans-serif" font-size="24">One tool to manage every AI agent&apos;s skills — install, audit, organize</text>
   <!-- Stats -->
   <g transform="translate(600, 470)" text-anchor="middle">
     <text x="-200" fill="#00ff41" font-family="monospace" font-size="36" font-weight="700">{{SKILL_COUNT}}+</text>

--- a/website-src/index.html
+++ b/website-src/index.html
@@ -3,19 +3,19 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ASM Skill Catalog — Agent Skill Manager</title>
+    <title>asm — One tool to manage every AI agent's skills</title>
     <meta
       name="description"
-      content="Browse, search, and install {{SKILL_COUNT}}+ agent skills for Claude Code, Codex, and more. The official skill catalog for agent-skill-manager (asm)."
+      content="agent-skill-manager (asm) is a single TUI and CLI to install, search, audit, and organize agent skills across Claude Code, Codex, Cursor, and 16+ more. Browse {{SKILL_COUNT}}+ skills online."
     />
     <link rel="canonical" href="https://luongnv.com/asm/" />
     <meta
       property="og:title"
-      content="ASM Skill Catalog — Agent Skill Manager"
+      content="asm — One tool to manage every AI agent's skills"
     />
     <meta
       property="og:description"
-      content="Browse, search, and install {{SKILL_COUNT}}+ agent skills for Claude Code, Codex, and more."
+      content="Install, search, audit, and organize agent skills across Claude Code, Codex, Cursor, and 16+ more — one TUI, one CLI. Browse {{SKILL_COUNT}}+ skills online."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://luongnv.com/asm/" />
@@ -23,15 +23,15 @@
       property="og:image"
       content="https://luongnv.com/asm/assets/og-image.svg"
     />
-    <meta property="og:site_name" content="ASM Skill Catalog" />
+    <meta property="og:site_name" content="agent-skill-manager" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta
       name="twitter:title"
-      content="ASM Skill Catalog — Agent Skill Manager"
+      content="asm — One tool to manage every AI agent's skills"
     />
     <meta
       name="twitter:description"
-      content="Browse, search, and install {{SKILL_COUNT}}+ agent skills for Claude Code, Codex, and more."
+      content="Install, search, audit, and organize agent skills across Claude Code, Codex, Cursor, and 16+ more — one TUI, one CLI. Browse {{SKILL_COUNT}}+ skills online."
     />
     <meta
       name="twitter:image"
@@ -43,9 +43,9 @@
         "@context": "https://schema.org",
         "@type": "WebApplication",
         "@id": "https://luongnv.com/asm/#webapp",
-        "name": "ASM Skill Catalog",
+        "name": "agent-skill-manager (asm)",
         "url": "https://luongnv.com/asm/",
-        "description": "Browse, search, and install agent skills for Claude Code, Codex, and other AI coding agents. The official skill catalog for agent-skill-manager (asm).",
+        "description": "agent-skill-manager (asm) is a single TUI and CLI to install, search, audit, and organize agent skills across Claude Code, Codex, Cursor, and 16+ other AI coding agents.",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "Any",
         "browserRequirements": "Requires JavaScript",

--- a/website-src/llms.txt
+++ b/website-src/llms.txt
@@ -1,10 +1,11 @@
-# ASM Skill Catalog
+# agent-skill-manager (asm)
 
-> The official skill catalog for agent-skill-manager (asm). Browse, search, and install {{SKILL_COUNT}}+ agent skills for AI coding agents like Claude Code, Codex, and more. Open-source CLI tool indexing {{REPO_COUNT}} repositories across {{CATEGORY_COUNT}} categories.
+> One tool to manage every AI agent's skills. asm is an open-source TUI and CLI to install, search, audit, and organize agent skills across Claude Code, Codex, Cursor, Windsurf, and 15+ other AI coding agents. The companion catalog indexes {{SKILL_COUNT}}+ skills from {{REPO_COUNT}} repositories across {{CATEGORY_COUNT}} categories.
 
 ## Getting Started
 
-- [ASM Catalog](https://luongnv.com/asm/): Browse and search all {{SKILL_COUNT}}+ skills
+- [asm Home](https://luongnv.com/asm/): What asm is and how to install it
+- [Skill Catalog](https://luongnv.com/asm/#/skills): Browse and search all {{SKILL_COUNT}}+ skills
 - [GitHub Repository](https://github.com/luongnv89/agent-skill-manager): Source code, issues, and contributions
 - [npm Package](https://www.npmjs.com/package/agent-skill-manager): Install via `npm i -g agent-skill-manager`
 

--- a/website-src/sitemap.xml
+++ b/website-src/sitemap.xml
@@ -3,17 +3,29 @@
   <url>
     <loc>https://luongnv.com/asm/</loc>
     <lastmod>{{LASTMOD}}</lastmod>
-    <changefreq>daily</changefreq>
+    <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://luongnv.com/asm/#docs</loc>
+    <loc>https://luongnv.com/asm/#/skills</loc>
+    <lastmod>{{LASTMOD}}</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://luongnv.com/asm/#/bundles</loc>
+    <lastmod>{{LASTMOD}}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://luongnv.com/asm/#/docs</loc>
     <lastmod>{{LASTMOD}}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://luongnv.com/asm/#changelog</loc>
+    <loc>https://luongnv.com/asm/#/changelog</loc>
     <lastmod>{{LASTMOD}}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>

--- a/website-src/src/App.jsx
+++ b/website-src/src/App.jsx
@@ -1,8 +1,9 @@
 import { useCallback, useState } from "react";
-import { Routes, Route, Navigate } from "react-router-dom";
+import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import Header from "./components/Header.jsx";
 import Footer from "./components/Footer.jsx";
 import BundleBuilderDialog from "./components/BundleBuilderDialog.jsx";
+import LandingPage from "./pages/LandingPage.jsx";
 import CatalogPage from "./pages/CatalogPage.jsx";
 import BundlesPage from "./pages/BundlesPage.jsx";
 import DocsPage from "./pages/DocsPage.jsx";
@@ -18,10 +19,17 @@ import { BundleCartProvider } from "./hooks/useBundleCart.jsx";
  * to HashRouter preserves external deep links and avoids the need for
  * server-side rewrites.
  *
- * Routing (#228): `/` and `/skills/:id` both render `CatalogPage` —
+ * Routing: `/` renders the marketing `LandingPage`; the catalog now
+ * lives at `/skills` and `/skills/:id` (both render `CatalogPage`) —
  * the catalog is always a two-pane layout, and the `:id` in the URL
  * simply selects which skill shows in the detail pane. Same pattern
  * for `/bundles` and `/bundles/:name`.
+ *
+ * Legacy deep links: the catalog used to live at `/`, so older shared
+ * URLs carry filter query params on the root (e.g. `#/?q=code-review`).
+ * `LegacyCatalogRedirect` forwards any root visit that carries those
+ * params to `/skills`, preserving the query string so the filters still
+ * apply. `/skills/:id` links were already that shape and keep working.
  *
  * Bundle builder (#238): dialog state lives at the app shell so the
  * header cart button (any route) can open it. The `BundleCartProvider`
@@ -41,7 +49,8 @@ export default function App() {
           <Header onOpenBundleBuilder={openBuilder} />
           <main className="flex-1 w-full max-w-[1280px] mx-auto px-4 sm:px-6 py-6">
             <Routes>
-              <Route path="/" element={<CatalogPage />} />
+              <Route path="/" element={<LegacyCatalogRedirect />} />
+              <Route path="/skills" element={<CatalogPage />} />
               <Route path="/skills/:id" element={<CatalogPage />} />
               <Route path="/bundles" element={<BundlesPage />} />
               <Route path="/bundles/:name" element={<BundlesPage />} />
@@ -59,4 +68,24 @@ export default function App() {
       </BundleCartProvider>
     </CatalogProvider>
   );
+}
+
+/**
+ * Root route. The catalog used to live here, so a root visit that still
+ * carries catalog filter params (`?q=`, `?cat=`, `?repo=`, `?facet=`,
+ * `?sort=`) is an old shared link — forward it to `/skills` with the
+ * query string intact. A bare root visit shows the new landing page.
+ */
+const CATALOG_PARAMS = ["q", "cat", "repo", "facet", "sort"];
+
+function LegacyCatalogRedirect() {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const isLegacyCatalogLink = CATALOG_PARAMS.some((k) => params.has(k));
+  if (isLegacyCatalogLink) {
+    return (
+      <Navigate to={{ pathname: "/skills", search: location.search }} replace />
+    );
+  }
+  return <LandingPage />;
 }

--- a/website-src/src/App.jsx
+++ b/website-src/src/App.jsx
@@ -72,11 +72,25 @@ export default function App() {
 
 /**
  * Root route. The catalog used to live here, so a root visit that still
- * carries catalog filter params (`?q=`, `?cat=`, `?repo=`, `?facet=`,
- * `?sort=`) is an old shared link — forward it to `/skills` with the
- * query string intact. A bare root visit shows the new landing page.
+ * carries any catalog filter param (search `?q=`, category `?cat=`, repo
+ * `?repo=`, the facet params `?license=`/`?grade=`/`?source=`/`?tools=`,
+ * the legacy `?verified=`, `?sort=`, or `?page=`) is an old shared link —
+ * forward it to `/skills` with the query string intact. A bare root visit
+ * shows the new landing page. Keep this list in sync with the params read
+ * by `useCatalogState`.
  */
-const CATALOG_PARAMS = ["q", "cat", "repo", "facet", "sort"];
+const CATALOG_PARAMS = [
+  "q",
+  "cat",
+  "repo",
+  "license",
+  "grade",
+  "source",
+  "tools",
+  "verified",
+  "sort",
+  "page",
+];
 
 function LegacyCatalogRedirect() {
   const location = useLocation();

--- a/website-src/src/__tests__/app-smoke.test.jsx
+++ b/website-src/src/__tests__/app-smoke.test.jsx
@@ -27,10 +27,15 @@ import { MINISEARCH_OPTIONS } from "../lib/minisearch-options.js";
 /**
  * End-to-end smoke tests for the React app.
  *
- * Updated for #228: the catalog now renders as a two-pane layout
- * (sidebar list + detail pane). These tests assert that the list
- * is visible, selecting a skill in the sidebar updates the URL and
- * renders the detail pane, and filter state survives selection.
+ * Updated for #228: the catalog renders as a two-pane layout (sidebar
+ * list + detail pane). These tests assert that the list is visible,
+ * selecting a skill in the sidebar updates the URL and renders the
+ * detail pane, and filter state survives selection.
+ *
+ * Updated for the landing page: `/` now renders the marketing landing
+ * page and the catalog moved to `/skills`, so the catalog tests below
+ * navigate to `/#/skills` before asserting. A separate test covers the
+ * root landing page and the legacy `/?cat=` → `/skills` redirect.
  */
 const generatedAt = "2026-04-22T00:00:00.000Z";
 
@@ -163,6 +168,7 @@ describe("App smoke", () => {
   });
 
   it("loads the catalog and renders skills in the sidebar list", async () => {
+    window.history.replaceState(null, "", "/#/skills");
     render(
       <HashRouter
         future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
@@ -180,6 +186,7 @@ describe("App smoke", () => {
   });
 
   it("selecting a sidebar row updates the URL and renders detail", async () => {
+    window.history.replaceState(null, "", "/#/skills");
     const { container } = render(
       <HashRouter
         future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
@@ -216,7 +223,9 @@ describe("App smoke", () => {
   });
 
   it("preserves filter query params across selection", async () => {
-    // Start with a category filter already active in the URL.
+    // A legacy catalog deep link: the catalog used to live at `/`, so a
+    // root URL carrying `?cat=` must redirect to `/skills?cat=demo` and
+    // keep the filter active. This exercises LegacyCatalogRedirect too.
     window.history.replaceState(null, "", "/#/?cat=demo");
     const { container } = render(
       <HashRouter
@@ -271,5 +280,24 @@ describe("App smoke", () => {
     await waitFor(() => {
       expect(screen.getByText(/asm bundle install starter/)).toBeTruthy();
     });
+  });
+
+  it("root path renders the marketing landing page, not the catalog", async () => {
+    window.history.replaceState(null, "", "/");
+    const { container } = render(
+      <HashRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <App />
+      </HashRouter>,
+    );
+    // Landing hero headline + a primary CTA into the catalog should mount.
+    await waitFor(() => {
+      expect(screen.getByText(/manage every AI agent/i)).toBeTruthy();
+    });
+    const catalogCta = container.querySelector("a[href$='/skills']");
+    expect(catalogCta).toBeTruthy();
+    // The catalog sidebar list must NOT be present on the landing page.
+    expect(container.querySelector("aside a[href*='/skills/']")).toBeNull();
   });
 });

--- a/website-src/src/__tests__/app-smoke.test.jsx
+++ b/website-src/src/__tests__/app-smoke.test.jsx
@@ -253,6 +253,28 @@ describe("App smoke", () => {
     });
   });
 
+  it("redirects a legacy root link carrying only a facet param to /skills", async () => {
+    // Regression: a root deep link carrying only a facet/page filter (here
+    // `?source=verified`, no q/cat/repo) is still an old catalog link and
+    // must redirect to `/skills` with the query intact — not fall through to
+    // the landing page. Guards against LegacyCatalogRedirect's param list
+    // drifting out of sync with the params `useCatalogState` reads.
+    window.history.replaceState(null, "", "/#/?source=verified");
+    render(
+      <HashRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <App />
+      </HashRouter>,
+    );
+    // The catalog (sidebar list) renders, not the landing hero.
+    await waitFor(() => expect(screen.getByText("hello-world")).toBeTruthy());
+    await waitFor(() => {
+      expect(window.location.hash).toContain("/skills");
+      expect(window.location.hash).toContain("source=verified");
+    });
+  });
+
   it("bundles page renders a sidebar list and detail empty state", async () => {
     window.history.replaceState(null, "", "/#/bundles");
     const { container } = render(

--- a/website-src/src/__tests__/bundle-cart.test.jsx
+++ b/website-src/src/__tests__/bundle-cart.test.jsx
@@ -134,7 +134,9 @@ function mockFetch() {
 
 describe("Bundle cart flow", () => {
   beforeEach(() => {
-    window.history.replaceState(null, "", "/");
+    // The catalog list (with add-to-bundle buttons) now lives at /skills;
+    // `/` renders the marketing landing page.
+    window.history.replaceState(null, "", "/#/skills");
     globalThis.fetch = mockFetch();
     installLocalStorageShim();
   });

--- a/website-src/src/components/Header.jsx
+++ b/website-src/src/components/Header.jsx
@@ -105,10 +105,12 @@ export default function Header({ onOpenBundleBuilder }) {
             className="w-7 h-7"
           />
           <span>asm</span>
-          <span className="text-[var(--fg-muted)] font-normal">catalog</span>
+          <span className="text-[var(--fg-muted)] font-normal hidden sm:inline">
+            agent-skill-manager
+          </span>
         </Link>
         <nav className="flex items-center gap-1 ml-4">
-          <NavLink to="/" end className={linkClass}>
+          <NavLink to="/skills" className={linkClass}>
             Skills
           </NavLink>
           <NavLink to="/bundles" className={linkClass}>

--- a/website-src/src/index.css
+++ b/website-src/src/index.css
@@ -622,3 +622,264 @@ mark.hl {
 .cl-outro a:hover {
   color: var(--cl-accent);
 }
+
+/* ─── Landing page (editorial / terminal) ──────────────────────────── */
+.lp {
+  --lp-serif: "Fraunces", "Instrument Serif", ui-serif, Georgia, serif;
+  --lp-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* Monospace eyebrow / kicker shared by every section */
+.lp-kicker {
+  font-family: var(--lp-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+.lp-kicker .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--brand);
+  box-shadow: 0 0 0 3px var(--brand-glow);
+  animation: cl-pulse 2.4s ease-in-out infinite;
+}
+
+/* Big editorial serif headline */
+.lp-title {
+  font-family: var(--lp-serif);
+  font-weight: 400;
+  font-size: clamp(44px, 6.5vw, 84px);
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+  color: var(--fg);
+  margin: 0;
+  font-variation-settings: "opsz" 144;
+}
+.lp-title em {
+  font-style: italic;
+  color: var(--brand);
+  font-family: "Instrument Serif", var(--lp-serif);
+}
+
+.lp-section-title {
+  font-family: var(--lp-serif);
+  font-weight: 400;
+  font-size: clamp(30px, 4vw, 46px);
+  line-height: 1.02;
+  letter-spacing: -0.03em;
+  color: var(--fg);
+  margin: 0;
+  font-variation-settings: "opsz" 120;
+}
+
+.lp-lede {
+  max-width: 620px;
+  font-size: clamp(16px, 1.4vw, 19px);
+  line-height: 1.55;
+  color: var(--fg-dim);
+}
+
+/* Terminal-style command chip */
+.lp-cmd {
+  font-family: var(--lp-mono);
+  font-size: 14px;
+  color: var(--fg);
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  overflow-x: auto;
+}
+.lp-cmd .prompt {
+  color: var(--brand);
+  user-select: none;
+}
+
+/* Hero terminal mock */
+.lp-term {
+  font-family: var(--lp-mono);
+  font-size: 12.5px;
+  line-height: 1.7;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.lp-term-bar {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-card);
+}
+.lp-term-bar .tdot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: var(--border);
+}
+.lp-term-bar .tlabel {
+  margin-left: 8px;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.lp-term-body {
+  padding: 16px 16px 18px;
+  color: var(--fg-dim);
+  white-space: pre-wrap;
+}
+.lp-term-body .c {
+  color: var(--brand);
+}
+.lp-term-body .dim {
+  color: var(--fg-muted);
+}
+.lp-term-body .warn {
+  color: var(--warn);
+}
+.lp-term-body .fg {
+  color: var(--fg);
+}
+
+/* Feature card */
+.lp-card {
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  border-radius: 12px;
+  padding: 22px 22px 24px;
+  transition:
+    border-color 180ms ease,
+    transform 180ms ease;
+}
+.lp-card:hover {
+  border-color: color-mix(in srgb, var(--brand) 45%, var(--border));
+  transform: translateY(-2px);
+}
+.lp-card-icon {
+  font-family: var(--lp-mono);
+  font-size: 12px;
+  color: var(--brand);
+  letter-spacing: 0.1em;
+}
+.lp-card h3 {
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--fg);
+  margin: 12px 0 8px;
+  line-height: 1.3;
+}
+.lp-card p {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--fg-dim);
+  margin: 0;
+}
+
+/* Numbered step */
+.lp-step-num {
+  font-family: var(--lp-serif);
+  font-size: clamp(40px, 5vw, 60px);
+  font-weight: 400;
+  line-height: 1;
+  color: color-mix(in srgb, var(--brand) 65%, transparent);
+  font-variation-settings: "opsz" 144;
+}
+
+/* Stat figure */
+.lp-stat-num {
+  font-family: var(--lp-serif);
+  font-size: clamp(34px, 4.5vw, 52px);
+  font-weight: 400;
+  line-height: 1;
+  color: var(--fg);
+  letter-spacing: -0.02em;
+  font-variation-settings: "opsz" 120;
+}
+.lp-stat-label {
+  font-family: var(--lp-mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin-top: 8px;
+}
+
+/* Primary CTA button */
+.lp-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 15px;
+  padding: 12px 22px;
+  border-radius: 9px;
+  background: var(--brand);
+  color: #06120a;
+  border: 1px solid var(--brand);
+  transition:
+    filter 160ms ease,
+    transform 160ms ease;
+}
+.lp-cta:hover {
+  filter: brightness(1.08);
+  transform: translateY(-1px);
+}
+.lp-cta-ghost {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 500;
+  font-size: 15px;
+  padding: 12px 20px;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--border);
+  transition:
+    border-color 160ms ease,
+    color 160ms ease;
+}
+.lp-cta-ghost:hover {
+  border-color: var(--brand);
+  color: var(--brand);
+}
+
+/* Section divider rule with a node */
+.lp-rule {
+  height: 1px;
+  background: var(--border);
+  position: relative;
+}
+.lp-rule::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: -3px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--brand);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lp-card:hover,
+  .lp-cta:hover,
+  .lp-cta-ghost:hover {
+    transform: none;
+  }
+  .lp-kicker .dot {
+    animation: none;
+  }
+}

--- a/website-src/src/pages/CatalogPage.jsx
+++ b/website-src/src/pages/CatalogPage.jsx
@@ -309,7 +309,7 @@ export default function CatalogPage() {
         </Button>
         {decodedId && (
           <Link
-            to={{ pathname: "/", search: location.search }}
+            to={{ pathname: "/skills", search: location.search }}
             className="text-xs text-[var(--fg-dim)] hover:text-[var(--brand)]"
           >
             ← Clear selection

--- a/website-src/src/pages/CatalogPage.jsx
+++ b/website-src/src/pages/CatalogPage.jsx
@@ -59,9 +59,9 @@ function SkillRow({
  * the selected skill's detail (when the URL is `/skills/:id`) or a
  * friendly empty state prompting the user to pick one.
  *
- * Both `/` and `/skills/:id` render this component so that:
+ * Both `/skills` and `/skills/:id` render this component so that:
  *   - direct deep-links to a skill still work (`:id` from useParams)
- *   - the sidebar is always present — the list is the home view
+ *   - the sidebar is always present — the list is the catalog home view
  *
  * The data contract (`skills.min.json` + `search.idx.json`) is
  * consumed unchanged; `scripts/build-catalog.ts` remains the sole

--- a/website-src/src/pages/LandingPage.jsx
+++ b/website-src/src/pages/LandingPage.jsx
@@ -1,0 +1,475 @@
+import { Link } from "react-router-dom";
+import { ArrowRight, Github } from "lucide-react";
+import { useCatalog } from "../hooks/useCatalog.jsx";
+import CopyButton from "../components/CopyButton.jsx";
+
+const REPO_URL = "https://github.com/luongnv89/asm";
+const NPM_CMD = "npm install -g agent-skill-manager";
+const PROVIDER_COUNT = 19;
+
+/**
+ * Marketing landing page (route `/`). The catalog lives at `/skills`.
+ *
+ * Copy follows a Problem → Agitate → Solution arc mirroring the README:
+ * "your skills are a mess" → "asm brings order". Visual language reuses
+ * the editorial/terminal system already established on the changelog
+ * page (Fraunces serif headlines, JetBrains Mono accents, hacker-green
+ * `--brand`). Headline stats (`skills`, `repos`, `categories`) are read
+ * live from the loaded catalog so they never drift from reality, with
+ * static fallbacks for the brief window before the catalog hydrates.
+ */
+export default function LandingPage() {
+  const { catalog } = useCatalog();
+  const skillCount = catalog?.totalSkills ?? 3800;
+  const repoCount = catalog?.totalRepos ?? 35;
+  const categoryCount = catalog?.categories?.length ?? 16;
+
+  const skillsLabel = skillCount.toLocaleString();
+
+  return (
+    <div className="lp flex flex-col gap-24 sm:gap-32 py-4 sm:py-8">
+      <Hero
+        skillsLabel={skillsLabel}
+        repoCount={repoCount}
+        providerCount={PROVIDER_COUNT}
+      />
+      <Stats
+        skillsLabel={skillsLabel}
+        repoCount={repoCount}
+        categoryCount={categoryCount}
+        providerCount={PROVIDER_COUNT}
+      />
+      <Problem />
+      <Solution />
+      <HowItWorks />
+      <Build />
+      <FinalCta skillsLabel={skillsLabel} />
+    </div>
+  );
+}
+
+/* ─── Hero ──────────────────────────────────────────────────────────── */
+
+function Hero({ skillsLabel, repoCount, providerCount }) {
+  return (
+    <section className="grid lg:grid-cols-[1.05fr_0.95fr] gap-12 lg:gap-16 items-center pt-2 sm:pt-6">
+      <div className="flex flex-col gap-7">
+        <span className="lp-kicker">
+          <span className="dot" aria-hidden="true" />
+          agent-skill-manager
+        </span>
+        <h1 className="lp-title">
+          One tool to manage every AI agent&apos;s <em>skills</em>.
+        </h1>
+        <p className="lp-lede">
+          Stop juggling skill directories across Claude Code, Codex, Cursor,
+          Windsurf and {providerCount - 4}+ other agents.{" "}
+          <strong className="text-[var(--fg)] font-semibold">asm</strong> gives
+          you a single TUI and CLI to install, search, audit, and organize all
+          your agent skills — everywhere.
+        </p>
+
+        <div className="flex flex-col gap-3 max-w-[520px]">
+          <div className="lp-cmd">
+            <span className="prompt" aria-hidden="true">
+              $
+            </span>
+            <span className="flex-1">{NPM_CMD}</span>
+            <CopyButton
+              text={NPM_CMD}
+              size="sm"
+              ariaLabel="Copy install command"
+            />
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <Link to="/skills" className="lp-cta">
+              Browse {skillsLabel} skills
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </Link>
+            <a
+              href={REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="lp-cta-ghost"
+            >
+              <Github className="h-4 w-4" aria-hidden="true" />
+              Star on GitHub
+            </a>
+          </div>
+          <p className="text-xs text-[var(--fg-muted)] font-[var(--lp-mono)]">
+            Free &amp; open source · MIT · Node.js ≥ 18 · No signup, no backend,
+            no tracking
+          </p>
+        </div>
+      </div>
+
+      <HeroTerminal repoCount={repoCount} />
+    </section>
+  );
+}
+
+function HeroTerminal({ repoCount }) {
+  return (
+    <div className="lp-term shadow-xl shadow-black/10">
+      <div className="lp-term-bar">
+        <span className="tdot" aria-hidden="true" />
+        <span className="tdot" aria-hidden="true" />
+        <span className="tdot" aria-hidden="true" />
+        <span className="tlabel">asm — ~/projects</span>
+      </div>
+      <div className="lp-term-body">
+        <span className="c">$</span> <span className="fg">asm install</span>{" "}
+        github:anthropics/skills
+        {"\n"}
+        <span className="dim"> ↳ cloning anthropics/skills…</span>
+        {"\n"}
+        <span className="dim"> ↳ </span>
+        <span className="c">✓ security scan passed</span>
+        <span className="dim"> — no risky patterns</span>
+        {"\n"}
+        <span className="dim"> ↳ </span>
+        <span className="c">✓ installed 7 skills</span>
+        <span className="dim"> → claude, codex</span>
+        {"\n\n"}
+        <span className="c">$</span> <span className="fg">asm audit</span>{" "}
+        duplicates
+        {"\n"}
+        <span className="dim"> ↳ </span>
+        <span className="warn">⚠ 3 duplicates</span>
+        <span className="dim"> across claude / cursor — </span>
+        <span className="fg">asm clean</span>
+        {"\n\n"}
+        <span className="c">$</span> <span className="fg">asm stats</span>
+        {"\n"}
+        <span className="dim">
+          {" "}
+          142 skills · {repoCount} repos · 6 providers
+        </span>
+        {"\n"}
+        <span className="c">▍</span>
+      </div>
+    </div>
+  );
+}
+
+/* ─── Stats bar ─────────────────────────────────────────────────────── */
+
+function Stats({ skillsLabel, repoCount, categoryCount, providerCount }) {
+  const items = [
+    { num: skillsLabel, label: "skills indexed" },
+    { num: repoCount, label: "curated repos" },
+    { num: categoryCount, label: "categories" },
+    { num: providerCount, label: "agents supported" },
+  ];
+  return (
+    <section
+      aria-label="Catalog at a glance"
+      className="grid grid-cols-2 sm:grid-cols-4 gap-y-8 gap-x-4 py-2"
+    >
+      {items.map((it) => (
+        <div key={it.label} className="flex flex-col items-center text-center">
+          <span className="lp-stat-num">{it.num}</span>
+          <span className="lp-stat-label">{it.label}</span>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+/* ─── Problem (Agitate) ─────────────────────────────────────────────── */
+
+function Problem() {
+  const pains = [
+    {
+      head: "Scattered everywhere",
+      body: "~/.claude/skills/, ~/.codex/skills/, ~/.cursor/… the same skill installed three times, and you can't remember which version is where.",
+    },
+    {
+      head: "Zero visibility",
+      body: "No quick way to see what's installed, what's duplicated, or what's outdated across all your agents. You ls through hidden directories.",
+    },
+    {
+      head: "Manual and risky",
+      body: "You clone repos, copy folders, hope the SKILL.md is valid — and pray you didn't just install something that exfiltrates your codebase.",
+    },
+  ];
+  return (
+    <section className="flex flex-col gap-10">
+      <header className="flex flex-col gap-4 max-w-[680px]">
+        <span className="lp-kicker">
+          <span className="dot" aria-hidden="true" />
+          the problem
+        </span>
+        <h2 className="lp-section-title">
+          Your AI agent skills are a&nbsp;mess.
+        </h2>
+        <p className="lp-lede">
+          You use Claude Code at work, Codex for side projects, Cursor for
+          experiments. Each tool hides skills in its own directory with its own
+          conventions. The more agents you adopt, the worse it gets — every new
+          one is another folder to babysit.
+        </p>
+      </header>
+      <div className="grid sm:grid-cols-3 gap-5">
+        {pains.map((p) => (
+          <div
+            key={p.head}
+            className="border-l-2 border-[var(--warn)] pl-5 py-1 flex flex-col gap-2"
+          >
+            <h3 className="text-[var(--fg)] font-semibold text-base">
+              {p.head}
+            </h3>
+            <p className="text-sm leading-relaxed text-[var(--fg-dim)]">
+              {p.body}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/* ─── Solution ──────────────────────────────────────────────────────── */
+
+function Solution() {
+  const features = [
+    {
+      icon: "01",
+      head: "See everything at once",
+      body: "List, search, and filter every skill across all providers and scopes from one dashboard. No more spelunking through hidden directories.",
+    },
+    {
+      icon: "02",
+      head: "Install from GitHub in one command",
+      body: "asm install github:user/repo handles cloning, validation, and placement — single skills, multi-skill collections, subfolders, and private repos over SSH.",
+    },
+    {
+      icon: "03",
+      head: "Catch problems before they bite",
+      body: "Built-in security scanning flags shell execution, network calls, credential exposure, and obfuscation before you install. Duplicate audit cleans the rest.",
+    },
+    {
+      icon: "04",
+      head: "Create, test, and publish",
+      body: "Scaffold with asm init, symlink for live reload with asm link, audit and verify metadata, then publish to the ASM Registry — one command each.",
+    },
+    {
+      icon: "05",
+      head: "Works with every major agent",
+      body: "19 providers built in: Claude Code, Codex, Cursor, Windsurf, Cline, Roo, Continue, Copilot, Aider, Zed, Gemini CLI, and more. Add custom ones in seconds.",
+    },
+    {
+      icon: "06",
+      head: "Two interfaces, one tool",
+      body: "A full interactive TUI with keyboard navigation and detail views — or the CLI with --json for scripting, CI, and automation.",
+    },
+  ];
+  return (
+    <section className="flex flex-col gap-10">
+      <header className="flex flex-col gap-4 max-w-[680px]">
+        <span className="lp-kicker">
+          <span className="dot" aria-hidden="true" />
+          the fix
+        </span>
+        <h2 className="lp-section-title">
+          <em className="not-italic text-[var(--brand)] font-[var(--lp-mono)] text-[0.7em] align-middle mr-1">
+            asm
+          </em>{" "}
+          brings order to the chaos.
+        </h2>
+        <p className="lp-lede">
+          One command that manages skills across every AI coding agent you use.
+          One TUI. One CLI. Every agent.
+        </p>
+      </header>
+      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
+        {features.map((f) => (
+          <article key={f.icon} className="lp-card">
+            <span className="lp-card-icon">{f.icon}</span>
+            <h3>{f.head}</h3>
+            <p>{f.body}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/* ─── How it works ──────────────────────────────────────────────────── */
+
+function HowItWorks() {
+  const steps = [
+    {
+      n: "1",
+      head: "Install asm",
+      body: "One command via npm or curl. Runs on Node.js ≥ 18 — no other runtime required.",
+    },
+    {
+      n: "2",
+      head: "Run asm",
+      body: "It auto-discovers skills across every configured agent directory on your machine.",
+    },
+    {
+      n: "3",
+      head: "Manage everything",
+      body: "Install, search, inspect, audit, and uninstall skills from the TUI or scriptable CLI.",
+    },
+    {
+      n: "4",
+      head: "Stay safe",
+      body: "Security-scan before installing, detect duplicates, and clean up with confidence.",
+    },
+  ];
+  return (
+    <section className="flex flex-col gap-10">
+      <header className="flex flex-col gap-4 max-w-[680px]">
+        <span className="lp-kicker">
+          <span className="dot" aria-hidden="true" />
+          how it works
+        </span>
+        <h2 className="lp-section-title">From chaos to clean in four steps.</h2>
+      </header>
+      <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-x-6 gap-y-10">
+        {steps.map((s) => (
+          <div key={s.n} className="flex flex-col gap-3">
+            <span className="lp-step-num">{s.n}</span>
+            <div className="lp-rule" />
+            <h3 className="text-[var(--fg)] font-semibold text-base mt-1">
+              {s.head}
+            </h3>
+            <p className="text-sm leading-relaxed text-[var(--fg-dim)]">
+              {s.body}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/* ─── Build your own ────────────────────────────────────────────────── */
+
+function Build() {
+  return (
+    <section className="grid lg:grid-cols-[0.95fr_1.05fr] gap-12 lg:gap-16 items-center">
+      <div className="flex flex-col gap-5 max-w-[560px]">
+        <span className="lp-kicker">
+          <span className="dot" aria-hidden="true" />
+          for skill authors
+        </span>
+        <h2 className="lp-section-title">
+          Build, test, and ship your own skills.
+        </h2>
+        <p className="lp-lede">
+          asm isn&apos;t just for consuming skills — it&apos;s the complete
+          toolkit for creating, developing, auditing, and testing them locally
+          before you share. Scaffold, symlink for live reload, scan for risks,
+          then publish to the registry with a single command.
+        </p>
+        <div className="flex flex-wrap items-center gap-3">
+          <a
+            href="https://github.com/luongnv89/asm#build-test-and-ship-your-own-skills"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="lp-cta-ghost"
+          >
+            Read the dev workflow
+            <ArrowRight className="h-4 w-4" aria-hidden="true" />
+          </a>
+          <Link
+            to="/bundles"
+            className="text-sm text-[var(--fg-dim)] hover:text-[var(--brand)] font-medium"
+          >
+            Explore bundles →
+          </Link>
+        </div>
+      </div>
+
+      <div className="lp-term">
+        <div className="lp-term-bar">
+          <span className="tdot" aria-hidden="true" />
+          <span className="tdot" aria-hidden="true" />
+          <span className="tdot" aria-hidden="true" />
+          <span className="tlabel">author workflow</span>
+        </div>
+        <div className="lp-term-body">
+          <span className="dim"># scaffold a new skill</span>
+          {"\n"}
+          <span className="c">$</span> <span className="fg">asm init</span>{" "}
+          my-skill -p claude
+          {"\n\n"}
+          <span className="dim"># live-reload while you edit</span>
+          {"\n"}
+          <span className="c">$</span> <span className="fg">asm link</span>{" "}
+          ./my-skill -p claude
+          {"\n\n"}
+          <span className="dim"># audit before you ship</span>
+          {"\n"}
+          <span className="c">$</span> <span className="fg">asm audit</span>{" "}
+          security ./my-skill
+          {"\n"}
+          <span className="dim"> ↳ </span>
+          <span className="c">✓ no dangerous patterns</span>
+          {"\n\n"}
+          <span className="dim"># publish to the registry</span>
+          {"\n"}
+          <span className="c">$</span> <span className="fg">asm publish</span>{" "}
+          ./my-skill
+          {"\n"}
+          <span className="dim"> ↳ </span>
+          <span className="c">✓ PR opened</span>
+          <span className="dim"> — installable by name once merged</span>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ─── Final CTA ─────────────────────────────────────────────────────── */
+
+function FinalCta({ skillsLabel }) {
+  return (
+    <section className="flex flex-col items-center text-center gap-7 py-6 sm:py-10 border-t border-[var(--border)]">
+      <span className="lp-kicker">
+        <span className="dot" aria-hidden="true" />
+        get started in 30 seconds
+      </span>
+      <h2 className="lp-section-title max-w-[680px]">
+        Bring order to your skills today.
+      </h2>
+      <p className="lp-lede mx-auto">
+        Install once, manage every agent. Or browse {skillsLabel} skills in your
+        browser first — no signup required.
+      </p>
+
+      <div className="flex flex-col gap-3 w-full max-w-[480px]">
+        <div className="lp-cmd">
+          <span className="prompt" aria-hidden="true">
+            $
+          </span>
+          <span className="flex-1 text-left">{NPM_CMD}</span>
+          <CopyButton
+            text={NPM_CMD}
+            size="sm"
+            ariaLabel="Copy install command"
+          />
+        </div>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <Link to="/skills" className="lp-cta">
+            Browse the catalog
+            <ArrowRight className="h-4 w-4" aria-hidden="true" />
+          </Link>
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="lp-cta-ghost"
+          >
+            <Github className="h-4 w-4" aria-hidden="true" />
+            View on GitHub
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a dedicated marketing **landing page** at `/` and moves the skill catalog to `/skills` (and `/skills/:id`).

Previously `/` rendered the catalog directly. The new home page introduces the product before sending visitors into the catalog.

## What changed

- **New `LandingPage`** (`/`) — a Problem → Agitate → Solution arc mirroring the README, in the existing editorial/terminal aesthetic (Fraunces serif, JetBrains Mono, hacker-green). Sections: hero (+ terminal mock), live stats bar, problem, solution (6 feature cards), how-it-works (4 steps), build-your-own (author terminal), final CTA. Headline stats (skills / repos / categories / agents) are read **live from the loaded catalog**, so they never drift.
- **Routing** — `/` → `LandingPage`; catalog → `/skills` + `/skills/:id`. `LegacyCatalogRedirect` forwards old root deep-links carrying filter params (`?q=`, `?cat=`, `?repo=`, `?facet=`, `?sort=`) to `/skills`, preserving the query string so shared catalog URLs keep working.
- **Header** — logo → `/`, "Skills" nav → `/skills`; brand label updated to `asm agent-skill-manager`.
- **SEO consistency** — `index.html` meta + JSON-LD, the `og-image.svg` social card, `llms.txt`, and `sitemap.xml` are now product-led with the catalog as a linked destination (`#/skills`, `#/bundles`).
- **README** — catalog/bundle links point at `/#/skills` and `/#/bundles`; refreshed the stale skill count.

## Testing

- Catalog-dependent smoke/bundle-cart suites updated to target `/skills`.
- Added coverage: `/` renders the landing page (not the catalog), and the legacy `?cat=` → `/skills` redirect.
- **All 58 site tests pass**; lint clean on every changed file.
- Visually verified dark/light desktop + mobile and the catalog route render with no console errors; re-rendered the og-image card to confirm the new title fits.
- Pre-push (prettier, build, node e2e) passed.
