### PR TITLE
refactor(skill-auto-improver): align with skill-creator predictability standard (#333)

### DIFF
--- a/skills/skill-auto-improver/SKILL.md
+++ b/skills/skill-auto-improver/SKILL.md
@@ -1,23 +1,26 @@
 ---
 name: skill-auto-improver
-description: "Improve a SKILL.md to pass the skill-creator standard (quick_validate, frontmatter audit, ≤500 lines) AND the asm-eval 85/8 floor. Use to level up a skill before publish. Don't use for authoring from scratch, bulk evaluation, or prose rewriting."
+description: "Improve an external, legacy, or drifted SKILL.md to the skill-creator standard — hard validation gates plus an advisory predictability audit. Don't use for authoring from scratch (skill-creator output is already standard), bulk eval, or prose edits."
 license: MIT
 compatibility: "Claude Code; requires `asm` on PATH and Python 3 for skill-creator's quick_validate.py"
 allowed-tools: Bash Read Write Edit Grep Glob
 effort: high
 metadata:
-  version: 1.0.2
+  version: 1.1.0
   author: luongnv89
 ---
 
 # Skill Auto-Improver
 
-You are running an eval-driven improvement loop for a SKILL.md-based skill. The target skill must clear **two gates** in this order:
+You run an eval-driven loop that **retrofits an existing SKILL.md to the current skill-creator standard**. This is the remediation tool for skills that did **not** go through skill-creator — external, legacy, manually-authored, or drifted. Fresh skill-creator output is publish-ready by construction (see skill-creator's `predictability-rubric.md` → _Publish-ready — no auto-improver dependency_) and should **not** normally need this skill.
 
-1. **Skill-creator standard (must-pass floor)** — `python scripts/quick_validate.py` is clean; the Frontmatter Audit passes; SKILL.md is under 500 lines; description has a negative-trigger clause; `metadata.version` and `metadata.author` are present; `docs/README.md` (if it exists) carries the AI-skip notice; bundled scripts print descriptive errors before exiting.
-2. **`asm eval` quality floor (supplementary)** — `overallScore > 85` AND every category score `>= 8`.
+The target must clear **two hard gates**, then gets one **advisory** audit:
 
-A skill that scores 92 on `asm eval` but fails `quick_validate.py` is **not** done. A skill that passes `quick_validate.py` but scores 70 on `asm eval` is **not** done. Both gates must clear, or the loop reports a blocker.
+1. **Gate 1 — skill-creator standard (must-pass floor)** — `quick_validate` clean, Frontmatter Audit passes, ≤500 lines (detail below).
+2. **Gate 2 — asm-eval floor (supplementary)** — `overallScore > 85` AND every category `>= 8`.
+3. **Advisory — predictability audit (Phase 2b, not a gate)** — judgment-based findings against skill-creator's rubric, reported separately, **never** blocking.
+
+A skill that scores 92 but fails `quick_validate.py` is not done; one that passes `quick_validate.py` but scores 70 is not done. **Both gates must clear, or the loop reports a blocker** — open predictability findings alone never make one.
 
 ## Repo Sync Before Edits (mandatory)
 
@@ -33,12 +36,14 @@ If the working tree is dirty, `git stash`, sync, then `git stash pop`. If `origi
 
 ## When to Use
 
-- The user asks to "improve", "level up", "fix", "polish", or "bring up to standard" an existing skill
-- A skill fails `quick_validate.py` or scores below the asm-eval 85/8 floor and must ship
-- You are preparing a skill for `asm publish` or inclusion in a catalog
-- You want to dogfood quality improvements on one of your own skills
+Reach for this on an **existing, external, legacy, manually-authored, or drifted** skill:
 
-If the user only wants a report without edits, run `asm eval <path>` and `python scripts/quick_validate.py <path>` directly — that is not this skill. If the user is authoring a brand-new skill from scratch, send them to `/skill-creator` instead — this skill assumes a SKILL.md already exists.
+- The user asks to "improve", "level up", "fix", "polish", or "bring up to standard" an existing skill
+- A skill was authored outside skill-creator (hand-written, imported, inherited) and must meet the current bar
+- A skill has **drifted** — predates the standard, or edits left it failing `quick_validate.py` or below the 85/8 floor
+- You are preparing such a skill for `asm publish` or a catalog
+
+**Not** for routine cleanup of fresh skill-creator output (publish-ready by construction — use `/skill-creator` to author). Assumes a SKILL.md exists. For a report only, run `asm eval` and `quick_validate.py` directly — not this skill.
 
 ## Prerequisites
 
@@ -50,11 +55,13 @@ Verify all of the following before touching any files. Stop and tell the user if
 - The working tree has no unrelated uncommitted edits (dirty files get mixed into diffs)
 - You have write access to the skill directory
 
-Resolve the path to skill-creator's validator once at the start and reuse it:
+Resolve skill-creator's validator (required) and rubric (fail-soft) once and reuse them. The rubric is **fail-soft** — a locally-installed skill-creator may predate the repo and not ship it; a missing file only degrades Phase 2b to a warning and never aborts the run:
 
 ```bash
 QV="$HOME/.claude/skills/skill-creator/scripts/quick_validate.py"
 test -f "$QV" || { echo "skill-creator not installed at $QV"; exit 1; }
+RUBRIC="$HOME/.claude/skills/skill-creator/references/predictability-rubric.md"
+test -f "$RUBRIC" || echo "⚠ predictability rubric missing — Phase 2b degraded (gates unaffected)"
 ```
 
 ## Inputs
@@ -67,7 +74,9 @@ The user provides one of:
 
 For GitHub inputs, ask the user to clone locally first or whether you should open a PR back to that repo. This skill's default path is **local editing** — remote editing is out of scope for v1.
 
-## The Two Gates
+## The Gates
+
+Keep two decision classes separate: **hard gates** (Gate 1, Gate 2) are mechanical and pass/fail — they alone decide PASS vs BLOCKER. **Predictability findings** (Phase 2b) are judgment-based and advisory — both gates green with open findings is still a PASS.
 
 ### Gate 1 — Skill-creator standard (must-pass floor)
 
@@ -89,7 +98,11 @@ This gate is **non-negotiable** — `asm publish` and the catalog rely on it.
 overallScore > 85   AND   min(categories[*].score) >= 8
 ```
 
-Stricter than overall score alone — a skill at 86 with a 5 in `testability` still fails. This forces balanced quality instead of letting one strong area hide a weak one.
+Stricter than overall alone — 86 with a 5 in `testability` still fails. Forces balanced quality instead of letting one strong area hide a weak one.
+
+### Advisory — predictability audit (not a gate)
+
+Both gates green does not guarantee the skill drives the same _process_ each run. The Phase 2b audit catches that — see `references/predictability-audit.md` for the checklist and finding classes.
 
 ## Workflow
 
@@ -156,7 +169,16 @@ Many skills jump 5–15 points on `asm eval` here without touching the body, and
 - Missing AI-skip notice in `docs/README.md` → prepend the HTML comment from `references/skill-creator-checklist.md`
 - Bundled script exits silently → add `echo "Error: ..." >&2` lines before each `exit 1` / `sys.exit(1)`
 
-Re-run `python "$QV" "$SKILL_PATH"` after every Gate 1 edit. Do not move to Phase 3 until Gate 1 is clean.
+Re-run `python "$QV" "$SKILL_PATH"` after every Gate 1 edit. Do not move to Phase 2b until Gate 1 is clean.
+
+### Phase 2b — Audit against the predictability rubric (advisory)
+
+With Gate 1 clean, audit against skill-creator's rubric **before** Phase 3 so the findings can steer your category edits. Advisory — never gates, never blocks.
+
+1. Confirm `$RUBRIC` resolved (Prerequisites). If missing, **skip fail-soft** — log `⚠ predictability audit skipped (rubric unavailable)` and move to Phase 3.
+2. Walk `references/predictability-audit.md` — record each of the 7 items as `pass` / `advisory` with a specific note, save to `.asm-improver/predictability-audit.md`.
+
+Act on findings only when _targeted_ (a predictability fix often also lifts an asm-eval category); never bloat to satisfy one. Finding-handling detail and the no-bloat rule live in `references/predictability-audit.md`.
 
 ### Phase 3 — Fix the lowest asm-eval categories
 
@@ -172,24 +194,7 @@ For each category below 8:
 
 ### Phase 4 — Watch for cross-gate tradeoffs (sidebar — applies during Phase 3)
 
-These principles apply continuously while doing Phase 3 category fixes, not as a separate sequential phase. Read them once before Phase 3 and keep them in mind on every edit.
-
-The two gates pull in opposite directions on body length:
-
-- `asm eval`'s `prompt-engineering` rewards bodies up to 3000 words
-- `asm eval`'s `context-efficiency` rewards bodies under 1500 words
-- Gate 1 caps SKILL.md at **500 lines** (the hard skill-creator rule, ~ a few thousand words)
-
-When you add content, default to **linking out, not inlining**:
-
-- Long examples → `references/examples.md` with `See references/examples.md for...`
-- Long scripts → `scripts/foo.sh` with `Run scripts/foo.sh to...`
-- Long tables → `references/rubric.md`
-- Long prerequisite lists → `references/prerequisites.md`
-
-This pattern earns `context-efficiency` points (the words "reference" / "see" / "link" / "template" are scanned for), keeps SKILL.md under the 500-line Gate 1 cap, and reduces token cost on every invocation.
-
-Concretely, if you would need more than ~80 lines to add a section, put it in `references/` and link to it from SKILL.md in 2-3 lines.
+A continuous sidebar, not a sequential phase: the two gates pull in opposite directions on body length, so a fix that lifts one asm-eval category can sink another or breach the 500-line cap. Read `references/cross-gate-tradeoffs.md` once before Phase 3 and default to **linking out, not inlining** on every edit.
 
 ### Phase 5 — Bump the target skill's `metadata.version`
 
@@ -222,20 +227,13 @@ Save every iteration's JSON to `.asm-improver/iter-N.json` and a one-line gate s
 
 ### Phase 7 — Write the final report
 
-On pass, write `.asm-improver/report.md` with:
+Write `.asm-improver/report.md` (full layout in `references/report-template.md`) keeping **three report sections visually distinct**:
 
-- Target skill path
-- Baseline vs final for **both gates**: `quick_validate.py` status, Frontmatter Audit findings cleared, `overallScore`, `grade`, per-category before/after table
-- Target skill's `metadata.version`: baseline → final
-- Files changed (list every path under the skill directory that was edited or created)
-- Iterations taken (N of 8)
-- Key fixes applied (one line per category or audit item that moved)
+1. **Gate status** — baseline vs final for both hard gates (`quick_validate.py`, Frontmatter Audit, `overallScore`, `grade`, per-category before/after). Decides PASS vs BLOCKER.
+2. **Predictability findings** (advisory) — Phase 2b findings per item, open ones with a one-line note; say so if it was skipped fail-soft. Never a gate failure.
+3. **Unresolved blockers** — BLOCKER only; each names the failed **hard gate** (Gate 1 or Gate 2), the specific check, and what was unresolvable. Predictability findings are never promoted here.
 
-On blocker, write the same report but add a "Blockers" section explaining why a gate was not cleared. Blocker entries must name the gate (Gate 1 or Gate 2), the specific failing check (e.g., `quick_validate.py: unexpected key 'tags'`), and what the loop was unable to resolve. Do not pretend a blocker is a pass.
-
-Example blocker entry:
-
-> **Gate 2 — testability** (stuck at 6/10): The evaluator wants verifiable outputs and an "Acceptance Criteria" section. The skill's output is a subjective rewrite of prose, which is hard to express as a testable assertion. Author decision needed: accept a 6 here, or redefine scope so output is machine-checkable.
+Also include: skill path, `metadata.version` baseline → final, files changed, iterations (N of 8), key fixes applied. Do not pretend a blocker is a pass.
 
 ## Step Completion Reports (mandatory)
 
@@ -252,28 +250,29 @@ After each phase, emit a compact status block so pass/fail is scannable:
   Result:              PASS | FAIL | PARTIAL
 ```
 
-Use `√` for pass, `×` for fail, `—` for context. Report per phase: Phase 0 (baseline captured), Phase 1 (deterministic + normalization), Phase 2 (Gate 1 fixes), Phase 3 (asm-eval category fixes), Phase 5 (version bump applied), Phase 6 (loop stop condition), Phase 7 (final report written).
+Use `√` for pass, `×` for fail, `—` for context. Report per phase: Phase 0 (baseline captured), Phase 1 (deterministic + normalization), Phase 2 (Gate 1 fixes), Phase 2b (predictability audit — report findings count and "advisory" / "skipped fail-soft"; this phase never gates), Phase 3 (asm-eval category fixes), Phase 5 (version bump applied), Phase 6 (loop stop condition), Phase 7 (final report written).
 
 ## Acceptance Criteria
 
 - `.asm-improver/baseline.json`, `.asm-improver/baseline-quickvalidate.txt`, and `.asm-improver/baseline-frontmatter-audit.md` captured before any edits
 - `asm eval --fix` applied, then frontmatter normalized so `quick_validate.py` accepts the result
 - Each Gate 1 check addressed at least once before any Gate 2 work
+- Predictability audit (Phase 2b) run after Gate 1 is clean — findings captured to `.asm-improver/predictability-audit.md`, or the skip logged when the rubric is unavailable. Findings are advisory and never gate the loop
 - Each `asm eval` category below 8 addressed at least once
 - Re-eval against **both** gates after every iteration, captured to `.asm-improver/iter-N.json` and `.asm-improver/iter-N-gates.txt`
 - Target skill's `metadata.version` bumped exactly once per iteration that produced edits
 - Loop stops on one of the 4 conditions in Phase 6 — never unbounded
-- `.asm-improver/report.md` exists on exit, pass or blocker
+- `.asm-improver/report.md` exists on exit, pass or blocker, with gate status, advisory predictability findings, and unresolved blockers as three visually distinct sections
 - On PASS: `python "$QV" "$SKILL_PATH"` exits 0 AND final eval JSON shows `overallScore > 85` AND `min(categories[*].score) >= 8`
-- On BLOCKER: report names every Gate 1 check still failing and every category still below 8 with a one-line reason
+- On BLOCKER: report names every Gate 1 check still failing and every category still below 8 with a one-line reason. Open predictability findings alone never constitute a blocker
 
 ### Expected output
 
-See `references/report-template.md` for the full PASS and BLOCKER report templates. On BLOCKER, include a `## Blockers` section naming each failing gate check with a one-line reason.
+See `references/report-template.md` for the full PASS and BLOCKER report templates. On BLOCKER, include an `## Unresolved blockers` section naming each failing **hard gate** check with a one-line reason.
 
 ## Edge Cases
 
-- **Skill already passes both gates**: stop at Phase 0, skip to report. Do not edit passing skills.
+- **Skill already passes both gates**: do not edit it. Still run the Phase 2b predictability audit read-only and report any advisory findings, then stop — passing gates does not guarantee a predictable process, but open findings here never force an edit.
 - **SKILL.md has no frontmatter**: `asm eval --fix` cannot add it. Ask the user whether to scaffold one (using the skill-creator template) or abort.
 - **Iterating regresses either gate**: revert the last edit (`cp SKILL.md.bak SKILL.md` if available, or undo via git) and try a different fix pattern from the playbook.
 - **`asm eval --fix` writes a key `quick_validate.py` rejects**: this is expected — Phase 1's normalization step handles it. Do not skip the normalization.
@@ -288,8 +287,11 @@ See `references/report-template.md` for the full PASS and BLOCKER report templat
 - `references/skill-creator-checklist.md` — Gate 1 retrofit playbook (frontmatter, README, scripts, body length)
 - `references/frontmatter-audit.md` — full audit checklist plus the `asm eval --fix` normalization migration
 - `references/category-playbook.md` — per-category fix patterns for `asm eval` Gate 2
+- `references/predictability-audit.md` — Phase 2b advisory audit checklist (the rubric's operational checklist, applied to the target skill)
+- `references/cross-gate-tradeoffs.md` — Phase 4 sidebar: the body-length tradeoff between the two gates and the link-out rule
 - `references/report-template.md` — PASS and BLOCKER report layouts
 - `~/.claude/skills/skill-creator/scripts/quick_validate.py` — the Gate 1 mechanical validator
 - `~/.claude/skills/skill-creator/references/frontmatter-rules.md` — upstream source of the audit rules
+- `~/.claude/skills/skill-creator/references/predictability-rubric.md` — upstream source of the Phase 2b audit (fail-soft if absent)
 - `asm eval --help` — flag reference for the evaluator
 - `src/evaluator.ts` in the ASM repo — source of truth for how each Gate 2 category is scored

--- a/skills/skill-auto-improver/references/cross-gate-tradeoffs.md
+++ b/skills/skill-auto-improver/references/cross-gate-tradeoffs.md
@@ -1,0 +1,22 @@
+# Cross-gate tradeoffs (Phase 4 sidebar)
+
+The principles to hold in mind throughout Phase 3 category fixes. This is **not** a sequential phase — read it once before Phase 3 and apply it on every edit.
+
+## The two gates pull in opposite directions on body length
+
+- `asm eval`'s `prompt-engineering` rewards bodies up to ~3000 words
+- `asm eval`'s `context-efficiency` rewards bodies under ~1500 words (and penalizes bodies over ~3000)
+- Gate 1 caps SKILL.md at **500 lines** (the hard skill-creator rule, ~a few thousand words)
+
+A fix that lifts one category can sink another: expanding the body for `testability` can tank `context-efficiency` or push SKILL.md over the 500-line cap (failing Gate 1). This is why Phase 3 works one category at a time, re-evals after each change, and reverts any edit that regresses either gate.
+
+## When you add content, default to linking out, not inlining
+
+- Long examples → `references/examples.md` with `See references/examples.md for...`
+- Long scripts → `scripts/foo.sh` with `Run scripts/foo.sh to...`
+- Long tables → `references/rubric.md`
+- Long prerequisite lists → `references/prerequisites.md`
+
+This pattern earns `context-efficiency` points (the words "reference" / "see" / "link" / "template" are scanned for), keeps SKILL.md under the 500-line Gate 1 cap, and cuts token cost on every invocation.
+
+**Rule of thumb:** if a new section would need more than ~80 lines, put it in `references/` and link to it from SKILL.md in 2–3 lines.

--- a/skills/skill-auto-improver/references/predictability-audit.md
+++ b/skills/skill-auto-improver/references/predictability-audit.md
@@ -1,0 +1,43 @@
+# Predictability audit (Phase 2b — advisory)
+
+The checklist for the advisory predictability audit. It applies skill-creator's predictability rubric to the **target** skill so the auto-improver can spot process-reliability gaps that the two hard gates miss. Findings here are **judgment-based and never pass/fail** — they inform targeted Phase 3 edits and a distinct report section, but they do not gate the loop.
+
+## Source of truth (link, do not copy)
+
+The rubric this audit scores against lives in skill-creator, not here:
+
+```
+~/.claude/skills/skill-creator/references/predictability-rubric.md
+```
+
+Read that file for the full _why_ and pass/fail bar of each item. This file is the **operational checklist** the auto-improver walks; it deliberately does not restate the rubric's prose (duplication is one of the things the rubric tells you to prune). If the two ever diverge, the rubric upstream wins.
+
+**Fail-soft.** A locally-installed skill-creator may predate the rubric (it shipped in a later repo revision). If `$RUBRIC` does not resolve, **skip this phase**: log `⚠ predictability audit skipped (rubric unavailable)`, note the skip in the report's advisory section, and proceed to Phase 3. The hard gates (Gate 1, Gate 2) are unaffected — they never depend on this file.
+
+## Root virtue
+
+**Predictability** — the skill should make the agent follow the _same reliable process_ every run. A converging _process_, not byte-identical _output_, is the bar. Every check below serves that.
+
+## The 7 checks
+
+Walk these in order. For each, record `pass` or `advisory` with a one-line, _specific_ note — never "looks fine." A finding names the concrete gap and, where useful, the targeted fix.
+
+| #   | Rubric item                                           | What an `advisory` finding looks like                                                                                                                                                                               |
+| --- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Invocation chosen intentionally**                   | Description optimizes for triggering but the skill is really user-invoked orchestration (or vice-versa); body voice and `description` job disagree with the actual invocation path.                                 |
+| 2   | **Branches mapped before the body**                   | The skill has distinct modes (create-vs-improve, per-framework, dry-run-vs-apply) but no early selector; every run reads branch-specific material it does not need.                                                 |
+| 3   | **Demanding, checkable completion criteria**          | A step ends on vibe ("done when it looks good") instead of a checkable bar tied to a command, file state, or count; the skill can declare success without meeting a verifiable condition.                           |
+| 4   | **Progressive disclosure for non-universal material** | Long, branch-specific, or rarely-needed content is inlined in SKILL.md instead of a one-line pointer to `references/`; SKILL.md drifts toward the 500-line cap.                                                     |
+| 5   | **Leading words**                                     | A recurring concept is re-explained in full at each use instead of named once (e.g. "atomic commit", "fail-soft", "publish-ready") and referred to by that name.                                                    |
+| 6   | **No duplication / stale sediment / sprawl / no-ops** | The same instruction appears in two places; a reference points to a file that no longer exists; a section grew past its value; a line says "be careful" / "use good judgment" without changing what the agent does. |
+| 7   | **Publish-ready — no auto-improver dependency**       | (Mostly informational here — this _is_ the auto-improver.) Note structural debt that would make the skill fail the rubric if re-created through skill-creator.                                                      |
+
+## Turning findings into action
+
+- **Targeted only.** Act on a finding when the fix is small and preserves the skill's intent. A good predictability fix often _also_ lifts an asm-eval category — adding a checkable completion bar (#3) helps `testability`; collapsing a re-explained concept into a leading word (#5) helps `context-efficiency`.
+- **Never bloat to satisfy a finding.** Do not inline long material or rewrite a skill wholesale to close a finding — that regresses `context-efficiency` and contradicts check #4. If a fix would grow SKILL.md past the 500-line cap, link out instead, or leave the finding open and advisory.
+- **Open findings stay advisory.** A finding you choose not to act on goes into the report's **Predictability findings** section as advisory. It does **not** block PASS and is **not** a blocker entry.
+
+## Output
+
+Save the walk to `.asm-improver/predictability-audit.md` as a 7-row table (item → `pass`/`advisory` → note). The report's advisory section (see `references/report-template.md`) lifts from this file.

--- a/skills/skill-auto-improver/references/report-template.md
+++ b/skills/skill-auto-improver/references/report-template.md
@@ -1,6 +1,12 @@
 # Report template
 
-The final `.asm-improver/report.md` produced by this skill. PASS layout first, BLOCKER layout second. The report covers **both gates** — the skill-creator standard (Gate 1) and the asm-eval 85/8 floor (Gate 2).
+The final `.asm-improver/report.md` produced by this skill. PASS layout first, BLOCKER layout second.
+
+The report keeps **three sections visually distinct** so a reader never confuses one for another:
+
+1. **Gate status** — the two hard gates (Gate 1 = skill-creator standard, Gate 2 = asm-eval 85/8). These decide PASS vs BLOCKER.
+2. **Predictability findings** — the advisory Phase 2b audit. Listed in rubric order (items 1–7), never pass/fail; an open finding here is _not_ a gate failure.
+3. **Unresolved blockers** — present only on BLOCKER, and only ever a failed **hard gate**.
 
 ## PASS example
 
@@ -11,6 +17,7 @@ Skill: skills/my-skill
 Verdict: PASS
 Gate 1 (skill-creator standard): √ pass
 Gate 2 (asm-eval): overallScore 91, min category 8
+Predictability audit: 5/7 pass, 2 advisory (non-blocking)
 Iterations: 3 of 8
 Target version: 0.2.0 → 1.0.0
 
@@ -41,6 +48,22 @@ Target version: 0.2.0 → 1.0.0
 | naming              | 10       | 10    | 0       |
 | **Overall**         | **57**   | **91**| **+34** |
 
+## Predictability findings (advisory — not gates)
+
+Source: Phase 2b audit against skill-creator's predictability rubric. None of these block PASS.
+
+| # | Rubric item                          | Status   | Note |
+|---|--------------------------------------|----------|------|
+| 1 | Invocation chosen intentionally      | pass     | model-invoked; description triggers reliably |
+| 2 | Branches mapped before the body      | pass     | create/improve selector at top |
+| 3 | Demanding, checkable completion bars | advisory | step 4 ends on "looks complete" — tie to a count; left as-is to avoid scope creep |
+| 4 | Progressive disclosure               | pass     | long tables already in references/ |
+| 5 | Leading words                        | pass     | — |
+| 6 | No duplication / sprawl / no-ops     | advisory | "be thorough" line in step 2 is a no-op; candidate for a later pass |
+| 7 | Publish-ready                        | pass     | would clear the rubric if re-created |
+
+(If Phase 2b was skipped fail-soft because the rubric was unavailable, this section reads: `Predictability audit skipped — rubric not found at $RUBRIC (hard gates unaffected).`)
+
 ## Files changed
 - SKILL.md
 - references/examples.md (new)
@@ -50,10 +73,10 @@ Target version: 0.2.0 → 1.0.0
 
 ## BLOCKER example
 
-Same layout as PASS, plus a `## Blockers` section listing every gate check still failing with a one-line reason:
+Same layout as PASS — including the advisory **Predictability findings** section — plus an `## Unresolved blockers` section listing every **hard gate** check still failing with a one-line reason. Only failed gates appear here; open predictability findings stay in the advisory section and are never promoted to blockers.
 
 ```
-## Blockers
+## Unresolved blockers
 
 - **Gate 1 — quick_validate.py**: still rejecting top-level key `architecture`. Field encodes no runtime info; author decision needed: drop it or move under metadata.
 - **Gate 2 — testability** (stuck at 6/10): evaluator wants verifiable outputs; skill output is subjective prose. Author decision needed.
@@ -66,6 +89,7 @@ The verdict line on a blocker reads:
 Verdict: BLOCKER
 Gate 1 (skill-creator standard): × failing 1 check
 Gate 2 (asm-eval): overallScore 86, min category 6 (below floor)
+Predictability audit: 4/7 pass, 3 advisory (non-blocking)
 ```
 
-Both gate states are reported even when only one is failing — so a reviewer can see at a glance which gate is the holdup.
+Both gate states are reported even when only one is failing — so a reviewer can see at a glance which gate is the holdup. The predictability line is informational: it never changes the verdict.


### PR DESCRIPTION
Closes #333

## Summary

Aligns `skill-auto-improver` with `skill-creator`'s newly-added predictability standard and makes the two skills' relationship explicit: `skill-auto-improver` is the **retrofit path** for existing, external, legacy, manually-authored, or drifted skills — not a routine cleanup pass for fresh `skill-creator` output, which is publish-ready by construction. The improvement workflow now audits a target against the same predictability rubric `skill-creator` enforces, kept strictly **advisory** so it never becomes a third hard gate.

## Approach

Targeted retrofit-role clarification plus a fail-soft advisory predictability audit. The rubric is **linked, not copied** (one source of truth), and predictability findings inform targeted edits without ever blocking the loop.

## Decision Record

- **Root cause:** `skill-creator` gained a predictability rubric (commit `15adaeb`) whose §7 states its output is publish-ready and should not need `skill-auto-improver`. The reciprocal statement — and an audit against that same rubric — was missing from `skill-auto-improver`, leaving the two skills' roles undefined.
- **Options considered:** Option 1 — copy the rubric into this skill; Option 2 — link the rubric + add a fail-soft advisory audit (selected); Option 3 — add predictability as a hard Gate 3.
- **Options rejected:** Option 1 — violates the rubric's own anti-duplication rule and creates two sources of truth; Option 3 — contradicts AC4, which requires separating hard gates from judgment-based findings.
- **Selected option:** Option 2 — link `skill-creator`'s `predictability-rubric.md`, add a **Phase 2b** advisory predictability audit (fail-soft when the rubric is absent), and restructure the report into three distinct sections (gate status / advisory predictability findings / unresolved blockers).
- **Residual risk:** The installed `skill-creator` copy may lag the repo and not ship `predictability-rubric.md` (it is missing locally today). Mitigated by the fail-soft prerequisite check — a missing rubric degrades Phase 2b to a warning and never aborts; the two hard gates are unaffected.

Analyzed at: `refactor/333-align-skill-auto-improver @ 783c661` (2026-06-30)

## Changes

| File | Change |
|------|--------|
| `skills/skill-auto-improver/SKILL.md` | Description (lead verb + retrofit role + negative-trigger clause), intro, When to Use, prerequisites (`$RUBRIC` fail-soft resolve), Gates section (two-decision-class separation), new **Phase 2b** audit, Phase 4 slimmed to a pointer, Phase 7 three-section report, Step Completion list, Acceptance Criteria, References; `metadata.version` 1.0.2 → 1.1.0 |
| `skills/skill-auto-improver/references/report-template.md` | Restructured into three visually distinct sections — gate status, advisory predictability findings, unresolved blockers — with PASS and BLOCKER examples |
| `skills/skill-auto-improver/references/predictability-audit.md` | **New** — Phase 2b advisory checklist; links (does not copy) `skill-creator`'s rubric; fail-soft; maps the 7 rubric items to checkable findings |
| `skills/skill-auto-improver/references/cross-gate-tradeoffs.md` | **New** — Phase 4 cross-gate body-length tradeoff detail moved out of SKILL.md for progressive disclosure |

## Test Results

This change edits a skill; its "test suite" is the skill-creator standard the skill itself enforces, run on the edited skill:

- Gate 1 (`quick_validate.py`): **clean** (exit 0, no warnings)
- Gate 2 (`asm eval`): **overall 96 (grade A), min category 8** — passes the 85/8 floor (baseline was 97/A/8)
- SKILL.md: 297 lines (<500 cap)
- Pre-commit hooks: passed (prettier, security scan, unit tests)
- QA cycles: 1 (3 non-blocking terminology nits found and fixed; all 6 acceptance criteria confirmed satisfied)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `skill-auto-improver` states it is for existing, external, legacy, manually-authored, or drifted skills | pass | `SKILL.md` intro (`retrofits an existing SKILL.md…`) + When to Use (`Reach for this on an existing, external, legacy, manually-authored, or drifted skill`) |
| States newly-created `skill-creator` output should already satisfy the standard and not normally need this skill | pass | `SKILL.md` intro (`Fresh skill-creator output is publish-ready by construction … should not normally need this skill`) + When to Use (`Not for routine cleanup of fresh skill-creator output`) |
| Workflow audits against the same predictability standard as `skill-creator` | pass | Phase 2b walks `skill-creator`'s rubric via `references/predictability-audit.md` (7 checks map 1:1 to the rubric's §§1–7) |
| Separates hard validation gates from judgment-based predictability findings | pass | "The Gates" section + intro distinguish two pass/fail gates from advisory Phase 2b findings; advisory-not-a-gate invariant verified across all four files |
| Prioritizes targeted improvements that preserve intent and avoid context bloat | pass | `references/predictability-audit.md` "Turning findings into action" (`Targeted only … Never bloat to satisfy a finding`); long content kept in `references/` |
| Final report distinguishes gate status, predictability findings, and unresolved blockers | pass | Phase 7 + `references/report-template.md` define three visually distinct sections |
