### PR TITLE
feat(skill-creator): add predictability rubric for new-skill creation (#332)

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,11 +1,10 @@
 ---
 name: skill-creator
-description: "Create, improve, evaluate, and benchmark skills. Use when authoring a new skill, updating an existing one, running evals, or optimizing a skill's description for triggering. Don't use for invoking skills, writing prose, or scaffolding Python projects."
+description: "Create, improve, evaluate, benchmark skills. Use when authoring a new skill, updating an existing one, running evals, or optimizing a skill's description for triggering. Don't use for invoking skills, writing prose, or scaffolding Python projects."
 license: MIT
-creator: Luong NGUYEN
 effort: max
 metadata:
-  version: 1.8.0
+  version: 1.9.0
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -107,10 +106,13 @@ Start by understanding the user's intent. The current conversation might already
    - Does the skill need independent quality review? → Review loop with fresh subagents
    - Will the skill produce large artifacts that require focused reasoning? → Executor subagent
      If any apply, design the skill with a main-agent-as-orchestrator architecture so subagents handle the heavy lifting and the main conversation context stays clean.
+6. **Model-invoked or user-invoked?** Decide the _primary_ invocation before drafting — it changes how you write the skill. **Model-invoked** (the default) is for a reusable discipline the agent applies on its own when the situation fits; optimize the description for reliable triggering. **User-invoked** (`/skill-name`) is for orchestration or control the user runs deliberately (a pipeline, an expensive or destructive action); the body reads as "the user asked for this, proceed." Weigh the **context-load and cognitive-load** budgets here too — keep the skill small and design its structure around them. See `references/predictability-rubric.md` for the full tradeoff.
 
 ### Interview and Research
 
 Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Wait to write test prompts until this part is ironed out. Check available MCPs — research in parallel via subagents if available, otherwise inline.
+
+**Map the skill's branches before drafting the body.** Identify the distinct modes the skill runs in — the paths that need different instructions (create-vs-improve, per-framework, per-environment, dry-run-vs-apply). Knowing them first lets you open the SKILL.md with a short selector and disclose branch-specific material only on the branch that uses it, instead of forcing every run to read every branch. The "Two entry paths" block at the top of this skill is itself an example of a branch selector. See `references/predictability-rubric.md` → _Map branches before drafting_.
 
 ### Write the SKILL.md
 
@@ -157,6 +159,17 @@ Read `references/writing-guide.md` for the full guide. It covers:
 - **Generate README.md** — `docs/README.md` only, with AI-skip notice; see `references/readme-template.md`.
 - **Test Cases** — 2-3 realistic prompts saved to `evals/evals.json`; see `references/schemas.md`.
 - **Optional pre-eval LLM validation** — see `references/validation-prompts.md`.
+
+### Make it predictable (publish-ready by construction)
+
+The goal of creating a skill here is a **predictable process** — the agent follows the same reliable path every run — and a skill that ships **publish-ready** without later needing a `skill-auto-improver` cleanup pass. Read `references/predictability-rubric.md` for the full standard and its checkable pass/fail bar; the hooks below are the ones you apply _while writing_:
+
+- **Demanding completion criteria.** For step-based workflows, end every major step with a bar the agent can _check_, not vibe — tied to a command, file state, or count. The Step Completion Reports format above is the vehicle (`√/×` checks + a `Result:` line). Strong criteria are what stop the agent declaring success early; this is the difference between a repeatable process and a hopeful one.
+- **Progressive disclosure for non-universal material.** Anything branch-specific, long, or not needed on every run goes to `references/` behind a one-line pointer (mechanics in `references/writing-guide.md` → _Progressive Disclosure_) — keeps context load low and SKILL.md under 500 lines.
+- **Leading words.** Name a recurring concept once with a short load-bearing term ("atomic commit", "fail-soft", "publish-ready") and reuse the term, rather than re-explaining it at each use.
+- **Pruning pass — run before finishing.** Make one explicit pass to cut **duplication** (the same instruction in two places — keep one home, link to it), **stale sediment** (leftover guidance, dead references, obsolete names), **sprawl** (sections grown past their value, prose that should be a table or a leading word), and **no-op instructions** (lines that change nothing the agent does — "be careful", "use good judgment" — replace with a checkable criterion or delete). This pass is what most often separates a skill-creator-authored skill from one that still needs `skill-auto-improver`.
+
+`skill-auto-improver` remains the remediation tool for _externally authored_ or _legacy_ skills — not a required second stage for a skill created through this path.
 
 ## Running and evaluating test cases
 
@@ -234,6 +247,7 @@ The `agents/` directory contains instructions for specialized subagents. Read th
 The `references/` directory has additional documentation:
 
 - `references/frontmatter-rules.md` — Version Management, YAML Safety, and Frontmatter Audit (mandatory).
+- `references/predictability-rubric.md` — The predictability standard a new skill must meet by construction: invocation choice, branch mapping, demanding completion criteria, leading words, the pruning pass, and publish-ready (no auto-improver dependency).
 - `references/writing-guide.md` — Anatomy, progressive disclosure, writing patterns, error messages, test cases.
 - `references/schemas.md` — JSON structures for evals.json, grading.json, etc.
 - `references/subagent-patterns.md` — When and how to design skills that use the Agent tool.

--- a/skills/skill-creator/references/predictability-rubric.md
+++ b/skills/skill-creator/references/predictability-rubric.md
@@ -1,0 +1,80 @@
+# Predictability Rubric
+
+The standard a skill must meet **by construction** when authored through skill-creator — so it ships publish-ready and does not need a later `skill-auto-improver` cleanup pass to become standard-compliant. Apply it during creation (the "Creating a skill" path in `SKILL.md`), not as an afterthought.
+
+**Root virtue: predictability.** A good skill makes the agent follow the _same reliable process_ every run. Identical _outputs_ are not the goal — a predictable _process_ is. Everything below serves that.
+
+Skills should stay **small, adaptable, composable**, and be designed around two budgets:
+
+- **Context load** — how many tokens the skill costs every time it loads. Lower is better; this is why SKILL.md has a 500-line cap and dense material moves to `references/` (progressive disclosure).
+- **Cognitive load** — how much the agent must hold in mind to act correctly. Ordered steps, leading words, and one-decision-at-a-time structure lower it.
+
+The rest of this file is the checkable rubric. The matching items in `SKILL.md` are the _hooks_ (do them while writing); this file is the _why_ and the pass/fail bar.
+
+## 1. Choose invocation intentionally
+
+Decide **model-invoked vs user-invoked** before drafting the body — it changes how the skill is written.
+
+| Invocation                       | Use when                                                                                                                                                       | Description job                                                                                                                |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **Model-invoked** (the default)  | The skill is a _reusable discipline_ the agent should apply on its own whenever the situation fits (a transform, a review pass, a fixed workflow).             | The `description` must trigger reliably — pushy positives + negative triggers (see `SKILL.md` → _Writing a good description_). |
+| **User-invoked** (`/skill-name`) | The skill is _orchestration or control_ the user runs deliberately — a multi-step pipeline, a destructive or expensive action, a thing the user must opt into. | The `description` documents intent for the listing; triggering matters less because the user names it.                         |
+
+A skill can be both, but pick the _primary_ path — it decides whether you optimize the description for triggering or for human-readable intent, and whether the body reads as "apply this now" or "the user asked for this, proceed."
+
+**Checkable:** the skill states (in its own design notes or its shape) which invocation it targets, and the description/body match that choice.
+
+## 2. Map branches before drafting
+
+Before writing substantial body content, identify the skill's distinct **branches / modes** — the paths through it that differ enough to need different instructions (create-vs-improve, per-framework, per-environment, dry-run-vs-apply).
+
+Why first: branches drive both structure _and_ progressive disclosure. Once you know them you can write a short selector at the top and disclose branch-specific material only on the branch that needs it — instead of forcing every run to read every branch.
+
+**Checkable:** the SKILL.md opens with (or quickly reaches) a branch selector, and branch-specific detail is not loaded on branches that don't use it.
+
+## 3. Demanding, checkable completion criteria
+
+Each ordered step ends with a completion bar the agent can _check_, not vibe. "Done when the report prints PASS and `quick_validate.py` is clean" beats "done when it looks good." Strong criteria are what make the process repeatable — they stop the agent from declaring success early.
+
+Use the Step Completion Reports format (`SKILL.md` → _Step Completion Reports_) for step-based workflows: explicit `√/×` checks plus a `Result: PASS | FAIL | PARTIAL` line. Make the checks _demanding_ — tie them to commands, file states, or counts, not impressions.
+
+**Checkable:** every major step in a step-based skill has a verifiable completion condition; the skill cannot report success without meeting it.
+
+## 4. Progressive disclosure for non-universal material
+
+Anything **branch-specific, long, or not needed on every run** belongs in `references/`, reached by a one-line pointer — not inlined into SKILL.md. This is the same rule SKILL.md already states for the 500-line cap; named here so the rubric is complete. Do not re-document the mechanics — see `writing-guide.md` → _Progressive Disclosure_.
+
+**Checkable:** SKILL.md stays under 500 lines; reference files are one level deep and pointed to with clear "read this when X" guidance.
+
+## 5. Leading words
+
+Use **leading words** — short, load-bearing terms that steer behavior and collapse a verbose concept into one token the agent already understands. "Atomic commit," "fail-soft," "red-capable test," "publish-ready" each carry a paragraph of meaning. Prefer one precise leading word over three sentences re-explaining it.
+
+**Checkable:** recurring concepts are named once and referred to by that name, rather than re-explained at each use.
+
+## 6. Pruning pass (run before finishing)
+
+Before the skill is done, do one explicit pass to remove what the rubric above is meant to prevent. This is the step that most often separates a skill-creator-authored skill from one that still needs `skill-auto-improver`.
+
+Cut, in this order:
+
+- **Duplication** — the same instruction stated in two places. Keep one home; link to it. (Re-explaining progressive disclosure in three files is duplication.)
+- **Stale sediment** — guidance left over from an earlier version that no longer matches the current flow, dead references, obsolete file names.
+- **Sprawl** — sections that grew past their value, prose that could be a table or a leading word, SKILL.md drifting toward the 500-line cap.
+- **No-op instructions** — lines that tell the agent nothing actionable ("be careful," "use good judgment," "make it high quality"). Replace with a checkable criterion or delete.
+
+**Checkable:** a reviewer reading the finished skill finds no instruction stated twice, no reference to something that no longer exists, and no line that fails to change what the agent does.
+
+## 7. Publish-ready — no auto-improver dependency
+
+The output of skill-creator is a **publish-ready** skill. A skill authored through this path should clear the skill-creator standard on its own — `quick_validate.py` clean, Frontmatter Audit passing, SKILL.md under 500 lines, description with a negative-trigger clause, the items above satisfied — **without** a follow-up `skill-auto-improver` run as a normal cleanup step.
+
+`skill-auto-improver` still has a job: bringing _externally authored_ or _legacy_ skills up to standard. It is the remediation tool for skills that did **not** go through this rubric — not a required second stage for ones that did.
+
+**Checkable:** running `skill-auto-improver` immediately after creation would find nothing structural to fix.
+
+---
+
+## How to apply this rubric
+
+Test and iterate until the skill produces a **predictable process**. Run the test prompts (`SKILL.md` → _Running and evaluating test cases_) more than once: a predictable skill drives the agent down the same path each time even when the wording of the request varies. If two runs diverge in _process_ (different steps, skipped checks), the skill is under-specified — tighten the ordered steps, completion criteria, or leading words until they converge. Converging _process_, not byte-identical _output_, is the bar.


### PR DESCRIPTION
Closes #332

## Summary

Embed a predictability authoring standard into `skill-creator` so skills created through it are publish-ready **by construction** and do not require a later `skill-auto-improver` cleanup pass. The standard centres on the root virtue the issue describes — predictability: the agent should follow the same reliable process every run. Because the edited file (`skill-creator/SKILL.md`) is itself a skill governed by this very standard, the change was held to its own rubric (no duplication, no sprawl, no no-op instructions, SKILL.md < 500 lines).

## Approach

**Balanced:** add a new named reference file `references/predictability-rubric.md` (the *why* + checkable pass/fail bar), and wire actionable *hooks* into the "Creating a skill" path of `SKILL.md` so the discipline is applied while writing — not as an afterthought. Progressive-disclosure mechanics stay owned solely by `writing-guide.md` (cross-referenced, not duplicated), which is what keeps the change from self-violating its own pruning criterion.

## Decision Record

- **Root cause:** `skill-creator` already covered structure, frontmatter, progressive disclosure, evals, and publishing, but never named the predictability-oriented creation discipline (intentional invocation choice, context/cognitive-load tradeoffs, branch mapping, demanding completion criteria, leading words, and a pruning pass). A skill authored through it could therefore still need a `skill-auto-improver` cleanup pass to reach standard.
- **Options considered:** Option 1 — new standalone `references/predictability-rubric.md` + SKILL.md hooks; Option 2 — fold the rubric into the existing `writing-guide.md`; Option 3 — inline the full rubric in SKILL.md.
- **Options rejected:** Option 2 — buries a named standard inside an anatomy doc, less discoverable; Option 3 — adds the most SKILL.md surface, risks the 500-line cap and reads as sprawl (mildly violates the pruning criterion the rubric itself adds).
- **Selected option:** Option 1 — new reference file + compliant-by-construction hooks (user-selected).
- **Residual risk:** none functional — documentation-only change to one skill. The rubric is prose guidance, so its long-term value depends on authors following it; it is enforced only where mechanically checkable (`quick_validate.py`, the Frontmatter Audit).

Analyzed at: `feat/332-skill-creator-predictability-rubric @ 9681fc2` (2026-06-30)

## Changes

| File | Change |
|------|--------|
| `skills/skill-creator/references/predictability-rubric.md` | **New.** The named standard: root virtue (predictability), context/cognitive-load budgets, and 7 checkable items — invocation choice, branch mapping, demanding completion criteria, progressive disclosure, leading words, pruning pass, and publish-ready (no auto-improver dependency) — plus a "how to apply" section on iterating to a predictable process. |
| `skills/skill-creator/SKILL.md` | Capture Intent gains Q6 (model- vs user-invoked + load budgets); Interview adds "map branches before drafting"; new "Make it predictable" subsection adds demanding completion criteria, a progressive-disclosure cross-ref, leading words, and the pruning pass, plus the publish-ready statement; new reference registered in the index. Also: removed the disallowed `creator:` frontmatter key (redundant with `metadata.author`) and trimmed the description to ≤250 chars so the skill passes its own `quick_validate.py`; bumped `metadata.version` 1.8.0 → 1.9.0. |

## Test Results

- Unit tests: passed (pre-commit `vitest run src/`)
- Integration tests: n/a
- E2e tests: passed (pre-push `vitest run tests/e2e/node-e2e.test.ts`)
- Build: passed (pre-push `npm run build`)
- Skill validation: `python3 skills/skill-creator/scripts/quick_validate.py skills/skill-creator` → "Skill is valid!" (exit 0, no warnings)
- QA cycles: 1 (code review PASS, zero fix issues)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `skill-creator` captures invocation choice (model- vs user-invoked) + context/cognitive-load tradeoffs during new-skill creation | pass | `SKILL.md` Capture Intent Q6 ("Model-invoked or user-invoked?"); `predictability-rubric.md` §1 with the model-vs-user tradeoff table |
| New-skill creation identifies distinct branches/modes before drafting substantial content | pass | `SKILL.md` Interview & Research → "Map the skill's branches before drafting the body"; `predictability-rubric.md` §2 (checkable: opens with/quickly reaches a branch selector) |
| Authoring guidance requires ordered steps with clear, checkable completion criteria | pass | `SKILL.md` "Make it predictable" → "Demanding completion criteria" (ties each step to a command/file-state/count via Step Completion Reports); `predictability-rubric.md` §3 |
| Authoring guidance promotes progressive disclosure for branch-specific/long/non-universal material | pass | `SKILL.md` "Make it predictable" → progressive-disclosure bullet; `predictability-rubric.md` §4 — both delegate mechanics to `writing-guide.md` (cross-reference, not re-documentation) |
| Authoring guidance includes a pruning pass for duplication, stale sediment, sprawl, and no-op instructions | pass | `SKILL.md` "Make it predictable" → "Pruning pass — run before finishing"; `predictability-rubric.md` §6 (ordered, checkable, with no-op examples) |
| Final guidance makes clear skill-creator-authored skills are publish-ready and don't depend on skill-auto-improver as a normal cleanup step | pass | `SKILL.md` "Make it predictable" intro + closing line (auto-improver = remediation for external/legacy skills only); `predictability-rubric.md` §7 |
