### PR TITLE
feat(index): publish find-me-skills and skill-creator from asm/skills

### DIFF
--- a/data/skill-index-resources.json
+++ b/data/skill-index-resources.json
@@ -1,12 +1,12 @@
 {
-  "updatedAt": "2026-06-29T00:00:00Z",
+  "updatedAt": "2026-06-29T21:45:00Z",
   "repos": [
     {
       "source": "github:luongnv89/asm",
       "url": "https://github.com/luongnv89/asm",
       "owner": "luongnv89",
       "repo": "asm",
-      "description": "Built-in ASM skills (only skill-auto-improver is published to the catalog)",
+      "description": "Built-in ASM skills (skill-auto-improver, find-me-skills, and skill-creator published to the catalog)",
       "maintainer": "@luongnv89",
       "enabled": false
     },

--- a/data/skill-index/luongnv89_asm.json
+++ b/data/skill-index/luongnv89_asm.json
@@ -12,7 +12,7 @@
       "license": "MIT",
       "creator": "luongnv89",
       "compatibility": "Claude Code; requires `asm` on PATH and Python 3 for skill-creator's quick_validate.py",
-      "allowedTools": [],
+      "allowedTools": ["Bash", "Read", "Write", "Edit", "Grep", "Glob"],
       "installUrl": "github:luongnv89/asm:skills/skill-auto-improver",
       "relPath": "skills/skill-auto-improver",
       "verified": true,

--- a/data/skill-index/luongnv89_asm.json
+++ b/data/skill-index/luongnv89_asm.json
@@ -2,24 +2,24 @@
   "repoUrl": "https://github.com/luongnv89/asm.git",
   "owner": "luongnv89",
   "repo": "asm",
-  "updatedAt": "2026-04-21T20:48:38.441Z",
-  "skillCount": 1,
+  "updatedAt": "2026-06-29T21:39:38.074Z",
+  "skillCount": 3,
   "skills": [
     {
       "name": "skill-auto-improver",
-      "description": "Improve a SKILL.md skill by running `asm eval`, fixing weakest categories, and looping until it clears the 85/8 floor or stops with a blocker. Use when leveling up a skill, preparing for publish, or rescuing a failing eval.",
-      "version": "0.1.0",
+      "description": "Improve a SKILL.md to pass the skill-creator standard (quick_validate, frontmatter audit, ≤500 lines) AND the asm-eval 85/8 floor. Use to level up a skill before publish. Don't use for authoring from scratch, bulk evaluation, or prose rewriting.",
+      "version": "1.0.2",
       "license": "MIT",
       "creator": "luongnv89",
-      "compatibility": "Claude Code",
-      "allowedTools": ["Bash", "Read", "Write", "Edit", "Grep", "Glob"],
+      "compatibility": "Claude Code; requires `asm` on PATH and Python 3 for skill-creator's quick_validate.py",
+      "allowedTools": [],
       "installUrl": "github:luongnv89/asm:skills/skill-auto-improver",
       "relPath": "skills/skill-auto-improver",
       "verified": true,
       "featured": true,
-      "tokenCount": 3101,
+      "tokenCount": 5435,
       "evalSummary": {
-        "overallScore": 100,
+        "overallScore": 97,
         "grade": "A",
         "categories": [
           {
@@ -43,7 +43,7 @@
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 10,
+            "score": 8,
             "max": 10
           },
           {
@@ -65,8 +65,134 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-21T20:48:38.441Z",
-        "evaluatedVersion": "0.1.0"
+        "evaluatedAt": "2026-06-29T21:39:38.069Z",
+        "evaluatedVersion": "1.0.2"
+      }
+    },
+    {
+      "name": "find-me-skills",
+      "description": "Discover which Agent Skills a user needs for a goal they can't name yet, then export an installable bundle. Use for 'I want to do X but don't know which skills', 'find me skills for', or 'recommend skills for my project'. Don't use for installing an already-named skill, authoring a skill (skill-creator), or maintaining the catalog.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "creator": "Luong NGUYEN <luongnv89@gmail.com>",
+      "compatibility": "Claude Code with the `asm` CLI on PATH",
+      "allowedTools": [],
+      "installUrl": "github:luongnv89/asm:skills/find-me-skills",
+      "relPath": "skills/find-me-skills",
+      "verified": true,
+      "tokenCount": 3563,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-06-29T21:39:38.071Z",
+        "evaluatedVersion": "1.0.0"
+      }
+    },
+    {
+      "name": "skill-creator",
+      "description": "Create, improve, evaluate, and benchmark skills. Use when authoring a new skill, updating an existing one, running evals, or optimizing a skill's description for triggering. Don't use for invoking skills, writing prose, or scaffolding Python projects.",
+      "version": "1.8.0",
+      "license": "MIT",
+      "creator": "Luong NGUYEN",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:luongnv89/asm:skills/skill-creator",
+      "relPath": "skills/skill-creator",
+      "verified": true,
+      "tokenCount": 4864,
+      "evalSummary": {
+        "overallScore": 97,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-06-29T21:39:38.073Z",
+        "evaluatedVersion": "1.8.0"
       }
     }
   ]


### PR DESCRIPTION
## Summary
- Expanded `data/skill-index/luongnv89_asm.json` from 1 → 3 catalog skills sourced from `skills/` in this repo
- Added **find-me-skills** and **skill-creator** alongside featured **skill-auto-improver**
- Refreshed `tokenCount` and `evalSummary` from local SKILL.md (eval run at index time)

### Catalog skills (luongnv89/asm)

| Skill | Eval | Notes |
|-------|------|-------|
| [skill-auto-improver](https://github.com/luongnv89/asm/tree/main/skills/skill-auto-improver) | 97 / A | featured |
| [find-me-skills](https://github.com/luongnv89/asm/tree/main/skills/find-me-skills) | 81 / B | new |
| [skill-creator](https://github.com/luongnv89/asm/tree/main/skills/skill-creator) | 97 / A | new |

### Audit summary (pre-index visibility)

| Skill | Audit | Eval | Notes |
|-------|-------|------|-------|
| find-me-skills | OK | 81 / B | name + description present; description length warning |
| skill-creator | OK | 97 / A | `creator` top-level key fails skill-best-practice (informational) |

Policy is permissive — no security flags blocking inclusion.

## Test Plan
- [x] `data/skill-index-resources.json` is valid JSON
- [x] `data/skill-index/luongnv89_asm.json` has 3 skills with `tokenCount` + `evalSummary`
- [x] `bun scripts/build-catalog.ts` succeeds; catalog includes all three install URLs
- [ ] CI passes on merge (website catalog rebuilt in deploy workflow)

## Follow-up

- Pre-existing CLI unit test failures (CI `unit-tests`) tracked in #326 — not introduced by this PR.
