### PR TITLE
feat(install): add neutral local library activation lifecycle

### DIFF
--- a/docs/superpowers/plans/2026-06-18-library-deactivate-update.md
+++ b/docs/superpowers/plans/2026-06-18-library-deactivate-update.md
@@ -1,0 +1,1222 @@
+# Library Deactivate and Update Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add safe deactivation of library symlinks and update support for centrally installed library skills.
+
+**Architecture:** Extend `src/library.ts` with pure library lifecycle primitives, then expose them through `src/cli.ts`. Deactivation is symlink-only and refuses anything outside the ASM library. Library update reads `library-lock.json`, refreshes source content into a temporary directory, validates `SKILL.md`, atomically replaces the library copy, and summarizes per-skill results.
+
+**Tech Stack:** TypeScript, Node `fs/promises`, Node `child_process` for remote clone updates, Vitest, existing ASM CLI parser/config/provider helpers.
+
+---
+
+## File Map
+
+- Modify `src/library.ts`: add `deactivateLibrarySkill`, library update result types, source refresh helpers, `updateLibrarySkill`, and `updateLibrarySkills`.
+- Modify `src/library.test.ts`: unit tests for safe deactivate behavior and local-source library updates.
+- Modify `src/cli.ts`: add `deactivate` command, expand `library` subcommands with `update`, help text, JSON/human output, and routing.
+- Modify `src/cli.test.ts`: parser and CLI integration tests for `deactivate` and `library update`.
+- No changes to provider install/update behavior outside explicit `deactivate` and `library update` commands.
+
+## Task 1: Library Deactivate Primitive
+
+**Files:**
+- Modify: `src/library.ts`
+- Modify: `src/library.test.ts`
+
+- [ ] **Step 1: Add failing tests for symlink-only deactivation**
+
+Append these imports in `src/library.test.ts`:
+
+```ts
+import { realpath } from "fs/promises";
+```
+
+Add `deactivateLibrarySkill` to the existing `./library` import.
+
+Append this test block:
+
+```ts
+describe("deactivateLibrarySkill", () => {
+  let tempDir: string;
+  let librarySkillsDir: string;
+  let libraryPath: string;
+  let targetDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-deactivate-"));
+    librarySkillsDir = join(tempDir, "library", "skills");
+    libraryPath = join(librarySkillsDir, "brainstorming");
+    targetDir = join(tempDir, "provider", "skills");
+    await mkdir(libraryPath, { recursive: true });
+    await mkdir(targetDir, { recursive: true });
+    await writeFile(
+      join(libraryPath, "SKILL.md"),
+      "---\nname: brainstorming\n---\n# Brainstorming\n",
+    );
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("removes a provider symlink pointing into the library", async () => {
+    const symlinkPath = join(targetDir, "brainstorming");
+    await symlink(libraryPath, symlinkPath, "dir");
+
+    const result = await deactivateLibrarySkill({
+      targetDir,
+      activationName: "brainstorming",
+      librarySkillsDir,
+      provider: "codex",
+      scope: "project",
+    });
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      provider: "codex",
+      scope: "project",
+      path: symlinkPath,
+      target: await realpath(libraryPath),
+    });
+    await expect(lstat(symlinkPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Brainstorming",
+    );
+  });
+
+  test("refuses to deactivate a real directory", async () => {
+    const realTarget = join(targetDir, "brainstorming");
+    await mkdir(realTarget, { recursive: true });
+
+    await expect(
+      deactivateLibrarySkill({
+        targetDir,
+        activationName: "brainstorming",
+        librarySkillsDir,
+        provider: "codex",
+        scope: "project",
+      }),
+    ).rejects.toThrow(`Refusing to deactivate non-symlink target: ${realTarget}.`);
+    await expect(lstat(realTarget)).resolves.toBeTruthy();
+  });
+
+  test("refuses to deactivate a symlink outside the library", async () => {
+    const externalDir = join(tempDir, "external");
+    const symlinkPath = join(targetDir, "brainstorming");
+    await mkdir(externalDir, { recursive: true });
+    await symlink(externalDir, symlinkPath, "dir");
+
+    await expect(
+      deactivateLibrarySkill({
+        targetDir,
+        activationName: "brainstorming",
+        librarySkillsDir,
+        provider: "codex",
+        scope: "project",
+      }),
+    ).rejects.toThrow(`Refusing to deactivate symlink outside the ASM library: ${symlinkPath}.`);
+    await expect(readlink(symlinkPath)).resolves.toBe(externalDir);
+  });
+
+  test("reports a missing activation", async () => {
+    await expect(
+      deactivateLibrarySkill({
+        targetDir,
+        activationName: "brainstorming",
+        librarySkillsDir,
+        provider: "codex",
+        scope: "project",
+      }),
+    ).rejects.toThrow('Skill "brainstorming" is not active for codex/project.');
+  });
+
+  test("rejects invalid activation names before touching filesystem targets", async () => {
+    const outsideDir = join(tempDir, "provider", "outside");
+    const outsideSentinel = join(outsideDir, "sentinel.txt");
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(outsideSentinel, "keep me", "utf-8");
+
+    await expect(
+      deactivateLibrarySkill({
+        targetDir,
+        activationName: "../outside",
+        librarySkillsDir,
+        provider: "codex",
+        scope: "project",
+      }),
+    ).rejects.toThrow(/Invalid skill name/);
+
+    await expect(readFile(outsideSentinel, "utf-8")).resolves.toBe("keep me");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts -t deactivateLibrarySkill
+```
+
+Expected: FAIL because `deactivateLibrarySkill` is not exported.
+
+- [ ] **Step 3: Implement `deactivateLibrarySkill`**
+
+Update imports in `src/library.ts`:
+
+```ts
+import {
+  access,
+  copyFile,
+  cp,
+  lstat,
+  mkdir,
+  readFile,
+  readlink,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "fs/promises";
+import { dirname, isAbsolute, join, relative, resolve } from "path";
+import { getLibraryLockPath, getLibrarySkillsDir } from "./config";
+```
+
+Add these types and helper after `findLibrarySkill`:
+
+```ts
+export interface DeactivateLibrarySkillInput {
+  targetDir: string;
+  activationName: string;
+  provider: string;
+  scope: "global" | "project";
+  librarySkillsDir?: string;
+}
+
+export interface DeactivateLibrarySkillResult {
+  name: string;
+  provider: string;
+  scope: "global" | "project";
+  path: string;
+  target: string;
+}
+
+function isInsideDirectory(parent: string, child: string): boolean {
+  const rel = relative(parent, child);
+  return rel === "" || (!!rel && !rel.startsWith("..") && !isAbsolute(rel));
+}
+
+export async function deactivateLibrarySkill(
+  input: DeactivateLibrarySkillInput,
+): Promise<DeactivateLibrarySkillResult> {
+  const activationName = validateSkillDirectoryName(input.activationName);
+  const symlinkPath = join(input.targetDir, activationName);
+
+  let stat;
+  try {
+    stat = await lstat(symlinkPath);
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      throw new Error(
+        `Skill "${activationName}" is not active for ${input.provider}/${input.scope}.`,
+      );
+    }
+    throw err;
+  }
+
+  if (!stat.isSymbolicLink()) {
+    throw new Error(`Refusing to deactivate non-symlink target: ${symlinkPath}.`);
+  }
+
+  const rawTarget = await readlink(symlinkPath);
+  const absoluteTarget = isAbsolute(rawTarget)
+    ? rawTarget
+    : resolve(dirname(symlinkPath), rawTarget);
+  const resolvedTarget = await realpath(absoluteTarget);
+  const resolvedLibrarySkillsDir = await realpath(
+    input.librarySkillsDir ?? getLibrarySkillsDir(),
+  );
+
+  if (!isInsideDirectory(resolvedLibrarySkillsDir, resolvedTarget)) {
+    throw new Error(
+      `Refusing to deactivate symlink outside the ASM library: ${symlinkPath}.`,
+    );
+  }
+
+  await rm(symlinkPath, { force: false });
+
+  return {
+    name: activationName,
+    provider: input.provider,
+    scope: input.scope,
+    path: symlinkPath,
+    target: resolvedTarget,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts -t deactivateLibrarySkill
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/library.ts src/library.test.ts
+git commit -m "Add library skill deactivation primitive"
+```
+
+## Task 2: CLI `asm deactivate`
+
+**Files:**
+- Modify: `src/cli.ts`
+- Modify: `src/cli.test.ts`
+
+- [ ] **Step 1: Add failing parser and CLI tests**
+
+In the parser tests section of `src/cli.test.ts`, add:
+
+```ts
+test("parses deactivate command", () => {
+  const result = parse("deactivate", "brainstorming", "-p", "codex", "-s", "project");
+  expect(result.command).toBe("deactivate");
+  expect(result.subcommand).toBe("brainstorming");
+  expect(result.flags.provider).toBe("codex");
+  expect(result.flags.scope).toBe("project");
+});
+```
+
+In `describe("CLI integration: install --library", ...)`, append:
+
+```ts
+test("deactivate removes a project activation symlink", async () => {
+  const source = join(tempDir, "source");
+  const sourceSkillDir = join(source, "skills", "brainstorming");
+  await mkdir(sourceSkillDir, { recursive: true });
+  await writeFile(
+    join(sourceSkillDir, "SKILL.md"),
+    "---\nname: brainstorming\nversion: 1.0.0\n---\n# Brainstorming\n",
+  );
+
+  const homeDir = join(tempDir, "home");
+  const projectDir = join(tempDir, "project");
+  await mkdir(projectDir, { recursive: true });
+
+  const installRes = await spawnCollect(
+    ["npx", "tsx", CLI_BIN, "install", sourceSkillDir, "--library", "-y", "--json"],
+    { env: { ...process.env, HOME: homeDir, NO_COLOR: "1" } },
+  );
+  expect(installRes.exitCode).toBe(0);
+
+  const activateRes = await spawnCollect(
+    ["npx", "tsx", CLI_BIN, "activate", "brainstorming", "-p", "codex", "-s", "project", "--json"],
+    { cwd: projectDir, env: { ...process.env, HOME: homeDir, NO_COLOR: "1" } },
+  );
+  expect(activateRes.exitCode).toBe(0);
+
+  const deactivateRes = await spawnCollect(
+    ["npx", "tsx", CLI_BIN, "deactivate", "brainstorming", "-p", "codex", "-s", "project", "--json"],
+    { cwd: projectDir, env: { ...process.env, HOME: homeDir, NO_COLOR: "1" } },
+  );
+
+  expect(deactivateRes.exitCode).toBe(0);
+  const payload = JSON.parse(deactivateRes.stdout);
+  expect(payload).toMatchObject({
+    name: "brainstorming",
+    provider: "codex",
+    scope: "project",
+  });
+  await expect(lstat(join(projectDir, ".codex", "skills", "brainstorming"))).rejects.toMatchObject({
+    code: "ENOENT",
+  });
+});
+
+test("deactivate refuses a real provider directory", async () => {
+  const homeDir = join(tempDir, "home");
+  const projectDir = join(tempDir, "project");
+  const targetPath = join(projectDir, ".codex", "skills", "brainstorming");
+  await mkdir(targetPath, { recursive: true });
+
+  const res = await spawnCollect(
+    ["npx", "tsx", CLI_BIN, "deactivate", "brainstorming", "-p", "codex", "-s", "project"],
+    { cwd: projectDir, env: { ...process.env, HOME: homeDir, NO_COLOR: "1" } },
+  );
+
+  expect(res.exitCode).toBe(1);
+  expect(res.stderr).toContain("Refusing to deactivate non-symlink target");
+  await expect(lstat(targetPath)).resolves.toBeTruthy();
+});
+
+test("deactivate reports missing activation", async () => {
+  const homeDir = join(tempDir, "home");
+  const projectDir = join(tempDir, "project");
+  await mkdir(projectDir, { recursive: true });
+
+  const res = await spawnCollect(
+    ["npx", "tsx", CLI_BIN, "deactivate", "brainstorming", "-p", "codex", "-s", "project"],
+    { cwd: projectDir, env: { ...process.env, HOME: homeDir, NO_COLOR: "1" } },
+  );
+
+  expect(res.exitCode).toBe(1);
+  expect(res.stderr).toContain('Skill "brainstorming" is not active for codex/project');
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts -t "parses deactivate|deactivate removes|deactivate refuses|deactivate reports"
+```
+
+Expected: FAIL because `deactivate` is not routed.
+
+- [ ] **Step 3: Add CLI command, help, and route**
+
+Update the library import in `src/cli.ts`:
+
+```ts
+import {
+  activateLibrarySkill,
+  deactivateLibrarySkill,
+  emptyLibraryLock,
+  findLibrarySkill,
+  installLibrarySkill,
+  listLibrarySkills,
+  readLibraryLock,
+  writeLibraryLock,
+} from "./library";
+```
+
+Add main help command line:
+
+```ts
+  deactivate <skill>     Remove a library activation symlink
+```
+
+Add help function near `printActivateHelp`:
+
+```ts
+function printDeactivateHelp() {
+  console.log(`${ansi.bold("Usage:")} asm deactivate <skill> -p <tool> -s <scope> [options]
+
+Remove a library activation symlink from a provider skill folder.
+
+${ansi.bold("Options:")}
+  -p, --tool <name>      Provider to deactivate from (e.g., claude, codex)
+  -s, --scope <scope>    Activation scope: global or project
+  --json                 Output as JSON object
+  -V, --verbose          Show debug output
+
+${ansi.bold("Examples:")}
+  asm deactivate brainstorming -p codex -s project
+  asm deactivate sp-brainstorming -p claude -s global --json`);
+}
+```
+
+Add command handler after `cmdActivate`:
+
+```ts
+async function cmdDeactivate(args: ParsedArgs) {
+  if (args.flags.help) {
+    printDeactivateHelp();
+    return;
+  }
+
+  const activationName = args.subcommand;
+  if (!activationName) {
+    error("Missing skill name. Use: asm deactivate <skill>");
+    console.error(`Run "asm deactivate --help" for usage.`);
+    process.exit(2);
+  }
+
+  if (args.flags.scope === "both") {
+    error("Deactivation requires --scope global or --scope project.");
+    process.exit(2);
+  }
+
+  const config = await loadConfig();
+  const { provider } = await resolveProvider(
+    config,
+    args.flags.provider,
+    process.stdin.isTTY,
+  );
+  const targetTemplate =
+    args.flags.scope === "global" ? provider.global : provider.project;
+  const targetDir = resolveProviderPath(targetTemplate);
+
+  const result = await deactivateLibrarySkill({
+    targetDir,
+    activationName,
+    provider: provider.name,
+    scope: args.flags.scope,
+  });
+
+  if (args.flags.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log(
+    `${ansi.green("✓")} deactivated ${result.name} (${provider.name}/${args.flags.scope})`,
+  );
+}
+```
+
+Route it:
+
+```ts
+case "deactivate":
+  await cmdDeactivate(args);
+  break;
+```
+
+Add `"deactivate"` to the `isCLIMode` command list.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts -t "parses deactivate|deactivate removes|deactivate refuses|deactivate reports"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli.ts src/cli.test.ts
+git commit -m "Add deactivate command for library activations"
+```
+
+## Task 3: Library Update Primitive
+
+**Files:**
+- Modify: `src/library.ts`
+- Modify: `src/library.test.ts`
+
+- [ ] **Step 1: Add failing tests for local-source update and recorded `skillPath`**
+
+Add this test block to `src/library.test.ts`:
+
+```ts
+describe("updateLibrarySkill", () => {
+  let tempDir: string;
+  let lockPath: string;
+  let skillsDir: string;
+  let sourceRoot: string;
+  let libraryPath: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-update-"));
+    lockPath = join(tempDir, "library-lock.json");
+    skillsDir = join(tempDir, "library", "skills");
+    sourceRoot = join(tempDir, "source");
+    libraryPath = join(skillsDir, "brainstorming");
+
+    await mkdir(join(sourceRoot, "skills", "brainstorming"), { recursive: true });
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Old Source\n",
+    );
+
+    await installLibrarySkill(
+      {
+        sourceDir: join(sourceRoot, "skills", "brainstorming"),
+        libraryName: "brainstorming",
+        source: `local:${sourceRoot}`,
+        sourceType: "local",
+        commitHash: "local",
+        ref: null,
+        skillPath: "skills/brainstorming",
+        force: false,
+      },
+      { skillsDir, lockPath },
+    );
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("updates a local-source library skill in place", async () => {
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 2.0.0\n---\n# New Source\n",
+    );
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result).toMatchObject({
+      name: "brainstorming",
+      status: "updated",
+      oldVersion: "1.0.0",
+      newVersion: "2.0.0",
+    });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# New Source",
+    );
+    const lock = await readLibraryLock(lockPath);
+    expect(lock.skills.brainstorming.version).toBe("2.0.0");
+    expect(lock.skills.brainstorming.skillPath).toBe("skills/brainstorming");
+  });
+
+  test("uses recorded skillPath instead of source root", async () => {
+    await writeFile(
+      join(sourceRoot, "SKILL.md"),
+      "---\nname: wrong-root\nversion: 9.9.9\n---\n# Wrong Root\n",
+    );
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 2.1.0\n---\n# Correct Subpath\n",
+    );
+
+    await updateLibrarySkill("brainstorming", { skillsDir, lockPath });
+
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Correct Subpath",
+    );
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.not.toContain(
+      "# Wrong Root",
+    );
+  });
+
+  test("fails without replacing the existing library copy when source skill is invalid", async () => {
+    await rm(join(sourceRoot, "skills", "brainstorming", "SKILL.md"), {
+      force: true,
+    });
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.reason).toContain("SKILL.md");
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+  });
+});
+```
+
+Add `updateLibrarySkill` to the `./library` import.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts -t updateLibrarySkill
+```
+
+Expected: FAIL because `updateLibrarySkill` is not exported.
+
+- [ ] **Step 3: Implement update types and local-source refresh**
+
+Add imports in `src/library.ts`:
+
+```ts
+import { execFile } from "child_process";
+import { tmpdir } from "os";
+import { promisify } from "util";
+import { sourceToCloneUrl } from "./updater";
+```
+
+Add near constants:
+
+```ts
+const execFileAsync = promisify(execFile);
+```
+
+Add result types after `LibrarySkillInfo`:
+
+```ts
+export interface LibraryUpdateResult {
+  name: string;
+  status: "updated" | "skipped" | "failed";
+  reason?: string;
+  oldVersion?: string;
+  newVersion?: string;
+  oldCommit?: string;
+  newCommit?: string;
+}
+
+export interface LibraryUpdateSummary {
+  results: LibraryUpdateResult[];
+  updatedCount: number;
+  skippedCount: number;
+  failedCount: number;
+  warnings: string[];
+}
+```
+
+Add helpers before `installLibrarySkill`:
+
+```ts
+function sourceBasePath(entry: LibrarySkillEntry): string | null {
+  if (entry.source.startsWith("local:")) {
+    return entry.source.slice("local:".length);
+  }
+  return null;
+}
+
+function shortCommit(hash: string): string {
+  return hash.length > 7 ? hash.slice(0, 7) : hash;
+}
+
+async function copyValidatedSkill(input: {
+  sourceDir: string;
+  libraryName: string;
+  entry: LibrarySkillEntry;
+  skillsDir: string;
+  lockPath: string;
+  newCommit: string;
+}): Promise<LibraryUpdateResult> {
+  const skillMarkdown = await readFile(join(input.sourceDir, "SKILL.md"), "utf-8");
+  const fm = parseFrontmatter(skillMarkdown);
+  const name = fm.name || input.libraryName;
+  const version = resolveVersion(fm);
+
+  const tmpTarget = join(input.skillsDir, `${input.libraryName}.tmp-${Date.now()}`);
+  const backupTarget = join(input.skillsDir, `${input.libraryName}.bak-${Date.now()}`);
+  const finalTarget = input.entry.libraryPath;
+
+  await cp(input.sourceDir, tmpTarget, { recursive: true });
+  await rm(join(tmpTarget, ".git"), { recursive: true, force: true });
+
+  try {
+    await rm(backupTarget, { recursive: true, force: true });
+    await rename(finalTarget, backupTarget);
+    await rename(tmpTarget, finalTarget);
+    await rm(backupTarget, { recursive: true, force: true });
+  } catch (err: any) {
+    try {
+      await rm(finalTarget, { recursive: true, force: true });
+      await rename(backupTarget, finalTarget);
+    } catch {
+      // best effort rollback
+    }
+    await rm(tmpTarget, { recursive: true, force: true });
+    return {
+      name: input.libraryName,
+      status: "failed",
+      reason: `Atomic swap failed: ${err.message}`,
+    };
+  }
+
+  const lock = await readLibraryLock(input.lockPath);
+  lock.skills[input.libraryName] = {
+    ...input.entry,
+    name,
+    version,
+    commitHash: input.newCommit,
+    installedAt: new Date().toISOString(),
+  };
+  await writeLibraryLock(lock, input.lockPath);
+
+  return {
+    name: input.libraryName,
+    status: "updated",
+    oldVersion: input.entry.version,
+    newVersion: version,
+    oldCommit: shortCommit(input.entry.commitHash),
+    newCommit: shortCommit(input.newCommit),
+  };
+}
+```
+
+Update the import from `fs/promises` to include `mkdtemp` and `rename`.
+
+Add `LibrarySkillEntry` to the type import:
+
+```ts
+import type { LibraryLockFile, LibrarySkillEntry } from "./utils/types";
+```
+
+Add the primitive:
+
+```ts
+export async function updateLibrarySkill(
+  name: string,
+  paths: LibraryPaths = {},
+): Promise<LibraryUpdateResult> {
+  const skillsDir = paths.skillsDir ?? getLibrarySkillsDir();
+  const lockPath = paths.lockPath ?? getLibraryLockPath();
+  const rows = await listLibrarySkills(lockPath);
+  const info = findLibrarySkill(rows, name);
+  if (!info) {
+    return {
+      name,
+      status: "failed",
+      reason: `Library skill "${name}" not found. Run "asm library list".`,
+    };
+  }
+
+  const lock = await readLibraryLock(lockPath);
+  const entry = lock.skills[info.dirName];
+  if (!entry) {
+    return {
+      name,
+      status: "failed",
+      reason: `Library skill "${name}" not found. Run "asm library list".`,
+    };
+  }
+
+  if (!entry.source) {
+    return { name: info.dirName, status: "failed", reason: "Missing update metadata: source" };
+  }
+  if (!entry.skillPath && entry.skillPath !== "") {
+    return { name: info.dirName, status: "failed", reason: "Missing update metadata: skillPath" };
+  }
+  if (!entry.libraryPath) {
+    return { name: info.dirName, status: "failed", reason: "Missing update metadata: libraryPath" };
+  }
+
+  let refreshRoot: string | null = null;
+  let cleanupRoot: string | null = null;
+  let newCommit = entry.commitHash || "unknown";
+
+  try {
+    const localBase = sourceBasePath(entry);
+    if (localBase) {
+      refreshRoot = localBase;
+      newCommit = "local";
+    } else {
+      const cloneUrl = sourceToCloneUrl(entry.source);
+      if (!cloneUrl) {
+        return {
+          name: info.dirName,
+          status: "failed",
+          reason: "Cannot determine remote URL",
+        };
+      }
+      cleanupRoot = await mkdtemp(join(tmpdir(), "asm-library-update-"));
+      const cloneArgs = ["clone", "--depth", "1"];
+      if (entry.ref && entry.ref !== "HEAD") {
+        cloneArgs.push("--branch", entry.ref);
+      }
+      cloneArgs.push(cloneUrl, cleanupRoot);
+      await execFileAsync("git", cloneArgs, { timeout: 60_000 });
+      const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+        cwd: cleanupRoot,
+        timeout: 5_000,
+      });
+      newCommit = stdout.trim();
+      refreshRoot = cleanupRoot;
+    }
+
+    const sourceDir = entry.skillPath ? join(refreshRoot, entry.skillPath) : refreshRoot;
+    return await copyValidatedSkill({
+      sourceDir,
+      libraryName: info.dirName,
+      entry,
+      skillsDir,
+      lockPath,
+      newCommit,
+    });
+  } catch (err: any) {
+    return {
+      name: info.dirName,
+      status: "failed",
+      reason: err?.message || String(err),
+    };
+  } finally {
+    if (cleanupRoot) {
+      await rm(cleanupRoot, { recursive: true, force: true });
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts -t updateLibrarySkill
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/library.ts src/library.test.ts
+git commit -m "Add library skill update primitive"
+```
+
+## Task 4: CLI `asm library update`
+
+**Files:**
+- Modify: `src/library.ts`
+- Modify: `src/cli.ts`
+- Modify: `src/cli.test.ts`
+
+- [ ] **Step 1: Add failing tests for `library update`**
+
+In `describe("CLI integration: install --library", ...)`, append:
+
+```ts
+test("library update refreshes a local-source skill", async () => {
+  const source = join(tempDir, "source");
+  const sourceSkillDir = join(source, "skills", "brainstorming");
+  await mkdir(sourceSkillDir, { recursive: true });
+  await writeFile(
+    join(sourceSkillDir, "SKILL.md"),
+    "---\nname: brainstorming\nversion: 1.0.0\n---\n# Old\n",
+  );
+
+  const homeDir = join(tempDir, "home");
+  const installRes = await spawnCollect(
+    ["npx", "tsx", CLI_BIN, "install", source, "--library", "--all", "-y", "--json"],
+    { env: { ...process.env, HOME: homeDir, NO_COLOR: "1" } },
+  );
+  expect(installRes.exitCode).toBe(0);
+
+  await writeFile(
+    join(sourceSkillDir, "SKILL.md"),
+    "---\nname: brainstorming\nversion: 2.0.0\n---\n# New\n",
+  );
+
+  const updateRes = await spawnCollect(
+    ["npx", "tsx", CLI_BIN, "library", "update", "brainstorming", "--json"],
+    { env: { ...process.env, HOME: homeDir, NO_COLOR: "1" } },
+  );
+
+  expect(updateRes.exitCode).toBe(0);
+  const payload = JSON.parse(updateRes.stdout);
+  expect(payload.results[0]).toMatchObject({
+    name: "brainstorming",
+    status: "updated",
+    oldVersion: "1.0.0",
+    newVersion: "2.0.0",
+  });
+  await expect(
+    readFile(
+      join(homeDir, ".config", "agent-skill-manager", "library", "skills", "brainstorming", "SKILL.md"),
+      "utf-8",
+    ),
+  ).resolves.toContain("# New");
+});
+
+test("library update unknown skill suggests library list", async () => {
+  const homeDir = join(tempDir, "home");
+  const res = await spawnCollect(
+    ["npx", "tsx", CLI_BIN, "library", "update", "missing", "--json"],
+    { env: { ...process.env, HOME: homeDir, NO_COLOR: "1" } },
+  );
+
+  expect(res.exitCode).toBe(1);
+  const payload = JSON.parse(res.stdout);
+  expect(payload.failedCount).toBe(1);
+  expect(payload.results[0]).toMatchObject({
+    name: "missing",
+    status: "failed",
+    reason: 'Library skill "missing" not found. Run "asm library list".',
+  });
+});
+
+test("library update --all --json reports partial failures", async () => {
+  const source = join(tempDir, "source");
+  await mkdir(join(source, "skills", "good"), { recursive: true });
+  await mkdir(join(source, "skills", "bad"), { recursive: true });
+  await writeFile(
+    join(source, "skills", "good", "SKILL.md"),
+    "---\nname: good\nversion: 1.0.0\n---\n# Good Old\n",
+  );
+  await writeFile(
+    join(source, "skills", "bad", "SKILL.md"),
+    "---\nname: bad\nversion: 1.0.0\n---\n# Bad Old\n",
+  );
+
+  const homeDir = join(tempDir, "home");
+  const installRes = await spawnCollect(
+    ["npx", "tsx", CLI_BIN, "install", source, "--library", "--all", "-y", "--json"],
+    { env: { ...process.env, HOME: homeDir, NO_COLOR: "1" } },
+  );
+  expect(installRes.exitCode).toBe(0);
+
+  await writeFile(
+    join(source, "skills", "good", "SKILL.md"),
+    "---\nname: good\nversion: 2.0.0\n---\n# Good New\n",
+  );
+  await rm(join(source, "skills", "bad", "SKILL.md"), { force: true });
+
+  const updateRes = await spawnCollect(
+    ["npx", "tsx", CLI_BIN, "library", "update", "--all", "--json"],
+    { env: { ...process.env, HOME: homeDir, NO_COLOR: "1" } },
+  );
+
+  expect(updateRes.exitCode).toBe(1);
+  const payload = JSON.parse(updateRes.stdout);
+  expect(payload.updatedCount).toBe(1);
+  expect(payload.failedCount).toBe(1);
+  expect(payload.results).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ name: "good", status: "updated" }),
+      expect.objectContaining({ name: "bad", status: "failed" }),
+    ]),
+  );
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts -t "library update"
+```
+
+Expected: FAIL because `library update` is not implemented.
+
+- [ ] **Step 3: Add `updateLibrarySkills` summary primitive**
+
+In `src/library.ts`, add:
+
+```ts
+export async function updateLibrarySkills(
+  names: string[] | null,
+  paths: LibraryPaths = {},
+): Promise<LibraryUpdateSummary> {
+  const lockPath = paths.lockPath ?? getLibraryLockPath();
+  const lock = await readLibraryLock(lockPath);
+  const selectedNames = names && names.length > 0 ? names : Object.keys(lock.skills);
+  const warnings: string[] = [];
+
+  if (selectedNames.length === 0) {
+    return {
+      results: [],
+      updatedCount: 0,
+      skippedCount: 0,
+      failedCount: 0,
+      warnings,
+    };
+  }
+
+  const results: LibraryUpdateResult[] = [];
+  for (const selectedName of selectedNames) {
+    const result = await updateLibrarySkill(selectedName, paths);
+    if (
+      result.status === "failed" &&
+      result.reason?.includes("Run \"asm library list\"")
+    ) {
+      warnings.push(result.reason);
+    }
+    results.push(result);
+  }
+
+  return {
+    results,
+    updatedCount: results.filter((r) => r.status === "updated").length,
+    skippedCount: results.filter((r) => r.status === "skipped").length,
+    failedCount: results.filter((r) => r.status === "failed").length,
+    warnings,
+  };
+}
+```
+
+- [ ] **Step 4: Add CLI handler for `asm library update`**
+
+Update the library import in `src/cli.ts`:
+
+```ts
+import {
+  activateLibrarySkill,
+  deactivateLibrarySkill,
+  emptyLibraryLock,
+  findLibrarySkill,
+  installLibrarySkill,
+  listLibrarySkills,
+  readLibraryLock,
+  updateLibrarySkills,
+  writeLibraryLock,
+} from "./library";
+```
+
+Update `printLibraryHelp`:
+
+```ts
+${ansi.bold("Subcommands:")}
+  list                 List skills installed in the local library
+  update <skill>       Update one local library skill
+  update --all         Update all local library skills
+```
+
+Add these functions near `cmdLibrary`:
+
+```ts
+function printLibraryUpdateHuman(summary: Awaited<ReturnType<typeof updateLibrarySkills>>) {
+  for (const result of summary.results) {
+    if (result.status === "updated") {
+      console.log(
+        `${ansi.green("✓")} ${result.name}: ${result.oldVersion ?? "unknown"} -> ${result.newVersion ?? "unknown"}`,
+      );
+    } else if (result.status === "skipped") {
+      console.log(`${ansi.yellow("-")} ${result.name}: ${result.reason ?? "skipped"}`);
+    } else {
+      console.log(`${ansi.red("x")} ${result.name}: ${result.reason ?? "failed"}`);
+    }
+  }
+  console.log(
+    `${summary.updatedCount} updated, ${summary.skippedCount} skipped, ${summary.failedCount} failed`,
+  );
+}
+
+async function cmdLibraryUpdate(args: ParsedArgs) {
+  const names: string[] = [];
+  if (args.positional.length > 0) {
+    names.push(...args.positional);
+  }
+  if (args.subcommand && args.subcommand !== "update") {
+    names.unshift(args.subcommand);
+  }
+
+  if (!args.flags.all && names.length === 0) {
+    error("Missing skill name. Use: asm library update <skill> or asm library update --all");
+    process.exit(2);
+  }
+  if (args.flags.all && names.length > 0) {
+    error("Use either asm library update <skill> or asm library update --all, not both.");
+    process.exit(2);
+  }
+
+  const summary = await updateLibrarySkills(args.flags.all ? null : names);
+
+  if (args.flags.json) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    printLibraryUpdateHuman(summary);
+  }
+
+  if (summary.failedCount > 0) {
+    process.exit(1);
+  }
+}
+```
+
+Adjust `cmdLibrary` so it dispatches:
+
+```ts
+async function cmdLibrary(args: ParsedArgs) {
+  if (args.flags.help) {
+    printLibraryHelp();
+    return;
+  }
+
+  if (args.subcommand === "list") {
+    const rows = await listLibrarySkills();
+    if (args.flags.json) {
+      console.log(JSON.stringify(rows, null, 2));
+      return;
+    }
+    printLibraryList(rows);
+    return;
+  }
+
+  if (args.subcommand === "update") {
+    await cmdLibraryUpdate(args);
+    return;
+  }
+
+  error("Missing or unknown library subcommand. Use: asm library list or asm library update");
+  process.exit(2);
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts -t "library update"
+npx vitest run src/library.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/library.ts src/cli.ts src/cli.test.ts
+git commit -m "Add library update command"
+```
+
+## Task 5: Final Verification and PR Update
+
+**Files:**
+- Modify only if verification reveals a real issue.
+
+- [ ] **Step 1: Run focused verification**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts src/cli.test.ts src/updater.test.ts
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run final status check**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline -8
+```
+
+Expected: clean branch with the new deactivate/update commits on top.
+
+- [ ] **Step 3: Update PR #320 body**
+
+Run:
+
+```bash
+gh pr view 320 --repo luongnv89/asm --json body --jq .body > /tmp/asm-pr-320-body.md
+```
+
+Edit the body so the summary also mentions:
+
+```md
+- Add `asm deactivate` to safely remove library activation symlinks without deleting central library copies.
+- Add `asm library update` to refresh centrally installed skills from recorded source metadata.
+```
+
+Keep the test plan lines:
+
+```md
+- [x] `npx vitest run src/library.test.ts src/cli.test.ts src/updater.test.ts`
+- [x] `npm run typecheck`
+```
+
+Then run:
+
+```bash
+gh pr edit 320 --repo luongnv89/asm --body-file /tmp/asm-pr-320-body.md
+```
+
+- [ ] **Step 4: Push**
+
+Run:
+
+```bash
+git push
+```
+
+Expected: branch `add-neutral-local-library-activation` updates PR #320.

--- a/docs/superpowers/plans/2026-06-18-local-library-activation.md
+++ b/docs/superpowers/plans/2026-06-18-local-library-activation.md
@@ -1,0 +1,1320 @@
+# Local Library Activation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a neutral ASM local library where skills can be installed once and activated into provider/project folders via symlinks.
+
+**Architecture:** Add a focused `src/library.ts` module for library paths, metadata, install copies, listing, and activation symlinks. Reuse existing install discovery/review logic in `src/cli.ts`; `--library` changes only the final target from provider path to ASM library path. Activation is symlink-only and uses the existing provider config resolver.
+
+**Tech Stack:** TypeScript, Node `fs/promises`, Vitest, existing ASM CLI parser and install/link patterns.
+
+---
+
+## File Map
+
+- Create `src/library.ts`: library root helpers, lock read/write, install copy, list records, activate symlink.
+- Create `src/library.test.ts`: focused unit tests for library lock, install copy, and activation behavior.
+- Modify `src/config.ts`: expose `getLibraryDir()`, `getLibrarySkillsDir()`, and `getLibraryLockPath()`.
+- Modify `src/utils/types.ts`: add `library` flag to install options/parsed flags and define library lock entry types.
+- Modify `src/cli.ts`: parse `--library`; add `cmdLibrary`; add `cmdActivate`; route commands; call library install path from `cmdInstall`.
+- Modify `src/cli.test.ts`: parser and CLI integration tests for `install --library`, `library list`, and `activate`.
+
+## Task 1: Library Storage Module
+
+**Files:**
+- Create: `src/library.ts`
+- Test: `src/library.test.ts`
+- Modify: `src/config.ts`
+- Modify: `src/utils/types.ts`
+
+- [ ] **Step 1: Write failing tests for empty library lock and path helpers**
+
+Add this to `src/library.test.ts`:
+
+```ts
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  emptyLibraryLock,
+  readLibraryLock,
+  writeLibraryLock,
+} from "./library";
+
+describe("library lock", () => {
+  let tempDir: string;
+  let lockPath: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-test-"));
+    lockPath = join(tempDir, "library-lock.json");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("readLibraryLock returns an empty lock when the file is missing", async () => {
+    await expect(readLibraryLock(lockPath)).resolves.toEqual({
+      version: 1,
+      skills: {},
+    });
+  });
+
+  test("writeLibraryLock persists a versioned lock file", async () => {
+    const lock = emptyLibraryLock();
+    lock.skills.brainstorming = {
+      name: "brainstorming",
+      version: "1.0.0",
+      source: "github:obra/superpowers",
+      sourceType: "github",
+      commitHash: "abc123",
+      ref: "main",
+      skillPath: "skills/brainstorming",
+      libraryPath: join(tempDir, "skills", "brainstorming"),
+      installedAt: "2026-06-18T00:00:00.000Z",
+    };
+
+    await writeLibraryLock(lock, lockPath);
+
+    await expect(readLibraryLock(lockPath)).resolves.toEqual(lock);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts
+```
+
+Expected: FAIL because `src/library.ts` does not exist.
+
+- [ ] **Step 3: Add library types and path helpers**
+
+In `src/utils/types.ts`, add these types near the lock types:
+
+```ts
+export interface LibrarySkillEntry {
+  name: string;
+  version: string;
+  source: string;
+  commitHash: string;
+  ref: string | null;
+  skillPath: string;
+  libraryPath: string;
+  installedAt: string;
+  sourceType?: "registry" | "github" | "local";
+}
+
+export interface LibraryLockFile {
+  version: 1;
+  skills: Record<string, LibrarySkillEntry>;
+}
+```
+
+In `src/config.ts`, add constants after `INDEX_DIR`:
+
+```ts
+const LIBRARY_DIR = join(CONFIG_DIR, "library");
+const LIBRARY_SKILLS_DIR = join(LIBRARY_DIR, "skills");
+const LIBRARY_LOCK_PATH = join(LIBRARY_DIR, "library-lock.json");
+```
+
+Add exports near the other getters:
+
+```ts
+export function getLibraryDir(): string {
+  return LIBRARY_DIR;
+}
+
+export function getLibrarySkillsDir(): string {
+  return LIBRARY_SKILLS_DIR;
+}
+
+export function getLibraryLockPath(): string {
+  return LIBRARY_LOCK_PATH;
+}
+```
+
+- [ ] **Step 4: Implement lock read/write**
+
+Create `src/library.ts`:
+
+```ts
+import { copyFile, mkdir, readFile, writeFile } from "fs/promises";
+import { dirname } from "path";
+import { getLibraryLockPath } from "./config";
+import { debug } from "./logger";
+import type { LibraryLockFile } from "./utils/types";
+
+export function emptyLibraryLock(): LibraryLockFile {
+  return { version: 1, skills: {} };
+}
+
+export async function readLibraryLock(
+  path: string = getLibraryLockPath(),
+): Promise<LibraryLockFile> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf-8");
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      debug("library: lock file not found, returning empty lock");
+      return emptyLibraryLock();
+    }
+    throw err;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      parsed.version !== 1 ||
+      typeof parsed.skills !== "object" ||
+      parsed.skills === null
+    ) {
+      throw new Error("invalid schema");
+    }
+    return parsed as LibraryLockFile;
+  } catch {
+    const backupPath = path + ".bak";
+    try {
+      await copyFile(path, backupPath);
+    } catch {
+      // best effort backup
+    }
+    console.error(
+      `Warning: library-lock.json was corrupted. Backup saved to ${backupPath}. Starting fresh.`,
+    );
+    return emptyLibraryLock();
+  }
+}
+
+export async function writeLibraryLock(
+  lock: LibraryLockFile,
+  path: string = getLibraryLockPath(),
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(lock, null, 2) + "\n", "utf-8");
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/library.ts src/library.test.ts src/config.ts src/utils/types.ts
+git commit -m "Add local library lock storage"
+```
+
+## Task 2: Library Install Primitives
+
+**Files:**
+- Modify: `src/library.ts`
+- Modify: `src/library.test.ts`
+
+- [ ] **Step 1: Write failing tests for installing a skill into the library**
+
+Append to `src/library.test.ts`:
+
+```ts
+import { mkdir, readFile, writeFile, lstat } from "fs/promises";
+import { installLibrarySkill } from "./library";
+
+describe("installLibrarySkill", () => {
+  let tempDir: string;
+  let lockPath: string;
+  let skillsDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-install-"));
+    lockPath = join(tempDir, "library-lock.json");
+    skillsDir = join(tempDir, "skills");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("copies a skill directory and writes source metadata", async () => {
+    const sourceDir = join(tempDir, "source", "skills", "brainstorming");
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(
+      join(sourceDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.2.3\n---\n# Brainstorming\n",
+    );
+
+    const result = await installLibrarySkill(
+      {
+        sourceDir,
+        libraryName: "brainstorming",
+        source: "github:obra/superpowers",
+        sourceType: "github",
+        commitHash: "abc123",
+        ref: "main",
+        skillPath: "skills/brainstorming",
+        force: false,
+      },
+      { skillsDir, lockPath },
+    );
+
+    expect(result.name).toBe("brainstorming");
+    expect(result.version).toBe("1.2.3");
+    expect(await readFile(join(result.libraryPath, "SKILL.md"), "utf-8")).toContain(
+      "Brainstorming",
+    );
+
+    const lock = await readLibraryLock(lockPath);
+    expect(lock.skills.brainstorming).toMatchObject({
+      name: "brainstorming",
+      version: "1.2.3",
+      source: "github:obra/superpowers",
+      sourceType: "github",
+      commitHash: "abc123",
+      ref: "main",
+      skillPath: "skills/brainstorming",
+      libraryPath: result.libraryPath,
+    });
+  });
+
+  test("refuses to overwrite an existing library skill without force", async () => {
+    const sourceDir = join(tempDir, "source", "skills", "brainstorming");
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(
+      join(sourceDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Body\n",
+    );
+
+    await installLibrarySkill(
+      {
+        sourceDir,
+        libraryName: "brainstorming",
+        source: "local:/tmp/source",
+        sourceType: "local",
+        commitHash: "unknown",
+        ref: null,
+        skillPath: "skills/brainstorming",
+        force: false,
+      },
+      { skillsDir, lockPath },
+    );
+
+    await expect(
+      installLibrarySkill(
+        {
+          sourceDir,
+          libraryName: "brainstorming",
+          source: "local:/tmp/source",
+          sourceType: "local",
+          commitHash: "unknown",
+          ref: null,
+          skillPath: "skills/brainstorming",
+          force: false,
+        },
+        { skillsDir, lockPath },
+      ),
+    ).rejects.toThrow(/already exists/);
+
+    await expect(lstat(join(skillsDir, "brainstorming"))).resolves.toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts
+```
+
+Expected: FAIL because `installLibrarySkill` is not exported.
+
+- [ ] **Step 3: Implement installLibrarySkill**
+
+Add imports in `src/library.ts`:
+
+```ts
+import { access, cp, rm } from "fs/promises";
+import { join } from "path";
+import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
+```
+
+Add interfaces and function:
+
+```ts
+export interface InstallLibrarySkillPlan {
+  sourceDir: string;
+  libraryName: string;
+  source: string;
+  commitHash: string;
+  ref: string | null;
+  skillPath: string;
+  force: boolean;
+  sourceType?: "registry" | "github" | "local";
+}
+
+export interface LibraryPaths {
+  skillsDir?: string;
+  lockPath?: string;
+}
+
+export async function installLibrarySkill(
+  plan: InstallLibrarySkillPlan,
+  paths: LibraryPaths = {},
+): Promise<{ name: string; version: string; libraryPath: string }> {
+  const skillsDir = paths.skillsDir ?? getLibrarySkillsDir();
+  const lockPath = paths.lockPath ?? getLibraryLockPath();
+  const libraryPath = join(skillsDir, plan.libraryName);
+
+  try {
+    await access(libraryPath);
+    if (!plan.force) {
+      throw new Error(
+        `Library skill already exists: ${libraryPath}. Use --force to overwrite.`,
+      );
+    }
+    await rm(libraryPath, { recursive: true, force: true });
+  } catch (err: any) {
+    if (err?.message?.includes("--force")) throw err;
+  }
+
+  await mkdir(skillsDir, { recursive: true });
+  await cp(plan.sourceDir, libraryPath, { recursive: true });
+  await rm(join(libraryPath, ".git"), { recursive: true, force: true });
+
+  const content = await readFile(join(libraryPath, "SKILL.md"), "utf-8");
+  const fm = parseFrontmatter(content);
+  const name = fm.name || plan.libraryName;
+  const version = resolveVersion(fm);
+
+  const lock = await readLibraryLock(lockPath);
+  lock.skills[plan.libraryName] = {
+    name,
+    version,
+    source: plan.source,
+    sourceType: plan.sourceType,
+    commitHash: plan.commitHash,
+    ref: plan.ref,
+    skillPath: plan.skillPath,
+    libraryPath,
+    installedAt: new Date().toISOString(),
+  };
+  await writeLibraryLock(lock, lockPath);
+
+  return { name, version, libraryPath };
+}
+```
+
+Ensure `src/library.ts` imports `getLibrarySkillsDir` and `getLibraryLockPath` from `./config`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/library.ts src/library.test.ts
+git commit -m "Add local library skill installs"
+```
+
+## Task 3: CLI Parser and Install --library
+
+**Files:**
+- Modify: `src/utils/types.ts`
+- Modify: `src/cli.ts`
+- Modify: `src/cli.test.ts`
+
+- [ ] **Step 1: Write failing parser test for --library**
+
+In `src/cli.test.ts`, inside `describe("parseArgs: install", ...)`, add:
+
+```ts
+  test("parses install --library", () => {
+    const result = parse("install", "github:user/repo", "--library");
+    expect(result.command).toBe("install");
+    expect(result.subcommand).toBe("github:user/repo");
+    expect(result.flags.library).toBe(true);
+  });
+```
+
+- [ ] **Step 2: Run parser test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected: FAIL because `flags.library` does not exist or `--library` is unknown.
+
+- [ ] **Step 3: Add parser support**
+
+In `src/utils/types.ts`, extend `InstallOptions`:
+
+```ts
+  library: boolean;
+```
+
+Find the `ParsedArgs` flags type in `src/cli.ts` and add:
+
+```ts
+  library: boolean;
+```
+
+In the default `flags` object in `parseArgs`, add:
+
+```ts
+      library: false,
+```
+
+In `parseArgs`, add this branch near other boolean flags:
+
+```ts
+    } else if (arg === "--library") {
+      result.flags.library = true;
+```
+
+- [ ] **Step 4: Run parser test to verify it passes**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing CLI integration test for library install**
+
+In `src/cli.test.ts`, create a new describe block near install integration tests:
+
+```ts
+describe("CLI integration: install --library", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-cli-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function runCLIWithHome(
+    home: string,
+    ...args: string[]
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    const res = await spawnCollect(["npx", "tsx", CLI_BIN, ...args], {
+      env: { ...process.env, NO_COLOR: "1", HOME: home },
+    });
+    return {
+      stdout: res.stdout.trim(),
+      stderr: res.stderr.trim(),
+      exitCode: res.exitCode,
+    };
+  }
+
+  test("installs all selected skills into the library without provider-visible installs", async () => {
+    const source = join(tempDir, "source");
+    await mkdir(join(source, "skills", "one"), { recursive: true });
+    await mkdir(join(source, "skills", "two"), { recursive: true });
+    await writeFile(
+      join(source, "skills", "one", "SKILL.md"),
+      "---\nname: one\nversion: 1.0.0\n---\n# One\n",
+    );
+    await writeFile(
+      join(source, "skills", "two", "SKILL.md"),
+      "---\nname: two\nversion: 1.0.0\n---\n# Two\n",
+    );
+
+    const { stdout, stderr, exitCode } = await runCLIWithHome(
+      tempDir,
+      "install",
+      source,
+      "--library",
+      "--all",
+      "-y",
+      "--json",
+    );
+
+    expect(exitCode).toBe(0);
+    const payload = JSON.parse(stdout);
+    expect(Array.isArray(payload)).toBe(true);
+    expect(payload.map((r: any) => r.name).sort()).toEqual(["one", "two"]);
+    expect(await readFile(join(tempDir, ".config", "agent-skill-manager", "library", "skills", "one", "SKILL.md"), "utf-8")).toContain("# One");
+    await expect(
+      lstat(join(tempDir, ".claude", "skills", "one")),
+    ).rejects.toThrow();
+    expect(stderr).not.toContain("Error");
+  });
+});
+```
+
+- [ ] **Step 6: Run CLI integration test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected: FAIL because `cmdInstall` still installs into provider paths.
+
+- [ ] **Step 7: Route install --library to library installs**
+
+In `src/cli.ts`, import:
+
+```ts
+import { getLibrarySkillsDir } from "./config";
+import { installLibrarySkill } from "./library";
+```
+
+Because `getLibrarySkillsDir` is already exported from `./config`, prefer adding it to the existing config import instead of a second import.
+
+Inside `cmdInstall`, after source parsing and before provider selection, branch the provider/scope steps:
+
+```ts
+    const config = await loadConfig();
+    let provider: ProviderConfig | null = null;
+    let allProviders: ProviderConfig[] | null = null;
+    let installScope: "global" | "project" = "global";
+
+    if (!args.flags.library) {
+      console.info(stepHeader("Selecting provider"));
+      const resolvedProvider = await resolveProvider(
+        config,
+        args.flags.provider,
+        !!process.stdin.isTTY,
+      );
+      provider = resolvedProvider.provider;
+      allProviders = resolvedProvider.allProviders;
+
+      console.info(stepHeader("Selecting scope"));
+      // keep existing scope-selection logic here
+    } else {
+      console.info(stepHeader("Selecting library"));
+      console.info(`  ${ansi.dim(getLibrarySkillsDir())}`);
+    }
+```
+
+Move the existing provider and scope selection code into the `!args.flags.library` branch. For code that later requires `provider`, use `provider!` only inside non-library branches.
+
+When inspecting selected skills, use the first enabled provider only for existing-skill status if `--library` is set:
+
+```ts
+    const inspectionProvider =
+      provider ?? config.providers.find((p) => p.enabled) ?? config.providers[0];
+```
+
+Pass `inspectionProvider` into `inspectSkillForInstall`.
+
+In the install loop, replace:
+
+```ts
+        const result = await executeSkillInstall(inspection.plan, allProviders);
+```
+
+with:
+
+```ts
+        const result = args.flags.library
+          ? await installSelectedLibrarySkill({
+              inspection,
+              source,
+              isLocal,
+              resolutionSource,
+              commitHash,
+              scanBaseDir,
+            })
+          : await executeSkillInstall(inspection.plan, allProviders);
+```
+
+Add this helper near `executeSkillInstall`:
+
+```ts
+async function installSelectedLibrarySkill(input: {
+  inspection: SkillInspection;
+  source: ReturnType<typeof parseSource>;
+  isLocal: boolean;
+  resolutionSource: ResolutionSource;
+  commitHash: string | null;
+  scanBaseDir: string;
+}): Promise<InstallResult> {
+  const { inspection, source, isLocal, resolutionSource, commitHash, scanBaseDir } =
+    input;
+  const sourceStr = isLocal
+    ? `local:${source.localPath}`
+    : `github:${source.owner}/${source.repo}`;
+  const sourceType = isLocal
+    ? ("local" as const)
+    : resolutionSource === "registry"
+      ? ("registry" as const)
+      : ("github" as const);
+  const skillPath = relativePath(scanBaseDir, inspection.plan.sourceDir);
+  const installed = await installLibrarySkill({
+    sourceDir: inspection.plan.sourceDir,
+    libraryName: inspection.skillName,
+    source: sourceStr,
+    sourceType,
+    commitHash: commitHash || "unknown",
+    ref: source.ref || "main",
+    skillPath,
+    force: inspection.plan.force,
+  });
+
+  return {
+    success: true,
+    path: installed.libraryPath,
+    name: installed.name,
+    version: installed.version,
+    provider: "Library",
+    source: sourceStr,
+  };
+}
+```
+
+Skip the existing `.skill-lock.json` `writeLockEntry` when `args.flags.library` is true because library installs write `library-lock.json`.
+
+- [ ] **Step 8: Run CLI integration test to verify it passes**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/cli.ts src/cli.test.ts src/utils/types.ts src/library.ts
+git commit -m "Add install --library flow"
+```
+
+## Task 4: Library List Command
+
+**Files:**
+- Modify: `src/library.ts`
+- Modify: `src/cli.ts`
+- Modify: `src/cli.test.ts`
+
+- [ ] **Step 1: Write failing CLI test for library list JSON**
+
+In the `CLI integration: install --library` describe block, add:
+
+```ts
+  test("library list --json returns centrally installed skills", async () => {
+    const source = join(tempDir, "source");
+    await mkdir(join(source, "skills", "one"), { recursive: true });
+    await writeFile(
+      join(source, "skills", "one", "SKILL.md"),
+      "---\nname: one\nversion: 1.0.0\n---\n# One\n",
+    );
+
+    await runCLIWithHome(
+      tempDir,
+      "install",
+      source,
+      "--library",
+      "--all",
+      "-y",
+      "--json",
+    );
+
+    const { stdout, exitCode } = await runCLIWithHome(
+      tempDir,
+      "library",
+      "list",
+      "--json",
+    );
+
+    expect(exitCode).toBe(0);
+    const rows = JSON.parse(stdout);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      dirName: "one",
+      name: "one",
+      version: "1.0.0",
+      source: "local:" + source,
+      skillPath: "skills/one",
+    });
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected: FAIL because `library` command is not routed.
+
+- [ ] **Step 3: Add listLibrarySkills**
+
+In `src/library.ts`, add:
+
+```ts
+export interface LibrarySkillInfo {
+  dirName: string;
+  name: string;
+  version: string;
+  source: string;
+  sourceType?: "registry" | "github" | "local";
+  commitHash: string;
+  ref: string | null;
+  skillPath: string;
+  libraryPath: string;
+  installedAt: string;
+  missing: boolean;
+}
+
+export async function listLibrarySkills(
+  path: string = getLibraryLockPath(),
+): Promise<LibrarySkillInfo[]> {
+  const lock = await readLibraryLock(path);
+  const rows: LibrarySkillInfo[] = [];
+  for (const [dirName, entry] of Object.entries(lock.skills)) {
+    let missing = false;
+    try {
+      await access(join(entry.libraryPath, "SKILL.md"));
+    } catch {
+      missing = true;
+    }
+    rows.push({ dirName, ...entry, missing });
+  }
+  rows.sort((a, b) => a.name.localeCompare(b.name));
+  return rows;
+}
+```
+
+- [ ] **Step 4: Add CLI command**
+
+In `src/cli.ts`, import `listLibrarySkills`.
+
+Add help:
+
+```ts
+function printLibraryHelp() {
+  console.log(`${ansi.bold("Usage:")} asm library list [options]
+
+List skills installed in ASM's central local library.
+
+${ansi.bold("Options:")}
+  --json       Output as JSON
+  --no-color   Disable ANSI colors
+  -V, --verbose Show debug output`);
+}
+```
+
+Add command:
+
+```ts
+async function cmdLibrary(args: ParsedArgs) {
+  if (args.flags.help) {
+    printLibraryHelp();
+    return;
+  }
+  if (args.subcommand !== "list") {
+    error("Missing or unknown library subcommand. Use: asm library list");
+    process.exit(2);
+  }
+
+  const rows = await listLibrarySkills();
+  if (args.flags.json) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+
+  if (rows.length === 0) {
+    console.log(ansi.dim("No skills installed in the local library."));
+    return;
+  }
+
+  const lines = ["Name  Version  Source  Skill Path  Library Path"];
+  for (const row of rows) {
+    const missing = row.missing ? " [missing]" : "";
+    lines.push(
+      `${row.name}${missing}  ${row.version}  ${row.source}  ${row.skillPath}  ${row.libraryPath}`,
+    );
+  }
+  console.log(lines.join("\n"));
+}
+```
+
+Add `library` to `printMainHelp()` command list.
+
+Route near other commands:
+
+```ts
+    case "library":
+      await cmdLibrary(args);
+      break;
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/library.ts src/cli.ts src/cli.test.ts
+git commit -m "Add library list command"
+```
+
+## Task 5: Activate Command
+
+**Files:**
+- Modify: `src/library.ts`
+- Modify: `src/library.test.ts`
+- Modify: `src/cli.ts`
+- Modify: `src/cli.test.ts`
+
+- [ ] **Step 1: Write failing unit tests for activation symlinks**
+
+Append to `src/library.test.ts`:
+
+```ts
+import { readlink, symlink } from "fs/promises";
+import { activateLibrarySkill } from "./library";
+
+describe("activateLibrarySkill", () => {
+  let tempDir: string;
+  let sourceDir: string;
+  let targetDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-activate-"));
+    sourceDir = join(tempDir, "library", "skills", "brainstorming");
+    targetDir = join(tempDir, "project", ".codex", "skills");
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(
+      join(sourceDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Body\n",
+    );
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("creates a symlink from provider target to library skill", async () => {
+    const result = await activateLibrarySkill({
+      libraryPath: sourceDir,
+      targetDir,
+      activationName: "brainstorming",
+      force: false,
+    });
+
+    expect(result.symlinkPath).toBe(join(targetDir, "brainstorming"));
+    expect(await readlink(result.symlinkPath)).toBe(sourceDir);
+  });
+
+  test("refuses an existing target without force", async () => {
+    await mkdir(targetDir, { recursive: true });
+    await symlink(sourceDir, join(targetDir, "brainstorming"), "dir");
+
+    await expect(
+      activateLibrarySkill({
+        libraryPath: sourceDir,
+        targetDir,
+        activationName: "brainstorming",
+        force: false,
+      }),
+    ).rejects.toThrow(/already exists/);
+  });
+});
+```
+
+- [ ] **Step 2: Run unit tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts
+```
+
+Expected: FAIL because `activateLibrarySkill` is not exported.
+
+- [ ] **Step 3: Implement activateLibrarySkill and resolution**
+
+In `src/library.ts`, add imports if missing:
+
+```ts
+import { lstat, symlink } from "fs/promises";
+```
+
+Add:
+
+```ts
+export function findLibrarySkill(
+  rows: LibrarySkillInfo[],
+  name: string,
+): LibrarySkillInfo | null {
+  const exactDir = rows.find((r) => r.dirName === name);
+  if (exactDir) return exactDir;
+  const exactName = rows.find((r) => r.name === name);
+  return exactName ?? null;
+}
+
+export async function activateLibrarySkill(input: {
+  libraryPath: string;
+  targetDir: string;
+  activationName: string;
+  force: boolean;
+}): Promise<{ symlinkPath: string; targetPath: string }> {
+  const symlinkPath = join(input.targetDir, input.activationName);
+  try {
+    await lstat(symlinkPath);
+    if (!input.force) {
+      throw new Error(
+        `Target already exists: ${symlinkPath}. Use --force to overwrite.`,
+      );
+    }
+    await rm(symlinkPath, { recursive: true, force: true });
+  } catch (err: any) {
+    if (err?.message?.includes("--force")) throw err;
+  }
+
+  await mkdir(input.targetDir, { recursive: true });
+  await symlink(input.libraryPath, symlinkPath, "dir");
+  return { symlinkPath, targetPath: input.libraryPath };
+}
+```
+
+- [ ] **Step 4: Run unit tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing CLI integration test for activate**
+
+In `CLI integration: install --library`, add:
+
+```ts
+  test("activate creates a project-scoped provider symlink from the library", async () => {
+    const source = join(tempDir, "source");
+    await mkdir(join(source, "skills", "brainstorming"), { recursive: true });
+    await writeFile(
+      join(source, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Brainstorming\n",
+    );
+
+    await runCLIWithHome(
+      tempDir,
+      "install",
+      source,
+      "--library",
+      "--all",
+      "-y",
+      "--json",
+    );
+
+    const projectDir = join(tempDir, "project");
+    await mkdir(projectDir, { recursive: true });
+    const res = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "activate",
+        "brainstorming",
+        "-p",
+        "codex",
+        "-s",
+        "project",
+        "--json",
+      ],
+      { env: { ...process.env, NO_COLOR: "1", HOME: tempDir }, cwd: projectDir },
+    );
+
+    expect(res.exitCode).toBe(0);
+    const payload = JSON.parse(res.stdout.trim());
+    expect(payload.name).toBe("brainstorming");
+    const linkPath = join(projectDir, ".codex", "skills", "brainstorming");
+    expect(await readlink(linkPath)).toBe(
+      join(tempDir, ".config", "agent-skill-manager", "library", "skills", "brainstorming"),
+    );
+  });
+```
+
+- [ ] **Step 6: Run CLI test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected: FAIL because `activate` command is not routed.
+
+- [ ] **Step 7: Add activate CLI command**
+
+In `src/cli.ts`, import `activateLibrarySkill` and `findLibrarySkill`.
+
+Add help:
+
+```ts
+function printActivateHelp() {
+  console.log(`${ansi.bold("Usage:")} asm activate <skill> [options]
+
+Activate a skill from ASM's local library into a provider skill folder.
+
+${ansi.bold("Options:")}
+  -p, --tool <name>    Target tool/provider
+  -s, --scope <s>      global or project
+  --name <name>        Activation symlink name
+  -f, --force          Overwrite existing target
+  --json               Output as JSON
+  --no-color           Disable ANSI colors
+  -V, --verbose        Show debug output`);
+}
+```
+
+Add command:
+
+```ts
+async function cmdActivate(args: ParsedArgs) {
+  if (args.flags.help) {
+    printActivateHelp();
+    return;
+  }
+  const skillName = args.subcommand;
+  if (!skillName) {
+    error("Missing required argument: <skill>");
+    process.exit(2);
+  }
+  if (args.flags.scope === "both") {
+    error("Activation requires --scope global or --scope project.");
+    process.exit(2);
+  }
+
+  const rows = await listLibrarySkills();
+  const skill = findLibrarySkill(rows, skillName);
+  if (!skill) {
+    error(`Library skill "${skillName}" not found. Run "asm library list".`);
+    process.exit(1);
+  }
+  if (skill.missing) {
+    error(`Library skill "${skillName}" is missing on disk: ${skill.libraryPath}`);
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const { provider } = await resolveProvider(
+    config,
+    args.flags.provider,
+    !!process.stdin.isTTY,
+  );
+  const template =
+    args.flags.scope === "project" ? provider.project : provider.global;
+  const targetDir = resolveProviderPath(template);
+  const activationName = args.flags.name || skill.dirName;
+  const result = await activateLibrarySkill({
+    libraryPath: skill.libraryPath,
+    targetDir,
+    activationName,
+    force: args.flags.force,
+  });
+
+  const output = {
+    name: activationName,
+    skill: skill.name,
+    provider: provider.name,
+    scope: args.flags.scope,
+    path: result.symlinkPath,
+    target: result.targetPath,
+  };
+  if (args.flags.json) {
+    console.log(JSON.stringify(output, null, 2));
+  } else {
+    console.log(
+      `${ansi.green("✓")} activated ${activationName} (${provider.name}, ${args.flags.scope}) -> ${result.targetPath}`,
+    );
+  }
+}
+```
+
+Add `activate` to `printMainHelp()` and route it:
+
+```ts
+    case "activate":
+      await cmdActivate(args);
+      break;
+```
+
+- [ ] **Step 8: Run CLI test to verify it passes**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/library.ts src/library.test.ts src/cli.ts src/cli.test.ts
+git commit -m "Add library skill activation"
+```
+
+## Task 6: Error Cases and Final Verification
+
+**Files:**
+- Modify: `src/cli.test.ts`
+- Modify: `src/cli.ts`
+- Modify: `src/library.ts`
+
+- [ ] **Step 1: Add failing CLI tests for activation errors**
+
+Add to `CLI integration: install --library`:
+
+```ts
+  test("activate unknown library skill exits with actionable message", async () => {
+    const { stderr, exitCode } = await runCLIWithHome(
+      tempDir,
+      "activate",
+      "missing-skill",
+      "-p",
+      "codex",
+      "-s",
+      "project",
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('Library skill "missing-skill" not found');
+    expect(stderr).toContain("asm library list");
+  });
+
+  test("activate refuses existing target without force", async () => {
+    const source = join(tempDir, "source");
+    await mkdir(join(source, "skills", "brainstorming"), { recursive: true });
+    await writeFile(
+      join(source, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Brainstorming\n",
+    );
+    await runCLIWithHome(tempDir, "install", source, "--library", "--all", "-y");
+
+    const projectDir = join(tempDir, "project");
+    const target = join(projectDir, ".codex", "skills", "brainstorming");
+    await mkdir(target, { recursive: true });
+
+    const res = await spawnCollect(
+      ["npx", "tsx", CLI_BIN, "activate", "brainstorming", "-p", "codex", "-s", "project"],
+      { env: { ...process.env, NO_COLOR: "1", HOME: tempDir }, cwd: projectDir },
+    );
+
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("Target already exists");
+    expect(res.stderr).toContain("--force");
+  });
+```
+
+- [ ] **Step 2: Run tests to verify the new assertions are enforced**
+
+Run:
+
+```bash
+npx vitest run src/cli.test.ts
+```
+
+Expected before Step 3: FAIL if `cmdActivate` does not print the exact missing-skill message or `activateLibrarySkill` does not print the exact existing-target message.
+
+- [ ] **Step 3: Set exact activation error messages**
+
+In `src/cli.ts`, ensure the missing library skill branch in `cmdActivate` is exactly:
+
+```ts
+error(`Library skill "${skillName}" not found. Run "asm library list".`);
+process.exit(1);
+```
+
+In `src/library.ts`, ensure the existing target branch in `activateLibrarySkill` throws exactly:
+
+```ts
+throw new Error(
+  `Target already exists: ${symlinkPath}. Use --force to overwrite.`,
+);
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts
+npx vitest run src/cli.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run typecheck**
+
+Run:
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS with `tsc --noEmit`.
+
+- [ ] **Step 6: Run final test set**
+
+Run:
+
+```bash
+npx vitest run src/library.test.ts
+npx vitest run src/updater.test.ts
+npx vitest run src/cli.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit final test/error adjustments**
+
+```bash
+git add src/cli.ts src/cli.test.ts src/library.ts src/library.test.ts
+git commit -m "Cover local library activation errors"
+```
+
+## Self-Review Notes
+
+- Spec coverage: Task 1 covers storage; Task 2 covers library install primitives; Task 3 covers `install --library`; Task 4 covers `library list`; Task 5 covers `activate`; Task 6 covers error cases and verification.
+- Dependency closure, presets, sandbox, deactivate, and library update remain explicit follow-ups, matching the spec non-goals.
+- Type names used by later tasks are introduced before use: `LibrarySkillEntry`, `LibraryLockFile`, `LibrarySkillInfo`, `InstallLibrarySkillPlan`, `installLibrarySkill`, `listLibrarySkills`, `findLibrarySkill`, and `activateLibrarySkill`.

--- a/docs/superpowers/specs/2026-06-18-library-deactivate-update-design.md
+++ b/docs/superpowers/specs/2026-06-18-library-deactivate-update-design.md
@@ -1,0 +1,117 @@
+# Library Deactivate and Update Design
+
+## Purpose
+
+The neutral local library flow can install skills centrally and activate them into a provider scope, but it still needs two management operations to feel complete:
+
+- remove an activation without deleting the central library copy
+- refresh centrally installed skills from their recorded sources
+
+This slice implements the first two open follow-ups from the local library activation spec. It intentionally does not implement dependency closure, presets, sandboxing, or bundle-style activation sets.
+
+## Goals
+
+- Add a safe `asm deactivate` command for removing provider activation symlinks.
+- Add `asm library update` for refreshing one or all library skills from recorded source metadata.
+- Preserve existing provider installs and links unless the user explicitly runs the new commands.
+- Keep deactivation conservative: it removes ASM library symlinks only, never real provider directories.
+- Reuse the source metadata already recorded in `library-lock.json`.
+
+## Non-Goals
+
+- Do not resolve dependencies for issue #247 yet.
+- Do not implement presets, activation profiles, or sandbox commands.
+- Do not update provider-visible copies created by regular `asm install`.
+- Do not make `deactivate --force` remove real directories in this slice.
+
+## Command Surface
+
+### Deactivate
+
+```sh
+asm deactivate <skill-name> -p <tool> -s <global|project> [--json]
+```
+
+Deactivation removes the symlink created by `asm activate`.
+
+Examples:
+
+```sh
+asm deactivate brainstorming -p codex -s project
+asm deactivate sp-brainstorming -p claude -s global --json
+```
+
+`<skill-name>` is the activation directory name in the provider scope. This keeps the command predictable when activation used `--name <alias>`.
+
+### Library Update
+
+```sh
+asm library update <skill-name> [--json]
+asm library update --all [--json]
+```
+
+`<skill-name>` resolves the same way `asm activate` does: exact library directory name first, then frontmatter `name`.
+
+## Data Flow
+
+Deactivation:
+
+1. Resolve provider and scope using the same provider config path logic as `asm activate`.
+2. Resolve `<provider-scope-dir>/<skill-name>`.
+3. If the path does not exist, return an actionable "not active" error.
+4. If the path is not a symlink, refuse to remove it.
+5. Resolve the symlink target.
+6. If the target is not inside ASM's library skills directory, refuse to remove it.
+7. Remove the symlink.
+8. Return a human or JSON result with provider, scope, path, and target.
+
+Library update:
+
+1. Read `library-lock.json`.
+2. Select one entry by directory/frontmatter name or all entries for `--all`.
+3. Validate that each selected entry has enough metadata to re-fetch the source: `source`, `sourceType`, `skillPath`, `libraryPath`, and commit/ref information when relevant.
+4. Resolve the source using existing install/update source helpers where possible.
+5. Locate the recorded `skillPath` in the refreshed source.
+6. Parse and validate the refreshed `SKILL.md`.
+7. Copy into a temporary sibling directory under the library skills root.
+8. Atomically replace the existing library directory after the refreshed skill is validated.
+9. Update `library-lock.json` with the new version, commit hash, installed timestamp, and preserved source path metadata.
+10. For `--all`, continue after per-skill failures and summarize successes and failures.
+
+## Safety Rules
+
+- `asm deactivate` is symlink-only. This slice does not add `deactivate --force`, and the command must not remove real directories.
+- `asm deactivate` must only remove symlinks whose resolved target is inside the ASM library skills directory.
+- `asm library update` must not leave a library entry half-replaced if source resolution or metadata parsing fails.
+- `asm library update --all` must not stop the whole batch because one library entry is broken or missing metadata.
+- Existing project/global provider installs remain outside this flow.
+
+## Error Handling
+
+- `asm deactivate <skill>` fails if scope is `both`; it requires `global` or `project`.
+- Missing deactivation target: `Skill "<name>" is not active for <provider>/<scope>.`
+- Real directory target: `Refusing to deactivate non-symlink target: <path>.`
+- External symlink target: `Refusing to deactivate symlink outside the ASM library: <path>.`
+- Unknown library update target suggests `asm library list`.
+- Missing update metadata names the exact lock field that is unavailable.
+- `library update --all --json` reports per-skill status instead of throwing away partial results.
+
+## Testing
+
+Add focused tests for:
+
+- `parseArgs` recognizes `deactivate`.
+- `asm deactivate <skill> -p codex -s project` removes a project activation symlink.
+- `asm deactivate` refuses a real provider directory.
+- `asm deactivate` refuses a symlink pointing outside the ASM library.
+- `asm deactivate` reports a missing activation with an actionable message.
+- `asm library update <skill>` updates a local-source library skill.
+- `asm library update <skill>` uses recorded `skillPath`, not the source root.
+- `asm library update --all --json` reports successes and failures independently.
+- Existing library install/list/activate tests still pass.
+
+## Open Follow-Ups
+
+- Dependency closure resolution for issue #247.
+- Sandbox or preset commands on top of library activations.
+- Optional activation manifest tracking if future UX needs to distinguish ASM-created symlinks from manually-created symlinks that point into the library.

--- a/docs/superpowers/specs/2026-06-18-local-library-activation-design.md
+++ b/docs/superpowers/specs/2026-06-18-local-library-activation-design.md
@@ -1,0 +1,147 @@
+# Local Library Activation Design
+
+## Purpose
+
+ASM should support a neutral local skill library where skills can be installed once without becoming visible to Claude, Codex, or any other provider. Projects and tools should opt into individual skills by activation, preferably via symlinks, so the active skill set stays small and project-specific.
+
+This is the next step toward issue #307's local/private skill management direction and prepares the source metadata needed for issue #247's dependency-aware installs. It builds on the lock metadata work that records install scope and repo-relative `skillPath`.
+
+## Goals
+
+- Install selected skills into an ASM-owned library path without exposing them to any provider.
+- List centrally installed library skills.
+- Activate a library skill into a provider and scope by creating a symlink.
+- Preserve source metadata for future update and dependency-resolution work.
+- Keep existing `asm install`, `asm link`, `asm update`, and provider behavior unchanged unless the user explicitly uses the new library flow.
+
+## Non-Goals
+
+- Do not resolve shared dependencies yet.
+- Do not implement presets or sandbox mode yet.
+- Do not copy library skills during activation in the first slice; activation is symlink-only.
+- Do not change how provider-global installs work today.
+
+## Command Surface
+
+### Library Install
+
+```sh
+asm install <source> --library [--all] [--path <subdir>] [--name <name>] [-y]
+```
+
+`--library` reuses the existing install pipeline:
+
+- source parsing and registry resolution
+- git clone or local source handling
+- subpath discovery
+- duplicate target-name detection
+- security warning preview and confirmation
+
+Instead of installing into a selected provider path, it copies each selected skill into the ASM library root.
+
+### Library List
+
+```sh
+asm library list [--json]
+```
+
+Lists skills installed in the central library. The human table should include name, version, source, skill path, installed date, and library path. JSON output should expose the same fields.
+
+### Activate
+
+```sh
+asm activate <skill-name> -p <tool> -s <global|project> [--name <alias>] [--force] [--json]
+```
+
+Activation creates a symlink from the selected provider/scope folder to the library skill directory.
+
+Examples:
+
+```sh
+asm install github:obra/superpowers --library --all -y
+asm activate brainstorming -p codex -s project
+asm activate brainstorming -p claude -s global --name sp-brainstorming
+```
+
+## Storage
+
+Default paths:
+
+```text
+~/.config/agent-skill-manager/library/
+  skills/
+    <skill-dir-name>/
+      SKILL.md
+      ...
+  library-lock.json
+```
+
+The first slice stores skills by install directory name. If two selected skills would map to the same library directory name, the same duplicate target-name protection used by provider installs should block the operation.
+
+`library-lock.json` should be versioned and keyed by library directory name:
+
+```json
+{
+  "version": 1,
+  "skills": {
+    "brainstorming": {
+      "name": "brainstorming",
+      "version": "1.0.0",
+      "source": "github:obra/superpowers",
+      "sourceType": "github",
+      "commitHash": "abc123...",
+      "ref": "main",
+      "skillPath": "skills/brainstorming",
+      "libraryPath": "/Users/example/.config/agent-skill-manager/library/skills/brainstorming",
+      "installedAt": "2026-06-18T00:00:00.000Z"
+    }
+  }
+}
+```
+
+## Data Flow
+
+Library install:
+
+1. Parse and resolve the source.
+2. Discover/select skill directories using the existing install logic.
+3. Build library install plans instead of provider install plans.
+4. Copy selected skill directories to `library/skills/<skill-dir-name>`.
+5. Write or update `library-lock.json` with source metadata, commit hash, and repo-relative `skillPath`.
+
+Activation:
+
+1. Load `library-lock.json`.
+2. Resolve the requested library skill by directory name or frontmatter name.
+3. Resolve the target provider and scope using existing provider config.
+4. Create a symlink at `<provider-scope-dir>/<activation-name>` pointing to `libraryPath`.
+5. Refuse to overwrite existing targets unless `--force` is provided.
+
+## Error Handling
+
+- `asm install --library` should fail with a clear error if selected skills collide on library directory name.
+- `asm activate <skill>` should fail if the skill is not in the library, suggesting `asm library list`.
+- Activation should refuse to overwrite real directories unless `--force` is used.
+- Activation should replace existing symlinks when `--force` is used.
+- Broken library entries should be shown by `asm library list` with a warning rather than crashing.
+- Existing provider installs and links should continue using their current conflict behavior.
+
+## Testing
+
+Add focused tests for:
+
+- `parseArgs` accepts `install --library`.
+- `asm install <local multi-skill-dir> --library --all -y` creates library copies and does not create provider-visible skills.
+- `asm library list --json` returns installed library skills.
+- `asm activate <skill> -p codex -s project` creates a symlink into `.codex/skills`.
+- Activation fails for unknown library skills with an actionable message.
+- Activation refuses an existing target without `--force`.
+- Activation with `--force` replaces an existing symlink.
+- Existing install, link, and update tests still pass.
+
+## Open Follow-Ups
+
+- Add `asm deactivate` to remove activation symlinks.
+- Add `asm library update` using the recorded source metadata.
+- Add dependency closure resolution for issue #247.
+- Add sandbox/preset commands on top of library activations.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1564,6 +1564,80 @@ describe("CLI integration: install --library", () => {
     ).resolves.toContain("# New");
   });
 
+  test("install --library records a root skillPath that library update can refresh", async () => {
+    const sourceSkillDir = join(tempDir, "root-skill");
+    await mkdir(sourceSkillDir, { recursive: true });
+    await writeFile(
+      join(sourceSkillDir, "SKILL.md"),
+      "---\nname: root-skill\nversion: 1.0.0\n---\n# Old Root\n",
+    );
+
+    const homeDir = join(tempDir, "home-root-library");
+    const installRes = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "install",
+        sourceSkillDir,
+        "--library",
+        "-y",
+        "--json",
+      ],
+      { env: { ...process.env, HOME: homeDir, NO_COLOR: "1" } },
+    );
+    expect(installRes.exitCode).toBe(0);
+    const lock = JSON.parse(
+      await readFile(
+        join(
+          homeDir,
+          ".config",
+          "agent-skill-manager",
+          "library",
+          "library-lock.json",
+        ),
+        "utf-8",
+      ),
+    );
+    expect(lock.skills["root-skill"]).toMatchObject({
+      name: "root-skill",
+      skillPath: "",
+    });
+
+    await writeFile(
+      join(sourceSkillDir, "SKILL.md"),
+      "---\nname: root-skill\nversion: 2.0.0\n---\n# New Root\n",
+    );
+
+    const updateRes = await spawnCollect(
+      ["npx", "tsx", CLI_BIN, "library", "update", "root-skill", "--json"],
+      { env: { ...process.env, HOME: homeDir, NO_COLOR: "1" } },
+    );
+
+    expect(updateRes.exitCode).toBe(0);
+    const payload = JSON.parse(updateRes.stdout);
+    expect(payload.results[0]).toMatchObject({
+      name: "root-skill",
+      status: "updated",
+      oldVersion: "1.0.0",
+      newVersion: "2.0.0",
+    });
+    await expect(
+      readFile(
+        join(
+          homeDir,
+          ".config",
+          "agent-skill-manager",
+          "library",
+          "skills",
+          "root-skill",
+          "SKILL.md",
+        ),
+        "utf-8",
+      ),
+    ).resolves.toContain("# New Root");
+  });
+
   test("library update unknown skill suggests library list and exits 1 with JSON summary", async () => {
     const homeDir = join(tempDir, "home");
     const res = await spawnCollect(

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1550,6 +1550,88 @@ describe("CLI integration: install --library", () => {
     await expect(readlink(targetPath)).resolves.toBe(libraryPath);
   });
 
+  test("activate unknown library skill exits with actionable message", async () => {
+    const homeDir = join(tempDir, "home");
+    const projectDir = join(tempDir, "project");
+    await mkdir(projectDir, { recursive: true });
+
+    const res = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "activate",
+        "missing-skill",
+        "-p",
+        "codex",
+        "-s",
+        "project",
+      ],
+      {
+        cwd: projectDir,
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain('Library skill "missing-skill" not found');
+    expect(res.stderr).toContain("asm library list");
+  });
+
+  test("activate refuses existing target without force", async () => {
+    const source = join(tempDir, "source");
+    const sourceSkillDir = join(source, "skills", "brainstorming");
+    await mkdir(sourceSkillDir, { recursive: true });
+    await writeFile(
+      join(sourceSkillDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Brainstorming\n",
+    );
+
+    const homeDir = join(tempDir, "home");
+    const installRes = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "install",
+        sourceSkillDir,
+        "--library",
+        "-y",
+        "--json",
+      ],
+      {
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+    expect(installRes.exitCode).toBe(0);
+
+    const projectDir = join(tempDir, "project");
+    const targetPath = join(projectDir, ".codex", "skills", "brainstorming");
+    await mkdir(targetPath, { recursive: true });
+
+    const res = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "activate",
+        "brainstorming",
+        "-p",
+        "codex",
+        "-s",
+        "project",
+      ],
+      {
+        cwd: projectDir,
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("Target already exists");
+    expect(res.stderr).toContain("--force");
+  });
+
   test("does not overwrite an existing library skill when only provider install exists", async () => {
     const homeDir = join(tempDir, "home");
     const providerSkillDir = join(homeDir, ".claude", "skills", "foo");

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -414,6 +414,7 @@ describe("CLI integration: --help", () => {
     expect(stdout).toContain("search");
     expect(stdout).toContain("inspect");
     expect(stdout).toContain("uninstall");
+    expect(stdout).toContain("library");
     expect(stdout).toContain("config");
   });
 
@@ -1437,6 +1438,51 @@ describe("CLI integration: install --library", () => {
     await expect(
       lstat(join(homeDir, ".claude", "skills", "one")),
     ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("library list --json returns centrally installed skills", async () => {
+    const source = join(tempDir, "source");
+    await mkdir(join(source, "skills", "one"), { recursive: true });
+    await writeFile(
+      join(source, "skills", "one", "SKILL.md"),
+      "---\nname: one\nversion: 1.0.0\n---\n# One\n",
+    );
+
+    const homeDir = join(tempDir, "home");
+    await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "install",
+        source,
+        "--library",
+        "--all",
+        "-y",
+        "--json",
+      ],
+      {
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    const res = await spawnCollect(
+      ["npx", "tsx", CLI_BIN, "library", "list", "--json"],
+      {
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(res.exitCode).toBe(0);
+    const rows = JSON.parse(res.stdout);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      dirName: "one",
+      name: "one",
+      version: "1.0.0",
+      source: "local:" + source,
+      skillPath: "skills/one",
+    });
   });
 
   test("does not overwrite an existing library skill when only provider install exists", async () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1485,6 +1485,71 @@ describe("CLI integration: install --library", () => {
     });
   });
 
+  test("activate links a library skill into a project provider", async () => {
+    const source = join(tempDir, "source");
+    const sourceSkillDir = join(source, "skills", "brainstorming");
+    await mkdir(sourceSkillDir, { recursive: true });
+    await writeFile(
+      join(sourceSkillDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Brainstorming\n",
+    );
+
+    const homeDir = join(tempDir, "home");
+    const installRes = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "install",
+        sourceSkillDir,
+        "--library",
+        "-y",
+        "--json",
+      ],
+      {
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+    expect(installRes.exitCode).toBe(0);
+
+    const projectDir = join(tempDir, "project");
+    await mkdir(projectDir, { recursive: true });
+    const activateRes = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "activate",
+        "brainstorming",
+        "-p",
+        "codex",
+        "-s",
+        "project",
+        "--json",
+      ],
+      {
+        cwd: projectDir,
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(activateRes.exitCode).toBe(0);
+    const payload = JSON.parse(activateRes.stdout);
+    expect(payload.name).toBe("brainstorming");
+
+    const targetPath = join(projectDir, ".codex", "skills", "brainstorming");
+    const libraryPath = join(
+      homeDir,
+      ".config",
+      "agent-skill-manager",
+      "library",
+      "skills",
+      "brainstorming",
+    );
+    expect((await lstat(targetPath)).isSymbolicLink()).toBe(true);
+    await expect(readlink(targetPath)).resolves.toBe(libraryPath);
+  });
+
   test("does not overwrite an existing library skill when only provider install exists", async () => {
     const homeDir = join(tempDir, "home");
     const providerSkillDir = join(homeDir, ".claude", "skills", "foo");

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -21,6 +21,7 @@ import {
   lstat,
   readlink,
   symlink,
+  chmod,
 } from "fs/promises";
 import { tmpdir, homedir } from "os";
 import { spawnCollect, runInlineTs } from "./utils/test-spawn";
@@ -1122,6 +1123,13 @@ describe("parseArgs: install", () => {
     expect(result.subcommand).toBe("github:user/repo");
   });
 
+  test("parses install --library", () => {
+    const result = parse("install", "github:user/repo", "--library");
+    expect(result.command).toBe("install");
+    expect(result.subcommand).toBe("github:user/repo");
+    expect(result.flags.library).toBe(true);
+  });
+
   test("parses --provider flag", () => {
     const result = parse("install", "github:user/repo", "--provider", "claude");
     expect(result.flags.provider).toBe("claude");
@@ -1345,6 +1353,280 @@ describe("CLI integration: install", () => {
   test("main --help includes install command", async () => {
     const { stdout } = await runCLI("--help");
     expect(stdout).toContain("install");
+  });
+});
+
+// ─── CLI integration: install --library ─────────────────────────────────────
+
+describe("CLI integration: install --library", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-test-install-library-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("installs selected local skills into the neutral library", async () => {
+    const sourceDir = join(tempDir, "source");
+    await mkdir(join(sourceDir, "one"), { recursive: true });
+    await mkdir(join(sourceDir, "two"), { recursive: true });
+    await writeFile(
+      join(sourceDir, "one", "SKILL.md"),
+      `---\nname: one\nversion: 1.0.0\n---\n# One\n`,
+    );
+    await writeFile(
+      join(sourceDir, "two", "SKILL.md"),
+      `---\nname: two\nversion: 1.0.0\n---\n# Two\n`,
+    );
+
+    const homeDir = join(tempDir, "home");
+    const res = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "install",
+        sourceDir,
+        "--library",
+        "--all",
+        "-y",
+        "--json",
+      ],
+      {
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(res.exitCode).toBe(0);
+    const jsonStart = res.stdout.lastIndexOf("[\n  {");
+    expect(jsonStart).toBeGreaterThanOrEqual(0);
+    const payload = JSON.parse(res.stdout.slice(jsonStart).trim());
+    expect(payload.map((r: { name: string }) => r.name).sort()).toEqual([
+      "one",
+      "two",
+    ]);
+
+    const librarySkillsDir = join(
+      homeDir,
+      ".config",
+      "agent-skill-manager",
+      "library",
+      "skills",
+    );
+    await expect(
+      readFile(join(librarySkillsDir, "one", "SKILL.md"), "utf-8"),
+    ).resolves.toContain("# One");
+    await expect(
+      readFile(join(librarySkillsDir, "two", "SKILL.md"), "utf-8"),
+    ).resolves.toContain("# Two");
+    await expect(
+      readFile(
+        join(
+          homeDir,
+          ".config",
+          "agent-skill-manager",
+          "library",
+          "library-lock.json",
+        ),
+        "utf-8",
+      ),
+    ).resolves.toContain('"one"');
+    await expect(
+      lstat(join(homeDir, ".claude", "skills", "one")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("does not overwrite an existing library skill when only provider install exists", async () => {
+    const homeDir = join(tempDir, "home");
+    const providerSkillDir = join(homeDir, ".claude", "skills", "foo");
+    await mkdir(providerSkillDir, { recursive: true });
+    await writeFile(
+      join(providerSkillDir, "SKILL.md"),
+      `---\nname: foo\nversion: 1.0.0\n---\n# Existing provider\n`,
+    );
+
+    const librarySkillDir = join(
+      homeDir,
+      ".config",
+      "agent-skill-manager",
+      "library",
+      "skills",
+      "foo",
+    );
+    await mkdir(librarySkillDir, { recursive: true });
+    await writeFile(
+      join(librarySkillDir, "SKILL.md"),
+      `---\nname: foo\nversion: 1.0.0\n---\n# Existing library\n`,
+    );
+    await mkdir(
+      join(homeDir, ".config", "agent-skill-manager", "library"),
+      { recursive: true },
+    );
+    await writeFile(
+      join(
+        homeDir,
+        ".config",
+        "agent-skill-manager",
+        "library",
+        "library-lock.json",
+      ),
+      JSON.stringify(
+        {
+          version: 1,
+          skills: {
+            foo: {
+              name: "foo",
+              version: "1.0.0",
+              source: "local:/existing",
+              sourceType: "local",
+              commitHash: "unknown",
+              ref: "main",
+              skillPath: "foo",
+              libraryPath: librarySkillDir,
+              installedAt: "2026-01-01T00:00:00.000Z",
+            },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+
+    const sourceSkillDir = join(tempDir, "source", "foo");
+    await mkdir(sourceSkillDir, { recursive: true });
+    await writeFile(
+      join(sourceSkillDir, "SKILL.md"),
+      `---\nname: foo\nversion: 2.0.0\n---\n# New source\n`,
+    );
+
+    const res = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "install",
+        sourceSkillDir,
+        "--library",
+        "-y",
+        "--json",
+      ],
+      {
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(res.exitCode).not.toBe(0);
+    expect(`${res.stdout}\n${res.stderr}`).toMatch(
+      /Library skill already exists|--force/,
+    );
+    const librarySkillMd = await readFile(
+      join(librarySkillDir, "SKILL.md"),
+      "utf-8",
+    );
+    expect(librarySkillMd).toContain("# Existing library");
+    expect(librarySkillMd).not.toContain("# New source");
+  });
+
+  test("does not let Vercel method implicit force overwrite an existing library skill", async () => {
+    const homeDir = join(tempDir, "home");
+    const providerSkillDir = join(homeDir, ".claude", "skills", "foo");
+    await mkdir(providerSkillDir, { recursive: true });
+    await writeFile(
+      join(providerSkillDir, "SKILL.md"),
+      `---\nname: foo\nversion: 1.0.0\n---\n# Existing provider\n`,
+    );
+
+    const librarySkillDir = join(
+      homeDir,
+      ".config",
+      "agent-skill-manager",
+      "library",
+      "skills",
+      "foo",
+    );
+    await mkdir(librarySkillDir, { recursive: true });
+    await writeFile(
+      join(librarySkillDir, "SKILL.md"),
+      `---\nname: foo\nversion: 1.0.0\n---\n# Existing library\n`,
+    );
+    await mkdir(
+      join(homeDir, ".config", "agent-skill-manager", "library"),
+      { recursive: true },
+    );
+    await writeFile(
+      join(
+        homeDir,
+        ".config",
+        "agent-skill-manager",
+        "library",
+        "library-lock.json",
+      ),
+      JSON.stringify({ version: 1, skills: {} }, null, 2) + "\n",
+    );
+
+    const sourceSkillDir = join(tempDir, "source-vercel", "foo");
+    await mkdir(sourceSkillDir, { recursive: true });
+    await writeFile(
+      join(sourceSkillDir, "SKILL.md"),
+      `---\nname: foo\nversion: 2.0.0\n---\n# New source\n`,
+    );
+
+    const fakeBinDir = join(tempDir, "fake-bin");
+    await mkdir(fakeBinDir, { recursive: true });
+    const fakeNpx = join(fakeBinDir, "npx");
+    await writeFile(
+      fakeNpx,
+      `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "10.0.0"
+  exit 0
+fi
+echo "fake skills add"
+exit 0
+`,
+    );
+    await chmod(fakeNpx, 0o755);
+
+    const res = await spawnCollect(
+      [
+        process.env.npm_node_execpath || process.execPath,
+        "--import",
+        "tsx",
+        CLI_BIN,
+        "install",
+        sourceSkillDir,
+        "--library",
+        "--method",
+        "vercel",
+        "-y",
+        "--json",
+      ],
+      {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          NO_COLOR: "1",
+          PATH: `${fakeBinDir}:${process.env.PATH}`,
+        },
+      },
+    );
+
+    expect(
+      res.exitCode,
+      `stdout:\n${res.stdout}\nstderr:\n${res.stderr}`,
+    ).not.toBe(0);
+    expect(`${res.stdout}\n${res.stderr}`).toMatch(
+      /Library skill already exists|--force/,
+    );
+    const librarySkillMd = await readFile(
+      join(librarySkillDir, "SKILL.md"),
+      "utf-8",
+    );
+    expect(librarySkillMd).toContain("# Existing library");
+    expect(librarySkillMd).not.toContain("# New source");
   });
 });
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -20,6 +20,7 @@ import {
   readFile,
   lstat,
   readlink,
+  realpath,
   symlink,
   chmod,
 } from "fs/promises";
@@ -106,6 +107,12 @@ describe("parseArgs", () => {
     expect(result.command).toBe("uninstall");
     expect(result.subcommand).toBe("blog-draft");
     expect(result.flags.yes).toBe(true);
+  });
+
+  test("parses deactivate with skill name", () => {
+    const result = parse("deactivate", "brainstorming");
+    expect(result.command).toBe("deactivate");
+    expect(result.subcommand).toBe("brainstorming");
   });
 
   test("parses -y as alias for --yes", () => {
@@ -350,6 +357,10 @@ describe("isCLIMode", () => {
     expect(check("uninstall")).toBe(true);
   });
 
+  test("deactivate → CLI mode", () => {
+    expect(check("deactivate")).toBe(true);
+  });
+
   test("config → CLI mode", () => {
     expect(check("config")).toBe(true);
   });
@@ -414,6 +425,7 @@ describe("CLI integration: --help", () => {
     expect(stdout).toContain("search");
     expect(stdout).toContain("inspect");
     expect(stdout).toContain("uninstall");
+    expect(stdout).toContain("deactivate");
     expect(stdout).toContain("library");
     expect(stdout).toContain("config");
   });
@@ -462,6 +474,13 @@ describe("CLI integration: per-command --help", () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain("asm uninstall");
     expect(stdout).toContain("--yes");
+  });
+
+  test("deactivate --help shows deactivate usage", async () => {
+    const { stdout, exitCode } = await runCLI("deactivate", "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("asm deactivate");
+    expect(stdout).toContain("<global|project>");
   });
 
   test("config --help shows config subcommands", async () => {
@@ -1630,6 +1649,228 @@ describe("CLI integration: install --library", () => {
     expect(res.exitCode).toBe(1);
     expect(res.stderr).toContain("Target already exists");
     expect(res.stderr).toContain("--force");
+  });
+
+  test("deactivate removes a project activation symlink after install+activate", async () => {
+    const source = join(tempDir, "source");
+    const sourceSkillDir = join(source, "skills", "brainstorming");
+    await mkdir(sourceSkillDir, { recursive: true });
+    await writeFile(
+      join(sourceSkillDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Brainstorming\n",
+    );
+
+    const homeDir = join(tempDir, "home");
+    const installRes = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "install",
+        sourceSkillDir,
+        "--library",
+        "-y",
+        "--json",
+      ],
+      {
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+    expect(installRes.exitCode).toBe(0);
+
+    const projectDir = join(tempDir, "project");
+    await mkdir(projectDir, { recursive: true });
+    const activateRes = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "activate",
+        "brainstorming",
+        "-p",
+        "codex",
+        "-s",
+        "project",
+        "--json",
+      ],
+      {
+        cwd: projectDir,
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+    expect(activateRes.exitCode).toBe(0);
+
+    const targetPath = join(projectDir, ".codex", "skills", "brainstorming");
+    expect((await lstat(targetPath)).isSymbolicLink()).toBe(true);
+    const resolvedProjectDir = await realpath(projectDir);
+    const resolvedTargetPath = join(
+      resolvedProjectDir,
+      ".codex",
+      "skills",
+      "brainstorming",
+    );
+
+    const deactivateRes = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "deactivate",
+        "brainstorming",
+        "-p",
+        "codex",
+        "-s",
+        "project",
+        "--json",
+      ],
+      {
+        cwd: projectDir,
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(deactivateRes.exitCode).toBe(0);
+    const payload = JSON.parse(deactivateRes.stdout);
+    expect(payload).toMatchObject({
+      name: "brainstorming",
+      provider: "codex",
+      scope: "project",
+      path: resolvedTargetPath,
+    });
+    await expect(lstat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      readFile(
+        join(
+          homeDir,
+          ".config",
+          "agent-skill-manager",
+          "library",
+          "skills",
+          "brainstorming",
+          "SKILL.md",
+        ),
+        "utf-8",
+      ),
+    ).resolves.toContain("# Brainstorming");
+  });
+
+  test("deactivate refuses a real provider directory", async () => {
+    const homeDir = join(tempDir, "home");
+    const projectDir = join(tempDir, "project");
+    const targetPath = join(projectDir, ".codex", "skills", "brainstorming");
+    await mkdir(targetPath, { recursive: true });
+
+    const res = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "deactivate",
+        "brainstorming",
+        "-p",
+        "codex",
+        "-s",
+        "project",
+      ],
+      {
+        cwd: projectDir,
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("Refusing to deactivate non-symlink target");
+    expect(res.stderr).not.toMatch(/\n\s+at\s+/);
+    await expect(lstat(targetPath)).resolves.toBeTruthy();
+  });
+
+  test("deactivate reports missing activation", async () => {
+    const homeDir = join(tempDir, "home");
+    const projectDir = join(tempDir, "project");
+    await mkdir(projectDir, { recursive: true });
+
+    const res = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "deactivate",
+        "brainstorming",
+        "-p",
+        "codex",
+        "-s",
+        "project",
+      ],
+      {
+        cwd: projectDir,
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain('Skill "brainstorming" is not active');
+    expect(res.stderr).not.toMatch(/\n\s+at\s+/);
+  });
+
+  test("deactivate missing activation --json returns structured error", async () => {
+    const homeDir = join(tempDir, "home");
+    const projectDir = join(tempDir, "project");
+    await mkdir(projectDir, { recursive: true });
+
+    const res = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "deactivate",
+        "brainstorming",
+        "-p",
+        "codex",
+        "-s",
+        "project",
+        "--json",
+      ],
+      {
+        cwd: projectDir,
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(res.exitCode).toBe(1);
+    expect(JSON.parse(res.stdout)).toEqual({
+      error: 'Skill "brainstorming" is not active for codex/project.',
+    });
+    expect(res.stderr).not.toMatch(/\n\s+at\s+/);
+  });
+
+  test("deactivate unknown provider exits 2 with usage error", async () => {
+    const homeDir = join(tempDir, "home");
+    const projectDir = join(tempDir, "project");
+    await mkdir(projectDir, { recursive: true });
+
+    const res = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "deactivate",
+        "brainstorming",
+        "-p",
+        "no-such-provider",
+        "-s",
+        "project",
+        "--json",
+      ],
+      {
+        cwd: projectDir,
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("Unknown provider");
+    expect(res.stdout).toBe("");
+    expect(res.stderr).not.toMatch(/\n\s+at\s+/);
   });
 
   test("does not overwrite an existing library skill when only provider install exists", async () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1723,42 +1723,8 @@ describe("CLI integration: install --library", () => {
     expect(librarySkillMd).not.toContain("# New source");
   });
 
-  test("does not let Vercel method implicit force overwrite an existing library skill", async () => {
+  test("rejects Vercel method for library installs before provider delegation", async () => {
     const homeDir = join(tempDir, "home");
-    const providerSkillDir = join(homeDir, ".claude", "skills", "foo");
-    await mkdir(providerSkillDir, { recursive: true });
-    await writeFile(
-      join(providerSkillDir, "SKILL.md"),
-      `---\nname: foo\nversion: 1.0.0\n---\n# Existing provider\n`,
-    );
-
-    const librarySkillDir = join(
-      homeDir,
-      ".config",
-      "agent-skill-manager",
-      "library",
-      "skills",
-      "foo",
-    );
-    await mkdir(librarySkillDir, { recursive: true });
-    await writeFile(
-      join(librarySkillDir, "SKILL.md"),
-      `---\nname: foo\nversion: 1.0.0\n---\n# Existing library\n`,
-    );
-    await mkdir(
-      join(homeDir, ".config", "agent-skill-manager", "library"),
-      { recursive: true },
-    );
-    await writeFile(
-      join(
-        homeDir,
-        ".config",
-        "agent-skill-manager",
-        "library",
-        "library-lock.json",
-      ),
-      JSON.stringify({ version: 1, skills: {} }, null, 2) + "\n",
-    );
 
     const sourceSkillDir = join(tempDir, "source-vercel", "foo");
     await mkdir(sourceSkillDir, { recursive: true });
@@ -1773,13 +1739,13 @@ describe("CLI integration: install --library", () => {
     await writeFile(
       fakeNpx,
       `#!/bin/sh
-if [ "$1" = "--version" ]; then
-  echo "10.0.0"
-  exit 0
-fi
-echo "fake skills add"
-exit 0
-`,
+	if [ "$1" = "--version" ]; then
+	  echo "10.0.0"
+	  exit 0
+	fi
+	echo "unexpected npx delegate"
+	exit 42
+	`,
     );
     await chmod(fakeNpx, 0o755);
 
@@ -1811,15 +1777,27 @@ exit 0
       res.exitCode,
       `stdout:\n${res.stdout}\nstderr:\n${res.stderr}`,
     ).not.toBe(0);
-    expect(`${res.stdout}\n${res.stderr}`).toMatch(
-      /Library skill already exists|--force/,
+    expect(`${res.stdout}\n${res.stderr}`).toContain(
+      "--library cannot be combined with --method vercel",
     );
-    const librarySkillMd = await readFile(
-      join(librarySkillDir, "SKILL.md"),
-      "utf-8",
+    expect(`${res.stdout}\n${res.stderr}`).not.toContain(
+      "unexpected npx delegate",
     );
-    expect(librarySkillMd).toContain("# Existing library");
-    expect(librarySkillMd).not.toContain("# New source");
+    await expect(
+      lstat(join(homeDir, ".claude", "skills", "foo")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      lstat(
+        join(
+          homeDir,
+          ".config",
+          "agent-skill-manager",
+          "library",
+          "skills",
+          "foo",
+        ),
+      ),
+    ).rejects.toMatchObject({ code: "ENOENT" });
   });
 });
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1504,6 +1504,136 @@ describe("CLI integration: install --library", () => {
     });
   });
 
+  test("library update refreshes a local-source skill and outputs JSON summary", async () => {
+    const source = join(tempDir, "source");
+    const sourceSkillDir = join(source, "skills", "brainstorming");
+    await mkdir(sourceSkillDir, { recursive: true });
+    await writeFile(
+      join(sourceSkillDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Old\n",
+    );
+
+    const homeDir = join(tempDir, "home");
+    const installRes = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "install",
+        source,
+        "--library",
+        "--all",
+        "-y",
+        "--json",
+      ],
+      { env: { ...process.env, HOME: homeDir, NO_COLOR: "1" } },
+    );
+    expect(installRes.exitCode).toBe(0);
+
+    await writeFile(
+      join(sourceSkillDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 2.0.0\n---\n# New\n",
+    );
+
+    const updateRes = await spawnCollect(
+      ["npx", "tsx", CLI_BIN, "library", "update", "brainstorming", "--json"],
+      { env: { ...process.env, HOME: homeDir, NO_COLOR: "1" } },
+    );
+
+    expect(updateRes.exitCode).toBe(0);
+    const payload = JSON.parse(updateRes.stdout);
+    expect(payload.results[0]).toMatchObject({
+      name: "brainstorming",
+      status: "updated",
+      oldVersion: "1.0.0",
+      newVersion: "2.0.0",
+    });
+    await expect(
+      readFile(
+        join(
+          homeDir,
+          ".config",
+          "agent-skill-manager",
+          "library",
+          "skills",
+          "brainstorming",
+          "SKILL.md",
+        ),
+        "utf-8",
+      ),
+    ).resolves.toContain("# New");
+  });
+
+  test("library update unknown skill suggests library list and exits 1 with JSON summary", async () => {
+    const homeDir = join(tempDir, "home");
+    const res = await spawnCollect(
+      ["npx", "tsx", CLI_BIN, "library", "update", "missing", "--json"],
+      { env: { ...process.env, HOME: homeDir, NO_COLOR: "1" } },
+    );
+
+    expect(res.exitCode).toBe(1);
+    const payload = JSON.parse(res.stdout);
+    expect(payload.failedCount).toBe(1);
+    expect(payload.results[0]).toMatchObject({
+      name: "missing",
+      status: "failed",
+      reason: 'Library skill "missing" not found. Run "asm library list".',
+    });
+  });
+
+  test("library update --all --json reports partial failures with counts", async () => {
+    const source = join(tempDir, "source");
+    await mkdir(join(source, "skills", "good"), { recursive: true });
+    await mkdir(join(source, "skills", "bad"), { recursive: true });
+    await writeFile(
+      join(source, "skills", "good", "SKILL.md"),
+      "---\nname: good\nversion: 1.0.0\n---\n# Good Old\n",
+    );
+    await writeFile(
+      join(source, "skills", "bad", "SKILL.md"),
+      "---\nname: bad\nversion: 1.0.0\n---\n# Bad Old\n",
+    );
+
+    const homeDir = join(tempDir, "home");
+    const installRes = await spawnCollect(
+      [
+        "npx",
+        "tsx",
+        CLI_BIN,
+        "install",
+        source,
+        "--library",
+        "--all",
+        "-y",
+        "--json",
+      ],
+      { env: { ...process.env, HOME: homeDir, NO_COLOR: "1" } },
+    );
+    expect(installRes.exitCode).toBe(0);
+
+    await writeFile(
+      join(source, "skills", "good", "SKILL.md"),
+      "---\nname: good\nversion: 2.0.0\n---\n# Good New\n",
+    );
+    await rm(join(source, "skills", "bad", "SKILL.md"), { force: true });
+
+    const updateRes = await spawnCollect(
+      ["npx", "tsx", CLI_BIN, "library", "update", "--all", "--json"],
+      { env: { ...process.env, HOME: homeDir, NO_COLOR: "1" } },
+    );
+
+    expect(updateRes.exitCode).toBe(1);
+    const payload = JSON.parse(updateRes.stdout);
+    expect(payload.updatedCount).toBe(1);
+    expect(payload.failedCount).toBe(1);
+    expect(payload.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "good", status: "updated" }),
+        expect.objectContaining({ name: "bad", status: "failed" }),
+      ]),
+    );
+  });
+
   test("activate links a library skill into a project provider", async () => {
     const source = join(tempDir, "source");
     const sourceSkillDir = join(source, "skills", "brainstorming");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,7 +171,7 @@ import type { SearchFilters } from "./skill-index";
 import { VERSION_STRING } from "./utils/version";
 import { buildShadowingReport } from "./utils/path-shadowing";
 import { parseEditorCommand } from "./utils/editor";
-import { installLibrarySkill } from "./library";
+import { installLibrarySkill, listLibrarySkills } from "./library";
 import { setVerbose } from "./logger";
 import { join as joinPath, resolve, relative as relativePath } from "path";
 import type {
@@ -546,6 +546,7 @@ ${ansi.bold("Commands:")}
   disable <target>       Disable skill(s) without uninstalling
   enable <target>        Re-enable disabled skill(s)
   install <source>       Install a skill from GitHub or local path
+  library                Manage centrally installed library skills
   audit                  Detect duplicate skills across tools
   audit security <name>  Run security audit on a skill (or GitHub source)
   export                 Export skill inventory as JSON manifest
@@ -797,6 +798,23 @@ ${ansi.bold("Examples:")}
   asm config show                   ${ansi.dim("View current config")}
   asm config edit                   ${ansi.dim("Edit in $EDITOR")}
   asm config reset -y               ${ansi.dim("Reset without confirmation")}`);
+}
+
+function printLibraryHelp() {
+  console.log(`${ansi.bold("Usage:")} asm library <subcommand> [options]
+
+Manage centrally installed library skills.
+
+${ansi.bold("Subcommands:")}
+  list     List skills installed in the local library
+
+${ansi.bold("Options:")}
+  --json            Output as JSON array
+  -V, --verbose     Show debug output
+
+${ansi.bold("Examples:")}
+  asm library list                  ${ansi.dim("List local library skills")}
+  asm library list --json           ${ansi.dim("Output as JSON")}`);
 }
 
 // ─── Command Handlers ───────────────────────────────────────────────────────
@@ -2057,6 +2075,67 @@ async function cmdConfig(args: ParsedArgs) {
       process.exit(2);
     }
   }
+}
+
+async function cmdLibrary(args: ParsedArgs) {
+  if (args.flags.help) {
+    printLibraryHelp();
+    return;
+  }
+
+  if (args.subcommand !== "list") {
+    error("Missing or unknown library subcommand. Use: asm library list");
+    console.error(`Run "asm library --help" for usage.`);
+    process.exit(2);
+  }
+
+  const rows = await listLibrarySkills();
+
+  if (args.flags.json) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+
+  if (rows.length === 0) {
+    console.log(ansi.dim("No skills installed in the local library."));
+    return;
+  }
+
+  const widths = {
+    name: Math.max("Name".length, ...rows.map((r) => r.name.length)),
+    version: Math.max("Version".length, ...rows.map((r) => r.version.length)),
+    source: Math.max("Source".length, ...rows.map((r) => r.source.length)),
+    path: Math.max("Path".length, ...rows.map((r) => r.skillPath.length)),
+    status: "Status".length,
+  };
+  const formatRow = (
+    name: string,
+    version: string,
+    source: string,
+    path: string,
+    status: string,
+  ) =>
+    [
+      name.padEnd(widths.name),
+      version.padEnd(widths.version),
+      source.padEnd(widths.source),
+      path.padEnd(widths.path),
+      status.padEnd(widths.status),
+    ].join("  ");
+
+  const lines = [
+    ansi.bold(formatRow("Name", "Version", "Source", "Path", "Status")),
+    ...rows.map((row) =>
+      formatRow(
+        row.name,
+        row.version,
+        row.source,
+        row.skillPath,
+        row.missing ? "missing" : "ok",
+      ),
+    ),
+  ];
+  console.log(lines.join("\n"));
 }
 
 function printInstallHelp() {
@@ -6046,6 +6125,9 @@ export async function runCLI(argv: string[]): Promise<void> {
     case "install":
       await cmdInstall(args);
       break;
+    case "library":
+      await cmdLibrary(args);
+      break;
     case "config":
       await cmdConfig(args);
       break;
@@ -6110,6 +6192,7 @@ export function isCLIMode(argv: string[]): boolean {
     "audit",
     "config",
     "install",
+    "library",
     "export",
     "import",
     "init",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,7 +171,12 @@ import type { SearchFilters } from "./skill-index";
 import { VERSION_STRING } from "./utils/version";
 import { buildShadowingReport } from "./utils/path-shadowing";
 import { parseEditorCommand } from "./utils/editor";
-import { installLibrarySkill, listLibrarySkills } from "./library";
+import {
+  activateLibrarySkill,
+  findLibrarySkill,
+  installLibrarySkill,
+  listLibrarySkills,
+} from "./library";
 import { setVerbose } from "./logger";
 import { join as joinPath, resolve, relative as relativePath } from "path";
 import type {
@@ -546,6 +551,7 @@ ${ansi.bold("Commands:")}
   disable <target>       Disable skill(s) without uninstalling
   enable <target>        Re-enable disabled skill(s)
   install <source>       Install a skill from GitHub or local path
+  activate <skill>       Link a library skill into a provider
   library                Manage centrally installed library skills
   audit                  Detect duplicate skills across tools
   audit security <name>  Run security audit on a skill (or GitHub source)
@@ -815,6 +821,24 @@ ${ansi.bold("Options:")}
 ${ansi.bold("Examples:")}
   asm library list                  ${ansi.dim("List local library skills")}
   asm library list --json           ${ansi.dim("Output as JSON")}`);
+}
+
+function printActivateHelp() {
+  console.log(`${ansi.bold("Usage:")} asm activate <skill> -p <tool> -s <scope> [options]
+
+Link a centrally installed library skill into a provider skill folder.
+
+${ansi.bold("Options:")}
+  -p, --tool <name>      Provider to activate into (e.g., claude, codex)
+  -s, --scope <scope>    Activation scope: global or project
+  --name <name>          Link name to create (default: library directory name)
+  -f, --force            Replace an existing target
+  --json                 Output as JSON object
+  -V, --verbose          Show debug output
+
+${ansi.bold("Examples:")}
+  asm activate brainstorming -p codex -s project
+  asm activate brainstorming -p claude -s global --json`);
 }
 
 // ─── Command Handlers ───────────────────────────────────────────────────────
@@ -2136,6 +2160,73 @@ async function cmdLibrary(args: ParsedArgs) {
     ),
   ];
   console.log(lines.join("\n"));
+}
+
+async function cmdActivate(args: ParsedArgs) {
+  if (args.flags.help) {
+    printActivateHelp();
+    return;
+  }
+
+  const skillName = args.subcommand;
+  if (!skillName) {
+    error("Missing skill name. Use: asm activate <skill>");
+    console.error(`Run "asm activate --help" for usage.`);
+    process.exit(2);
+  }
+
+  if (args.flags.scope === "both") {
+    error("Activation requires --scope global or --scope project.");
+    process.exit(2);
+  }
+
+  const rows = await listLibrarySkills();
+  const skill = findLibrarySkill(rows, skillName);
+  if (!skill) {
+    error(`Library skill "${skillName}" not found. Run "asm library list".`);
+    process.exit(1);
+  }
+  if (skill.missing) {
+    error(
+      `Library skill "${skillName}" is missing on disk: ${skill.libraryPath}`,
+    );
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const { provider } = await resolveProvider(
+    config,
+    args.flags.provider,
+    process.stdin.isTTY,
+  );
+  const targetTemplate =
+    args.flags.scope === "global" ? provider.global : provider.project;
+  const targetDir = resolveProviderPath(targetTemplate);
+  const activationName = args.flags.name || skill.dirName;
+  const result = await activateLibrarySkill({
+    libraryPath: skill.libraryPath,
+    targetDir,
+    activationName,
+    force: args.flags.force,
+  });
+
+  const payload = {
+    name: activationName,
+    skill: skill.dirName,
+    provider: provider.name,
+    scope: args.flags.scope,
+    path: result.symlinkPath,
+    target: result.targetPath,
+  };
+
+  if (args.flags.json) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  console.log(
+    `${ansi.green("✓")} activated ${activationName} (${provider.name}/${args.flags.scope}) -> ${result.targetPath}`,
+  );
 }
 
 function printInstallHelp() {
@@ -6125,6 +6216,9 @@ export async function runCLI(argv: string[]): Promise<void> {
     case "install":
       await cmdInstall(args);
       break;
+    case "activate":
+      await cmdActivate(args);
+      break;
     case "library":
       await cmdLibrary(args);
       break;
@@ -6192,6 +6286,7 @@ export function isCLIMode(argv: string[]): boolean {
     "audit",
     "config",
     "install",
+    "activate",
     "library",
     "export",
     "import",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2738,6 +2738,12 @@ async function cmdInstall(args: ParsedArgs) {
       console.info(`  ${ansi.dim(sourceStr)}`);
     }
 
+    if (args.flags.library && args.flags.method === "vercel") {
+      throw new Error(
+        "--library cannot be combined with --method vercel because the Vercel installer writes to provider skill folders. Use the default method for library installs.",
+      );
+    }
+
     // Vercel method: delegate to npx skills add and then continue with
     // standard asm install to register in asm's local inventory
     if (args.flags.method === "vercel") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@ import {
   loadConfig,
   getConfigPath,
   getDefaultConfig,
+  getLibrarySkillsDir,
   saveConfig,
   resolveProviderPath,
 } from "./config";
@@ -170,6 +171,7 @@ import type { SearchFilters } from "./skill-index";
 import { VERSION_STRING } from "./utils/version";
 import { buildShadowingReport } from "./utils/path-shadowing";
 import { parseEditorCommand } from "./utils/editor";
+import { installLibrarySkill } from "./library";
 import { setVerbose } from "./logger";
 import { join as joinPath, resolve, relative as relativePath } from "path";
 import type {
@@ -244,6 +246,7 @@ interface ParsedArgs {
     force: boolean;
     path: string | null;
     all: boolean;
+    library: boolean;
     verbose: boolean;
     flat: boolean;
     transport: TransportMode;
@@ -316,6 +319,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
       force: false,
       path: null,
       all: false,
+      library: false,
       verbose: false,
       flat: false,
       transport: "auto",
@@ -398,6 +402,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       result.flags.path = args[i] || null;
     } else if (arg === "--all") {
       result.flags.all = true;
+    } else if (arg === "--library") {
+      result.flags.library = true;
     } else if (arg === "--verbose" || arg === "-V") {
       result.flags.verbose = true;
     } else if (arg === "--flat") {
@@ -2081,6 +2087,7 @@ ${ansi.bold("Options:")}
   --path <subdir>        Install skill from a subdirectory of the repo
   --skill <name>         Alias for --path (Vercel skills CLI compatibility)
   --all                  Install all skills found in the repo
+  --library              Install into asm's neutral local library
   -m, --method <method>  Install method: default or vercel (default: default)
                          vercel delegates to npx skills add for tracking
   -t, --transport <mode> Transport: https, ssh, or auto (default: auto)
@@ -2104,6 +2111,7 @@ ${ansi.bold("Local folder:")}
   asm install ~/skills/my-skill            ${ansi.dim("(home-relative path)")}
   asm install ../other-project/skill       ${ansi.dim("(parent-relative path)")}
   asm install ./skills-dir --all           ${ansi.dim("(all skills in directory)")}
+  asm install ./skills-dir --library --all -y ${ansi.dim("(install to local library)")}
 
 ${ansi.bold("Single-skill repo:")}
   asm install github:user/my-skill
@@ -2333,6 +2341,54 @@ async function executeSkillInstall(
   return await executeInstall(plan);
 }
 
+async function installSelectedLibrarySkill(input: {
+  inspection: SkillInspection;
+  source: ReturnType<typeof parseSource>;
+  isLocal: boolean;
+  resolutionSource: ResolutionSource;
+  commitHash: string | null;
+  scanBaseDir: string;
+  force: boolean;
+}): Promise<InstallResult> {
+  const {
+    inspection,
+    source,
+    isLocal,
+    resolutionSource,
+    commitHash,
+    scanBaseDir,
+    force,
+  } = input;
+  const sourceStr = isLocal
+    ? `local:${source.localPath}`
+    : `github:${source.owner}/${source.repo}`;
+  const sourceType = isLocal
+    ? ("local" as const)
+    : resolutionSource === "registry"
+      ? ("registry" as const)
+      : ("github" as const);
+  const skillPath = relativePath(scanBaseDir, inspection.plan.sourceDir);
+  const installed = await installLibrarySkill({
+    sourceDir: inspection.plan.sourceDir,
+    libraryName: inspection.skillName,
+    source: sourceStr,
+    sourceType,
+    commitHash: commitHash || "unknown",
+    ref: source.ref || "main",
+    skillPath,
+    force,
+  });
+
+  return {
+    success: true,
+    path: installed.libraryPath,
+    name: installed.name,
+    version: installed.version,
+    provider: "Library",
+    source: sourceStr,
+  };
+}
+
 async function cmdInstall(args: ParsedArgs) {
   if (args.flags.help) {
     printInstallHelp();
@@ -2344,6 +2400,7 @@ async function cmdInstall(args: ParsedArgs) {
     : undefined;
 
   const startTime = performance.now();
+  const explicitForce = args.flags.force;
   let sourceStr = args.subcommand;
   if (!sourceStr) {
     error("Missing required argument: <source>");
@@ -2543,54 +2600,70 @@ async function cmdInstall(args: ParsedArgs) {
     }
 
     // Step 2: Select provider (before cloning — no wasted time if user cancels)
-    console.info(stepHeader("Selecting provider"));
     const config = await loadConfig();
-    const { provider, allProviders } = await resolveProvider(
-      config,
-      args.flags.provider,
-      !!process.stdin.isTTY,
-    );
+    let provider: ProviderConfig;
+    let allProviders: ProviderConfig[] | null = null;
+    let installScope: "global" | "project" = "global";
 
-    // Step 3: Select scope (global or project)
-    console.info(stepHeader("Selecting scope"));
-    let installScope: "global" | "project";
-
-    if (args.flags.scope === "global" || args.flags.scope === "project") {
-      // Explicit --scope flag provided
-      installScope = args.flags.scope;
-      console.info(
-        `  ${ansi.dim(`scope: ${installScope}`)}${installScope === "global" ? ` (${provider.global})` : ` (${provider.project})`}`,
-      );
-    } else if (!process.stdin.isTTY || args.flags.yes) {
-      // Non-interactive mode: default to global
-      installScope = "global";
-      console.info(
-        `  ${ansi.dim(`scope: global (default)`)} (${provider.global})`,
-      );
-    } else {
-      // Interactive: prompt user to choose
-      const scopeItems = [
-        {
-          label: `Global (${provider.global})`,
-          hint: "Available in all projects",
-          checked: true,
-        },
-        {
-          label: `Project (${provider.project})`,
-          hint: "Available only in this project",
-          checked: false,
-        },
-      ];
-      console.info(""); // blank line before picker
-      const scopeIndices = await checkboxPicker({ items: scopeItems });
-      if (scopeIndices.length === 0) {
-        throw new Error("No scope selected. Aborting.");
+    if (args.flags.library) {
+      console.info(stepHeader("Selecting library"));
+      const inspectionProvider =
+        config.providers.find((p) => p.enabled) ?? config.providers[0];
+      if (!inspectionProvider) {
+        throw new Error("No providers configured.");
       }
-      // Use the first selected scope (single-select behavior)
-      installScope = scopeIndices[0] === 0 ? "global" : "project";
-      console.info(
-        `  Selected: ${ansi.bold(installScope)} ${ansi.dim(`(${installScope === "global" ? provider.global : provider.project})`)}`,
+      provider = inspectionProvider;
+      console.info(`  ${ansi.dim(`library: ${getLibrarySkillsDir()}`)}`);
+    } else {
+      console.info(stepHeader("Selecting provider"));
+      const resolved = await resolveProvider(
+        config,
+        args.flags.provider,
+        !!process.stdin.isTTY,
       );
+      provider = resolved.provider;
+      allProviders = resolved.allProviders;
+
+      // Step 3: Select scope (global or project)
+      console.info(stepHeader("Selecting scope"));
+
+      if (args.flags.scope === "global" || args.flags.scope === "project") {
+        // Explicit --scope flag provided
+        installScope = args.flags.scope;
+        console.info(
+          `  ${ansi.dim(`scope: ${installScope}`)}${installScope === "global" ? ` (${provider.global})` : ` (${provider.project})`}`,
+        );
+      } else if (!process.stdin.isTTY || args.flags.yes) {
+        // Non-interactive mode: default to global
+        installScope = "global";
+        console.info(
+          `  ${ansi.dim(`scope: global (default)`)} (${provider.global})`,
+        );
+      } else {
+        // Interactive: prompt user to choose
+        const scopeItems = [
+          {
+            label: `Global (${provider.global})`,
+            hint: "Available in all projects",
+            checked: true,
+          },
+          {
+            label: `Project (${provider.project})`,
+            hint: "Available only in this project",
+            checked: false,
+          },
+        ];
+        console.info(""); // blank line before picker
+        const scopeIndices = await checkboxPicker({ items: scopeItems });
+        if (scopeIndices.length === 0) {
+          throw new Error("No scope selected. Aborting.");
+        }
+        // Use the first selected scope (single-select behavior)
+        installScope = scopeIndices[0] === 0 ? "global" : "project";
+        console.info(
+          `  Selected: ${ansi.bold(installScope)} ${ansi.dim(`(${installScope === "global" ? provider.global : provider.project})`)}`,
+        );
+      }
     }
 
     // Step 4: Clone repository (or read local source)
@@ -2963,41 +3036,53 @@ async function cmdInstall(args: ParsedArgs) {
         console.info(
           `${progress}Installing ${ansi.bold(inspection.metadata.name)}...`,
         );
-        const result = await executeSkillInstall(inspection.plan, allProviders);
+        const result = args.flags.library
+          ? await installSelectedLibrarySkill({
+              inspection,
+              source,
+              isLocal,
+              resolutionSource,
+              commitHash,
+              scanBaseDir,
+              force: explicitForce,
+            })
+          : await executeSkillInstall(inspection.plan, allProviders);
         results.push(result);
         console.info(
-          `${progress}${ansi.green("✓")} ${inspection.metadata.name} installed to ${ansi.dim(inspection.plan.targetDir)}`,
+          `${progress}${ansi.green("✓")} ${inspection.metadata.name} installed to ${ansi.dim(result.path)}`,
         );
 
         // Write lock entry for tracking
-        try {
-          const sourceStr = isLocal
-            ? `local:${source.localPath}`
-            : `github:${source.owner}/${source.repo}`;
-          const sourceType = isLocal
-            ? ("local" as const)
-            : resolutionSource === "registry"
-              ? ("registry" as const)
-              : ("github" as const);
-          await writeLockEntry(result.name, {
-            source: sourceStr,
-            commitHash: commitHash || "unknown",
-            ref: source.ref || "main",
-            installedAt: new Date().toISOString(),
-            provider: inspection.plan.providerName,
-            scope: inspection.plan.scope,
-            skillPath: relativePath(
-              inspection.plan.tempDir,
-              inspection.plan.sourceDir,
-            ),
-            targetDir: inspection.plan.targetDir,
-            sourceType,
-            ...(resolutionSource === "registry"
-              ? { registryName: result.name }
-              : {}),
-          });
-        } catch {
-          // Lock write failure is non-fatal
+        if (!args.flags.library) {
+          try {
+            const sourceStr = isLocal
+              ? `local:${source.localPath}`
+              : `github:${source.owner}/${source.repo}`;
+            const sourceType = isLocal
+              ? ("local" as const)
+              : resolutionSource === "registry"
+                ? ("registry" as const)
+                : ("github" as const);
+            await writeLockEntry(result.name, {
+              source: sourceStr,
+              commitHash: commitHash || "unknown",
+              ref: source.ref || "main",
+              installedAt: new Date().toISOString(),
+              provider: inspection.plan.providerName,
+              scope: inspection.plan.scope,
+              skillPath: relativePath(
+                inspection.plan.tempDir,
+                inspection.plan.sourceDir,
+              ),
+              targetDir: inspection.plan.targetDir,
+              sourceType,
+              ...(resolutionSource === "registry"
+                ? { registryName: result.name }
+                : {}),
+            });
+          } catch {
+            // Lock write failure is non-fatal
+          }
         }
       } catch (installErr: any) {
         failures.push({
@@ -3021,6 +3106,9 @@ async function cmdInstall(args: ParsedArgs) {
       );
       for (const f of failures) {
         console.error(`  ${ansi.red("✗")} ${f.name}: ${f.error}`);
+      }
+      if (args.flags.library) {
+        process.exitCode = 1;
       }
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -177,6 +177,7 @@ import {
   findLibrarySkill,
   installLibrarySkill,
   listLibrarySkills,
+  updateLibrarySkills,
 } from "./library";
 import { setVerbose } from "./logger";
 import { join as joinPath, resolve, relative as relativePath } from "path";
@@ -814,15 +815,18 @@ function printLibraryHelp() {
 Manage centrally installed library skills.
 
 ${ansi.bold("Subcommands:")}
-  list     List skills installed in the local library
+  list                 List skills installed in the local library
+  update <skill>       Update one local library skill
+  update --all         Update all local library skills
 
 ${ansi.bold("Options:")}
-  --json            Output as JSON array
+  --json            Output as JSON
   -V, --verbose     Show debug output
 
 ${ansi.bold("Examples:")}
   asm library list                  ${ansi.dim("List local library skills")}
-  asm library list --json           ${ansi.dim("Output as JSON")}`);
+  asm library update brainstorming  ${ansi.dim("Update one local library skill")}
+  asm library update --all --json   ${ansi.dim("Update all and output as JSON")}`);
 }
 
 function printActivateHelp() {
@@ -2125,19 +2129,31 @@ async function cmdLibrary(args: ParsedArgs) {
     return;
   }
 
-  if (args.subcommand !== "list") {
-    error("Missing or unknown library subcommand. Use: asm library list");
-    console.error(`Run "asm library --help" for usage.`);
-    process.exit(2);
-  }
-
-  const rows = await listLibrarySkills();
-
-  if (args.flags.json) {
-    console.log(JSON.stringify(rows, null, 2));
+  if (args.subcommand === "update") {
+    await cmdLibraryUpdate(args);
     return;
   }
 
+  if (args.subcommand === "list") {
+    const rows = await listLibrarySkills();
+
+    if (args.flags.json) {
+      console.log(JSON.stringify(rows, null, 2));
+      return;
+    }
+
+    printLibraryList(rows);
+    return;
+  }
+
+  error(
+    "Missing or unknown library subcommand. Use: asm library list or asm library update",
+  );
+  console.error(`Run "asm library --help" for usage.`);
+  process.exit(2);
+}
+
+function printLibraryList(rows: Awaited<ReturnType<typeof listLibrarySkills>>) {
   if (rows.length === 0) {
     console.log(ansi.dim("No skills installed in the local library."));
     return;
@@ -2178,6 +2194,61 @@ async function cmdLibrary(args: ParsedArgs) {
     ),
   ];
   console.log(lines.join("\n"));
+}
+
+function printLibraryUpdateHuman(
+  summary: Awaited<ReturnType<typeof updateLibrarySkills>>,
+) {
+  for (const result of summary.results) {
+    if (result.status === "updated") {
+      console.log(
+        `${ansi.green("✓")} ${result.name}: ${
+          result.oldVersion ?? "unknown"
+        } -> ${result.newVersion ?? "unknown"}`,
+      );
+    } else if (result.status === "skipped") {
+      console.log(
+        `${ansi.yellow("-")} ${result.name}: ${result.reason ?? "skipped"}`,
+      );
+    } else {
+      console.log(
+        `${ansi.red("x")} ${result.name}: ${result.reason ?? "failed"}`,
+      );
+    }
+  }
+
+  console.log(
+    `${summary.updatedCount} updated, ${summary.skippedCount} skipped, ${summary.failedCount} failed`,
+  );
+}
+
+async function cmdLibraryUpdate(args: ParsedArgs) {
+  const names = [...args.positional];
+
+  if (!args.flags.all && names.length === 0) {
+    error(
+      "Missing skill name. Use: asm library update <skill> or asm library update --all",
+    );
+    process.exit(2);
+  }
+  if (args.flags.all && names.length > 0) {
+    error(
+      "Use either asm library update <skill> or asm library update --all, not both.",
+    );
+    process.exit(2);
+  }
+
+  const summary = await updateLibrarySkills(args.flags.all ? null : names);
+
+  if (args.flags.json) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    printLibraryUpdateHuman(summary);
+  }
+
+  if (summary.failedCount > 0) {
+    process.exit(1);
+  }
 }
 
 async function cmdActivate(args: ParsedArgs) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,7 +171,7 @@ import { VERSION_STRING } from "./utils/version";
 import { buildShadowingReport } from "./utils/path-shadowing";
 import { parseEditorCommand } from "./utils/editor";
 import { setVerbose } from "./logger";
-import { join as joinPath, resolve } from "path";
+import { join as joinPath, resolve, relative as relativePath } from "path";
 import type {
   Scope,
   SortBy,
@@ -2985,6 +2985,12 @@ async function cmdInstall(args: ParsedArgs) {
             ref: source.ref || "main",
             installedAt: new Date().toISOString(),
             provider: inspection.plan.providerName,
+            scope: inspection.plan.scope,
+            skillPath: relativePath(
+              inspection.plan.tempDir,
+              inspection.plan.sourceDir,
+            ),
+            targetDir: inspection.plan.targetDir,
             sourceType,
             ...(resolutionSource === "registry"
               ? { registryName: result.name }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -173,6 +173,7 @@ import { buildShadowingReport } from "./utils/path-shadowing";
 import { parseEditorCommand } from "./utils/editor";
 import {
   activateLibrarySkill,
+  deactivateLibrarySkill,
   findLibrarySkill,
   installLibrarySkill,
   listLibrarySkills,
@@ -552,6 +553,7 @@ ${ansi.bold("Commands:")}
   enable <target>        Re-enable disabled skill(s)
   install <source>       Install a skill from GitHub or local path
   activate <skill>       Link a library skill into a provider
+  deactivate <skill>     Remove a library activation from a provider
   library                Manage centrally installed library skills
   audit                  Detect duplicate skills across tools
   audit security <name>  Run security audit on a skill (or GitHub source)
@@ -839,6 +841,22 @@ ${ansi.bold("Options:")}
 ${ansi.bold("Examples:")}
   asm activate brainstorming -p codex -s project
   asm activate brainstorming -p claude -s global --json`);
+}
+
+function printDeactivateHelp() {
+  console.log(`${ansi.bold("Usage:")} asm deactivate <skill> -p <tool> -s <global|project> [options]
+
+Remove a centrally activated library skill from a provider skill folder.
+
+${ansi.bold("Options:")}
+  -p, --tool <name>      Provider to deactivate from (e.g., claude, codex)
+  -s, --scope <scope>    Activation scope: global or project
+  --json                 Output as JSON object
+  -V, --verbose          Show debug output
+
+${ansi.bold("Examples:")}
+  asm deactivate brainstorming -p codex -s project
+  asm deactivate brainstorming -p claude -s global --json`);
 }
 
 // ─── Command Handlers ───────────────────────────────────────────────────────
@@ -2227,6 +2245,66 @@ async function cmdActivate(args: ParsedArgs) {
   console.log(
     `${ansi.green("✓")} activated ${activationName} (${provider.name}/${args.flags.scope}) -> ${result.targetPath}`,
   );
+}
+
+async function cmdDeactivate(args: ParsedArgs) {
+  if (args.flags.help) {
+    printDeactivateHelp();
+    return;
+  }
+
+  const skillName = args.subcommand;
+  if (!skillName) {
+    error("Missing skill name. Use: asm deactivate <skill>");
+    console.error(`Run "asm deactivate --help" for usage.`);
+    process.exit(2);
+  }
+
+  if (args.flags.scope === "both") {
+    error("Deactivation requires --scope global or --scope project.");
+    process.exit(2);
+  }
+
+  const config = await loadConfig();
+  let provider: ProviderConfig;
+  try {
+    provider = (
+      await resolveProvider(config, args.flags.provider, process.stdin.isTTY)
+    ).provider;
+  } catch (err: any) {
+    const message = err instanceof Error ? err.message : String(err);
+    error(message);
+    process.exit(2);
+  }
+
+  try {
+    const targetTemplate =
+      args.flags.scope === "global" ? provider.global : provider.project;
+    const targetDir = resolveProviderPath(targetTemplate);
+    const result = await deactivateLibrarySkill({
+      targetDir,
+      activationName: skillName,
+      provider: provider.name,
+      scope: args.flags.scope,
+    });
+
+    if (args.flags.json) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+
+    console.log(
+      `${ansi.green("✓")} deactivated ${result.name} (${result.provider}/${result.scope}) -> ${result.target}`,
+    );
+  } catch (err: any) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (args.flags.json) {
+      console.log(JSON.stringify({ error: message }, null, 2));
+      process.exit(1);
+    }
+    error(message);
+    process.exit(1);
+  }
 }
 
 function printInstallHelp() {
@@ -6225,6 +6303,9 @@ export async function runCLI(argv: string[]): Promise<void> {
     case "activate":
       await cmdActivate(args);
       break;
+    case "deactivate":
+      await cmdDeactivate(args);
+      break;
     case "library":
       await cmdLibrary(args);
       break;
@@ -6293,6 +6374,7 @@ export function isCLIMode(argv: string[]): boolean {
     "config",
     "install",
     "activate",
+    "deactivate",
     "library",
     "export",
     "import",

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,9 @@ const CONFIG_PATH = join(CONFIG_DIR, "config.json");
 const LOCK_PATH = join(CONFIG_DIR, ".skill-lock.json");
 const SKILL_STATE_PATH = join(CONFIG_DIR, "skill-state.json");
 const INDEX_DIR = join(CONFIG_DIR, "skill-index");
+const LIBRARY_DIR = join(CONFIG_DIR, "library");
+const LIBRARY_SKILLS_DIR = join(LIBRARY_DIR, "skills");
+const LIBRARY_LOCK_PATH = join(LIBRARY_DIR, "library-lock.json");
 
 const DEFAULT_PROVIDERS: ProviderConfig[] = [
   // ── Priority providers (ordered by user preference) ──
@@ -188,6 +191,18 @@ export function getSkillStatePath(): string {
 
 export function getIndexDir(): string {
   return INDEX_DIR;
+}
+
+export function getLibraryDir(): string {
+  return LIBRARY_DIR;
+}
+
+export function getLibrarySkillsDir(): string {
+  return LIBRARY_SKILLS_DIR;
+}
+
+export function getLibraryLockPath(): string {
+  return LIBRARY_LOCK_PATH;
 }
 
 export function getBundledIndexDir(): string {

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -1,9 +1,19 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
-import { lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readlink,
+  rm,
+  symlink,
+  writeFile,
+} from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
   emptyLibraryLock,
+  activateLibrarySkill,
   installLibrarySkill,
   readLibraryLock,
   writeLibraryLock,
@@ -195,6 +205,94 @@ describe("installLibrarySkill", () => {
     await expect(readLibraryLock(lockPath)).resolves.toEqual({
       version: 1,
       skills: {},
+    });
+  });
+});
+
+describe("activateLibrarySkill", () => {
+  let tempDir: string;
+  let libraryPath: string;
+  let targetDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-activate-"));
+    libraryPath = join(tempDir, "library", "skills", "brainstorming");
+    targetDir = join(tempDir, "provider", "skills");
+    await mkdir(libraryPath, { recursive: true });
+    await writeFile(
+      join(libraryPath, "SKILL.md"),
+      "---\nname: brainstorming\n---\n# Brainstorming\n",
+    );
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("creates a symlink from provider target to library skill", async () => {
+    const result = await activateLibrarySkill({
+      libraryPath,
+      targetDir,
+      activationName: "brainstorming",
+      force: false,
+    });
+
+    const symlinkPath = join(targetDir, "brainstorming");
+    expect(result).toEqual({ symlinkPath, targetPath: libraryPath });
+    await expect(readlink(symlinkPath)).resolves.toBe(libraryPath);
+    await expect(lstat(symlinkPath)).resolves.toMatchObject({
+      isSymbolicLink: expect.any(Function),
+    });
+    expect((await lstat(symlinkPath)).isSymbolicLink()).toBe(true);
+  });
+
+  test("refuses an existing target without force", async () => {
+    const symlinkPath = join(targetDir, "brainstorming");
+    const existingPath = join(tempDir, "existing");
+    await mkdir(targetDir, { recursive: true });
+    await mkdir(existingPath, { recursive: true });
+    await symlink(existingPath, symlinkPath, "dir");
+
+    await expect(
+      activateLibrarySkill({
+        libraryPath,
+        targetDir,
+        activationName: "brainstorming",
+        force: false,
+      }),
+    ).rejects.toThrow(
+      `Target already exists: ${symlinkPath}. Use --force to overwrite.`,
+    );
+
+    await expect(readlink(symlinkPath)).resolves.toBe(existingPath);
+  });
+
+  test("rejects invalid activation names before touching filesystem targets", async () => {
+    const outsideDir = join(tempDir, "provider", "outside");
+    const outsideSentinel = join(outsideDir, "sentinel.txt");
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(outsideSentinel, "keep me", "utf-8");
+
+    for (const activationName of [
+      "",
+      "../outside",
+      "nested/name",
+      "nested\\name",
+      "bad\0name",
+    ]) {
+      await expect(
+        activateLibrarySkill({
+          libraryPath,
+          targetDir,
+          activationName,
+          force: true,
+        }),
+      ).rejects.toThrow(/Invalid skill name/);
+    }
+
+    await expect(readFile(outsideSentinel, "utf-8")).resolves.toBe("keep me");
+    await expect(lstat(join(targetDir, "nested"))).rejects.toMatchObject({
+      code: "ENOENT",
     });
   });
 });

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -1,9 +1,10 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
   emptyLibraryLock,
+  installLibrarySkill,
   readLibraryLock,
   writeLibraryLock,
 } from "./library";
@@ -59,5 +60,141 @@ describe("library lock", () => {
     await expect(readFile(lockPath + ".bak", "utf-8")).resolves.toBe(
       invalidLock,
     );
+  });
+});
+
+describe("installLibrarySkill", () => {
+  let tempDir: string;
+  let lockPath: string;
+  let skillsDir: string;
+  let sourceDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-install-"));
+    lockPath = join(tempDir, "library-lock.json");
+    skillsDir = join(tempDir, "skills");
+    sourceDir = join(tempDir, "source", "skills", "brainstorming");
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(
+      join(sourceDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Body\n",
+    );
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("copies a skill directory and writes source metadata", async () => {
+    await writeFile(
+      join(sourceDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.2.3\n---\n# Brainstorming\n",
+    );
+
+    const result = await installLibrarySkill(
+      {
+        sourceDir,
+        libraryName: "brainstorming",
+        source: "github:obra/superpowers",
+        sourceType: "github",
+        commitHash: "abc123",
+        ref: "main",
+        skillPath: "skills/brainstorming",
+        force: false,
+      },
+      { skillsDir, lockPath },
+    );
+
+    expect(result.name).toBe("brainstorming");
+    expect(result.version).toBe("1.2.3");
+    expect(
+      await readFile(join(result.libraryPath, "SKILL.md"), "utf-8"),
+    ).toContain("Brainstorming");
+
+    const lock = await readLibraryLock(lockPath);
+    expect(lock.skills.brainstorming).toMatchObject({
+      name: "brainstorming",
+      version: "1.2.3",
+      source: "github:obra/superpowers",
+      sourceType: "github",
+      commitHash: "abc123",
+      ref: "main",
+      skillPath: "skills/brainstorming",
+      libraryPath: result.libraryPath,
+    });
+  });
+
+  test("refuses to overwrite an existing library skill without force", async () => {
+    await installLibrarySkill(
+      {
+        sourceDir,
+        libraryName: "brainstorming",
+        source: "local:/tmp/source",
+        sourceType: "local",
+        commitHash: "unknown",
+        ref: null,
+        skillPath: "skills/brainstorming",
+        force: false,
+      },
+      { skillsDir, lockPath },
+    );
+
+    await expect(
+      installLibrarySkill(
+        {
+          sourceDir,
+          libraryName: "brainstorming",
+          source: "local:/tmp/source",
+          sourceType: "local",
+          commitHash: "unknown",
+          ref: null,
+          skillPath: "skills/brainstorming",
+          force: false,
+        },
+        { skillsDir, lockPath },
+      ),
+    ).rejects.toThrow(/already exists/);
+
+    await expect(lstat(join(skillsDir, "brainstorming"))).resolves.toBeTruthy();
+  });
+
+  test("rejects invalid library names before touching filesystem targets", async () => {
+    const outsideDir = join(tempDir, "outside");
+    const outsideSentinel = join(outsideDir, "sentinel.txt");
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(outsideSentinel, "keep me", "utf-8");
+
+    for (const libraryName of [
+      "",
+      "../outside",
+      "nested/name",
+      "nested\\name",
+      "bad\0name",
+    ]) {
+      await expect(
+        installLibrarySkill(
+          {
+            sourceDir,
+            libraryName,
+            source: "local:/tmp/source",
+            sourceType: "local",
+            commitHash: "unknown",
+            ref: null,
+            skillPath: "skills/brainstorming",
+            force: true,
+          },
+          { skillsDir, lockPath },
+        ),
+      ).rejects.toThrow(/Invalid skill name/);
+    }
+
+    await expect(readFile(outsideSentinel, "utf-8")).resolves.toBe("keep me");
+    await expect(lstat(join(skillsDir, "nested"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(readLibraryLock(lockPath)).resolves.toEqual({
+      version: 1,
+      skills: {},
+    });
   });
 });

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -5,15 +5,17 @@ import {
   mkdtemp,
   readFile,
   readlink,
+  realpath,
   rm,
   symlink,
   writeFile,
 } from "fs/promises";
 import { tmpdir } from "os";
-import { join } from "path";
+import { join, relative, resolve } from "path";
 import {
   emptyLibraryLock,
   activateLibrarySkill,
+  deactivateLibrarySkill,
   installLibrarySkill,
   readLibraryLock,
   writeLibraryLock,
@@ -294,5 +296,220 @@ describe("activateLibrarySkill", () => {
     await expect(lstat(join(targetDir, "nested"))).rejects.toMatchObject({
       code: "ENOENT",
     });
+  });
+});
+
+describe("deactivateLibrarySkill", () => {
+  let tempDir: string;
+  let librarySkillsDir: string;
+  let libraryPath: string;
+  let targetDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-deactivate-"));
+    librarySkillsDir = join(tempDir, "library", "skills");
+    libraryPath = join(librarySkillsDir, "brainstorming");
+    targetDir = join(tempDir, "provider", "skills");
+    await mkdir(libraryPath, { recursive: true });
+    await mkdir(targetDir, { recursive: true });
+    await writeFile(
+      join(libraryPath, "SKILL.md"),
+      "---\nname: brainstorming\n---\n# Brainstorming\n",
+    );
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("removes a provider symlink pointing into the library", async () => {
+    const symlinkPath = join(targetDir, "brainstorming");
+    await symlink(libraryPath, symlinkPath, "dir");
+    const target = await realpath(libraryPath);
+
+    const result = await deactivateLibrarySkill({
+      targetDir,
+      activationName: "brainstorming",
+      librarySkillsDir,
+      provider: "codex",
+      scope: "project",
+    });
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      provider: "codex",
+      scope: "project",
+      path: symlinkPath,
+      target,
+    });
+    await expect(lstat(symlinkPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Brainstorming",
+    );
+  });
+
+  test("removes a provider symlink with a relative target into the library", async () => {
+    const symlinkPath = join(targetDir, "brainstorming");
+    const relativeTarget = relative(targetDir, libraryPath);
+    await symlink(relativeTarget, symlinkPath, "dir");
+    const target = await realpath(libraryPath);
+
+    const result = await deactivateLibrarySkill({
+      targetDir,
+      activationName: "brainstorming",
+      librarySkillsDir,
+      provider: "codex",
+      scope: "project",
+    });
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      provider: "codex",
+      scope: "project",
+      path: symlinkPath,
+      target,
+    });
+    await expect(lstat(symlinkPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Brainstorming",
+    );
+  });
+
+  test("removes a broken relative symlink that lexically points into the library", async () => {
+    const symlinkPath = join(targetDir, "brainstorming");
+    const relativeTarget = relative(targetDir, libraryPath);
+    const expectedTarget = resolve(targetDir, relativeTarget);
+    await symlink(relativeTarget, symlinkPath, "dir");
+    await rm(libraryPath, { recursive: true, force: true });
+
+    const result = await deactivateLibrarySkill({
+      targetDir,
+      activationName: "brainstorming",
+      librarySkillsDir,
+      provider: "codex",
+      scope: "project",
+    });
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      provider: "codex",
+      scope: "project",
+      path: symlinkPath,
+      target: expectedTarget,
+    });
+    await expect(lstat(symlinkPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("removes a symlink into the library when the library dir was deleted", async () => {
+    const symlinkPath = join(targetDir, "brainstorming");
+    const expectedTarget = libraryPath;
+    await symlink(libraryPath, symlinkPath, "dir");
+    await rm(join(tempDir, "library"), { recursive: true, force: true });
+
+    const result = await deactivateLibrarySkill({
+      targetDir,
+      activationName: "brainstorming",
+      librarySkillsDir,
+      provider: "codex",
+      scope: "project",
+    });
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      provider: "codex",
+      scope: "project",
+      path: symlinkPath,
+      target: expectedTarget,
+    });
+    await expect(lstat(symlinkPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("refuses a broken symlink that lexically points outside the library", async () => {
+    const externalDir = join(tempDir, "external");
+    const symlinkPath = join(targetDir, "brainstorming");
+    const relativeTarget = relative(targetDir, externalDir);
+    await mkdir(externalDir, { recursive: true });
+    await symlink(relativeTarget, symlinkPath, "dir");
+    await rm(externalDir, { recursive: true, force: true });
+
+    await expect(
+      deactivateLibrarySkill({
+        targetDir,
+        activationName: "brainstorming",
+        librarySkillsDir,
+        provider: "codex",
+        scope: "project",
+      }),
+    ).rejects.toThrow(
+      `Refusing to deactivate symlink outside the ASM library: ${symlinkPath}.`,
+    );
+    await expect(readlink(symlinkPath)).resolves.toBe(relativeTarget);
+  });
+
+  test("refuses to deactivate a real directory", async () => {
+    const realTarget = join(targetDir, "brainstorming");
+    await mkdir(realTarget, { recursive: true });
+
+    await expect(
+      deactivateLibrarySkill({
+        targetDir,
+        activationName: "brainstorming",
+        librarySkillsDir,
+        provider: "codex",
+        scope: "project",
+      }),
+    ).rejects.toThrow(`Refusing to deactivate non-symlink target: ${realTarget}.`);
+    await expect(lstat(realTarget)).resolves.toBeTruthy();
+  });
+
+  test("refuses to deactivate a symlink outside the library", async () => {
+    const externalDir = join(tempDir, "external");
+    const symlinkPath = join(targetDir, "brainstorming");
+    await mkdir(externalDir, { recursive: true });
+    await symlink(externalDir, symlinkPath, "dir");
+
+    await expect(
+      deactivateLibrarySkill({
+        targetDir,
+        activationName: "brainstorming",
+        librarySkillsDir,
+        provider: "codex",
+        scope: "project",
+      }),
+    ).rejects.toThrow(
+      `Refusing to deactivate symlink outside the ASM library: ${symlinkPath}.`,
+    );
+    await expect(readlink(symlinkPath)).resolves.toBe(externalDir);
+  });
+
+  test("reports a missing activation", async () => {
+    await expect(
+      deactivateLibrarySkill({
+        targetDir,
+        activationName: "brainstorming",
+        librarySkillsDir,
+        provider: "codex",
+        scope: "project",
+      }),
+    ).rejects.toThrow('Skill "brainstorming" is not active for codex/project.');
+  });
+
+  test("rejects invalid activation names before touching filesystem targets", async () => {
+    const outsideDir = join(tempDir, "provider", "outside");
+    const outsideSentinel = join(outsideDir, "sentinel.txt");
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(outsideSentinel, "keep me", "utf-8");
+
+    await expect(
+      deactivateLibrarySkill({
+        targetDir,
+        activationName: "../outside",
+        librarySkillsDir,
+        provider: "codex",
+        scope: "project",
+      }),
+    ).rejects.toThrow(/Invalid skill name/);
+
+    await expect(readFile(outsideSentinel, "utf-8")).resolves.toBe("keep me");
   });
 });

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -20,6 +20,7 @@ import {
   installLibrarySkill,
   readLibraryLock,
   updateLibrarySkill,
+  updateLibrarySkills,
   writeLibraryLock,
 } from "./library";
 
@@ -580,6 +581,63 @@ describe("updateLibrarySkill", () => {
     expect(lock.skills.brainstorming.skillPath).toBe("skills/brainstorming");
   });
 
+  test("updates a local root-source library skill with blank skillPath", async () => {
+    const rootSource = join(tempDir, "root-source");
+    const rootLibraryPath = join(skillsDir, "root-skill");
+    await mkdir(rootSource, { recursive: true });
+    await writeFile(
+      join(rootSource, "SKILL.md"),
+      "---\nname: root-skill\nversion: 1.0.0\n---\n# Old Root\n",
+    );
+    await installLibrarySkill(
+      {
+        sourceDir: rootSource,
+        libraryName: "root-skill",
+        source: `local:${rootSource}`,
+        sourceType: "local",
+        commitHash: "local-root",
+        ref: null,
+        skillPath: "",
+        force: false,
+      },
+      { skillsDir, lockPath },
+    );
+    const originalLock = await readLibraryLock(lockPath);
+    const originalEntry = {
+      ...originalLock.skills["root-skill"],
+      installedAt: "2026-06-18T00:00:00.000Z",
+      ref: "HEAD",
+    };
+    originalLock.skills["root-skill"] = originalEntry;
+    await writeLibraryLock(originalLock, lockPath);
+
+    await writeFile(
+      join(rootSource, "SKILL.md"),
+      "---\nname: root-skill\nversion: 2.0.0\n---\n# New Root\n",
+    );
+
+    const result = await updateLibrarySkill("root-skill", { skillsDir, lockPath });
+
+    expect(result).toMatchObject({
+      name: "root-skill",
+      status: "updated",
+      oldVersion: "1.0.0",
+      newVersion: "2.0.0",
+    });
+    await expect(
+      readFile(join(rootLibraryPath, "SKILL.md"), "utf-8"),
+    ).resolves.toContain("# New Root");
+    const updatedLock = await readLibraryLock(lockPath);
+    const updatedEntry = updatedLock.skills["root-skill"];
+    expect(updatedEntry.source).toBe(originalEntry.source);
+    expect(updatedEntry.sourceType).toBe("local");
+    expect(updatedEntry.ref).toBe("HEAD");
+    expect(updatedEntry.skillPath).toBe("");
+    expect(updatedEntry.libraryPath).toBe(originalEntry.libraryPath);
+    expect(updatedEntry.installedAt).not.toBe(originalEntry.installedAt);
+    expect(updatedEntry.commitHash).not.toBe(originalEntry.commitHash);
+  });
+
   test("preserves update metadata while refreshing version, commit, and installedAt", async () => {
     const originalLock = await readLibraryLock(lockPath);
     const originalEntry = {
@@ -846,9 +904,8 @@ describe("updateLibrarySkill", () => {
     expect(updatedLock).toEqual(blankSourceLock);
   });
 
-  test("returns missing or blank skillPath metadata without replacing library copy", async () => {
+  test("returns missing skillPath metadata without replacing library copy", async () => {
     const lock = await readLibraryLock(lockPath);
-    const originalEntry = { ...lock.skills.brainstorming };
     delete (lock.skills.brainstorming as any).skillPath;
     await writeLibraryLock(lock, lockPath);
     const missingSkillPathLock = await readLibraryLock(lockPath);
@@ -866,54 +923,80 @@ describe("updateLibrarySkill", () => {
     await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
       "# Old Source",
     );
-    let updatedLock = await readLibraryLock(lockPath);
+    const updatedLock = await readLibraryLock(lockPath);
     expect(updatedLock).toEqual(missingSkillPathLock);
-
-    updatedLock.skills.brainstorming = { ...originalEntry, skillPath: "" };
-    await writeLibraryLock(updatedLock, lockPath);
-    const blankSkillPathLock = await readLibraryLock(lockPath);
-
-    const blankResult = await updateLibrarySkill("brainstorming", {
-      skillsDir,
-      lockPath,
-    });
-
-    expect(blankResult).toEqual({
-      name: "brainstorming",
-      status: "failed",
-      reason: "Missing update metadata: skillPath",
-    });
-    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
-      "# Old Source",
-    );
-    updatedLock = await readLibraryLock(lockPath);
-    expect(updatedLock).toEqual(blankSkillPathLock);
   });
 
-  test("rejects unsupported sourceType without replacing library copy", async () => {
-    await writeFile(
-      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
-      "---\nname: brainstorming\nversion: 2.0.0\n---\n# New Source\n",
-    );
+  test.each(["github", "registry"] as const)(
+    "updates a %s-source library skill from recorded clone metadata",
+    async (sourceType) => {
+      const { execFile } = await import("child_process");
+      const { promisify } = await import("util");
+      const exec = promisify(execFile);
+
+      const workDir = join(tempDir, `${sourceType}-work`);
+      const bareRepoPath = join(tempDir, `${sourceType}.git`);
+      await mkdir(join(workDir, "skills", "brainstorming"), { recursive: true });
+      await exec("git", ["init", workDir]);
+      await exec("git", ["-C", workDir, "config", "user.email", "test@test.com"]);
+      await exec("git", ["-C", workDir, "config", "user.name", "Test"]);
+      await writeFile(
+        join(workDir, "skills", "brainstorming", "SKILL.md"),
+        "---\nname: brainstorming\nversion: 2.0.0\n---\n# Remote Source\n",
+      );
+      await exec("git", ["-C", workDir, "add", "."]);
+      await exec("git", ["-C", workDir, "commit", "-m", "remote update"]);
+      const { stdout } = await exec("git", ["-C", workDir, "rev-parse", "HEAD"]);
+      const newCommit = stdout.trim();
+      await exec("git", ["clone", "--bare", workDir, bareRepoPath]);
+
+      const lock = await readLibraryLock(lockPath);
+      lock.skills.brainstorming = {
+        ...lock.skills.brainstorming,
+        source: `file://${bareRepoPath}`,
+        sourceType,
+        commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ref: null,
+      };
+      await writeLibraryLock(lock, lockPath);
+
+      const result = await updateLibrarySkill("brainstorming", {
+        skillsDir,
+        lockPath,
+      });
+
+      expect(result).toMatchObject({
+        name: "brainstorming",
+        status: "updated",
+        oldCommit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        newCommit,
+        oldVersion: "1.0.0",
+        newVersion: "2.0.0",
+      });
+      await expect(
+        readFile(join(libraryPath, "SKILL.md"), "utf-8"),
+      ).resolves.toContain("# Remote Source");
+      const updatedLock = await readLibraryLock(lockPath);
+      expect(updatedLock.skills.brainstorming.commitHash).toBe(newCommit);
+      expect(updatedLock.skills.brainstorming.sourceType).toBe(sourceType);
+      expect(updatedLock.skills.brainstorming.skillPath).toBe("skills/brainstorming");
+    },
+  );
+
+  test("library update --all attempts remote entries instead of treating them as unsupported", async () => {
     const lock = await readLibraryLock(lockPath);
     lock.skills.brainstorming.sourceType = "github";
+    lock.skills.brainstorming.source = "not-a-cloneable-source";
     await writeLibraryLock(lock, lockPath);
 
-    const result = await updateLibrarySkill("brainstorming", {
-      skillsDir,
-      lockPath,
-    });
+    const summary = await updateLibrarySkills(null, { skillsDir, lockPath });
 
-    expect(result).toEqual({
+    expect(summary.failedCount).toBe(1);
+    expect(summary.results[0]).toMatchObject({
       name: "brainstorming",
       status: "failed",
-      reason: "Unsupported library source type for update: github",
+      reason: "Cannot determine remote URL",
     });
-    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
-      "# Old Source",
-    );
-    const updatedLock = await readLibraryLock(lockPath);
-    expect(updatedLock.skills.brainstorming.version).toBe("1.0.0");
   });
 
   test("returns missing libraryPath metadata before touching filesystem", async () => {

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  emptyLibraryLock,
+  readLibraryLock,
+  writeLibraryLock,
+} from "./library";
+
+describe("library lock", () => {
+  let tempDir: string;
+  let lockPath: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-test-"));
+    lockPath = join(tempDir, "library-lock.json");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("readLibraryLock returns an empty lock when the file is missing", async () => {
+    await expect(readLibraryLock(lockPath)).resolves.toEqual({
+      version: 1,
+      skills: {},
+    });
+  });
+
+  test("writeLibraryLock persists a versioned lock file", async () => {
+    const lock = emptyLibraryLock();
+    lock.skills.brainstorming = {
+      name: "brainstorming",
+      version: "1.0.0",
+      source: "github:obra/superpowers",
+      sourceType: "github",
+      commitHash: "abc123",
+      ref: "main",
+      skillPath: "skills/brainstorming",
+      libraryPath: join(tempDir, "skills", "brainstorming"),
+      installedAt: "2026-06-18T00:00:00.000Z",
+    };
+
+    await writeLibraryLock(lock, lockPath);
+
+    await expect(readLibraryLock(lockPath)).resolves.toEqual(lock);
+  });
+
+  test("readLibraryLock rejects array skills and backs up the invalid lock", async () => {
+    const invalidLock = JSON.stringify({ version: 1, skills: [] }, null, 2);
+    await writeFile(lockPath, invalidLock, "utf-8");
+
+    await expect(readLibraryLock(lockPath)).resolves.toEqual({
+      version: 1,
+      skills: {},
+    });
+
+    await expect(readFile(lockPath + ".bak", "utf-8")).resolves.toBe(
+      invalidLock,
+    );
+  });
+});

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -6,6 +6,7 @@ import {
   readFile,
   readlink,
   realpath,
+  rename,
   rm,
   symlink,
   writeFile,
@@ -18,6 +19,7 @@ import {
   deactivateLibrarySkill,
   installLibrarySkill,
   readLibraryLock,
+  updateLibrarySkill,
   writeLibraryLock,
 } from "./library";
 
@@ -511,5 +513,587 @@ describe("deactivateLibrarySkill", () => {
     ).rejects.toThrow(/Invalid skill name/);
 
     await expect(readFile(outsideSentinel, "utf-8")).resolves.toBe("keep me");
+  });
+});
+
+describe("updateLibrarySkill", () => {
+  let tempDir: string;
+  let lockPath: string;
+  let skillsDir: string;
+  let sourceRoot: string;
+  let libraryPath: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-library-update-"));
+    lockPath = join(tempDir, "library-lock.json");
+    skillsDir = join(tempDir, "library", "skills");
+    sourceRoot = join(tempDir, "source");
+    libraryPath = join(skillsDir, "brainstorming");
+
+    await mkdir(join(sourceRoot, "skills", "brainstorming"), { recursive: true });
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 1.0.0\n---\n# Old Source\n",
+    );
+
+    await installLibrarySkill(
+      {
+        sourceDir: join(sourceRoot, "skills", "brainstorming"),
+        libraryName: "brainstorming",
+        source: `local:${sourceRoot}`,
+        sourceType: "local",
+        commitHash: "local",
+        ref: null,
+        skillPath: "skills/brainstorming",
+        force: false,
+      },
+      { skillsDir, lockPath },
+    );
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("updates a local-source library skill in place", async () => {
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 2.0.0\n---\n# New Source\n",
+    );
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result).toMatchObject({
+      name: "brainstorming",
+      status: "updated",
+      oldVersion: "1.0.0",
+      newVersion: "2.0.0",
+    });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# New Source",
+    );
+    const lock = await readLibraryLock(lockPath);
+    expect(lock.skills.brainstorming.version).toBe("2.0.0");
+    expect(lock.skills.brainstorming.skillPath).toBe("skills/brainstorming");
+  });
+
+  test("preserves update metadata while refreshing version, commit, and installedAt", async () => {
+    const originalLock = await readLibraryLock(lockPath);
+    const originalEntry = {
+      ...originalLock.skills.brainstorming,
+      installedAt: "2026-06-18T00:00:00.000Z",
+      ref: "main",
+    };
+    originalLock.skills.brainstorming = originalEntry;
+    await writeLibraryLock(originalLock, lockPath);
+
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 2.0.0\n---\n# New Source\n",
+    );
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result.status).toBe("updated");
+    const updatedLock = await readLibraryLock(lockPath);
+    const updatedEntry = updatedLock.skills.brainstorming;
+    expect(updatedEntry.installedAt).not.toBe(originalEntry.installedAt);
+    expect(updatedEntry.commitHash).not.toBe(originalEntry.commitHash);
+    expect(updatedEntry.version).toBe("2.0.0");
+    expect(updatedEntry.source).toBe(originalEntry.source);
+    expect(updatedEntry.sourceType).toBe(originalEntry.sourceType);
+    expect(updatedEntry.ref).toBe(originalEntry.ref);
+    expect(updatedEntry.skillPath).toBe(originalEntry.skillPath);
+    expect(updatedEntry.libraryPath).toBe(originalEntry.libraryPath);
+  });
+
+  test("uses recorded skillPath instead of source root", async () => {
+    await writeFile(
+      join(sourceRoot, "SKILL.md"),
+      "---\nname: wrong-root\nversion: 9.9.9\n---\n# Wrong Root\n",
+    );
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 2.1.0\n---\n# Correct Subpath\n",
+    );
+
+    await updateLibrarySkill("brainstorming", { skillsDir, lockPath });
+
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Correct Subpath",
+    );
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.not.toContain(
+      "# Wrong Root",
+    );
+  });
+
+  test("falls back to frontmatter name while keeping original lock directory key", async () => {
+    const rawLibraryPath = join(skillsDir, "raw-brainstorming");
+    await rename(libraryPath, rawLibraryPath);
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: friendly-brainstorming\nversion: 2.2.0\n---\n# Renamed Source\n",
+    );
+
+    const lock = await readLibraryLock(lockPath);
+    lock.skills["raw-brainstorming"] = {
+      ...lock.skills.brainstorming,
+      name: "friendly-brainstorming",
+      libraryPath: rawLibraryPath,
+    };
+    delete lock.skills.brainstorming;
+    await writeLibraryLock(lock, lockPath);
+
+    const result = await updateLibrarySkill("friendly-brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result).toMatchObject({
+      name: "friendly-brainstorming",
+      status: "updated",
+      oldVersion: "1.0.0",
+      newVersion: "2.2.0",
+    });
+    await expect(
+      readFile(join(rawLibraryPath, "SKILL.md"), "utf-8"),
+    ).resolves.toContain("# Renamed Source");
+    const updatedLock = await readLibraryLock(lockPath);
+    expect(updatedLock.skills.brainstorming).toBeUndefined();
+    expect(updatedLock.skills["raw-brainstorming"]).toMatchObject({
+      name: "friendly-brainstorming",
+      version: "2.2.0",
+      libraryPath: rawLibraryPath,
+    });
+  });
+
+  test("fails without replacing the existing library copy when source skill is invalid", async () => {
+    await rm(join(sourceRoot, "skills", "brainstorming", "SKILL.md"), {
+      force: true,
+    });
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.reason).toContain("SKILL.md");
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+  });
+
+  test("rejects refreshed source SKILL.md with missing name before replacing library copy", async () => {
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nversion: 2.0.0\n---\n# New Source\n",
+    );
+    const originalLock = await readLibraryLock(lockPath);
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason: "Invalid source SKILL.md: missing name",
+    });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+    await expect(readLibraryLock(lockPath)).resolves.toEqual(originalLock);
+  });
+
+  test("rejects refreshed source SKILL.md with missing version before replacing library copy", async () => {
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\n---\n# New Source\n",
+    );
+    const originalLock = await readLibraryLock(lockPath);
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason: "Invalid source SKILL.md: missing version",
+    });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+    await expect(readLibraryLock(lockPath)).resolves.toEqual(originalLock);
+  });
+
+  test("rejects refreshed source SKILL.md with invalid version before replacing library copy", async () => {
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 2.0\n---\n# New Source\n",
+    );
+    const originalLock = await readLibraryLock(lockPath);
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason: "Invalid source SKILL.md: invalid version",
+    });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+    await expect(readLibraryLock(lockPath)).resolves.toEqual(originalLock);
+  });
+
+  test("returns missing or blank sourceType metadata without replacing library copy", async () => {
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 2.0.0\n---\n# New Source\n",
+    );
+    const lock = await readLibraryLock(lockPath);
+    delete lock.skills.brainstorming.sourceType;
+    await writeLibraryLock(lock, lockPath);
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason: "Missing update metadata: sourceType",
+    });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+    const updatedLock = await readLibraryLock(lockPath);
+    expect(updatedLock.skills.brainstorming.version).toBe("1.0.0");
+
+    updatedLock.skills.brainstorming.sourceType = "" as any;
+    await writeLibraryLock(updatedLock, lockPath);
+
+    const blankResult = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(blankResult).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason: "Missing update metadata: sourceType",
+    });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+  });
+
+  test("returns missing or blank source metadata without replacing library copy", async () => {
+    const lock = await readLibraryLock(lockPath);
+    const originalEntry = { ...lock.skills.brainstorming };
+    delete (lock.skills.brainstorming as any).source;
+    await writeLibraryLock(lock, lockPath);
+    const missingSourceLock = await readLibraryLock(lockPath);
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason: "Missing update metadata: source",
+    });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+    let updatedLock = await readLibraryLock(lockPath);
+    expect(updatedLock).toEqual(missingSourceLock);
+
+    updatedLock.skills.brainstorming = { ...originalEntry, source: "" };
+    await writeLibraryLock(updatedLock, lockPath);
+    const blankSourceLock = await readLibraryLock(lockPath);
+
+    const blankResult = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(blankResult).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason: "Missing update metadata: source",
+    });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+    updatedLock = await readLibraryLock(lockPath);
+    expect(updatedLock).toEqual(blankSourceLock);
+  });
+
+  test("returns missing or blank skillPath metadata without replacing library copy", async () => {
+    const lock = await readLibraryLock(lockPath);
+    const originalEntry = { ...lock.skills.brainstorming };
+    delete (lock.skills.brainstorming as any).skillPath;
+    await writeLibraryLock(lock, lockPath);
+    const missingSkillPathLock = await readLibraryLock(lockPath);
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason: "Missing update metadata: skillPath",
+    });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+    let updatedLock = await readLibraryLock(lockPath);
+    expect(updatedLock).toEqual(missingSkillPathLock);
+
+    updatedLock.skills.brainstorming = { ...originalEntry, skillPath: "" };
+    await writeLibraryLock(updatedLock, lockPath);
+    const blankSkillPathLock = await readLibraryLock(lockPath);
+
+    const blankResult = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(blankResult).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason: "Missing update metadata: skillPath",
+    });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+    updatedLock = await readLibraryLock(lockPath);
+    expect(updatedLock).toEqual(blankSkillPathLock);
+  });
+
+  test("rejects unsupported sourceType without replacing library copy", async () => {
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 2.0.0\n---\n# New Source\n",
+    );
+    const lock = await readLibraryLock(lockPath);
+    lock.skills.brainstorming.sourceType = "github";
+    await writeLibraryLock(lock, lockPath);
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason: "Unsupported library source type for update: github",
+    });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+    const updatedLock = await readLibraryLock(lockPath);
+    expect(updatedLock.skills.brainstorming.version).toBe("1.0.0");
+  });
+
+  test("returns missing libraryPath metadata before touching filesystem", async () => {
+    const lock = await readLibraryLock(lockPath);
+    lock.skills.brainstorming.libraryPath = "" as any;
+    await writeLibraryLock(lock, lockPath);
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason: "Missing update metadata: libraryPath",
+    });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+  });
+
+  test("rejects skillPath traversal without replacing library copy", async () => {
+    const lock = await readLibraryLock(lockPath);
+    lock.skills.brainstorming.skillPath = "../outside/brainstorming";
+    await writeLibraryLock(lock, lockPath);
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason: "Invalid update metadata: skillPath escapes source root",
+    });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+  });
+
+  test("rejects symlink skillPath escape without replacing library copy", async () => {
+    const externalSkillDir = join(tempDir, "external", "brainstorming");
+    await rm(join(sourceRoot, "skills"), { recursive: true, force: true });
+    await mkdir(externalSkillDir, { recursive: true });
+    await writeFile(
+      join(externalSkillDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 2.0.0\n---\n# Escaped Source\n",
+    );
+    await symlink(join(tempDir, "external"), join(sourceRoot, "skills"), "dir");
+
+    const originalLock = await readLibraryLock(lockPath);
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason: "Invalid update metadata: skillPath escapes source root",
+    });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+    await expect(readLibraryLock(lockPath)).resolves.toEqual(originalLock);
+  });
+
+  test("rejects libraryPath outside skillsDir without replacing outside target", async () => {
+    const outsideDir = join(tempDir, "outside-library");
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(join(outsideDir, "sentinel.txt"), "keep me", "utf-8");
+    const lock = await readLibraryLock(lockPath);
+    lock.skills.brainstorming.libraryPath = outsideDir;
+    await writeLibraryLock(lock, lockPath);
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason: "Invalid update metadata: libraryPath escapes library skills directory",
+    });
+    await expect(readFile(join(outsideDir, "sentinel.txt"), "utf-8")).resolves.toBe(
+      "keep me",
+    );
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+  });
+
+  test("rejects symlink libraryPath escape without replacing library or external target", async () => {
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 2.0.0\n---\n# New Source\n",
+    );
+    const externalDir = join(tempDir, "external-library");
+    const linkPath = join(skillsDir, "link");
+    await mkdir(externalDir, { recursive: true });
+    await symlink(externalDir, linkPath, "dir");
+
+    const lock = await readLibraryLock(lockPath);
+    lock.skills.brainstorming.libraryPath = join(linkPath, "brainstorming");
+    await writeLibraryLock(lock, lockPath);
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason: "Invalid update metadata: libraryPath escapes library skills directory",
+    });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+    const updatedLock = await readLibraryLock(lockPath);
+    expect(updatedLock.skills.brainstorming.version).toBe("1.0.0");
+    await expect(
+      readFile(join(externalDir, "brainstorming", "SKILL.md"), "utf-8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("includes non-SKILL.md files in local commit hash", async () => {
+    await writeFile(join(sourceRoot, "skills", "brainstorming", "notes.txt"), "alpha");
+    const firstResult = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+    const firstLock = await readLibraryLock(lockPath);
+    const firstHash = firstLock.skills.brainstorming.commitHash;
+
+    await writeFile(join(sourceRoot, "skills", "brainstorming", "notes.txt"), "bravo");
+    const secondResult = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+    const secondLock = await readLibraryLock(lockPath);
+    const secondHash = secondLock.skills.brainstorming.commitHash;
+
+    expect(firstResult.status).toBe("updated");
+    expect(secondResult.status).toBe("updated");
+    expect(firstHash).not.toBe(secondHash);
+    await expect(
+      readFile(join(libraryPath, "notes.txt"), "utf-8"),
+    ).resolves.toBe("bravo");
+  });
+
+  test("restores old library copy when lock write fails after swap", async () => {
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 3.0.0\n---\n# New Source\n",
+    );
+
+    const result = await updateLibrarySkill(
+      "brainstorming",
+      { skillsDir, lockPath },
+      {
+        writeLibraryLockFn: async () => {
+          throw new Error("lock write boom");
+        },
+      },
+    );
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason: "Updated library copy, but failed to write lock file: lock write boom",
+    });
+    await expect(readFile(join(libraryPath, "SKILL.md"), "utf-8")).resolves.toContain(
+      "# Old Source",
+    );
+    const lock = await readLibraryLock(lockPath);
+    expect(lock.skills.brainstorming.version).toBe("1.0.0");
   });
 });

--- a/src/library.ts
+++ b/src/library.ts
@@ -14,12 +14,17 @@ import {
   symlink,
   writeFile,
 } from "fs/promises";
+import { execFile } from "child_process";
 import { createHash } from "crypto";
+import { promisify } from "util";
 import { dirname, isAbsolute, join, relative, resolve } from "path";
 import { getLibraryLockPath, getLibrarySkillsDir } from "./config";
 import { debug } from "./logger";
 import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
+import { sourceToCloneUrl } from "./updater";
 import type { LibraryLockFile, LibrarySkillEntry } from "./utils/types";
+
+const execFileAsync = promisify(execFile);
 
 const LIBRARY_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
 const MAX_LIBRARY_NAME_LENGTH = 128;
@@ -173,10 +178,6 @@ function librarySourceRoot(entry: LibrarySkillEntry): string | null {
   return resolve(basePath);
 }
 
-function hashSourceMarkdown(markdown: string): string {
-  return createHash("sha256").update(markdown).digest("hex");
-}
-
 function validateSourceSkillFrontmatter(
   frontmatter: Record<string, string>,
 ): { name: string; version: string } | { reason: string } {
@@ -270,6 +271,81 @@ async function hashDirectoryContents(dir: string): Promise<string> {
 
   await walk(dir, "");
   return hash.digest("hex");
+}
+
+async function cloneRemoteLibrarySource(
+  entry: LibrarySkillEntry,
+  dirName: string,
+  lockPath: string,
+): Promise<
+  | { tempDir: string; commitHash: string }
+  | { reason: string; tempDir?: string }
+> {
+  const cloneUrl = sourceToCloneUrl(entry.source);
+  if (!cloneUrl) {
+    return { reason: "Cannot determine remote URL" };
+  }
+
+  const tempParent = join(dirname(lockPath), ".tmp");
+  await mkdir(tempParent, { recursive: true });
+  const tempDir = await mkdtemp(join(tempParent, `${dirName}-`));
+  const ref = entry.ref && entry.ref !== "HEAD" ? entry.ref : null;
+  const isCommitSha = !!ref && /^[0-9a-f]{40}$/i.test(ref);
+  const cloneArgs = ["clone", "--depth", "1"];
+  if (ref && !isCommitSha) {
+    cloneArgs.push("--branch", ref);
+  }
+  cloneArgs.push(cloneUrl, tempDir);
+
+  try {
+    await execFileAsync("git", cloneArgs, { timeout: 60_000 });
+  } catch (err: any) {
+    return {
+      tempDir,
+      reason: `Clone failed: ${err?.stderr || err?.message || String(err)}`,
+    };
+  }
+
+  if (ref && isCommitSha) {
+    try {
+      await execFileAsync("git", ["checkout", ref], {
+        cwd: tempDir,
+        timeout: 30_000,
+      });
+    } catch {
+      try {
+        await execFileAsync("git", ["fetch", "--depth", "1", "origin", ref], {
+          cwd: tempDir,
+          timeout: 60_000,
+        });
+        await execFileAsync("git", ["checkout", "FETCH_HEAD"], {
+          cwd: tempDir,
+          timeout: 30_000,
+        });
+      } catch (err: any) {
+        return {
+          tempDir,
+          reason: `Checkout failed for ref ${ref}: ${
+            err?.stderr || err?.message || String(err)
+          }`,
+        };
+      }
+    }
+  }
+
+  try {
+    const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+      cwd: tempDir,
+      timeout: 5_000,
+    });
+    const commitHash = stdout.trim();
+    if (!/^[0-9a-f]{40}$/i.test(commitHash)) {
+      return { tempDir, reason: "Could not read new commit" };
+    }
+    return { tempDir, commitHash };
+  } catch {
+    return { tempDir, reason: "Could not read new commit" };
+  }
 }
 
 async function replaceDirectoryAtomically(input: {
@@ -380,127 +456,158 @@ export async function updateLibrarySkill(
   if (!entry.sourceType || !entry.sourceType.trim()) {
     return libraryUpdateFailure(dirName, "Missing update metadata: sourceType");
   }
-  if (entry.sourceType !== "local") {
-    return libraryUpdateFailure(
-      dirName,
-      `Unsupported library source type for update: ${entry.sourceType}`,
-    );
-  }
-  if (!entry.skillPath || !entry.skillPath.trim()) {
+  if (entry.skillPath === undefined || entry.skillPath === null) {
     return libraryUpdateFailure(dirName, "Missing update metadata: skillPath");
   }
   if (!entry.libraryPath || !entry.libraryPath.trim()) {
     return libraryUpdateFailure(dirName, "Missing update metadata: libraryPath");
   }
 
-  const sourceRoot = librarySourceRoot(entry);
-  if (!sourceRoot) {
-    return libraryUpdateFailure(
-      dirName,
-      `Unsupported library source for update: ${entry.source}`,
-    );
-  }
-
-  const sourceDir = resolveContainedPath(sourceRoot, join(sourceRoot, entry.skillPath));
-  if (!sourceDir) {
-    return libraryUpdateFailure(
-      dirName,
-      "Invalid update metadata: skillPath escapes source root",
-    );
-  }
-
-  const sourceSkillPath = join(sourceDir, "SKILL.md");
-  let realSourceRoot: string;
-  let realSourceDir: string;
+  let cleanupSourceRoot: string | null = null;
   try {
-    [realSourceRoot, realSourceDir] = await Promise.all([
-      realpath(sourceRoot),
-      realpath(sourceDir),
-    ]);
-  } catch (err: any) {
-    return libraryUpdateFailure(
-      dirName,
-      `Unable to read source SKILL.md at ${sourceSkillPath}: ${
-        err?.message ?? String(err)
-      }`,
-    );
-  }
-  if (!isContainedPath(realSourceRoot, realSourceDir)) {
-    return libraryUpdateFailure(
-      dirName,
-      "Invalid update metadata: skillPath escapes source root",
-    );
-  }
+    let sourceRoot: string;
+    let nextCommitHash: string | null = null;
 
-  const libraryPath = resolveContainedPath(skillsDir, entry.libraryPath);
-  if (!libraryPath) {
-    return libraryUpdateFailure(
-      dirName,
-      "Invalid update metadata: libraryPath escapes library skills directory",
-    );
-  }
-  if (!(await libraryPathRealpathIsContained(skillsDir, libraryPath))) {
-    return libraryUpdateFailure(
-      dirName,
-      "Invalid update metadata: libraryPath escapes library skills directory",
-    );
-  }
+    if (entry.sourceType === "local") {
+      const localSourceRoot = librarySourceRoot(entry);
+      if (!localSourceRoot) {
+        return libraryUpdateFailure(
+          dirName,
+          `Unsupported library source for update: ${entry.source}`,
+        );
+      }
+      sourceRoot = localSourceRoot;
+    } else if (entry.sourceType === "github" || entry.sourceType === "registry") {
+      const cloneResult = await cloneRemoteLibrarySource(entry, dirName, lockPath);
+      if ("reason" in cloneResult) {
+        if (cloneResult.tempDir) {
+          cleanupSourceRoot = cloneResult.tempDir;
+        }
+        return libraryUpdateFailure(dirName, cloneResult.reason);
+      }
+      sourceRoot = cloneResult.tempDir;
+      cleanupSourceRoot = cloneResult.tempDir;
+      nextCommitHash = cloneResult.commitHash;
+    } else {
+      return libraryUpdateFailure(
+        dirName,
+        `Unsupported library source type for update: ${entry.sourceType}`,
+      );
+    }
 
-  let sourceMarkdown: string;
-  try {
-    sourceMarkdown = await readFile(sourceSkillPath, "utf-8");
-  } catch (err: any) {
-    return libraryUpdateFailure(
-      dirName,
-      `Unable to read source SKILL.md at ${sourceSkillPath}: ${
-        err?.message ?? String(err)
-      }`,
+    const sourceDir = resolveContainedPath(
+      sourceRoot,
+      join(sourceRoot, entry.skillPath),
     );
-  }
+    if (!sourceDir) {
+      return libraryUpdateFailure(
+        dirName,
+        "Invalid update metadata: skillPath escapes source root",
+      );
+    }
 
-  const frontmatter = parseFrontmatter(sourceMarkdown);
-  const sourceMetadata = validateSourceSkillFrontmatter(frontmatter);
-  if ("reason" in sourceMetadata) {
-    return libraryUpdateFailure(dirName, sourceMetadata.reason);
-  }
+    const sourceSkillPath = join(sourceDir, "SKILL.md");
+    let realSourceRoot: string;
+    let realSourceDir: string;
+    try {
+      [realSourceRoot, realSourceDir] = await Promise.all([
+        realpath(sourceRoot),
+        realpath(sourceDir),
+      ]);
+    } catch (err: any) {
+      return libraryUpdateFailure(
+        dirName,
+        `Unable to read source SKILL.md at ${sourceSkillPath}: ${
+          err?.message ?? String(err)
+        }`,
+      );
+    }
+    if (!isContainedPath(realSourceRoot, realSourceDir)) {
+      return libraryUpdateFailure(
+        dirName,
+        "Invalid update metadata: skillPath escapes source root",
+      );
+    }
 
-  const nameFromSource = sourceMetadata.name;
-  const versionFromSource = sourceMetadata.version;
-  const nextCommitHash = await hashDirectoryContents(sourceDir);
-  const updatedLock = {
-    ...lock,
-    skills: {
-      ...lock.skills,
-      [dirName]: {
-        ...entry,
-        name: nameFromSource,
-        version: versionFromSource,
-        commitHash: nextCommitHash,
-        installedAt: new Date().toISOString(),
+    const libraryPath = resolveContainedPath(skillsDir, entry.libraryPath);
+    if (!libraryPath) {
+      return libraryUpdateFailure(
+        dirName,
+        "Invalid update metadata: libraryPath escapes library skills directory",
+      );
+    }
+    if (!(await libraryPathRealpathIsContained(skillsDir, libraryPath))) {
+      return libraryUpdateFailure(
+        dirName,
+        "Invalid update metadata: libraryPath escapes library skills directory",
+      );
+    }
+
+    let sourceMarkdown: string;
+    try {
+      sourceMarkdown = await readFile(sourceSkillPath, "utf-8");
+    } catch (err: any) {
+      return libraryUpdateFailure(
+        dirName,
+        `Unable to read source SKILL.md at ${sourceSkillPath}: ${
+          err?.message ?? String(err)
+        }`,
+      );
+    }
+
+    const frontmatter = parseFrontmatter(sourceMarkdown);
+    const sourceMetadata = validateSourceSkillFrontmatter(frontmatter);
+    if ("reason" in sourceMetadata) {
+      return libraryUpdateFailure(dirName, sourceMetadata.reason);
+    }
+
+    const nameFromSource = sourceMetadata.name;
+    const versionFromSource = sourceMetadata.version;
+    if (entry.sourceType === "local") {
+      nextCommitHash = await hashDirectoryContents(sourceDir);
+    }
+    if (!nextCommitHash) {
+      return libraryUpdateFailure(dirName, "Could not read new commit");
+    }
+    const updatedLock = {
+      ...lock,
+      skills: {
+        ...lock.skills,
+        [dirName]: {
+          ...entry,
+          name: nameFromSource,
+          version: versionFromSource,
+          commitHash: nextCommitHash,
+          installedAt: new Date().toISOString(),
+        },
       },
-    },
-  };
+    };
 
-  const swapResult = await replaceDirectoryAtomically({
-    sourceDir,
-    targetDir: libraryPath,
-    writeLock: () => writeLibraryLockFn(updatedLock, lockPath),
-  });
-  if (swapResult) {
-    return libraryUpdateFailure(
-      dirName,
-      swapResult.reason ?? "Failed to update library skill",
-    );
+    const swapResult = await replaceDirectoryAtomically({
+      sourceDir,
+      targetDir: libraryPath,
+      writeLock: () => writeLibraryLockFn(updatedLock, lockPath),
+    });
+    if (swapResult) {
+      return libraryUpdateFailure(
+        dirName,
+        swapResult.reason ?? "Failed to update library skill",
+      );
+    }
+
+    return {
+      name: nameFromSource,
+      status: "updated",
+      oldVersion: entry.version,
+      newVersion: versionFromSource,
+      oldCommit: entry.commitHash,
+      newCommit: nextCommitHash,
+    };
+  } finally {
+    if (cleanupSourceRoot) {
+      await rm(cleanupSourceRoot, { recursive: true, force: true });
+    }
   }
-
-  return {
-    name: nameFromSource,
-    status: "updated",
-    oldVersion: entry.version,
-    newVersion: versionFromSource,
-    oldCommit: entry.commitHash,
-    newCommit: nextCommitHash,
-  };
 }
 
 export async function updateLibrarySkills(

--- a/src/library.ts
+++ b/src/library.ts
@@ -2,9 +2,11 @@ import {
   access,
   copyFile,
   cp,
+  lstat,
   mkdir,
   readFile,
   rm,
+  symlink,
   writeFile,
 } from "fs/promises";
 import { dirname, join } from "path";
@@ -120,6 +122,41 @@ export async function listLibrarySkills(
   return rows;
 }
 
+export function findLibrarySkill(
+  rows: LibrarySkillInfo[],
+  name: string,
+): LibrarySkillInfo | null {
+  const exactDir = rows.find((r) => r.dirName === name);
+  if (exactDir) return exactDir;
+  const exactName = rows.find((r) => r.name === name);
+  return exactName ?? null;
+}
+
+export async function activateLibrarySkill(input: {
+  libraryPath: string;
+  targetDir: string;
+  activationName: string;
+  force: boolean;
+}): Promise<{ symlinkPath: string; targetPath: string }> {
+  const activationName = validateSkillDirectoryName(input.activationName);
+  const symlinkPath = join(input.targetDir, activationName);
+  try {
+    await lstat(symlinkPath);
+    if (!input.force) {
+      throw new Error(
+        `Target already exists: ${symlinkPath}. Use --force to overwrite.`,
+      );
+    }
+    await rm(symlinkPath, { recursive: true, force: true });
+  } catch (err: any) {
+    if (err?.message?.includes("--force")) throw err;
+  }
+
+  await mkdir(input.targetDir, { recursive: true });
+  await symlink(input.libraryPath, symlinkPath, "dir");
+  return { symlinkPath, targetPath: input.libraryPath };
+}
+
 async function pathExists(path: string): Promise<boolean> {
   try {
     await access(path);
@@ -130,7 +167,7 @@ async function pathExists(path: string): Promise<boolean> {
   }
 }
 
-function validateLibraryName(name: string): string {
+function validateSkillDirectoryName(name: string): string {
   if (!name) {
     throw new Error("Invalid skill name: name cannot be empty");
   }
@@ -169,7 +206,7 @@ export async function installLibrarySkill(
 ): Promise<{ name: string; version: string; libraryPath: string }> {
   const skillsDir = paths.skillsDir ?? getLibrarySkillsDir();
   const lockPath = paths.lockPath ?? getLibraryLockPath();
-  const libraryName = validateLibraryName(plan.libraryName);
+  const libraryName = validateSkillDirectoryName(plan.libraryName);
   const libraryPath = join(skillsDir, libraryName);
 
   if (await pathExists(libraryPath)) {

--- a/src/library.ts
+++ b/src/library.ts
@@ -503,6 +503,36 @@ export async function updateLibrarySkill(
   };
 }
 
+export async function updateLibrarySkills(
+  names: string[] | null,
+  paths: LibraryPaths = {},
+): Promise<LibraryUpdateSummary> {
+  const lockPath = paths.lockPath ?? getLibraryLockPath();
+  const lock = await readLibraryLock(lockPath);
+  const selectedNames = names === null ? Object.keys(lock.skills) : names;
+  const warnings: string[] = [];
+  const results: LibraryUpdateResult[] = [];
+
+  for (const selectedName of selectedNames) {
+    const result = await updateLibrarySkill(selectedName, paths);
+    if (
+      result.status === "failed" &&
+      result.reason?.includes('Run "asm library list"')
+    ) {
+      warnings.push(result.reason);
+    }
+    results.push(result);
+  }
+
+  return {
+    results,
+    updatedCount: results.filter((result) => result.status === "updated").length,
+    skippedCount: results.filter((result) => result.status === "skipped").length,
+    failedCount: results.filter((result) => result.status === "failed").length,
+    warnings,
+  };
+}
+
 export interface DeactivateLibrarySkillInput {
   targetDir: string;
   activationName: string;

--- a/src/library.ts
+++ b/src/library.ts
@@ -5,11 +5,13 @@ import {
   lstat,
   mkdir,
   readFile,
+  readlink,
+  realpath,
   rm,
   symlink,
   writeFile,
 } from "fs/promises";
-import { dirname, join } from "path";
+import { dirname, isAbsolute, join, relative, resolve } from "path";
 import { getLibraryLockPath, getLibrarySkillsDir } from "./config";
 import { debug } from "./logger";
 import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
@@ -130,6 +132,97 @@ export function findLibrarySkill(
   if (exactDir) return exactDir;
   const exactName = rows.find((r) => r.name === name);
   return exactName ?? null;
+}
+
+export interface DeactivateLibrarySkillInput {
+  targetDir: string;
+  activationName: string;
+  provider: string;
+  scope: "global" | "project";
+  librarySkillsDir?: string;
+}
+
+export interface DeactivateLibrarySkillResult {
+  name: string;
+  provider: string;
+  scope: "global" | "project";
+  path: string;
+  target: string;
+}
+
+function isInsideDirectory(parent: string, child: string): boolean {
+  const rel = relative(parent, child);
+  return rel === "" || (!!rel && !rel.startsWith("..") && !isAbsolute(rel));
+}
+
+async function realpathIfExists(path: string): Promise<{
+  path: string;
+  exists: boolean;
+}> {
+  try {
+    return { path: await realpath(path), exists: true };
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      return { path: resolve(path), exists: false };
+    }
+    throw err;
+  }
+}
+
+export async function deactivateLibrarySkill(
+  input: DeactivateLibrarySkillInput,
+): Promise<DeactivateLibrarySkillResult> {
+  const activationName = validateSkillDirectoryName(input.activationName);
+  const symlinkPath = join(input.targetDir, activationName);
+
+  let stat;
+  try {
+    stat = await lstat(symlinkPath);
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      throw new Error(
+        `Skill "${activationName}" is not active for ${input.provider}/${input.scope}.`,
+      );
+    }
+    throw err;
+  }
+
+  if (!stat.isSymbolicLink()) {
+    throw new Error(
+      `Refusing to deactivate non-symlink target: ${symlinkPath}.`,
+    );
+  }
+
+  const rawTarget = await readlink(symlinkPath);
+  const absoluteTarget = isAbsolute(rawTarget)
+    ? rawTarget
+    : resolve(dirname(symlinkPath), rawTarget);
+  const librarySkillsDir = input.librarySkillsDir ?? getLibrarySkillsDir();
+  const resolvedTarget = await realpathIfExists(absoluteTarget);
+  const resolvedLibrarySkillsDir = await realpathIfExists(librarySkillsDir);
+  const useRealPaths = resolvedTarget.exists && resolvedLibrarySkillsDir.exists;
+  const targetPathForContainment = useRealPaths
+    ? resolvedTarget.path
+    : resolve(absoluteTarget);
+  const libraryPathForContainment = useRealPaths
+    ? resolvedLibrarySkillsDir.path
+    : resolve(librarySkillsDir);
+
+  if (!isInsideDirectory(libraryPathForContainment, targetPathForContainment)) {
+    throw new Error(
+      `Refusing to deactivate symlink outside the ASM library: ${symlinkPath}.`,
+    );
+  }
+
+  await rm(symlinkPath);
+
+  return {
+    name: activationName,
+    provider: input.provider,
+    scope: input.scope,
+    path: symlinkPath,
+    target: targetPathForContainment,
+  };
 }
 
 export async function activateLibrarySkill(input: {

--- a/src/library.ts
+++ b/src/library.ts
@@ -1,0 +1,59 @@
+import { copyFile, mkdir, readFile, writeFile } from "fs/promises";
+import { dirname } from "path";
+import { getLibraryLockPath } from "./config";
+import { debug } from "./logger";
+import type { LibraryLockFile } from "./utils/types";
+
+export function emptyLibraryLock(): LibraryLockFile {
+  return { version: 1, skills: {} };
+}
+
+export async function readLibraryLock(
+  path: string = getLibraryLockPath(),
+): Promise<LibraryLockFile> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf-8");
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      debug("library: lock file not found, returning empty lock");
+      return emptyLibraryLock();
+    }
+    throw err;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed) ||
+      parsed.version !== 1 ||
+      typeof parsed.skills !== "object" ||
+      parsed.skills === null ||
+      Array.isArray(parsed.skills)
+    ) {
+      throw new Error("invalid schema");
+    }
+    return parsed as LibraryLockFile;
+  } catch {
+    const backupPath = path + ".bak";
+    try {
+      await copyFile(path, backupPath);
+    } catch {
+      // best effort backup
+    }
+    console.error(
+      `Warning: library-lock.json was corrupted. Backup saved to ${backupPath}. Starting fresh.`,
+    );
+    return emptyLibraryLock();
+  }
+}
+
+export async function writeLibraryLock(
+  lock: LibraryLockFile,
+  path: string = getLibraryLockPath(),
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(lock, null, 2) + "\n", "utf-8");
+}

--- a/src/library.ts
+++ b/src/library.ts
@@ -1,8 +1,36 @@
-import { copyFile, mkdir, readFile, writeFile } from "fs/promises";
-import { dirname } from "path";
-import { getLibraryLockPath } from "./config";
+import {
+  access,
+  copyFile,
+  cp,
+  mkdir,
+  readFile,
+  rm,
+  writeFile,
+} from "fs/promises";
+import { dirname, join } from "path";
+import { getLibraryLockPath, getLibrarySkillsDir } from "./config";
 import { debug } from "./logger";
+import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
 import type { LibraryLockFile } from "./utils/types";
+
+const LIBRARY_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+const MAX_LIBRARY_NAME_LENGTH = 128;
+
+export interface InstallLibrarySkillPlan {
+  sourceDir: string;
+  libraryName: string;
+  source: string;
+  sourceType: "registry" | "github" | "local";
+  commitHash: string;
+  ref: string | null;
+  skillPath: string;
+  force: boolean;
+}
+
+export interface LibraryPaths {
+  skillsDir?: string;
+  lockPath?: string;
+}
 
 export function emptyLibraryLock(): LibraryLockFile {
   return { version: 1, skills: {} };
@@ -56,4 +84,91 @@ export async function writeLibraryLock(
 ): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, JSON.stringify(lock, null, 2) + "\n", "utf-8");
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch (err: any) {
+    if (err?.code === "ENOENT") return false;
+    throw err;
+  }
+}
+
+function validateLibraryName(name: string): string {
+  if (!name) {
+    throw new Error("Invalid skill name: name cannot be empty");
+  }
+  if (name.includes("\0")) {
+    throw new Error(
+      "Invalid skill name: contains unsafe characters (null byte)",
+    );
+  }
+  if (name.includes("..")) {
+    throw new Error("Invalid skill name: contains unsafe characters (..)");
+  }
+  if (name.includes("/") || name.includes("\\")) {
+    throw new Error(
+      "Invalid skill name: contains unsafe characters (path separator)",
+    );
+  }
+  if (name.startsWith(".")) {
+    throw new Error("Invalid skill name: must not start with a dot");
+  }
+  if (name.length > MAX_LIBRARY_NAME_LENGTH) {
+    throw new Error(
+      `Invalid skill name: exceeds maximum length of ${MAX_LIBRARY_NAME_LENGTH} characters`,
+    );
+  }
+  if (!LIBRARY_NAME_RE.test(name)) {
+    throw new Error(
+      `Invalid skill name: "${name}" does not match allowed pattern [a-zA-Z0-9][a-zA-Z0-9._-]*`,
+    );
+  }
+  return name;
+}
+
+export async function installLibrarySkill(
+  plan: InstallLibrarySkillPlan,
+  paths: LibraryPaths = {},
+): Promise<{ name: string; version: string; libraryPath: string }> {
+  const skillsDir = paths.skillsDir ?? getLibrarySkillsDir();
+  const lockPath = paths.lockPath ?? getLibraryLockPath();
+  const libraryName = validateLibraryName(plan.libraryName);
+  const libraryPath = join(skillsDir, libraryName);
+
+  if (await pathExists(libraryPath)) {
+    if (!plan.force) {
+      throw new Error(
+        `Library skill already exists: ${libraryPath}. Use --force to overwrite.`,
+      );
+    }
+    await rm(libraryPath, { recursive: true, force: true });
+  }
+
+  await mkdir(skillsDir, { recursive: true });
+  await cp(plan.sourceDir, libraryPath, { recursive: true });
+  await rm(join(libraryPath, ".git"), { recursive: true, force: true });
+
+  const skillMarkdown = await readFile(join(libraryPath, "SKILL.md"), "utf-8");
+  const fm = parseFrontmatter(skillMarkdown);
+  const name = fm.name || libraryName;
+  const version = resolveVersion(fm);
+
+  const lock = await readLibraryLock(lockPath);
+  lock.skills[libraryName] = {
+    name,
+    version,
+    source: plan.source,
+    sourceType: plan.sourceType,
+    commitHash: plan.commitHash,
+    ref: plan.ref,
+    skillPath: plan.skillPath,
+    libraryPath,
+    installedAt: new Date().toISOString(),
+  };
+  await writeLibraryLock(lock, lockPath);
+
+  return { name, version, libraryPath };
 }

--- a/src/library.ts
+++ b/src/library.ts
@@ -2,23 +2,29 @@ import {
   access,
   copyFile,
   cp,
+  mkdtemp,
   lstat,
   mkdir,
+  readdir,
   readFile,
   readlink,
   realpath,
+  rename,
   rm,
   symlink,
   writeFile,
 } from "fs/promises";
+import { createHash } from "crypto";
 import { dirname, isAbsolute, join, relative, resolve } from "path";
 import { getLibraryLockPath, getLibrarySkillsDir } from "./config";
 import { debug } from "./logger";
 import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
-import type { LibraryLockFile } from "./utils/types";
+import type { LibraryLockFile, LibrarySkillEntry } from "./utils/types";
 
 const LIBRARY_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
 const MAX_LIBRARY_NAME_LENGTH = 128;
+const SOURCE_VERSION_RE =
+  /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
 export interface InstallLibrarySkillPlan {
   sourceDir: string;
@@ -48,6 +54,24 @@ export interface LibrarySkillInfo {
   libraryPath: string;
   installedAt: string;
   missing: boolean;
+}
+
+export interface LibraryUpdateResult {
+  name: string;
+  status: "updated" | "skipped" | "failed";
+  reason?: string;
+  oldVersion?: string;
+  newVersion?: string;
+  oldCommit?: string;
+  newCommit?: string;
+}
+
+export interface LibraryUpdateSummary {
+  results: LibraryUpdateResult[];
+  updatedCount: number;
+  skippedCount: number;
+  failedCount: number;
+  warnings: string[];
 }
 
 export function emptyLibraryLock(): LibraryLockFile {
@@ -132,6 +156,351 @@ export function findLibrarySkill(
   if (exactDir) return exactDir;
   const exactName = rows.find((r) => r.name === name);
   return exactName ?? null;
+}
+
+function libraryUpdateFailure(name: string, reason: string): LibraryUpdateResult {
+  return { name, status: "failed", reason };
+}
+
+function librarySourceRoot(entry: LibrarySkillEntry): string | null {
+  if (!entry.source.startsWith("local:")) {
+    return null;
+  }
+  const basePath = entry.source.slice("local:".length);
+  if (!basePath) {
+    return null;
+  }
+  return resolve(basePath);
+}
+
+function hashSourceMarkdown(markdown: string): string {
+  return createHash("sha256").update(markdown).digest("hex");
+}
+
+function validateSourceSkillFrontmatter(
+  frontmatter: Record<string, string>,
+): { name: string; version: string } | { reason: string } {
+  const name = frontmatter.name?.trim();
+  if (!name) {
+    return { reason: "Invalid source SKILL.md: missing name" };
+  }
+
+  const version = (frontmatter["metadata.version"] || frontmatter.version)?.trim();
+  if (!version) {
+    return { reason: "Invalid source SKILL.md: missing version" };
+  }
+  if (!SOURCE_VERSION_RE.test(version)) {
+    return { reason: "Invalid source SKILL.md: invalid version" };
+  }
+
+  return { name, version };
+}
+
+function isContainedPath(parent: string, child: string): boolean {
+  const resolvedParent = resolve(parent);
+  const resolvedChild = resolve(child);
+  const rel = relative(resolvedParent, resolvedChild);
+  return rel === "" || (!!rel && !rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function resolveContainedPath(parent: string, child: string): string | null {
+  const resolvedParent = resolve(parent);
+  const resolvedChild = resolve(child);
+  return isContainedPath(resolvedParent, resolvedChild) ? resolvedChild : null;
+}
+
+async function realpathDeepestExistingAncestor(path: string): Promise<string> {
+  let current = resolve(path);
+  while (true) {
+    try {
+      return await realpath(current);
+    } catch (err: any) {
+      if (err?.code !== "ENOENT") {
+        throw err;
+      }
+      const parent = dirname(current);
+      if (parent === current) {
+        throw err;
+      }
+      current = parent;
+    }
+  }
+}
+
+async function libraryPathRealpathIsContained(
+  skillsDir: string,
+  libraryPath: string,
+): Promise<boolean> {
+  try {
+    const [realSkillsDir, realLibraryAncestor] = await Promise.all([
+      realpath(skillsDir),
+      realpathDeepestExistingAncestor(libraryPath),
+    ]);
+    return isContainedPath(realSkillsDir, realLibraryAncestor);
+  } catch {
+    return false;
+  }
+}
+
+async function hashDirectoryContents(dir: string): Promise<string> {
+  const hash = createHash("sha256");
+
+  async function walk(currentDir: string, relativeDir: string): Promise<void> {
+    const entries = await readdir(currentDir, { withFileTypes: true });
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of entries) {
+      if (entry.name === ".git") {
+        continue;
+      }
+      const entryRelativePath = relativeDir
+        ? join(relativeDir, entry.name)
+        : entry.name;
+      const entryPath = join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        hash.update(`dir:${entryRelativePath}\n`);
+        await walk(entryPath, entryRelativePath);
+      } else if (entry.isFile()) {
+        hash.update(`file:${entryRelativePath}\n`);
+        hash.update(await readFile(entryPath));
+        hash.update("\n");
+      }
+    }
+  }
+
+  await walk(dir, "");
+  return hash.digest("hex");
+}
+
+async function replaceDirectoryAtomically(input: {
+  sourceDir: string;
+  targetDir: string;
+  writeLock: () => Promise<void>;
+}): Promise<LibraryUpdateResult | null> {
+  const parentDir = dirname(input.targetDir);
+  const stagedDir = await mkdtemp(join(parentDir, ".library-update-"));
+  let backupDir: string | null = null;
+  let preserveBackup = false;
+
+  try {
+    try {
+      await cp(input.sourceDir, stagedDir, { recursive: true });
+      await rm(join(stagedDir, ".git"), { recursive: true, force: true });
+
+      if (await pathExists(input.targetDir)) {
+        backupDir = join(parentDir, `.library-update-backup-${Date.now()}`);
+        await rename(input.targetDir, backupDir);
+      }
+
+      await rename(stagedDir, input.targetDir);
+
+      try {
+        await input.writeLock();
+        return null;
+      } catch (err: any) {
+        await rm(input.targetDir, { recursive: true, force: true });
+        if (backupDir) {
+          try {
+            await rename(backupDir, input.targetDir);
+            backupDir = null;
+          } catch {
+            preserveBackup = true;
+            return {
+              name: "",
+              status: "failed",
+              reason: `Updated library copy, but failed to write lock file: ${
+                err?.message ?? String(err)
+              }. Restore of previous library copy also failed; backup preserved at ${backupDir}.`,
+            };
+          }
+        }
+        return {
+          name: "",
+          status: "failed",
+          reason: `Updated library copy, but failed to write lock file: ${
+            err?.message ?? String(err)
+          }`,
+        };
+      }
+    } catch (err: any) {
+      if (backupDir) {
+        try {
+          await rename(backupDir, input.targetDir);
+          backupDir = null;
+        } catch {
+          preserveBackup = true;
+        }
+      }
+      return {
+        name: "",
+        status: "failed",
+        reason: `Failed to refresh library skill: ${err?.message ?? String(err)}`,
+      };
+    }
+  } finally {
+    await rm(stagedDir, { recursive: true, force: true });
+    if (backupDir && !preserveBackup) {
+      await rm(backupDir, { recursive: true, force: true });
+    }
+  }
+}
+
+export async function updateLibrarySkill(
+  name: string,
+  paths: LibraryPaths = {},
+  _overrides?: {
+    writeLibraryLockFn?: typeof writeLibraryLock;
+  },
+): Promise<LibraryUpdateResult> {
+  const lockPath = paths.lockPath ?? getLibraryLockPath();
+  const skillsDir = paths.skillsDir ?? getLibrarySkillsDir();
+  const writeLibraryLockFn = _overrides?.writeLibraryLockFn ?? writeLibraryLock;
+  const lock = await readLibraryLock(lockPath);
+  const directEntry = lock.skills[name] ?? null;
+  const nameMatch =
+    (Object.entries(lock.skills) as Array<[string, LibrarySkillEntry]>).find(
+      ([, entry]) => entry.name === name,
+    ) ?? null;
+  const selected: [string, LibrarySkillEntry] | null = directEntry
+    ? [name, directEntry]
+    : nameMatch;
+
+  if (!selected) {
+    return libraryUpdateFailure(
+      name,
+      `Library skill "${name}" not found. Run "asm library list".`,
+    );
+  }
+
+  const [dirName, entry] = selected;
+
+  if (!entry.source || !entry.source.trim()) {
+    return libraryUpdateFailure(dirName, "Missing update metadata: source");
+  }
+  if (!entry.sourceType || !entry.sourceType.trim()) {
+    return libraryUpdateFailure(dirName, "Missing update metadata: sourceType");
+  }
+  if (entry.sourceType !== "local") {
+    return libraryUpdateFailure(
+      dirName,
+      `Unsupported library source type for update: ${entry.sourceType}`,
+    );
+  }
+  if (!entry.skillPath || !entry.skillPath.trim()) {
+    return libraryUpdateFailure(dirName, "Missing update metadata: skillPath");
+  }
+  if (!entry.libraryPath || !entry.libraryPath.trim()) {
+    return libraryUpdateFailure(dirName, "Missing update metadata: libraryPath");
+  }
+
+  const sourceRoot = librarySourceRoot(entry);
+  if (!sourceRoot) {
+    return libraryUpdateFailure(
+      dirName,
+      `Unsupported library source for update: ${entry.source}`,
+    );
+  }
+
+  const sourceDir = resolveContainedPath(sourceRoot, join(sourceRoot, entry.skillPath));
+  if (!sourceDir) {
+    return libraryUpdateFailure(
+      dirName,
+      "Invalid update metadata: skillPath escapes source root",
+    );
+  }
+
+  const sourceSkillPath = join(sourceDir, "SKILL.md");
+  let realSourceRoot: string;
+  let realSourceDir: string;
+  try {
+    [realSourceRoot, realSourceDir] = await Promise.all([
+      realpath(sourceRoot),
+      realpath(sourceDir),
+    ]);
+  } catch (err: any) {
+    return libraryUpdateFailure(
+      dirName,
+      `Unable to read source SKILL.md at ${sourceSkillPath}: ${
+        err?.message ?? String(err)
+      }`,
+    );
+  }
+  if (!isContainedPath(realSourceRoot, realSourceDir)) {
+    return libraryUpdateFailure(
+      dirName,
+      "Invalid update metadata: skillPath escapes source root",
+    );
+  }
+
+  const libraryPath = resolveContainedPath(skillsDir, entry.libraryPath);
+  if (!libraryPath) {
+    return libraryUpdateFailure(
+      dirName,
+      "Invalid update metadata: libraryPath escapes library skills directory",
+    );
+  }
+  if (!(await libraryPathRealpathIsContained(skillsDir, libraryPath))) {
+    return libraryUpdateFailure(
+      dirName,
+      "Invalid update metadata: libraryPath escapes library skills directory",
+    );
+  }
+
+  let sourceMarkdown: string;
+  try {
+    sourceMarkdown = await readFile(sourceSkillPath, "utf-8");
+  } catch (err: any) {
+    return libraryUpdateFailure(
+      dirName,
+      `Unable to read source SKILL.md at ${sourceSkillPath}: ${
+        err?.message ?? String(err)
+      }`,
+    );
+  }
+
+  const frontmatter = parseFrontmatter(sourceMarkdown);
+  const sourceMetadata = validateSourceSkillFrontmatter(frontmatter);
+  if ("reason" in sourceMetadata) {
+    return libraryUpdateFailure(dirName, sourceMetadata.reason);
+  }
+
+  const nameFromSource = sourceMetadata.name;
+  const versionFromSource = sourceMetadata.version;
+  const nextCommitHash = await hashDirectoryContents(sourceDir);
+  const updatedLock = {
+    ...lock,
+    skills: {
+      ...lock.skills,
+      [dirName]: {
+        ...entry,
+        name: nameFromSource,
+        version: versionFromSource,
+        commitHash: nextCommitHash,
+        installedAt: new Date().toISOString(),
+      },
+    },
+  };
+
+  const swapResult = await replaceDirectoryAtomically({
+    sourceDir,
+    targetDir: libraryPath,
+    writeLock: () => writeLibraryLockFn(updatedLock, lockPath),
+  });
+  if (swapResult) {
+    return libraryUpdateFailure(
+      dirName,
+      swapResult.reason ?? "Failed to update library skill",
+    );
+  }
+
+  return {
+    name: nameFromSource,
+    status: "updated",
+    oldVersion: entry.version,
+    newVersion: versionFromSource,
+    oldCommit: entry.commitHash,
+    newCommit: nextCommitHash,
+  };
 }
 
 export interface DeactivateLibrarySkillInput {

--- a/src/library.ts
+++ b/src/library.ts
@@ -32,6 +32,20 @@ export interface LibraryPaths {
   lockPath?: string;
 }
 
+export interface LibrarySkillInfo {
+  dirName: string;
+  name: string;
+  version: string;
+  source: string;
+  sourceType?: "registry" | "github" | "local";
+  commitHash: string;
+  ref: string | null;
+  skillPath: string;
+  libraryPath: string;
+  installedAt: string;
+  missing: boolean;
+}
+
 export function emptyLibraryLock(): LibraryLockFile {
   return { version: 1, skills: {} };
 }
@@ -84,6 +98,26 @@ export async function writeLibraryLock(
 ): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, JSON.stringify(lock, null, 2) + "\n", "utf-8");
+}
+
+export async function listLibrarySkills(
+  path: string = getLibraryLockPath(),
+): Promise<LibrarySkillInfo[]> {
+  const lock = await readLibraryLock(path);
+  const rows: LibrarySkillInfo[] = [];
+
+  for (const [dirName, entry] of Object.entries(lock.skills)) {
+    let missing = false;
+    try {
+      await access(join(entry.libraryPath, "SKILL.md"));
+    } catch {
+      missing = true;
+    }
+    rows.push({ dirName, ...entry, missing });
+  }
+
+  rows.sort((a, b) => a.name.localeCompare(b.name));
+  return rows;
 }
 
 async function pathExists(path: string): Promise<boolean> {

--- a/src/updater.test.ts
+++ b/src/updater.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, writeFile, mkdir, rm } from "fs/promises";
+import { mkdtemp, writeFile, mkdir, rm, readFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -760,6 +760,87 @@ describe("updateSkill happy path", () => {
       "utf-8",
     );
     expect(installedContent).toContain("New version");
+  });
+
+  test("updates nested skills from their recorded skillPath and project scope", async () => {
+    const { execFile } = await import("child_process");
+    const { promisify } = await import("util");
+    const exec = promisify(execFile);
+
+    const workDir = join(tempDir, "nested-work");
+    const bareRepoPath = join(tempDir, "nested.git");
+    await mkdir(join(workDir, "skills", "pdf"), { recursive: true });
+    await exec("git", ["init", workDir]);
+    await exec("git", ["-C", workDir, "config", "user.email", "test@test.com"]);
+    await exec("git", ["-C", workDir, "config", "user.name", "Test"]);
+    await writeFile(
+      join(workDir, "README.md"),
+      "repo wrapper that should not be installed\n",
+    );
+    await writeFile(
+      join(workDir, "skills", "pdf", "SKILL.md"),
+      "---\nname: pdf\nversion: 2.0.0\n---\n# New nested pdf\n",
+    );
+    await exec("git", ["-C", workDir, "add", "."]);
+    await exec("git", ["-C", workDir, "commit", "-m", "init"]);
+    const { stdout } = await exec("git", ["-C", workDir, "rev-parse", "HEAD"]);
+    const newCommit = stdout.trim();
+    await exec("git", ["clone", "--bare", workDir, bareRepoPath]);
+
+    const projectSkillsDir = join(tempDir, "project", ".codex", "skills");
+    const installedDir = join(projectSkillsDir, "pdf");
+    await mkdir(installedDir, { recursive: true });
+    await writeFile(
+      join(installedDir, "SKILL.md"),
+      "---\nname: pdf\nversion: 1.0.0\n---\n# Old pdf\n",
+    );
+
+    let writtenLock: any = null;
+    const { updateSkill } = await import("./updater");
+    const entry = {
+      source: `file://${bareRepoPath}`,
+      commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ref: null,
+      installedAt: "2026-01-01T00:00:00.000Z",
+      provider: "codex",
+      sourceType: "github" as const,
+      scope: "project" as const,
+      skillPath: "skills/pdf",
+    } satisfies LockEntry & { scope: "project"; skillPath: string };
+
+    const result = await updateSkill("pdf", entry, false, {
+      auditFn: async () => ({ verdict: "safe" }),
+      loadConfigFn: async () =>
+        ({
+          providers: [
+            {
+              name: "codex",
+              global: join(tempDir, "global", ".codex", "skills"),
+              project: projectSkillsDir,
+            },
+          ],
+        }) as any,
+      resolveProviderPathFn: (p: string) => p,
+      writeLockEntryFn: async (name: string, e: any) => {
+        writtenLock = { name, entry: e };
+      },
+    });
+
+    expect(result.status).toBe("updated");
+    expect(writtenLock).toMatchObject({
+      name: "pdf",
+      entry: {
+        commitHash: newCommit,
+        skillPath: "skills/pdf",
+        scope: "project",
+      },
+    });
+    expect(await readFile(join(installedDir, "SKILL.md"), "utf-8")).toContain(
+      "New nested pdf",
+    );
+    await expect(
+      readFile(join(installedDir, "README.md"), "utf-8"),
+    ).rejects.toThrow();
   });
 
   test("updateSkill skips when security audit returns dangerous", async () => {

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -169,6 +169,10 @@ export function extractOwnerRepo(
   return { owner: parts[0], repo: parts[1] };
 }
 
+function getUpdateSourceDir(tempDir: string, entry: LockEntry): string {
+  return entry.skillPath ? join(tempDir, entry.skillPath) : tempDir;
+}
+
 // ─── Outdated Check ─────────────────────────────────────────────────────────
 
 /**
@@ -408,6 +412,8 @@ export async function updateSkill(
       return { name, status: "skipped", reason: "Already up to date" };
     }
 
+    const updateSourceDir = getUpdateSourceDir(tempDir, entry);
+
     // Step 2: Security audit on the new version
     debug(`updater: running security audit on ${name}`);
     let securityVerdict: SecurityVerdict = "safe";
@@ -415,7 +421,7 @@ export async function updateSkill(
       const auditFn = _overrides?.auditFn ?? auditSkillSecurity;
       const ownerRepo = extractOwnerRepo(entry.source);
       const auditReport = await auditFn(
-        tempDir,
+        updateSourceDir,
         name,
         ownerRepo?.owner,
         ownerRepo?.repo,
@@ -457,10 +463,6 @@ export async function updateSkill(
 
     // Step 3: Atomic swap
     // Determine the installed path from the provider config.
-    // NOTE: The lock entry does not currently record scope (global vs project).
-    // updateSkill always assumes global path. Scope tracking would be a
-    // separate issue — for now we look up the provider's configured global path
-    // from AppConfig rather than hard-coding it.
     const loadConfigFn = _overrides?.loadConfigFn ?? loadConfig;
     const resolvePathFn =
       _overrides?.resolveProviderPathFn ?? resolveProviderPath;
@@ -468,10 +470,13 @@ export async function updateSkill(
     const providerConfig = config.providers.find(
       (p) => p.name === entry.provider,
     );
-    const globalPath = providerConfig
-      ? providerConfig.global
+    const scope = entry.scope ?? "global";
+    const configuredPath = providerConfig
+      ? scope === "project"
+        ? providerConfig.project
+        : providerConfig.global
       : `~/.${entry.provider}/skills`;
-    const installedPath = resolvePathFn(globalPath);
+    const installedPath = resolvePathFn(configuredPath);
     const targetDir = join(installedPath, name);
 
     // Remove .git from cloned repo
@@ -488,7 +493,8 @@ export async function updateSkill(
     } catch {
       // Target doesn't exist — just copy
       const writeLockFn = _overrides?.writeLockEntryFn ?? writeLockEntry;
-      await cp(tempDir, targetDir, { recursive: true });
+      await mkdir(installedPath, { recursive: true });
+      await cp(updateSourceDir, targetDir, { recursive: true });
       await writeLockFn(name, {
         ...entry,
         commitHash: newCommit,
@@ -507,7 +513,7 @@ export async function updateSkill(
     const backupDir = `${targetDir}.bak-${Date.now()}`;
     try {
       await rename(targetDir, backupDir);
-      await cp(tempDir, targetDir, { recursive: true });
+      await cp(updateSourceDir, targetDir, { recursive: true });
       await rm(backupDir, { recursive: true, force: true });
     } catch (swapErr: any) {
       // Rollback: try to restore backup

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -150,6 +150,23 @@ export interface LockFile {
   skills: Record<string, LockEntry>;
 }
 
+export interface LibrarySkillEntry {
+  name: string;
+  version: string;
+  source: string;
+  commitHash: string;
+  ref: string | null;
+  skillPath: string;
+  libraryPath: string;
+  installedAt: string;
+  sourceType?: "registry" | "github" | "local";
+}
+
+export interface LibraryLockFile {
+  version: 1;
+  skills: Record<string, LibrarySkillEntry>;
+}
+
 // ─── Export Types ───────────────────────────────────────────────────────────
 
 export interface ExportedSkill {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -338,6 +338,7 @@ export interface InstallOptions {
   yes: boolean;
   path: string | null;
   all: boolean;
+  library: boolean;
   transport: TransportMode;
   method: InstallMethod;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -133,6 +133,12 @@ export interface LockEntry {
   ref: string | null;
   installedAt: string;
   provider: string;
+  /** Scope where the tracked skill was installed. Older lock entries omit this and are treated as global. */
+  scope?: "global" | "project";
+  /** Repo/local-source relative path to the skill directory. Empty string means repository root. */
+  skillPath?: string;
+  /** Absolute installed directory at the time the lock entry was written. */
+  targetDir?: string;
   /** How the skill was resolved: registry, github, or local */
   sourceType?: "registry" | "github" | "local";
   /** Registry name for registry-installed skills (e.g. "code-review") */


### PR DESCRIPTION
## Summary
- Add an ASM-owned neutral local library under the config root so skills can be installed once without appearing in provider/global skill folders.
- Add `asm install --library`, `asm library list`, `asm activate`, and `asm deactivate` so library skills are explicitly linked into and removed from selected provider scopes.
- Add `asm library update <skill>` / `asm library update --all` to refresh centrally installed skills from recorded source metadata, including local root skills and GitHub/registry-backed library entries.
- Persist source type, repo-relative skill path, target library path, commit/ref metadata, and installed timestamps so updates use the originally discovered skill subpath.
- Guard duplicate installs, force behavior, Vercel-method leakage, path traversal, symlink escapes, stale activations, invalid refreshed metadata, and lock-write rollback.

## Why
This moves ASM toward the desired local/private skill-library workflow: keep reusable skills in one central ASM location, then explicitly activate only the skills a project/provider should see.

It also preserves and uses the real discovered `skillPath`, avoiding the class of update bug described in rohitg00/skillkit#133 where update logic later looks in the wrong subdirectory.

## Related Issues
- Refs #307: neutral local/private skill library and explicit activation.
- Refs #92: local activation/deactivation lifecycle via provider symlinks.
- Prepares #247: central storage and recorded skill-path metadata needed for dependency-aware installs.
- Related external bug: rohitg00/skillkit#133.

## Test Plan
- [x] `npm test` (53 files, 1821 tests)
- [x] `npm run typecheck`
- [x] Subagent spec and code-quality reviews for deactivate/update primitives and CLI commands

## Notes
- `--library --method vercel` is rejected because the Vercel installer writes to provider skill folders, which would break the neutral-library guarantee.
- `asm activate` is symlink-only and requires explicit provider/scope selection.
- `asm deactivate` removes only symlinks that resolve into the ASM library; it refuses real directories and external symlinks.
- `asm library update --all` reports per-skill results and continues after individual failures.
