### PR TITLE
Add neutral local library activation

### DIFF
--- a/docs/superpowers/plans/2026-06-18-local-library-activation.md
+++ b/docs/superpowers/plans/2026-06-18-local-library-activation.md
@@ -1,0 +1,1320 @@
+# Local Library Activation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a neutral ASM local library where skills can be installed once and activated into provider/project folders via symlinks.
+
+**Architecture:** Add a focused `src/library.ts` module for library paths, metadata, install copies, listing, and activation symlinks. Reuse existing install discovery/review logic in `src/cli.ts`; `--library` changes only the final target from provider path to ASM library path. Activation is symlink-only and uses the existing provider config resolver.
+
+**Tech Stack:** TypeScript, Node `fs/promises`, Vitest, existing ASM CLI parser and install/link patterns.
+
+---
+
+## File Map
+
+- Create `src/library.ts`: library root helpers, lock read/write, install copy, list records, activate symlink.
+- Create `src/library.test.ts`: focused unit tests for library lock, install copy, and activation behavior.
+- Modify `src/config.ts`: expose `getLibraryDir()`, `getLibrarySkillsDir()`, and `getLibraryLockPath()`.
+- Modify `src/utils/types.ts`: add `library` flag to install options/parsed flags and define library lock entry types.
+- Modify `src/cli.ts`: parse `--library`; add `cmdLibrary`; add `cmdActivate`; route commands; call library install path from `cmdInstall`.
+- Modify `src/cli.test.ts`: parser and CLI integration tests for `install --library`, `library list`, and `activate`.
+
+## Task 1: Library Storage Module
+
+**Files:**
+- Create: `src/library.ts`
+- Test: `src/library.test.ts`
+- Modify: `src/config.ts`
+- Modify: `src/utils/types.ts`
+
+- [ ] **Step 1: Write failing tests for empty library lock and path helpers**
+
+Add this to `src/library.test.ts`:
+
+```ts
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  emptyLibraryLock,
+  readLibraryLock,
+  writeLibraryLock,
+} from "./library";
+
+describe("library lock", () => {
+  let tempDir: string;
+  let lockPath: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-test-"));
+    lockPath = join(tempDir, "library-lock.json");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("readLibraryLock returns an empty lock when the file is missing", async () => {
+    await expect(readLibraryLock(lockPath)).resolves.toEqual({
+      version: 1,
+      skills: {},
+    });
+  });
+
+  test("writeLibraryLock persists a versioned lock file", async () => {
+    const lock = emptyLibraryLock();
+    lock.skills.brainstorming = {
+      name: "brainstorming",
+      version: "1.0.0",
+      source: "github:obra/superpowers",
+      sourceType: "github",
+      commitHash: "abc123",
+      ref: "main",
+      skillPath: "skills/brainstorming",
+      libraryPath: join(tempDir, "skills", "brainstorming"),
+      installedAt: "2026-06-18T00:00:00.000Z",
+    };
+
+    await writeLibraryLock(lock, lockPath);
+
+    await expect(readLibraryLock(lockPath)).resolves.toEqual(lock);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts
+```
+
+Expected: FAIL because `src/library.ts` does not exist.
+
+- [ ] **Step 3: Add library types and path helpers**
+
+In `src/utils/types.ts`, add these types near the lock types:
+
+```ts
+export interface LibrarySkillEntry {
+  name: string;
+  version: string;
+  source: string;
+  commitHash: string;
+  ref: string | null;
+  skillPath: string;
+  libraryPath: string;
+  installedAt: string;
+  sourceType?: "registry" | "github" | "local";
+}
+
+export interface LibraryLockFile {
+  version: 1;
+  skills: Record<string, LibrarySkillEntry>;
+}
+```
+
+In `src/config.ts`, add constants after `INDEX_DIR`:
+
+```ts
+const LIBRARY_DIR = join(CONFIG_DIR, "library");
+const LIBRARY_SKILLS_DIR = join(LIBRARY_DIR, "skills");
+const LIBRARY_LOCK_PATH = join(LIBRARY_DIR, "library-lock.json");
+```
+
+Add exports near the other getters:
+
+```ts
+export function getLibraryDir(): string {
+  return LIBRARY_DIR;
+}
+
+export function getLibrarySkillsDir(): string {
+  return LIBRARY_SKILLS_DIR;
+}
+
+export function getLibraryLockPath(): string {
+  return LIBRARY_LOCK_PATH;
+}
+```
+
+- [ ] **Step 4: Implement lock read/write**
+
+Create `src/library.ts`:
+
+```ts
+import { copyFile, mkdir, readFile, writeFile } from "fs/promises";
+import { dirname } from "path";
+import { getLibraryLockPath } from "./config";
+import { debug } from "./logger";
+import type { LibraryLockFile } from "./utils/types";
+
+export function emptyLibraryLock(): LibraryLockFile {
+  return { version: 1, skills: {} };
+}
+
+export async function readLibraryLock(
+  path: string = getLibraryLockPath(),
+): Promise<LibraryLockFile> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf-8");
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      debug("library: lock file not found, returning empty lock");
+      return emptyLibraryLock();
+    }
+    throw err;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      parsed.version !== 1 ||
+      typeof parsed.skills !== "object" ||
+      parsed.skills === null
+    ) {
+      throw new Error("invalid schema");
+    }
+    return parsed as LibraryLockFile;
+  } catch {
+    const backupPath = path + ".bak";
+    try {
+      await copyFile(path, backupPath);
+    } catch {
+      // best effort backup
+    }
+    console.error(
+      `Warning: library-lock.json was corrupted. Backup saved to ${backupPath}. Starting fresh.`,
+    );
+    return emptyLibraryLock();
+  }
+}
+
+export async function writeLibraryLock(
+  lock: LibraryLockFile,
+  path: string = getLibraryLockPath(),
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(lock, null, 2) + "\n", "utf-8");
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/library.ts src/library.test.ts src/config.ts src/utils/types.ts
+git commit -m "Add local library lock storage"
+```
+
+## Task 2: Library Install Primitives
+
+**Files:**
+- Modify: `src/library.ts`
+- Modify: `src/library.test.ts`
+
+- [ ] **Step 1: Write failing tests for installing a skill into the library**
+
+Append to `src/library.test.ts`:
+
+```ts
+import { mkdir, readFile, writeFile, lstat } from "fs/promises";
+import { installLibrarySkill } from "./library";
+
+describe("installLibrarySkill", () => {
+  let tempDir: string;
+  let lockPath: string;
+  let skillsDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-install-"));
+    lockPath = join(tempDir, "library-lock.json");
+    skillsDir = join(tempDir, "skills");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("copies a skill directory and writes source metadata", async () => {
+    const sourceDir = join(tempDir, "source", "skills", "brainstorming");
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(
+      join(sourceDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.2.3\n---\n# Brainstorming\n",
+    );
+
+    const result = await installLibrarySkill(
+      {
+        sourceDir,
+        libraryName: "brainstorming",
+        source: "github:obra/superpowers",
+        sourceType: "github",
+        commitHash: "abc123",
+        ref: "main",
+        skillPath: "skills/brainstorming",
+        force: false,
+      },
+      { skillsDir, lockPath },
+    );
+
+    expect(result.name).toBe("brainstorming");
+    expect(result.version).toBe("1.2.3");
+    expect(await readFile(join(result.libraryPath, "SKILL.md"), "utf-8")).toContain(
+      "Brainstorming",
+    );
+
+    const lock = await readLibraryLock(lockPath);
+    expect(lock.skills.brainstorming).toMatchObject({
+      name: "brainstorming",
+      version: "1.2.3",
+      source: "github:obra/superpowers",
+      sourceType: "github",
+      commitHash: "abc123",
+      ref: "main",
+      skillPath: "skills/brainstorming",
+      libraryPath: result.libraryPath,
+    });
+  });
+
+  test("refuses to overwrite an existing library skill without force", async () => {
+    const sourceDir = join(tempDir, "source", "skills", "brainstorming");
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(
+      join(sourceDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Body\n",
+    );
+
+    await installLibrarySkill(
+      {
+        sourceDir,
+        libraryName: "brainstorming",
+        source: "local:/tmp/source",
+        sourceType: "local",
+        commitHash: "unknown",
+        ref: null,
+        skillPath: "skills/brainstorming",
+        force: false,
+      },
+      { skillsDir, lockPath },
+    );
+
+    await expect(
+      installLibrarySkill(
+        {
+          sourceDir,
+          libraryName: "brainstorming",
+          source: "local:/tmp/source",
+          sourceType: "local",
+          commitHash: "unknown",
+          ref: null,
+          skillPath: "skills/brainstorming",
+          force: false,
+        },
+        { skillsDir, lockPath },
+      ),
+    ).rejects.toThrow(/already exists/);
+
+    await expect(lstat(join(skillsDir, "brainstorming"))).resolves.toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts
+```
+
+Expected: FAIL because `installLibrarySkill` is not exported.
+
+- [ ] **Step 3: Implement installLibrarySkill**
+
+Add imports in `src/library.ts`:
+
+```ts
+import { access, cp, rm } from "fs/promises";
+import { join } from "path";
+import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
+```
+
+Add interfaces and function:
+
+```ts
+export interface InstallLibrarySkillPlan {
+  sourceDir: string;
+  libraryName: string;
+  source: string;
+  commitHash: string;
+  ref: string | null;
+  skillPath: string;
+  force: boolean;
+  sourceType?: "registry" | "github" | "local";
+}
+
+export interface LibraryPaths {
+  skillsDir?: string;
+  lockPath?: string;
+}
+
+export async function installLibrarySkill(
+  plan: InstallLibrarySkillPlan,
+  paths: LibraryPaths = {},
+): Promise<{ name: string; version: string; libraryPath: string }> {
+  const skillsDir = paths.skillsDir ?? getLibrarySkillsDir();
+  const lockPath = paths.lockPath ?? getLibraryLockPath();
+  const libraryPath = join(skillsDir, plan.libraryName);
+
+  try {
+    await access(libraryPath);
+    if (!plan.force) {
+      throw new Error(
+        `Library skill already exists: ${libraryPath}. Use --force to overwrite.`,
+      );
+    }
+    await rm(libraryPath, { recursive: true, force: true });
+  } catch (err: any) {
+    if (err?.message?.includes("--force")) throw err;
+  }
+
+  await mkdir(skillsDir, { recursive: true });
+  await cp(plan.sourceDir, libraryPath, { recursive: true });
+  await rm(join(libraryPath, ".git"), { recursive: true, force: true });
+
+  const content = await readFile(join(libraryPath, "SKILL.md"), "utf-8");
+  const fm = parseFrontmatter(content);
+  const name = fm.name || plan.libraryName;
+  const version = resolveVersion(fm);
+
+  const lock = await readLibraryLock(lockPath);
+  lock.skills[plan.libraryName] = {
+    name,
+    version,
+    source: plan.source,
+    sourceType: plan.sourceType,
+    commitHash: plan.commitHash,
+    ref: plan.ref,
+    skillPath: plan.skillPath,
+    libraryPath,
+    installedAt: new Date().toISOString(),
+  };
+  await writeLibraryLock(lock, lockPath);
+
+  return { name, version, libraryPath };
+}
+```
+
+Ensure `src/library.ts` imports `getLibrarySkillsDir` and `getLibraryLockPath` from `./config`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/library.ts src/library.test.ts
+git commit -m "Add local library skill installs"
+```
+
+## Task 3: CLI Parser and Install --library
+
+**Files:**
+- Modify: `src/utils/types.ts`
+- Modify: `src/cli.ts`
+- Modify: `src/cli.test.ts`
+
+- [ ] **Step 1: Write failing parser test for --library**
+
+In `src/cli.test.ts`, inside `describe("parseArgs: install", ...)`, add:
+
+```ts
+  test("parses install --library", () => {
+    const result = parse("install", "github:user/repo", "--library");
+    expect(result.command).toBe("install");
+    expect(result.subcommand).toBe("github:user/repo");
+    expect(result.flags.library).toBe(true);
+  });
+```
+
+- [ ] **Step 2: Run parser test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected: FAIL because `flags.library` does not exist or `--library` is unknown.
+
+- [ ] **Step 3: Add parser support**
+
+In `src/utils/types.ts`, extend `InstallOptions`:
+
+```ts
+  library: boolean;
+```
+
+Find the `ParsedArgs` flags type in `src/cli.ts` and add:
+
+```ts
+  library: boolean;
+```
+
+In the default `flags` object in `parseArgs`, add:
+
+```ts
+      library: false,
+```
+
+In `parseArgs`, add this branch near other boolean flags:
+
+```ts
+    } else if (arg === "--library") {
+      result.flags.library = true;
+```
+
+- [ ] **Step 4: Run parser test to verify it passes**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing CLI integration test for library install**
+
+In `src/cli.test.ts`, create a new describe block near install integration tests:
+
+```ts
+describe("CLI integration: install --library", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-cli-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function runCLIWithHome(
+    home: string,
+    ...args: string[]
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    const res = await spawnCollect(["npx", "tsx", CLI_BIN, ...args], {
+      env: { ...process.env, NO_COLOR: "1", HOME: home },
+    });
+    return {
+      stdout: res.stdout.trim(),
+      stderr: res.stderr.trim(),
+      exitCode: res.exitCode,
+    };
+  }
+
+  test("installs all selected skills into the library without provider-visible installs", async () => {
+    const source = join(tempDir, "source");
+    await mkdir(join(source, "skills", "one"), { recursive: true });
+    await mkdir(join(source, "skills", "two"), { recursive: true });
+    await writeFile(
+      join(source, "skills", "one", "SKILL.md"),
+      "---\nname: one\nversion: 1.0.0\n---\n# One\n",
+    );
+    await writeFile(
+      join(source, "skills", "two", "SKILL.md"),
+      "---\nname: two\nversion: 1.0.0\n---\n# Two\n",
+    );
+
+    const { stdout, stderr, exitCode } = await runCLIWithHome(
+      tempDir,
+      "install",
+      source,
+      "--library",
+      "--all",
+      "-y",
+      "--json",
+    );
+
+    expect(exitCode).toBe(0);
+    const payload = JSON.parse(stdout);
+    expect(Array.isArray(payload)).toBe(true);
+    expect(payload.map((r: any) => r.name).sort()).toEqual(["one", "two"]);
+    expect(await readFile(join(tempDir, ".config", "agent-skill-manager", "library", "skills", "one", "SKILL.md"), "utf-8")).toContain("# One");
+    await expect(
+      lstat(join(tempDir, ".claude", "skills", "one")),
+    ).rejects.toThrow();
+    expect(stderr).not.toContain("Error");
+  });
+});
+```
+
+- [ ] **Step 6: Run CLI integration test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected: FAIL because `cmdInstall` still installs into provider paths.
+
+- [ ] **Step 7: Route install --library to library installs**
+
+In `src/cli.ts`, import:
+
+```ts
+import { getLibrarySkillsDir } from "./config";
+import { installLibrarySkill } from "./library";
+```
+
+Because `getLibrarySkillsDir` is already exported from `./config`, prefer adding it to the existing config import instead of a second import.
+
+Inside `cmdInstall`, after source parsing and before provider selection, branch the provider/scope steps:
+
+```ts
+    const config = await loadConfig();
+    let provider: ProviderConfig | null = null;
+    let allProviders: ProviderConfig[] | null = null;
+    let installScope: "global" | "project" = "global";
+
+    if (!args.flags.library) {
+      console.info(stepHeader("Selecting provider"));
+      const resolvedProvider = await resolveProvider(
+        config,
+        args.flags.provider,
+        !!process.stdin.isTTY,
+      );
+      provider = resolvedProvider.provider;
+      allProviders = resolvedProvider.allProviders;
+
+      console.info(stepHeader("Selecting scope"));
+      // keep existing scope-selection logic here
+    } else {
+      console.info(stepHeader("Selecting library"));
+      console.info(`  ${ansi.dim(getLibrarySkillsDir())}`);
+    }
+```
+
+Move the existing provider and scope selection code into the `!args.flags.library` branch. For code that later requires `provider`, use `provider!` only inside non-library branches.
+
+When inspecting selected skills, use the first enabled provider only for existing-skill status if `--library` is set:
+
+```ts
+    const inspectionProvider =
+      provider ?? config.providers.find((p) => p.enabled) ?? config.providers[0];
+```
+
+Pass `inspectionProvider` into `inspectSkillForInstall`.
+
+In the install loop, replace:
+
+```ts
+        const result = await executeSkillInstall(inspection.plan, allProviders);
+```
+
+with:
+
+```ts
+        const result = args.flags.library
+          ? await installSelectedLibrarySkill({
+              inspection,
+              source,
+              isLocal,
+              resolutionSource,
+              commitHash,
+              scanBaseDir,
+            })
+          : await executeSkillInstall(inspection.plan, allProviders);
+```
+
+Add this helper near `executeSkillInstall`:
+
+```ts
+async function installSelectedLibrarySkill(input: {
+  inspection: SkillInspection;
+  source: ReturnType<typeof parseSource>;
+  isLocal: boolean;
+  resolutionSource: ResolutionSource;
+  commitHash: string | null;
+  scanBaseDir: string;
+}): Promise<InstallResult> {
+  const { inspection, source, isLocal, resolutionSource, commitHash, scanBaseDir } =
+    input;
+  const sourceStr = isLocal
+    ? `local:${source.localPath}`
+    : `github:${source.owner}/${source.repo}`;
+  const sourceType = isLocal
+    ? ("local" as const)
+    : resolutionSource === "registry"
+      ? ("registry" as const)
+      : ("github" as const);
+  const skillPath = relativePath(scanBaseDir, inspection.plan.sourceDir);
+  const installed = await installLibrarySkill({
+    sourceDir: inspection.plan.sourceDir,
+    libraryName: inspection.skillName,
+    source: sourceStr,
+    sourceType,
+    commitHash: commitHash || "unknown",
+    ref: source.ref || "main",
+    skillPath,
+    force: inspection.plan.force,
+  });
+
+  return {
+    success: true,
+    path: installed.libraryPath,
+    name: installed.name,
+    version: installed.version,
+    provider: "Library",
+    source: sourceStr,
+  };
+}
+```
+
+Skip the existing `.skill-lock.json` `writeLockEntry` when `args.flags.library` is true because library installs write `library-lock.json`.
+
+- [ ] **Step 8: Run CLI integration test to verify it passes**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/cli.ts src/cli.test.ts src/utils/types.ts src/library.ts
+git commit -m "Add install --library flow"
+```
+
+## Task 4: Library List Command
+
+**Files:**
+- Modify: `src/library.ts`
+- Modify: `src/cli.ts`
+- Modify: `src/cli.test.ts`
+
+- [ ] **Step 1: Write failing CLI test for library list JSON**
+
+In the `CLI integration: install --library` describe block, add:
+
+```ts
+  test("library list --json returns centrally installed skills", async () => {
+    const source = join(tempDir, "source");
+    await mkdir(join(source, "skills", "one"), { recursive: true });
+    await writeFile(
+      join(source, "skills", "one", "SKILL.md"),
+      "---\nname: one\nversion: 1.0.0\n---\n# One\n",
+    );
+
+    await runCLIWithHome(
+      tempDir,
+      "install",
+      source,
+      "--library",
+      "--all",
+      "-y",
+      "--json",
+    );
+
+    const { stdout, exitCode } = await runCLIWithHome(
+      tempDir,
+      "library",
+      "list",
+      "--json",
+    );
+
+    expect(exitCode).toBe(0);
+    const rows = JSON.parse(stdout);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      dirName: "one",
+      name: "one",
+      version: "1.0.0",
+      source: "local:" + source,
+      skillPath: "skills/one",
+    });
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected: FAIL because `library` command is not routed.
+
+- [ ] **Step 3: Add listLibrarySkills**
+
+In `src/library.ts`, add:
+
+```ts
+export interface LibrarySkillInfo {
+  dirName: string;
+  name: string;
+  version: string;
+  source: string;
+  sourceType?: "registry" | "github" | "local";
+  commitHash: string;
+  ref: string | null;
+  skillPath: string;
+  libraryPath: string;
+  installedAt: string;
+  missing: boolean;
+}
+
+export async function listLibrarySkills(
+  path: string = getLibraryLockPath(),
+): Promise<LibrarySkillInfo[]> {
+  const lock = await readLibraryLock(path);
+  const rows: LibrarySkillInfo[] = [];
+  for (const [dirName, entry] of Object.entries(lock.skills)) {
+    let missing = false;
+    try {
+      await access(join(entry.libraryPath, "SKILL.md"));
+    } catch {
+      missing = true;
+    }
+    rows.push({ dirName, ...entry, missing });
+  }
+  rows.sort((a, b) => a.name.localeCompare(b.name));
+  return rows;
+}
+```
+
+- [ ] **Step 4: Add CLI command**
+
+In `src/cli.ts`, import `listLibrarySkills`.
+
+Add help:
+
+```ts
+function printLibraryHelp() {
+  console.log(`${ansi.bold("Usage:")} asm library list [options]
+
+List skills installed in ASM's central local library.
+
+${ansi.bold("Options:")}
+  --json       Output as JSON
+  --no-color   Disable ANSI colors
+  -V, --verbose Show debug output`);
+}
+```
+
+Add command:
+
+```ts
+async function cmdLibrary(args: ParsedArgs) {
+  if (args.flags.help) {
+    printLibraryHelp();
+    return;
+  }
+  if (args.subcommand !== "list") {
+    error("Missing or unknown library subcommand. Use: asm library list");
+    process.exit(2);
+  }
+
+  const rows = await listLibrarySkills();
+  if (args.flags.json) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+
+  if (rows.length === 0) {
+    console.log(ansi.dim("No skills installed in the local library."));
+    return;
+  }
+
+  const lines = ["Name  Version  Source  Skill Path  Library Path"];
+  for (const row of rows) {
+    const missing = row.missing ? " [missing]" : "";
+    lines.push(
+      `${row.name}${missing}  ${row.version}  ${row.source}  ${row.skillPath}  ${row.libraryPath}`,
+    );
+  }
+  console.log(lines.join("\n"));
+}
+```
+
+Add `library` to `printMainHelp()` command list.
+
+Route near other commands:
+
+```ts
+    case "library":
+      await cmdLibrary(args);
+      break;
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/library.ts src/cli.ts src/cli.test.ts
+git commit -m "Add library list command"
+```
+
+## Task 5: Activate Command
+
+**Files:**
+- Modify: `src/library.ts`
+- Modify: `src/library.test.ts`
+- Modify: `src/cli.ts`
+- Modify: `src/cli.test.ts`
+
+- [ ] **Step 1: Write failing unit tests for activation symlinks**
+
+Append to `src/library.test.ts`:
+
+```ts
+import { readlink, symlink } from "fs/promises";
+import { activateLibrarySkill } from "./library";
+
+describe("activateLibrarySkill", () => {
+  let tempDir: string;
+  let sourceDir: string;
+  let targetDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-activate-"));
+    sourceDir = join(tempDir, "library", "skills", "brainstorming");
+    targetDir = join(tempDir, "project", ".codex", "skills");
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(
+      join(sourceDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Body\n",
+    );
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("creates a symlink from provider target to library skill", async () => {
+    const result = await activateLibrarySkill({
+      libraryPath: sourceDir,
+      targetDir,
+      activationName: "brainstorming",
+      force: false,
+    });
+
+    expect(result.symlinkPath).toBe(join(targetDir, "brainstorming"));
+    expect(await readlink(result.symlinkPath)).toBe(sourceDir);
+  });
+
+  test("refuses an existing target without force", async () => {
+    await mkdir(targetDir, { recursive: true });
+    await symlink(sourceDir, join(targetDir, "brainstorming"), "dir");
+
+    await expect(
+      activateLibrarySkill({
+        libraryPath: sourceDir,
+        targetDir,
+        activationName: "brainstorming",
+        force: false,
+      }),
+    ).rejects.toThrow(/already exists/);
+  });
+});
+```
+
+- [ ] **Step 2: Run unit tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts
+```
+
+Expected: FAIL because `activateLibrarySkill` is not exported.
+
+- [ ] **Step 3: Implement activateLibrarySkill and resolution**
+
+In `src/library.ts`, add imports if missing:
+
+```ts
+import { lstat, symlink } from "fs/promises";
+```
+
+Add:
+
+```ts
+export function findLibrarySkill(
+  rows: LibrarySkillInfo[],
+  name: string,
+): LibrarySkillInfo | null {
+  const exactDir = rows.find((r) => r.dirName === name);
+  if (exactDir) return exactDir;
+  const exactName = rows.find((r) => r.name === name);
+  return exactName ?? null;
+}
+
+export async function activateLibrarySkill(input: {
+  libraryPath: string;
+  targetDir: string;
+  activationName: string;
+  force: boolean;
+}): Promise<{ symlinkPath: string; targetPath: string }> {
+  const symlinkPath = join(input.targetDir, input.activationName);
+  try {
+    await lstat(symlinkPath);
+    if (!input.force) {
+      throw new Error(
+        `Target already exists: ${symlinkPath}. Use --force to overwrite.`,
+      );
+    }
+    await rm(symlinkPath, { recursive: true, force: true });
+  } catch (err: any) {
+    if (err?.message?.includes("--force")) throw err;
+  }
+
+  await mkdir(input.targetDir, { recursive: true });
+  await symlink(input.libraryPath, symlinkPath, "dir");
+  return { symlinkPath, targetPath: input.libraryPath };
+}
+```
+
+- [ ] **Step 4: Run unit tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing CLI integration test for activate**
+
+In `CLI integration: install --library`, add:
+
+```ts
+  test("activate creates a project-scoped provider symlink from the library", async () => {
+    const source = join(tempDir, "source");
+    await mkdir(join(source, "skills", "brainstorming"), { recursive: true });
+    await writeFile(
+      join(source, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Brainstorming\n",
+    );
+
+    await runCLIWithHome(
+      tempDir,
+      "install",
+      source,
+      "--library",
+      "--all",
+      "-y",
+      "--json",
+    );
+
+    const projectDir = join(tempDir, "project");
+    await mkdir(projectDir, { recursive: true });
+    const res = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "activate",
+        "brainstorming",
+        "-p",
+        "codex",
+        "-s",
+        "project",
+        "--json",
+      ],
+      { env: { ...process.env, NO_COLOR: "1", HOME: tempDir }, cwd: projectDir },
+    );
+
+    expect(res.exitCode).toBe(0);
+    const payload = JSON.parse(res.stdout.trim());
+    expect(payload.name).toBe("brainstorming");
+    const linkPath = join(projectDir, ".codex", "skills", "brainstorming");
+    expect(await readlink(linkPath)).toBe(
+      join(tempDir, ".config", "agent-skill-manager", "library", "skills", "brainstorming"),
+    );
+  });
+```
+
+- [ ] **Step 6: Run CLI test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected: FAIL because `activate` command is not routed.
+
+- [ ] **Step 7: Add activate CLI command**
+
+In `src/cli.ts`, import `activateLibrarySkill` and `findLibrarySkill`.
+
+Add help:
+
+```ts
+function printActivateHelp() {
+  console.log(`${ansi.bold("Usage:")} asm activate <skill> [options]
+
+Activate a skill from ASM's local library into a provider skill folder.
+
+${ansi.bold("Options:")}
+  -p, --tool <name>    Target tool/provider
+  -s, --scope <s>      global or project
+  --name <name>        Activation symlink name
+  -f, --force          Overwrite existing target
+  --json               Output as JSON
+  --no-color           Disable ANSI colors
+  -V, --verbose        Show debug output`);
+}
+```
+
+Add command:
+
+```ts
+async function cmdActivate(args: ParsedArgs) {
+  if (args.flags.help) {
+    printActivateHelp();
+    return;
+  }
+  const skillName = args.subcommand;
+  if (!skillName) {
+    error("Missing required argument: <skill>");
+    process.exit(2);
+  }
+  if (args.flags.scope === "both") {
+    error("Activation requires --scope global or --scope project.");
+    process.exit(2);
+  }
+
+  const rows = await listLibrarySkills();
+  const skill = findLibrarySkill(rows, skillName);
+  if (!skill) {
+    error(`Library skill "${skillName}" not found. Run "asm library list".`);
+    process.exit(1);
+  }
+  if (skill.missing) {
+    error(`Library skill "${skillName}" is missing on disk: ${skill.libraryPath}`);
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const { provider } = await resolveProvider(
+    config,
+    args.flags.provider,
+    !!process.stdin.isTTY,
+  );
+  const template =
+    args.flags.scope === "project" ? provider.project : provider.global;
+  const targetDir = resolveProviderPath(template);
+  const activationName = args.flags.name || skill.dirName;
+  const result = await activateLibrarySkill({
+    libraryPath: skill.libraryPath,
+    targetDir,
+    activationName,
+    force: args.flags.force,
+  });
+
+  const output = {
+    name: activationName,
+    skill: skill.name,
+    provider: provider.name,
+    scope: args.flags.scope,
+    path: result.symlinkPath,
+    target: result.targetPath,
+  };
+  if (args.flags.json) {
+    console.log(JSON.stringify(output, null, 2));
+  } else {
+    console.log(
+      `${ansi.green("✓")} activated ${activationName} (${provider.name}, ${args.flags.scope}) -> ${result.targetPath}`,
+    );
+  }
+}
+```
+
+Add `activate` to `printMainHelp()` and route it:
+
+```ts
+    case "activate":
+      await cmdActivate(args);
+      break;
+```
+
+- [ ] **Step 8: Run CLI test to verify it passes**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/library.ts src/library.test.ts src/cli.ts src/cli.test.ts
+git commit -m "Add library skill activation"
+```
+
+## Task 6: Error Cases and Final Verification
+
+**Files:**
+- Modify: `src/cli.test.ts`
+- Modify: `src/cli.ts`
+- Modify: `src/library.ts`
+
+- [ ] **Step 1: Add failing CLI tests for activation errors**
+
+Add to `CLI integration: install --library`:
+
+```ts
+  test("activate unknown library skill exits with actionable message", async () => {
+    const { stderr, exitCode } = await runCLIWithHome(
+      tempDir,
+      "activate",
+      "missing-skill",
+      "-p",
+      "codex",
+      "-s",
+      "project",
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('Library skill "missing-skill" not found');
+    expect(stderr).toContain("asm library list");
+  });
+
+  test("activate refuses existing target without force", async () => {
+    const source = join(tempDir, "source");
+    await mkdir(join(source, "skills", "brainstorming"), { recursive: true });
+    await writeFile(
+      join(source, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Brainstorming\n",
+    );
+    await runCLIWithHome(tempDir, "install", source, "--library", "--all", "-y");
+
+    const projectDir = join(tempDir, "project");
+    const target = join(projectDir, ".codex", "skills", "brainstorming");
+    await mkdir(target, { recursive: true });
+
+    const res = await spawnCollect(
+      ["npx", "tsx", CLI_BIN, "activate", "brainstorming", "-p", "codex", "-s", "project"],
+      { env: { ...process.env, NO_COLOR: "1", HOME: tempDir }, cwd: projectDir },
+    );
+
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("Target already exists");
+    expect(res.stderr).toContain("--force");
+  });
+```
+
+- [ ] **Step 2: Run tests to verify the new assertions are enforced**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected before Step 3: FAIL if `cmdActivate` does not print the exact missing-skill message or `activateLibrarySkill` does not print the exact existing-target message.
+
+- [ ] **Step 3: Set exact activation error messages**
+
+In `src/cli.ts`, ensure the missing library skill branch in `cmdActivate` is exactly:
+
+```ts
+error(`Library skill "${skillName}" not found. Run "asm library list".`);
+process.exit(1);
+```
+
+In `src/library.ts`, ensure the existing target branch in `activateLibrarySkill` throws exactly:
+
+```ts
+throw new Error(
+  `Target already exists: ${symlinkPath}. Use --force to overwrite.`,
+);
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts
+npx vitest run src/cli.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run typecheck**
+
+Run:
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS with `tsc --noEmit`.
+
+- [ ] **Step 6: Run final test set**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts
+npx vitest run src/updater.test.ts
+npx vitest run src/cli.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit final test/error adjustments**
+
+```bash
+git add src/cli.ts src/cli.test.ts src/library.ts src/library.test.ts
+git commit -m "Cover local library activation errors"
+```
+
+## Self-Review Notes
+
+- Spec coverage: Task 1 covers storage; Task 2 covers library install primitives; Task 3 covers `install --library`; Task 4 covers `library list`; Task 5 covers `activate`; Task 6 covers error cases and verification.
+- Dependency closure, presets, sandbox, deactivate, and library update remain explicit follow-ups, matching the spec non-goals.
+- Type names used by later tasks are introduced before use: `LibrarySkillEntry`, `LibraryLockFile`, `LibrarySkillInfo`, `InstallLibrarySkillPlan`, `installLibrarySkill`, `listLibrarySkills`, `findLibrarySkill`, and `activateLibrarySkill`.

--- a/docs/superpowers/specs/2026-06-18-local-library-activation-design.md
+++ b/docs/superpowers/specs/2026-06-18-local-library-activation-design.md
@@ -1,0 +1,147 @@
+# Local Library Activation Design
+
+## Purpose
+
+ASM should support a neutral local skill library where skills can be installed once without becoming visible to Claude, Codex, or any other provider. Projects and tools should opt into individual skills by activation, preferably via symlinks, so the active skill set stays small and project-specific.
+
+This is the next step toward issue #307's local/private skill management direction and prepares the source metadata needed for issue #247's dependency-aware installs. It builds on the lock metadata work that records install scope and repo-relative `skillPath`.
+
+## Goals
+
+- Install selected skills into an ASM-owned library path without exposing them to any provider.
+- List centrally installed library skills.
+- Activate a library skill into a provider and scope by creating a symlink.
+- Preserve source metadata for future update and dependency-resolution work.
+- Keep existing `asm install`, `asm link`, `asm update`, and provider behavior unchanged unless the user explicitly uses the new library flow.
+
+## Non-Goals
+
+- Do not resolve shared dependencies yet.
+- Do not implement presets or sandbox mode yet.
+- Do not copy library skills during activation in the first slice; activation is symlink-only.
+- Do not change how provider-global installs work today.
+
+## Command Surface
+
+### Library Install
+
+```sh
+asm install <source> --library [--all] [--path <subdir>] [--name <name>] [-y]
+```
+
+`--library` reuses the existing install pipeline:
+
+- source parsing and registry resolution
+- git clone or local source handling
+- subpath discovery
+- duplicate target-name detection
+- security warning preview and confirmation
+
+Instead of installing into a selected provider path, it copies each selected skill into the ASM library root.
+
+### Library List
+
+```sh
+asm library list [--json]
+```
+
+Lists skills installed in the central library. The human table should include name, version, source, skill path, installed date, and library path. JSON output should expose the same fields.
+
+### Activate
+
+```sh
+asm activate <skill-name> -p <tool> -s <global|project> [--name <alias>] [--force] [--json]
+```
+
+Activation creates a symlink from the selected provider/scope folder to the library skill directory.
+
+Examples:
+
+```sh
+asm install github:obra/superpowers --library --all -y
+asm activate brainstorming -p codex -s project
+asm activate brainstorming -p claude -s global --name sp-brainstorming
+```
+
+## Storage
+
+Default paths:
+
+```text
+~/.config/agent-skill-manager/library/
+  skills/
+    <skill-dir-name>/
+      SKILL.md
+      ...
+  library-lock.json
+```
+
+The first slice stores skills by install directory name. If two selected skills would map to the same library directory name, the same duplicate target-name protection used by provider installs should block the operation.
+
+`library-lock.json` should be versioned and keyed by library directory name:
+
+```json
+{
+  "version": 1,
+  "skills": {
+    "brainstorming": {
+      "name": "brainstorming",
+      "version": "1.0.0",
+      "source": "github:obra/superpowers",
+      "sourceType": "github",
+      "commitHash": "abc123...",
+      "ref": "main",
+      "skillPath": "skills/brainstorming",
+      "libraryPath": "/Users/example/.config/agent-skill-manager/library/skills/brainstorming",
+      "installedAt": "2026-06-18T00:00:00.000Z"
+    }
+  }
+}
+```
+
+## Data Flow
+
+Library install:
+
+1. Parse and resolve the source.
+2. Discover/select skill directories using the existing install logic.
+3. Build library install plans instead of provider install plans.
+4. Copy selected skill directories to `library/skills/<skill-dir-name>`.
+5. Write or update `library-lock.json` with source metadata, commit hash, and repo-relative `skillPath`.
+
+Activation:
+
+1. Load `library-lock.json`.
+2. Resolve the requested library skill by directory name or frontmatter name.
+3. Resolve the target provider and scope using existing provider config.
+4. Create a symlink at `<provider-scope-dir>/<activation-name>` pointing to `libraryPath`.
+5. Refuse to overwrite existing targets unless `--force` is provided.
+
+## Error Handling
+
+- `asm install --library` should fail with a clear error if selected skills collide on library directory name.
+- `asm activate <skill>` should fail if the skill is not in the library, suggesting `asm library list`.
+- Activation should refuse to overwrite real directories unless `--force` is used.
+- Activation should replace existing symlinks when `--force` is used.
+- Broken library entries should be shown by `asm library list` with a warning rather than crashing.
+- Existing provider installs and links should continue using their current conflict behavior.
+
+## Testing
+
+Add focused tests for:
+
+- `parseArgs` accepts `install --library`.
+- `asm install <local multi-skill-dir> --library --all -y` creates library copies and does not create provider-visible skills.
+- `asm library list --json` returns installed library skills.
+- `asm activate <skill> -p codex -s project` creates a symlink into `.codex/skills`.
+- Activation fails for unknown library skills with an actionable message.
+- Activation refuses an existing target without `--force`.
+- Activation with `--force` replaces an existing symlink.
+- Existing install, link, and update tests still pass.
+
+## Open Follow-Ups
+
+- Add `asm deactivate` to remove activation symlinks.
+- Add `asm library update` using the recorded source metadata.
+- Add dependency closure resolution for issue #247.
+- Add sandbox/preset commands on top of library activations.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1550,6 +1550,88 @@ describe("CLI integration: install --library", () => {
     await expect(readlink(targetPath)).resolves.toBe(libraryPath);
   });
 
+  test("activate unknown library skill exits with actionable message", async () => {
+    const homeDir = join(tempDir, "home");
+    const projectDir = join(tempDir, "project");
+    await mkdir(projectDir, { recursive: true });
+
+    const res = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "activate",
+        "missing-skill",
+        "-p",
+        "codex",
+        "-s",
+        "project",
+      ],
+      {
+        cwd: projectDir,
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain('Library skill "missing-skill" not found');
+    expect(res.stderr).toContain("asm library list");
+  });
+
+  test("activate refuses existing target without force", async () => {
+    const source = join(tempDir, "source");
+    const sourceSkillDir = join(source, "skills", "brainstorming");
+    await mkdir(sourceSkillDir, { recursive: true });
+    await writeFile(
+      join(sourceSkillDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Brainstorming\n",
+    );
+
+    const homeDir = join(tempDir, "home");
+    const installRes = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "install",
+        sourceSkillDir,
+        "--library",
+        "-y",
+        "--json",
+      ],
+      {
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+    expect(installRes.exitCode).toBe(0);
+
+    const projectDir = join(tempDir, "project");
+    const targetPath = join(projectDir, ".codex", "skills", "brainstorming");
+    await mkdir(targetPath, { recursive: true });
+
+    const res = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "activate",
+        "brainstorming",
+        "-p",
+        "codex",
+        "-s",
+        "project",
+      ],
+      {
+        cwd: projectDir,
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("Target already exists");
+    expect(res.stderr).toContain("--force");
+  });
+
   test("does not overwrite an existing library skill when only provider install exists", async () => {
     const homeDir = join(tempDir, "home");
     const providerSkillDir = join(homeDir, ".claude", "skills", "foo");

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -414,6 +414,7 @@ describe("CLI integration: --help", () => {
     expect(stdout).toContain("search");
     expect(stdout).toContain("inspect");
     expect(stdout).toContain("uninstall");
+    expect(stdout).toContain("library");
     expect(stdout).toContain("config");
   });
 
@@ -1437,6 +1438,51 @@ describe("CLI integration: install --library", () => {
     await expect(
       lstat(join(homeDir, ".claude", "skills", "one")),
     ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("library list --json returns centrally installed skills", async () => {
+    const source = join(tempDir, "source");
+    await mkdir(join(source, "skills", "one"), { recursive: true });
+    await writeFile(
+      join(source, "skills", "one", "SKILL.md"),
+      "---\nname: one\nversion: 1.0.0\n---\n# One\n",
+    );
+
+    const homeDir = join(tempDir, "home");
+    await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "install",
+        source,
+        "--library",
+        "--all",
+        "-y",
+        "--json",
+      ],
+      {
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    const res = await spawnCollect(
+      ["npx", "tsx", CLI_BIN, "library", "list", "--json"],
+      {
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(res.exitCode).toBe(0);
+    const rows = JSON.parse(res.stdout);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      dirName: "one",
+      name: "one",
+      version: "1.0.0",
+      source: "local:" + source,
+      skillPath: "skills/one",
+    });
   });
 
   test("does not overwrite an existing library skill when only provider install exists", async () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1485,6 +1485,71 @@ describe("CLI integration: install --library", () => {
     });
   });
 
+  test("activate links a library skill into a project provider", async () => {
+    const source = join(tempDir, "source");
+    const sourceSkillDir = join(source, "skills", "brainstorming");
+    await mkdir(sourceSkillDir, { recursive: true });
+    await writeFile(
+      join(sourceSkillDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Brainstorming\n",
+    );
+
+    const homeDir = join(tempDir, "home");
+    const installRes = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "install",
+        sourceSkillDir,
+        "--library",
+        "-y",
+        "--json",
+      ],
+      {
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+    expect(installRes.exitCode).toBe(0);
+
+    const projectDir = join(tempDir, "project");
+    await mkdir(projectDir, { recursive: true });
+    const activateRes = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "activate",
+        "brainstorming",
+        "-p",
+        "codex",
+        "-s",
+        "project",
+        "--json",
+      ],
+      {
+        cwd: projectDir,
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(activateRes.exitCode).toBe(0);
+    const payload = JSON.parse(activateRes.stdout);
+    expect(payload.name).toBe("brainstorming");
+
+    const targetPath = join(projectDir, ".codex", "skills", "brainstorming");
+    const libraryPath = join(
+      homeDir,
+      ".config",
+      "agent-skill-manager",
+      "library",
+      "skills",
+      "brainstorming",
+    );
+    expect((await lstat(targetPath)).isSymbolicLink()).toBe(true);
+    await expect(readlink(targetPath)).resolves.toBe(libraryPath);
+  });
+
   test("does not overwrite an existing library skill when only provider install exists", async () => {
     const homeDir = join(tempDir, "home");
     const providerSkillDir = join(homeDir, ".claude", "skills", "foo");

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -21,6 +21,7 @@ import {
   lstat,
   readlink,
   symlink,
+  chmod,
 } from "fs/promises";
 import { tmpdir, homedir } from "os";
 import { spawnCollect, runInlineTs } from "./utils/test-spawn";
@@ -1122,6 +1123,13 @@ describe("parseArgs: install", () => {
     expect(result.subcommand).toBe("github:user/repo");
   });
 
+  test("parses install --library", () => {
+    const result = parse("install", "github:user/repo", "--library");
+    expect(result.command).toBe("install");
+    expect(result.subcommand).toBe("github:user/repo");
+    expect(result.flags.library).toBe(true);
+  });
+
   test("parses --provider flag", () => {
     const result = parse("install", "github:user/repo", "--provider", "claude");
     expect(result.flags.provider).toBe("claude");
@@ -1345,6 +1353,280 @@ describe("CLI integration: install", () => {
   test("main --help includes install command", async () => {
     const { stdout } = await runCLI("--help");
     expect(stdout).toContain("install");
+  });
+});
+
+// ─── CLI integration: install --library ─────────────────────────────────────
+
+describe("CLI integration: install --library", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-test-install-library-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("installs selected local skills into the neutral library", async () => {
+    const sourceDir = join(tempDir, "source");
+    await mkdir(join(sourceDir, "one"), { recursive: true });
+    await mkdir(join(sourceDir, "two"), { recursive: true });
+    await writeFile(
+      join(sourceDir, "one", "SKILL.md"),
+      `---\nname: one\nversion: 1.0.0\n---\n# One\n`,
+    );
+    await writeFile(
+      join(sourceDir, "two", "SKILL.md"),
+      `---\nname: two\nversion: 1.0.0\n---\n# Two\n`,
+    );
+
+    const homeDir = join(tempDir, "home");
+    const res = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "install",
+        sourceDir,
+        "--library",
+        "--all",
+        "-y",
+        "--json",
+      ],
+      {
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(res.exitCode).toBe(0);
+    const jsonStart = res.stdout.lastIndexOf("[\n  {");
+    expect(jsonStart).toBeGreaterThanOrEqual(0);
+    const payload = JSON.parse(res.stdout.slice(jsonStart).trim());
+    expect(payload.map((r: { name: string }) => r.name).sort()).toEqual([
+      "one",
+      "two",
+    ]);
+
+    const librarySkillsDir = join(
+      homeDir,
+      ".config",
+      "agent-skill-manager",
+      "library",
+      "skills",
+    );
+    await expect(
+      readFile(join(librarySkillsDir, "one", "SKILL.md"), "utf-8"),
+    ).resolves.toContain("# One");
+    await expect(
+      readFile(join(librarySkillsDir, "two", "SKILL.md"), "utf-8"),
+    ).resolves.toContain("# Two");
+    await expect(
+      readFile(
+        join(
+          homeDir,
+          ".config",
+          "agent-skill-manager",
+          "library",
+          "library-lock.json",
+        ),
+        "utf-8",
+      ),
+    ).resolves.toContain('"one"');
+    await expect(
+      lstat(join(homeDir, ".claude", "skills", "one")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("does not overwrite an existing library skill when only provider install exists", async () => {
+    const homeDir = join(tempDir, "home");
+    const providerSkillDir = join(homeDir, ".claude", "skills", "foo");
+    await mkdir(providerSkillDir, { recursive: true });
+    await writeFile(
+      join(providerSkillDir, "SKILL.md"),
+      `---\nname: foo\nversion: 1.0.0\n---\n# Existing provider\n`,
+    );
+
+    const librarySkillDir = join(
+      homeDir,
+      ".config",
+      "agent-skill-manager",
+      "library",
+      "skills",
+      "foo",
+    );
+    await mkdir(librarySkillDir, { recursive: true });
+    await writeFile(
+      join(librarySkillDir, "SKILL.md"),
+      `---\nname: foo\nversion: 1.0.0\n---\n# Existing library\n`,
+    );
+    await mkdir(
+      join(homeDir, ".config", "agent-skill-manager", "library"),
+      { recursive: true },
+    );
+    await writeFile(
+      join(
+        homeDir,
+        ".config",
+        "agent-skill-manager",
+        "library",
+        "library-lock.json",
+      ),
+      JSON.stringify(
+        {
+          version: 1,
+          skills: {
+            foo: {
+              name: "foo",
+              version: "1.0.0",
+              source: "local:/existing",
+              sourceType: "local",
+              commitHash: "unknown",
+              ref: "main",
+              skillPath: "foo",
+              libraryPath: librarySkillDir,
+              installedAt: "2026-01-01T00:00:00.000Z",
+            },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+
+    const sourceSkillDir = join(tempDir, "source", "foo");
+    await mkdir(sourceSkillDir, { recursive: true });
+    await writeFile(
+      join(sourceSkillDir, "SKILL.md"),
+      `---\nname: foo\nversion: 2.0.0\n---\n# New source\n`,
+    );
+
+    const res = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "install",
+        sourceSkillDir,
+        "--library",
+        "-y",
+        "--json",
+      ],
+      {
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(res.exitCode).not.toBe(0);
+    expect(`${res.stdout}\n${res.stderr}`).toMatch(
+      /Library skill already exists|--force/,
+    );
+    const librarySkillMd = await readFile(
+      join(librarySkillDir, "SKILL.md"),
+      "utf-8",
+    );
+    expect(librarySkillMd).toContain("# Existing library");
+    expect(librarySkillMd).not.toContain("# New source");
+  });
+
+  test("does not let Vercel method implicit force overwrite an existing library skill", async () => {
+    const homeDir = join(tempDir, "home");
+    const providerSkillDir = join(homeDir, ".claude", "skills", "foo");
+    await mkdir(providerSkillDir, { recursive: true });
+    await writeFile(
+      join(providerSkillDir, "SKILL.md"),
+      `---\nname: foo\nversion: 1.0.0\n---\n# Existing provider\n`,
+    );
+
+    const librarySkillDir = join(
+      homeDir,
+      ".config",
+      "agent-skill-manager",
+      "library",
+      "skills",
+      "foo",
+    );
+    await mkdir(librarySkillDir, { recursive: true });
+    await writeFile(
+      join(librarySkillDir, "SKILL.md"),
+      `---\nname: foo\nversion: 1.0.0\n---\n# Existing library\n`,
+    );
+    await mkdir(
+      join(homeDir, ".config", "agent-skill-manager", "library"),
+      { recursive: true },
+    );
+    await writeFile(
+      join(
+        homeDir,
+        ".config",
+        "agent-skill-manager",
+        "library",
+        "library-lock.json",
+      ),
+      JSON.stringify({ version: 1, skills: {} }, null, 2) + "\n",
+    );
+
+    const sourceSkillDir = join(tempDir, "source-vercel", "foo");
+    await mkdir(sourceSkillDir, { recursive: true });
+    await writeFile(
+      join(sourceSkillDir, "SKILL.md"),
+      `---\nname: foo\nversion: 2.0.0\n---\n# New source\n`,
+    );
+
+    const fakeBinDir = join(tempDir, "fake-bin");
+    await mkdir(fakeBinDir, { recursive: true });
+    const fakeNpx = join(fakeBinDir, "npx");
+    await writeFile(
+      fakeNpx,
+      `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "10.0.0"
+  exit 0
+fi
+echo "fake skills add"
+exit 0
+`,
+    );
+    await chmod(fakeNpx, 0o755);
+
+    const res = await spawnCollect(
+      [
+        process.env.npm_node_execpath || process.execPath,
+        "--import",
+        "tsx",
+        CLI_BIN,
+        "install",
+        sourceSkillDir,
+        "--library",
+        "--method",
+        "vercel",
+        "-y",
+        "--json",
+      ],
+      {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          NO_COLOR: "1",
+          PATH: `${fakeBinDir}:${process.env.PATH}`,
+        },
+      },
+    );
+
+    expect(
+      res.exitCode,
+      `stdout:\n${res.stdout}\nstderr:\n${res.stderr}`,
+    ).not.toBe(0);
+    expect(`${res.stdout}\n${res.stderr}`).toMatch(
+      /Library skill already exists|--force/,
+    );
+    const librarySkillMd = await readFile(
+      join(librarySkillDir, "SKILL.md"),
+      "utf-8",
+    );
+    expect(librarySkillMd).toContain("# Existing library");
+    expect(librarySkillMd).not.toContain("# New source");
   });
 });
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1723,42 +1723,8 @@ describe("CLI integration: install --library", () => {
     expect(librarySkillMd).not.toContain("# New source");
   });
 
-  test("does not let Vercel method implicit force overwrite an existing library skill", async () => {
+  test("rejects Vercel method for library installs before provider delegation", async () => {
     const homeDir = join(tempDir, "home");
-    const providerSkillDir = join(homeDir, ".claude", "skills", "foo");
-    await mkdir(providerSkillDir, { recursive: true });
-    await writeFile(
-      join(providerSkillDir, "SKILL.md"),
-      `---\nname: foo\nversion: 1.0.0\n---\n# Existing provider\n`,
-    );
-
-    const librarySkillDir = join(
-      homeDir,
-      ".config",
-      "agent-skill-manager",
-      "library",
-      "skills",
-      "foo",
-    );
-    await mkdir(librarySkillDir, { recursive: true });
-    await writeFile(
-      join(librarySkillDir, "SKILL.md"),
-      `---\nname: foo\nversion: 1.0.0\n---\n# Existing library\n`,
-    );
-    await mkdir(
-      join(homeDir, ".config", "agent-skill-manager", "library"),
-      { recursive: true },
-    );
-    await writeFile(
-      join(
-        homeDir,
-        ".config",
-        "agent-skill-manager",
-        "library",
-        "library-lock.json",
-      ),
-      JSON.stringify({ version: 1, skills: {} }, null, 2) + "\n",
-    );
 
     const sourceSkillDir = join(tempDir, "source-vercel", "foo");
     await mkdir(sourceSkillDir, { recursive: true });
@@ -1773,13 +1739,13 @@ describe("CLI integration: install --library", () => {
     await writeFile(
       fakeNpx,
       `#!/bin/sh
-if [ "$1" = "--version" ]; then
-  echo "10.0.0"
-  exit 0
-fi
-echo "fake skills add"
-exit 0
-`,
+	if [ "$1" = "--version" ]; then
+	  echo "10.0.0"
+	  exit 0
+	fi
+	echo "unexpected npx delegate"
+	exit 42
+	`,
     );
     await chmod(fakeNpx, 0o755);
 
@@ -1811,15 +1777,27 @@ exit 0
       res.exitCode,
       `stdout:\n${res.stdout}\nstderr:\n${res.stderr}`,
     ).not.toBe(0);
-    expect(`${res.stdout}\n${res.stderr}`).toMatch(
-      /Library skill already exists|--force/,
+    expect(`${res.stdout}\n${res.stderr}`).toContain(
+      "--library cannot be combined with --method vercel",
     );
-    const librarySkillMd = await readFile(
-      join(librarySkillDir, "SKILL.md"),
-      "utf-8",
+    expect(`${res.stdout}\n${res.stderr}`).not.toContain(
+      "unexpected npx delegate",
     );
-    expect(librarySkillMd).toContain("# Existing library");
-    expect(librarySkillMd).not.toContain("# New source");
+    await expect(
+      lstat(join(homeDir, ".claude", "skills", "foo")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      lstat(
+        join(
+          homeDir,
+          ".config",
+          "agent-skill-manager",
+          "library",
+          "skills",
+          "foo",
+        ),
+      ),
+    ).rejects.toMatchObject({ code: "ENOENT" });
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,7 +171,7 @@ import type { SearchFilters } from "./skill-index";
 import { VERSION_STRING } from "./utils/version";
 import { buildShadowingReport } from "./utils/path-shadowing";
 import { parseEditorCommand } from "./utils/editor";
-import { installLibrarySkill } from "./library";
+import { installLibrarySkill, listLibrarySkills } from "./library";
 import { setVerbose } from "./logger";
 import { join as joinPath, resolve, relative as relativePath } from "path";
 import type {
@@ -546,6 +546,7 @@ ${ansi.bold("Commands:")}
   disable <target>       Disable skill(s) without uninstalling
   enable <target>        Re-enable disabled skill(s)
   install <source>       Install a skill from GitHub or local path
+  library                Manage centrally installed library skills
   audit                  Detect duplicate skills across tools
   audit security <name>  Run security audit on a skill (or GitHub source)
   export                 Export skill inventory as JSON manifest
@@ -797,6 +798,23 @@ ${ansi.bold("Examples:")}
   asm config show                   ${ansi.dim("View current config")}
   asm config edit                   ${ansi.dim("Edit in $EDITOR")}
   asm config reset -y               ${ansi.dim("Reset without confirmation")}`);
+}
+
+function printLibraryHelp() {
+  console.log(`${ansi.bold("Usage:")} asm library <subcommand> [options]
+
+Manage centrally installed library skills.
+
+${ansi.bold("Subcommands:")}
+  list     List skills installed in the local library
+
+${ansi.bold("Options:")}
+  --json            Output as JSON array
+  -V, --verbose     Show debug output
+
+${ansi.bold("Examples:")}
+  asm library list                  ${ansi.dim("List local library skills")}
+  asm library list --json           ${ansi.dim("Output as JSON")}`);
 }
 
 // ─── Command Handlers ───────────────────────────────────────────────────────
@@ -2057,6 +2075,67 @@ async function cmdConfig(args: ParsedArgs) {
       process.exit(2);
     }
   }
+}
+
+async function cmdLibrary(args: ParsedArgs) {
+  if (args.flags.help) {
+    printLibraryHelp();
+    return;
+  }
+
+  if (args.subcommand !== "list") {
+    error("Missing or unknown library subcommand. Use: asm library list");
+    console.error(`Run "asm library --help" for usage.`);
+    process.exit(2);
+  }
+
+  const rows = await listLibrarySkills();
+
+  if (args.flags.json) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+
+  if (rows.length === 0) {
+    console.log(ansi.dim("No skills installed in the local library."));
+    return;
+  }
+
+  const widths = {
+    name: Math.max("Name".length, ...rows.map((r) => r.name.length)),
+    version: Math.max("Version".length, ...rows.map((r) => r.version.length)),
+    source: Math.max("Source".length, ...rows.map((r) => r.source.length)),
+    path: Math.max("Path".length, ...rows.map((r) => r.skillPath.length)),
+    status: "Status".length,
+  };
+  const formatRow = (
+    name: string,
+    version: string,
+    source: string,
+    path: string,
+    status: string,
+  ) =>
+    [
+      name.padEnd(widths.name),
+      version.padEnd(widths.version),
+      source.padEnd(widths.source),
+      path.padEnd(widths.path),
+      status.padEnd(widths.status),
+    ].join("  ");
+
+  const lines = [
+    ansi.bold(formatRow("Name", "Version", "Source", "Path", "Status")),
+    ...rows.map((row) =>
+      formatRow(
+        row.name,
+        row.version,
+        row.source,
+        row.skillPath,
+        row.missing ? "missing" : "ok",
+      ),
+    ),
+  ];
+  console.log(lines.join("\n"));
 }
 
 function printInstallHelp() {
@@ -6046,6 +6125,9 @@ export async function runCLI(argv: string[]): Promise<void> {
     case "install":
       await cmdInstall(args);
       break;
+    case "library":
+      await cmdLibrary(args);
+      break;
     case "config":
       await cmdConfig(args);
       break;
@@ -6110,6 +6192,7 @@ export function isCLIMode(argv: string[]): boolean {
     "audit",
     "config",
     "install",
+    "library",
     "export",
     "import",
     "init",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,7 +171,12 @@ import type { SearchFilters } from "./skill-index";
 import { VERSION_STRING } from "./utils/version";
 import { buildShadowingReport } from "./utils/path-shadowing";
 import { parseEditorCommand } from "./utils/editor";
-import { installLibrarySkill, listLibrarySkills } from "./library";
+import {
+  activateLibrarySkill,
+  findLibrarySkill,
+  installLibrarySkill,
+  listLibrarySkills,
+} from "./library";
 import { setVerbose } from "./logger";
 import { join as joinPath, resolve, relative as relativePath } from "path";
 import type {
@@ -546,6 +551,7 @@ ${ansi.bold("Commands:")}
   disable <target>       Disable skill(s) without uninstalling
   enable <target>        Re-enable disabled skill(s)
   install <source>       Install a skill from GitHub or local path
+  activate <skill>       Link a library skill into a provider
   library                Manage centrally installed library skills
   audit                  Detect duplicate skills across tools
   audit security <name>  Run security audit on a skill (or GitHub source)
@@ -815,6 +821,24 @@ ${ansi.bold("Options:")}
 ${ansi.bold("Examples:")}
   asm library list                  ${ansi.dim("List local library skills")}
   asm library list --json           ${ansi.dim("Output as JSON")}`);
+}
+
+function printActivateHelp() {
+  console.log(`${ansi.bold("Usage:")} asm activate <skill> -p <tool> -s <scope> [options]
+
+Link a centrally installed library skill into a provider skill folder.
+
+${ansi.bold("Options:")}
+  -p, --tool <name>      Provider to activate into (e.g., claude, codex)
+  -s, --scope <scope>    Activation scope: global or project
+  --name <name>          Link name to create (default: library directory name)
+  -f, --force            Replace an existing target
+  --json                 Output as JSON object
+  -V, --verbose          Show debug output
+
+${ansi.bold("Examples:")}
+  asm activate brainstorming -p codex -s project
+  asm activate brainstorming -p claude -s global --json`);
 }
 
 // ─── Command Handlers ───────────────────────────────────────────────────────
@@ -2136,6 +2160,73 @@ async function cmdLibrary(args: ParsedArgs) {
     ),
   ];
   console.log(lines.join("\n"));
+}
+
+async function cmdActivate(args: ParsedArgs) {
+  if (args.flags.help) {
+    printActivateHelp();
+    return;
+  }
+
+  const skillName = args.subcommand;
+  if (!skillName) {
+    error("Missing skill name. Use: asm activate <skill>");
+    console.error(`Run "asm activate --help" for usage.`);
+    process.exit(2);
+  }
+
+  if (args.flags.scope === "both") {
+    error("Activation requires --scope global or --scope project.");
+    process.exit(2);
+  }
+
+  const rows = await listLibrarySkills();
+  const skill = findLibrarySkill(rows, skillName);
+  if (!skill) {
+    error(`Library skill "${skillName}" not found. Run "asm library list".`);
+    process.exit(1);
+  }
+  if (skill.missing) {
+    error(
+      `Library skill "${skillName}" is missing on disk: ${skill.libraryPath}`,
+    );
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const { provider } = await resolveProvider(
+    config,
+    args.flags.provider,
+    process.stdin.isTTY,
+  );
+  const targetTemplate =
+    args.flags.scope === "global" ? provider.global : provider.project;
+  const targetDir = resolveProviderPath(targetTemplate);
+  const activationName = args.flags.name || skill.dirName;
+  const result = await activateLibrarySkill({
+    libraryPath: skill.libraryPath,
+    targetDir,
+    activationName,
+    force: args.flags.force,
+  });
+
+  const payload = {
+    name: activationName,
+    skill: skill.dirName,
+    provider: provider.name,
+    scope: args.flags.scope,
+    path: result.symlinkPath,
+    target: result.targetPath,
+  };
+
+  if (args.flags.json) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  console.log(
+    `${ansi.green("✓")} activated ${activationName} (${provider.name}/${args.flags.scope}) -> ${result.targetPath}`,
+  );
 }
 
 function printInstallHelp() {
@@ -6125,6 +6216,9 @@ export async function runCLI(argv: string[]): Promise<void> {
     case "install":
       await cmdInstall(args);
       break;
+    case "activate":
+      await cmdActivate(args);
+      break;
     case "library":
       await cmdLibrary(args);
       break;
@@ -6192,6 +6286,7 @@ export function isCLIMode(argv: string[]): boolean {
     "audit",
     "config",
     "install",
+    "activate",
     "library",
     "export",
     "import",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2738,6 +2738,12 @@ async function cmdInstall(args: ParsedArgs) {
       console.info(`  ${ansi.dim(sourceStr)}`);
     }
 
+    if (args.flags.library && args.flags.method === "vercel") {
+      throw new Error(
+        "--library cannot be combined with --method vercel because the Vercel installer writes to provider skill folders. Use the default method for library installs.",
+      );
+    }
+
     // Vercel method: delegate to npx skills add and then continue with
     // standard asm install to register in asm's local inventory
     if (args.flags.method === "vercel") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@ import {
   loadConfig,
   getConfigPath,
   getDefaultConfig,
+  getLibrarySkillsDir,
   saveConfig,
   resolveProviderPath,
 } from "./config";
@@ -170,6 +171,7 @@ import type { SearchFilters } from "./skill-index";
 import { VERSION_STRING } from "./utils/version";
 import { buildShadowingReport } from "./utils/path-shadowing";
 import { parseEditorCommand } from "./utils/editor";
+import { installLibrarySkill } from "./library";
 import { setVerbose } from "./logger";
 import { join as joinPath, resolve, relative as relativePath } from "path";
 import type {
@@ -244,6 +246,7 @@ interface ParsedArgs {
     force: boolean;
     path: string | null;
     all: boolean;
+    library: boolean;
     verbose: boolean;
     flat: boolean;
     transport: TransportMode;
@@ -316,6 +319,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
       force: false,
       path: null,
       all: false,
+      library: false,
       verbose: false,
       flat: false,
       transport: "auto",
@@ -398,6 +402,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       result.flags.path = args[i] || null;
     } else if (arg === "--all") {
       result.flags.all = true;
+    } else if (arg === "--library") {
+      result.flags.library = true;
     } else if (arg === "--verbose" || arg === "-V") {
       result.flags.verbose = true;
     } else if (arg === "--flat") {
@@ -2081,6 +2087,7 @@ ${ansi.bold("Options:")}
   --path <subdir>        Install skill from a subdirectory of the repo
   --skill <name>         Alias for --path (Vercel skills CLI compatibility)
   --all                  Install all skills found in the repo
+  --library              Install into asm's neutral local library
   -m, --method <method>  Install method: default or vercel (default: default)
                          vercel delegates to npx skills add for tracking
   -t, --transport <mode> Transport: https, ssh, or auto (default: auto)
@@ -2104,6 +2111,7 @@ ${ansi.bold("Local folder:")}
   asm install ~/skills/my-skill            ${ansi.dim("(home-relative path)")}
   asm install ../other-project/skill       ${ansi.dim("(parent-relative path)")}
   asm install ./skills-dir --all           ${ansi.dim("(all skills in directory)")}
+  asm install ./skills-dir --library --all -y ${ansi.dim("(install to local library)")}
 
 ${ansi.bold("Single-skill repo:")}
   asm install github:user/my-skill
@@ -2333,6 +2341,54 @@ async function executeSkillInstall(
   return await executeInstall(plan);
 }
 
+async function installSelectedLibrarySkill(input: {
+  inspection: SkillInspection;
+  source: ReturnType<typeof parseSource>;
+  isLocal: boolean;
+  resolutionSource: ResolutionSource;
+  commitHash: string | null;
+  scanBaseDir: string;
+  force: boolean;
+}): Promise<InstallResult> {
+  const {
+    inspection,
+    source,
+    isLocal,
+    resolutionSource,
+    commitHash,
+    scanBaseDir,
+    force,
+  } = input;
+  const sourceStr = isLocal
+    ? `local:${source.localPath}`
+    : `github:${source.owner}/${source.repo}`;
+  const sourceType = isLocal
+    ? ("local" as const)
+    : resolutionSource === "registry"
+      ? ("registry" as const)
+      : ("github" as const);
+  const skillPath = relativePath(scanBaseDir, inspection.plan.sourceDir);
+  const installed = await installLibrarySkill({
+    sourceDir: inspection.plan.sourceDir,
+    libraryName: inspection.skillName,
+    source: sourceStr,
+    sourceType,
+    commitHash: commitHash || "unknown",
+    ref: source.ref || "main",
+    skillPath,
+    force,
+  });
+
+  return {
+    success: true,
+    path: installed.libraryPath,
+    name: installed.name,
+    version: installed.version,
+    provider: "Library",
+    source: sourceStr,
+  };
+}
+
 async function cmdInstall(args: ParsedArgs) {
   if (args.flags.help) {
     printInstallHelp();
@@ -2344,6 +2400,7 @@ async function cmdInstall(args: ParsedArgs) {
     : undefined;
 
   const startTime = performance.now();
+  const explicitForce = args.flags.force;
   let sourceStr = args.subcommand;
   if (!sourceStr) {
     error("Missing required argument: <source>");
@@ -2543,54 +2600,70 @@ async function cmdInstall(args: ParsedArgs) {
     }
 
     // Step 2: Select provider (before cloning — no wasted time if user cancels)
-    console.info(stepHeader("Selecting provider"));
     const config = await loadConfig();
-    const { provider, allProviders } = await resolveProvider(
-      config,
-      args.flags.provider,
-      !!process.stdin.isTTY,
-    );
+    let provider: ProviderConfig;
+    let allProviders: ProviderConfig[] | null = null;
+    let installScope: "global" | "project" = "global";
 
-    // Step 3: Select scope (global or project)
-    console.info(stepHeader("Selecting scope"));
-    let installScope: "global" | "project";
-
-    if (args.flags.scope === "global" || args.flags.scope === "project") {
-      // Explicit --scope flag provided
-      installScope = args.flags.scope;
-      console.info(
-        `  ${ansi.dim(`scope: ${installScope}`)}${installScope === "global" ? ` (${provider.global})` : ` (${provider.project})`}`,
-      );
-    } else if (!process.stdin.isTTY || args.flags.yes) {
-      // Non-interactive mode: default to global
-      installScope = "global";
-      console.info(
-        `  ${ansi.dim(`scope: global (default)`)} (${provider.global})`,
-      );
-    } else {
-      // Interactive: prompt user to choose
-      const scopeItems = [
-        {
-          label: `Global (${provider.global})`,
-          hint: "Available in all projects",
-          checked: true,
-        },
-        {
-          label: `Project (${provider.project})`,
-          hint: "Available only in this project",
-          checked: false,
-        },
-      ];
-      console.info(""); // blank line before picker
-      const scopeIndices = await checkboxPicker({ items: scopeItems });
-      if (scopeIndices.length === 0) {
-        throw new Error("No scope selected. Aborting.");
+    if (args.flags.library) {
+      console.info(stepHeader("Selecting library"));
+      const inspectionProvider =
+        config.providers.find((p) => p.enabled) ?? config.providers[0];
+      if (!inspectionProvider) {
+        throw new Error("No providers configured.");
       }
-      // Use the first selected scope (single-select behavior)
-      installScope = scopeIndices[0] === 0 ? "global" : "project";
-      console.info(
-        `  Selected: ${ansi.bold(installScope)} ${ansi.dim(`(${installScope === "global" ? provider.global : provider.project})`)}`,
+      provider = inspectionProvider;
+      console.info(`  ${ansi.dim(`library: ${getLibrarySkillsDir()}`)}`);
+    } else {
+      console.info(stepHeader("Selecting provider"));
+      const resolved = await resolveProvider(
+        config,
+        args.flags.provider,
+        !!process.stdin.isTTY,
       );
+      provider = resolved.provider;
+      allProviders = resolved.allProviders;
+
+      // Step 3: Select scope (global or project)
+      console.info(stepHeader("Selecting scope"));
+
+      if (args.flags.scope === "global" || args.flags.scope === "project") {
+        // Explicit --scope flag provided
+        installScope = args.flags.scope;
+        console.info(
+          `  ${ansi.dim(`scope: ${installScope}`)}${installScope === "global" ? ` (${provider.global})` : ` (${provider.project})`}`,
+        );
+      } else if (!process.stdin.isTTY || args.flags.yes) {
+        // Non-interactive mode: default to global
+        installScope = "global";
+        console.info(
+          `  ${ansi.dim(`scope: global (default)`)} (${provider.global})`,
+        );
+      } else {
+        // Interactive: prompt user to choose
+        const scopeItems = [
+          {
+            label: `Global (${provider.global})`,
+            hint: "Available in all projects",
+            checked: true,
+          },
+          {
+            label: `Project (${provider.project})`,
+            hint: "Available only in this project",
+            checked: false,
+          },
+        ];
+        console.info(""); // blank line before picker
+        const scopeIndices = await checkboxPicker({ items: scopeItems });
+        if (scopeIndices.length === 0) {
+          throw new Error("No scope selected. Aborting.");
+        }
+        // Use the first selected scope (single-select behavior)
+        installScope = scopeIndices[0] === 0 ? "global" : "project";
+        console.info(
+          `  Selected: ${ansi.bold(installScope)} ${ansi.dim(`(${installScope === "global" ? provider.global : provider.project})`)}`,
+        );
+      }
     }
 
     // Step 4: Clone repository (or read local source)
@@ -2963,41 +3036,53 @@ async function cmdInstall(args: ParsedArgs) {
         console.info(
           `${progress}Installing ${ansi.bold(inspection.metadata.name)}...`,
         );
-        const result = await executeSkillInstall(inspection.plan, allProviders);
+        const result = args.flags.library
+          ? await installSelectedLibrarySkill({
+              inspection,
+              source,
+              isLocal,
+              resolutionSource,
+              commitHash,
+              scanBaseDir,
+              force: explicitForce,
+            })
+          : await executeSkillInstall(inspection.plan, allProviders);
         results.push(result);
         console.info(
-          `${progress}${ansi.green("✓")} ${inspection.metadata.name} installed to ${ansi.dim(inspection.plan.targetDir)}`,
+          `${progress}${ansi.green("✓")} ${inspection.metadata.name} installed to ${ansi.dim(result.path)}`,
         );
 
         // Write lock entry for tracking
-        try {
-          const sourceStr = isLocal
-            ? `local:${source.localPath}`
-            : `github:${source.owner}/${source.repo}`;
-          const sourceType = isLocal
-            ? ("local" as const)
-            : resolutionSource === "registry"
-              ? ("registry" as const)
-              : ("github" as const);
-          await writeLockEntry(result.name, {
-            source: sourceStr,
-            commitHash: commitHash || "unknown",
-            ref: source.ref || "main",
-            installedAt: new Date().toISOString(),
-            provider: inspection.plan.providerName,
-            scope: inspection.plan.scope,
-            skillPath: relativePath(
-              inspection.plan.tempDir,
-              inspection.plan.sourceDir,
-            ),
-            targetDir: inspection.plan.targetDir,
-            sourceType,
-            ...(resolutionSource === "registry"
-              ? { registryName: result.name }
-              : {}),
-          });
-        } catch {
-          // Lock write failure is non-fatal
+        if (!args.flags.library) {
+          try {
+            const sourceStr = isLocal
+              ? `local:${source.localPath}`
+              : `github:${source.owner}/${source.repo}`;
+            const sourceType = isLocal
+              ? ("local" as const)
+              : resolutionSource === "registry"
+                ? ("registry" as const)
+                : ("github" as const);
+            await writeLockEntry(result.name, {
+              source: sourceStr,
+              commitHash: commitHash || "unknown",
+              ref: source.ref || "main",
+              installedAt: new Date().toISOString(),
+              provider: inspection.plan.providerName,
+              scope: inspection.plan.scope,
+              skillPath: relativePath(
+                inspection.plan.tempDir,
+                inspection.plan.sourceDir,
+              ),
+              targetDir: inspection.plan.targetDir,
+              sourceType,
+              ...(resolutionSource === "registry"
+                ? { registryName: result.name }
+                : {}),
+            });
+          } catch {
+            // Lock write failure is non-fatal
+          }
         }
       } catch (installErr: any) {
         failures.push({
@@ -3021,6 +3106,9 @@ async function cmdInstall(args: ParsedArgs) {
       );
       for (const f of failures) {
         console.error(`  ${ansi.red("✗")} ${f.name}: ${f.error}`);
+      }
+      if (args.flags.library) {
+        process.exitCode = 1;
       }
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,7 +171,7 @@ import { VERSION_STRING } from "./utils/version";
 import { buildShadowingReport } from "./utils/path-shadowing";
 import { parseEditorCommand } from "./utils/editor";
 import { setVerbose } from "./logger";
-import { join as joinPath, resolve } from "path";
+import { join as joinPath, resolve, relative as relativePath } from "path";
 import type {
   Scope,
   SortBy,
@@ -2985,6 +2985,12 @@ async function cmdInstall(args: ParsedArgs) {
             ref: source.ref || "main",
             installedAt: new Date().toISOString(),
             provider: inspection.plan.providerName,
+            scope: inspection.plan.scope,
+            skillPath: relativePath(
+              inspection.plan.tempDir,
+              inspection.plan.sourceDir,
+            ),
+            targetDir: inspection.plan.targetDir,
             sourceType,
             ...(resolutionSource === "registry"
               ? { registryName: result.name }

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,9 @@ const CONFIG_PATH = join(CONFIG_DIR, "config.json");
 const LOCK_PATH = join(CONFIG_DIR, ".skill-lock.json");
 const SKILL_STATE_PATH = join(CONFIG_DIR, "skill-state.json");
 const INDEX_DIR = join(CONFIG_DIR, "skill-index");
+const LIBRARY_DIR = join(CONFIG_DIR, "library");
+const LIBRARY_SKILLS_DIR = join(LIBRARY_DIR, "skills");
+const LIBRARY_LOCK_PATH = join(LIBRARY_DIR, "library-lock.json");
 
 const DEFAULT_PROVIDERS: ProviderConfig[] = [
   // ── Priority providers (ordered by user preference) ──
@@ -188,6 +191,18 @@ export function getSkillStatePath(): string {
 
 export function getIndexDir(): string {
   return INDEX_DIR;
+}
+
+export function getLibraryDir(): string {
+  return LIBRARY_DIR;
+}
+
+export function getLibrarySkillsDir(): string {
+  return LIBRARY_SKILLS_DIR;
+}
+
+export function getLibraryLockPath(): string {
+  return LIBRARY_LOCK_PATH;
 }
 
 export function getBundledIndexDir(): string {

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -1,9 +1,19 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
-import { lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readlink,
+  rm,
+  symlink,
+  writeFile,
+} from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
   emptyLibraryLock,
+  activateLibrarySkill,
   installLibrarySkill,
   readLibraryLock,
   writeLibraryLock,
@@ -195,6 +205,94 @@ describe("installLibrarySkill", () => {
     await expect(readLibraryLock(lockPath)).resolves.toEqual({
       version: 1,
       skills: {},
+    });
+  });
+});
+
+describe("activateLibrarySkill", () => {
+  let tempDir: string;
+  let libraryPath: string;
+  let targetDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-activate-"));
+    libraryPath = join(tempDir, "library", "skills", "brainstorming");
+    targetDir = join(tempDir, "provider", "skills");
+    await mkdir(libraryPath, { recursive: true });
+    await writeFile(
+      join(libraryPath, "SKILL.md"),
+      "---\nname: brainstorming\n---\n# Brainstorming\n",
+    );
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("creates a symlink from provider target to library skill", async () => {
+    const result = await activateLibrarySkill({
+      libraryPath,
+      targetDir,
+      activationName: "brainstorming",
+      force: false,
+    });
+
+    const symlinkPath = join(targetDir, "brainstorming");
+    expect(result).toEqual({ symlinkPath, targetPath: libraryPath });
+    await expect(readlink(symlinkPath)).resolves.toBe(libraryPath);
+    await expect(lstat(symlinkPath)).resolves.toMatchObject({
+      isSymbolicLink: expect.any(Function),
+    });
+    expect((await lstat(symlinkPath)).isSymbolicLink()).toBe(true);
+  });
+
+  test("refuses an existing target without force", async () => {
+    const symlinkPath = join(targetDir, "brainstorming");
+    const existingPath = join(tempDir, "existing");
+    await mkdir(targetDir, { recursive: true });
+    await mkdir(existingPath, { recursive: true });
+    await symlink(existingPath, symlinkPath, "dir");
+
+    await expect(
+      activateLibrarySkill({
+        libraryPath,
+        targetDir,
+        activationName: "brainstorming",
+        force: false,
+      }),
+    ).rejects.toThrow(
+      `Target already exists: ${symlinkPath}. Use --force to overwrite.`,
+    );
+
+    await expect(readlink(symlinkPath)).resolves.toBe(existingPath);
+  });
+
+  test("rejects invalid activation names before touching filesystem targets", async () => {
+    const outsideDir = join(tempDir, "provider", "outside");
+    const outsideSentinel = join(outsideDir, "sentinel.txt");
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(outsideSentinel, "keep me", "utf-8");
+
+    for (const activationName of [
+      "",
+      "../outside",
+      "nested/name",
+      "nested\\name",
+      "bad\0name",
+    ]) {
+      await expect(
+        activateLibrarySkill({
+          libraryPath,
+          targetDir,
+          activationName,
+          force: true,
+        }),
+      ).rejects.toThrow(/Invalid skill name/);
+    }
+
+    await expect(readFile(outsideSentinel, "utf-8")).resolves.toBe("keep me");
+    await expect(lstat(join(targetDir, "nested"))).rejects.toMatchObject({
+      code: "ENOENT",
     });
   });
 });

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -1,9 +1,10 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
   emptyLibraryLock,
+  installLibrarySkill,
   readLibraryLock,
   writeLibraryLock,
 } from "./library";
@@ -59,5 +60,141 @@ describe("library lock", () => {
     await expect(readFile(lockPath + ".bak", "utf-8")).resolves.toBe(
       invalidLock,
     );
+  });
+});
+
+describe("installLibrarySkill", () => {
+  let tempDir: string;
+  let lockPath: string;
+  let skillsDir: string;
+  let sourceDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-install-"));
+    lockPath = join(tempDir, "library-lock.json");
+    skillsDir = join(tempDir, "skills");
+    sourceDir = join(tempDir, "source", "skills", "brainstorming");
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(
+      join(sourceDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Body\n",
+    );
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("copies a skill directory and writes source metadata", async () => {
+    await writeFile(
+      join(sourceDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.2.3\n---\n# Brainstorming\n",
+    );
+
+    const result = await installLibrarySkill(
+      {
+        sourceDir,
+        libraryName: "brainstorming",
+        source: "github:obra/superpowers",
+        sourceType: "github",
+        commitHash: "abc123",
+        ref: "main",
+        skillPath: "skills/brainstorming",
+        force: false,
+      },
+      { skillsDir, lockPath },
+    );
+
+    expect(result.name).toBe("brainstorming");
+    expect(result.version).toBe("1.2.3");
+    expect(
+      await readFile(join(result.libraryPath, "SKILL.md"), "utf-8"),
+    ).toContain("Brainstorming");
+
+    const lock = await readLibraryLock(lockPath);
+    expect(lock.skills.brainstorming).toMatchObject({
+      name: "brainstorming",
+      version: "1.2.3",
+      source: "github:obra/superpowers",
+      sourceType: "github",
+      commitHash: "abc123",
+      ref: "main",
+      skillPath: "skills/brainstorming",
+      libraryPath: result.libraryPath,
+    });
+  });
+
+  test("refuses to overwrite an existing library skill without force", async () => {
+    await installLibrarySkill(
+      {
+        sourceDir,
+        libraryName: "brainstorming",
+        source: "local:/tmp/source",
+        sourceType: "local",
+        commitHash: "unknown",
+        ref: null,
+        skillPath: "skills/brainstorming",
+        force: false,
+      },
+      { skillsDir, lockPath },
+    );
+
+    await expect(
+      installLibrarySkill(
+        {
+          sourceDir,
+          libraryName: "brainstorming",
+          source: "local:/tmp/source",
+          sourceType: "local",
+          commitHash: "unknown",
+          ref: null,
+          skillPath: "skills/brainstorming",
+          force: false,
+        },
+        { skillsDir, lockPath },
+      ),
+    ).rejects.toThrow(/already exists/);
+
+    await expect(lstat(join(skillsDir, "brainstorming"))).resolves.toBeTruthy();
+  });
+
+  test("rejects invalid library names before touching filesystem targets", async () => {
+    const outsideDir = join(tempDir, "outside");
+    const outsideSentinel = join(outsideDir, "sentinel.txt");
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(outsideSentinel, "keep me", "utf-8");
+
+    for (const libraryName of [
+      "",
+      "../outside",
+      "nested/name",
+      "nested\\name",
+      "bad\0name",
+    ]) {
+      await expect(
+        installLibrarySkill(
+          {
+            sourceDir,
+            libraryName,
+            source: "local:/tmp/source",
+            sourceType: "local",
+            commitHash: "unknown",
+            ref: null,
+            skillPath: "skills/brainstorming",
+            force: true,
+          },
+          { skillsDir, lockPath },
+        ),
+      ).rejects.toThrow(/Invalid skill name/);
+    }
+
+    await expect(readFile(outsideSentinel, "utf-8")).resolves.toBe("keep me");
+    await expect(lstat(join(skillsDir, "nested"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(readLibraryLock(lockPath)).resolves.toEqual({
+      version: 1,
+      skills: {},
+    });
   });
 });

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  emptyLibraryLock,
+  readLibraryLock,
+  writeLibraryLock,
+} from "./library";
+
+describe("library lock", () => {
+  let tempDir: string;
+  let lockPath: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-test-"));
+    lockPath = join(tempDir, "library-lock.json");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("readLibraryLock returns an empty lock when the file is missing", async () => {
+    await expect(readLibraryLock(lockPath)).resolves.toEqual({
+      version: 1,
+      skills: {},
+    });
+  });
+
+  test("writeLibraryLock persists a versioned lock file", async () => {
+    const lock = emptyLibraryLock();
+    lock.skills.brainstorming = {
+      name: "brainstorming",
+      version: "1.0.0",
+      source: "github:obra/superpowers",
+      sourceType: "github",
+      commitHash: "abc123",
+      ref: "main",
+      skillPath: "skills/brainstorming",
+      libraryPath: join(tempDir, "skills", "brainstorming"),
+      installedAt: "2026-06-18T00:00:00.000Z",
+    };
+
+    await writeLibraryLock(lock, lockPath);
+
+    await expect(readLibraryLock(lockPath)).resolves.toEqual(lock);
+  });
+
+  test("readLibraryLock rejects array skills and backs up the invalid lock", async () => {
+    const invalidLock = JSON.stringify({ version: 1, skills: [] }, null, 2);
+    await writeFile(lockPath, invalidLock, "utf-8");
+
+    await expect(readLibraryLock(lockPath)).resolves.toEqual({
+      version: 1,
+      skills: {},
+    });
+
+    await expect(readFile(lockPath + ".bak", "utf-8")).resolves.toBe(
+      invalidLock,
+    );
+  });
+});

--- a/src/library.ts
+++ b/src/library.ts
@@ -2,9 +2,11 @@ import {
   access,
   copyFile,
   cp,
+  lstat,
   mkdir,
   readFile,
   rm,
+  symlink,
   writeFile,
 } from "fs/promises";
 import { dirname, join } from "path";
@@ -120,6 +122,41 @@ export async function listLibrarySkills(
   return rows;
 }
 
+export function findLibrarySkill(
+  rows: LibrarySkillInfo[],
+  name: string,
+): LibrarySkillInfo | null {
+  const exactDir = rows.find((r) => r.dirName === name);
+  if (exactDir) return exactDir;
+  const exactName = rows.find((r) => r.name === name);
+  return exactName ?? null;
+}
+
+export async function activateLibrarySkill(input: {
+  libraryPath: string;
+  targetDir: string;
+  activationName: string;
+  force: boolean;
+}): Promise<{ symlinkPath: string; targetPath: string }> {
+  const activationName = validateSkillDirectoryName(input.activationName);
+  const symlinkPath = join(input.targetDir, activationName);
+  try {
+    await lstat(symlinkPath);
+    if (!input.force) {
+      throw new Error(
+        `Target already exists: ${symlinkPath}. Use --force to overwrite.`,
+      );
+    }
+    await rm(symlinkPath, { recursive: true, force: true });
+  } catch (err: any) {
+    if (err?.message?.includes("--force")) throw err;
+  }
+
+  await mkdir(input.targetDir, { recursive: true });
+  await symlink(input.libraryPath, symlinkPath, "dir");
+  return { symlinkPath, targetPath: input.libraryPath };
+}
+
 async function pathExists(path: string): Promise<boolean> {
   try {
     await access(path);
@@ -130,7 +167,7 @@ async function pathExists(path: string): Promise<boolean> {
   }
 }
 
-function validateLibraryName(name: string): string {
+function validateSkillDirectoryName(name: string): string {
   if (!name) {
     throw new Error("Invalid skill name: name cannot be empty");
   }
@@ -169,7 +206,7 @@ export async function installLibrarySkill(
 ): Promise<{ name: string; version: string; libraryPath: string }> {
   const skillsDir = paths.skillsDir ?? getLibrarySkillsDir();
   const lockPath = paths.lockPath ?? getLibraryLockPath();
-  const libraryName = validateLibraryName(plan.libraryName);
+  const libraryName = validateSkillDirectoryName(plan.libraryName);
   const libraryPath = join(skillsDir, libraryName);
 
   if (await pathExists(libraryPath)) {

--- a/src/library.ts
+++ b/src/library.ts
@@ -1,0 +1,59 @@
+import { copyFile, mkdir, readFile, writeFile } from "fs/promises";
+import { dirname } from "path";
+import { getLibraryLockPath } from "./config";
+import { debug } from "./logger";
+import type { LibraryLockFile } from "./utils/types";
+
+export function emptyLibraryLock(): LibraryLockFile {
+  return { version: 1, skills: {} };
+}
+
+export async function readLibraryLock(
+  path: string = getLibraryLockPath(),
+): Promise<LibraryLockFile> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf-8");
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      debug("library: lock file not found, returning empty lock");
+      return emptyLibraryLock();
+    }
+    throw err;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed) ||
+      parsed.version !== 1 ||
+      typeof parsed.skills !== "object" ||
+      parsed.skills === null ||
+      Array.isArray(parsed.skills)
+    ) {
+      throw new Error("invalid schema");
+    }
+    return parsed as LibraryLockFile;
+  } catch {
+    const backupPath = path + ".bak";
+    try {
+      await copyFile(path, backupPath);
+    } catch {
+      // best effort backup
+    }
+    console.error(
+      `Warning: library-lock.json was corrupted. Backup saved to ${backupPath}. Starting fresh.`,
+    );
+    return emptyLibraryLock();
+  }
+}
+
+export async function writeLibraryLock(
+  lock: LibraryLockFile,
+  path: string = getLibraryLockPath(),
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(lock, null, 2) + "\n", "utf-8");
+}

--- a/src/library.ts
+++ b/src/library.ts
@@ -1,8 +1,36 @@
-import { copyFile, mkdir, readFile, writeFile } from "fs/promises";
-import { dirname } from "path";
-import { getLibraryLockPath } from "./config";
+import {
+  access,
+  copyFile,
+  cp,
+  mkdir,
+  readFile,
+  rm,
+  writeFile,
+} from "fs/promises";
+import { dirname, join } from "path";
+import { getLibraryLockPath, getLibrarySkillsDir } from "./config";
 import { debug } from "./logger";
+import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
 import type { LibraryLockFile } from "./utils/types";
+
+const LIBRARY_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+const MAX_LIBRARY_NAME_LENGTH = 128;
+
+export interface InstallLibrarySkillPlan {
+  sourceDir: string;
+  libraryName: string;
+  source: string;
+  sourceType: "registry" | "github" | "local";
+  commitHash: string;
+  ref: string | null;
+  skillPath: string;
+  force: boolean;
+}
+
+export interface LibraryPaths {
+  skillsDir?: string;
+  lockPath?: string;
+}
 
 export function emptyLibraryLock(): LibraryLockFile {
   return { version: 1, skills: {} };
@@ -56,4 +84,91 @@ export async function writeLibraryLock(
 ): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, JSON.stringify(lock, null, 2) + "\n", "utf-8");
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch (err: any) {
+    if (err?.code === "ENOENT") return false;
+    throw err;
+  }
+}
+
+function validateLibraryName(name: string): string {
+  if (!name) {
+    throw new Error("Invalid skill name: name cannot be empty");
+  }
+  if (name.includes("\0")) {
+    throw new Error(
+      "Invalid skill name: contains unsafe characters (null byte)",
+    );
+  }
+  if (name.includes("..")) {
+    throw new Error("Invalid skill name: contains unsafe characters (..)");
+  }
+  if (name.includes("/") || name.includes("\\")) {
+    throw new Error(
+      "Invalid skill name: contains unsafe characters (path separator)",
+    );
+  }
+  if (name.startsWith(".")) {
+    throw new Error("Invalid skill name: must not start with a dot");
+  }
+  if (name.length > MAX_LIBRARY_NAME_LENGTH) {
+    throw new Error(
+      `Invalid skill name: exceeds maximum length of ${MAX_LIBRARY_NAME_LENGTH} characters`,
+    );
+  }
+  if (!LIBRARY_NAME_RE.test(name)) {
+    throw new Error(
+      `Invalid skill name: "${name}" does not match allowed pattern [a-zA-Z0-9][a-zA-Z0-9._-]*`,
+    );
+  }
+  return name;
+}
+
+export async function installLibrarySkill(
+  plan: InstallLibrarySkillPlan,
+  paths: LibraryPaths = {},
+): Promise<{ name: string; version: string; libraryPath: string }> {
+  const skillsDir = paths.skillsDir ?? getLibrarySkillsDir();
+  const lockPath = paths.lockPath ?? getLibraryLockPath();
+  const libraryName = validateLibraryName(plan.libraryName);
+  const libraryPath = join(skillsDir, libraryName);
+
+  if (await pathExists(libraryPath)) {
+    if (!plan.force) {
+      throw new Error(
+        `Library skill already exists: ${libraryPath}. Use --force to overwrite.`,
+      );
+    }
+    await rm(libraryPath, { recursive: true, force: true });
+  }
+
+  await mkdir(skillsDir, { recursive: true });
+  await cp(plan.sourceDir, libraryPath, { recursive: true });
+  await rm(join(libraryPath, ".git"), { recursive: true, force: true });
+
+  const skillMarkdown = await readFile(join(libraryPath, "SKILL.md"), "utf-8");
+  const fm = parseFrontmatter(skillMarkdown);
+  const name = fm.name || libraryName;
+  const version = resolveVersion(fm);
+
+  const lock = await readLibraryLock(lockPath);
+  lock.skills[libraryName] = {
+    name,
+    version,
+    source: plan.source,
+    sourceType: plan.sourceType,
+    commitHash: plan.commitHash,
+    ref: plan.ref,
+    skillPath: plan.skillPath,
+    libraryPath,
+    installedAt: new Date().toISOString(),
+  };
+  await writeLibraryLock(lock, lockPath);
+
+  return { name, version, libraryPath };
 }

--- a/src/library.ts
+++ b/src/library.ts
@@ -32,6 +32,20 @@ export interface LibraryPaths {
   lockPath?: string;
 }
 
+export interface LibrarySkillInfo {
+  dirName: string;
+  name: string;
+  version: string;
+  source: string;
+  sourceType?: "registry" | "github" | "local";
+  commitHash: string;
+  ref: string | null;
+  skillPath: string;
+  libraryPath: string;
+  installedAt: string;
+  missing: boolean;
+}
+
 export function emptyLibraryLock(): LibraryLockFile {
   return { version: 1, skills: {} };
 }
@@ -84,6 +98,26 @@ export async function writeLibraryLock(
 ): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, JSON.stringify(lock, null, 2) + "\n", "utf-8");
+}
+
+export async function listLibrarySkills(
+  path: string = getLibraryLockPath(),
+): Promise<LibrarySkillInfo[]> {
+  const lock = await readLibraryLock(path);
+  const rows: LibrarySkillInfo[] = [];
+
+  for (const [dirName, entry] of Object.entries(lock.skills)) {
+    let missing = false;
+    try {
+      await access(join(entry.libraryPath, "SKILL.md"));
+    } catch {
+      missing = true;
+    }
+    rows.push({ dirName, ...entry, missing });
+  }
+
+  rows.sort((a, b) => a.name.localeCompare(b.name));
+  return rows;
 }
 
 async function pathExists(path: string): Promise<boolean> {

--- a/src/updater.test.ts
+++ b/src/updater.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, writeFile, mkdir, rm } from "fs/promises";
+import { mkdtemp, writeFile, mkdir, rm, readFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -760,6 +760,87 @@ describe("updateSkill happy path", () => {
       "utf-8",
     );
     expect(installedContent).toContain("New version");
+  });
+
+  test("updates nested skills from their recorded skillPath and project scope", async () => {
+    const { execFile } = await import("child_process");
+    const { promisify } = await import("util");
+    const exec = promisify(execFile);
+
+    const workDir = join(tempDir, "nested-work");
+    const bareRepoPath = join(tempDir, "nested.git");
+    await mkdir(join(workDir, "skills", "pdf"), { recursive: true });
+    await exec("git", ["init", workDir]);
+    await exec("git", ["-C", workDir, "config", "user.email", "test@test.com"]);
+    await exec("git", ["-C", workDir, "config", "user.name", "Test"]);
+    await writeFile(
+      join(workDir, "README.md"),
+      "repo wrapper that should not be installed\n",
+    );
+    await writeFile(
+      join(workDir, "skills", "pdf", "SKILL.md"),
+      "---\nname: pdf\nversion: 2.0.0\n---\n# New nested pdf\n",
+    );
+    await exec("git", ["-C", workDir, "add", "."]);
+    await exec("git", ["-C", workDir, "commit", "-m", "init"]);
+    const { stdout } = await exec("git", ["-C", workDir, "rev-parse", "HEAD"]);
+    const newCommit = stdout.trim();
+    await exec("git", ["clone", "--bare", workDir, bareRepoPath]);
+
+    const projectSkillsDir = join(tempDir, "project", ".codex", "skills");
+    const installedDir = join(projectSkillsDir, "pdf");
+    await mkdir(installedDir, { recursive: true });
+    await writeFile(
+      join(installedDir, "SKILL.md"),
+      "---\nname: pdf\nversion: 1.0.0\n---\n# Old pdf\n",
+    );
+
+    let writtenLock: any = null;
+    const { updateSkill } = await import("./updater");
+    const entry = {
+      source: `file://${bareRepoPath}`,
+      commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ref: null,
+      installedAt: "2026-01-01T00:00:00.000Z",
+      provider: "codex",
+      sourceType: "github" as const,
+      scope: "project" as const,
+      skillPath: "skills/pdf",
+    } satisfies LockEntry & { scope: "project"; skillPath: string };
+
+    const result = await updateSkill("pdf", entry, false, {
+      auditFn: async () => ({ verdict: "safe" }),
+      loadConfigFn: async () =>
+        ({
+          providers: [
+            {
+              name: "codex",
+              global: join(tempDir, "global", ".codex", "skills"),
+              project: projectSkillsDir,
+            },
+          ],
+        }) as any,
+      resolveProviderPathFn: (p: string) => p,
+      writeLockEntryFn: async (name: string, e: any) => {
+        writtenLock = { name, entry: e };
+      },
+    });
+
+    expect(result.status).toBe("updated");
+    expect(writtenLock).toMatchObject({
+      name: "pdf",
+      entry: {
+        commitHash: newCommit,
+        skillPath: "skills/pdf",
+        scope: "project",
+      },
+    });
+    expect(await readFile(join(installedDir, "SKILL.md"), "utf-8")).toContain(
+      "New nested pdf",
+    );
+    await expect(
+      readFile(join(installedDir, "README.md"), "utf-8"),
+    ).rejects.toThrow();
   });
 
   test("updateSkill skips when security audit returns dangerous", async () => {

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -169,6 +169,10 @@ export function extractOwnerRepo(
   return { owner: parts[0], repo: parts[1] };
 }
 
+function getUpdateSourceDir(tempDir: string, entry: LockEntry): string {
+  return entry.skillPath ? join(tempDir, entry.skillPath) : tempDir;
+}
+
 // ─── Outdated Check ─────────────────────────────────────────────────────────
 
 /**
@@ -408,6 +412,8 @@ export async function updateSkill(
       return { name, status: "skipped", reason: "Already up to date" };
     }
 
+    const updateSourceDir = getUpdateSourceDir(tempDir, entry);
+
     // Step 2: Security audit on the new version
     debug(`updater: running security audit on ${name}`);
     let securityVerdict: SecurityVerdict = "safe";
@@ -415,7 +421,7 @@ export async function updateSkill(
       const auditFn = _overrides?.auditFn ?? auditSkillSecurity;
       const ownerRepo = extractOwnerRepo(entry.source);
       const auditReport = await auditFn(
-        tempDir,
+        updateSourceDir,
         name,
         ownerRepo?.owner,
         ownerRepo?.repo,
@@ -457,10 +463,6 @@ export async function updateSkill(
 
     // Step 3: Atomic swap
     // Determine the installed path from the provider config.
-    // NOTE: The lock entry does not currently record scope (global vs project).
-    // updateSkill always assumes global path. Scope tracking would be a
-    // separate issue — for now we look up the provider's configured global path
-    // from AppConfig rather than hard-coding it.
     const loadConfigFn = _overrides?.loadConfigFn ?? loadConfig;
     const resolvePathFn =
       _overrides?.resolveProviderPathFn ?? resolveProviderPath;
@@ -468,10 +470,13 @@ export async function updateSkill(
     const providerConfig = config.providers.find(
       (p) => p.name === entry.provider,
     );
-    const globalPath = providerConfig
-      ? providerConfig.global
+    const scope = entry.scope ?? "global";
+    const configuredPath = providerConfig
+      ? scope === "project"
+        ? providerConfig.project
+        : providerConfig.global
       : `~/.${entry.provider}/skills`;
-    const installedPath = resolvePathFn(globalPath);
+    const installedPath = resolvePathFn(configuredPath);
     const targetDir = join(installedPath, name);
 
     // Remove .git from cloned repo
@@ -488,7 +493,8 @@ export async function updateSkill(
     } catch {
       // Target doesn't exist — just copy
       const writeLockFn = _overrides?.writeLockEntryFn ?? writeLockEntry;
-      await cp(tempDir, targetDir, { recursive: true });
+      await mkdir(installedPath, { recursive: true });
+      await cp(updateSourceDir, targetDir, { recursive: true });
       await writeLockFn(name, {
         ...entry,
         commitHash: newCommit,
@@ -507,7 +513,7 @@ export async function updateSkill(
     const backupDir = `${targetDir}.bak-${Date.now()}`;
     try {
       await rename(targetDir, backupDir);
-      await cp(tempDir, targetDir, { recursive: true });
+      await cp(updateSourceDir, targetDir, { recursive: true });
       await rm(backupDir, { recursive: true, force: true });
     } catch (swapErr: any) {
       // Rollback: try to restore backup

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -150,6 +150,23 @@ export interface LockFile {
   skills: Record<string, LockEntry>;
 }
 
+export interface LibrarySkillEntry {
+  name: string;
+  version: string;
+  source: string;
+  commitHash: string;
+  ref: string | null;
+  skillPath: string;
+  libraryPath: string;
+  installedAt: string;
+  sourceType?: "registry" | "github" | "local";
+}
+
+export interface LibraryLockFile {
+  version: 1;
+  skills: Record<string, LibrarySkillEntry>;
+}
+
 // ─── Export Types ───────────────────────────────────────────────────────────
 
 export interface ExportedSkill {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -338,6 +338,7 @@ export interface InstallOptions {
   yes: boolean;
   path: string | null;
   all: boolean;
+  library: boolean;
   transport: TransportMode;
   method: InstallMethod;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -133,6 +133,12 @@ export interface LockEntry {
   ref: string | null;
   installedAt: string;
   provider: string;
+  /** Scope where the tracked skill was installed. Older lock entries omit this and are treated as global. */
+  scope?: "global" | "project";
+  /** Repo/local-source relative path to the skill directory. Empty string means repository root. */
+  skillPath?: string;
+  /** Absolute installed directory at the time the lock entry was written. */
+  targetDir?: string;
   /** How the skill was resolved: registry, github, or local */
   sourceType?: "registry" | "github" | "local";
   /** Registry name for registry-installed skills (e.g. "code-review") */


### PR DESCRIPTION
## Summary
- Add an ASM-owned neutral local library under the config root so skills can be installed once without appearing in provider/global skill folders.
- Add `asm install --library`, `asm library list`, and `asm activate` to explicitly symlink library skills into a selected provider/scope.
- Track library metadata in a separate lock file and guard path names, force behavior, duplicate installs, and Vercel-method leakage.

## Related Issues
- Addresses the end-state behind #247 by separating central skill storage from provider visibility.
- Builds on #307-era multi-skill/source-path handling so library installs preserve source metadata.
- Mirrors the activation/config concern discussed in SkillKit #133.

## Test Plan
- [x] `npx vitest run src/library.test.ts src/cli.test.ts src/updater.test.ts`
- [x] `npm run typecheck`

## Notes
- `--library --method vercel` is rejected because the Vercel installer writes to provider skill folders, which would break the neutral-library guarantee.
- `asm activate` is symlink-only and requires explicit provider/scope selection.