### PR TITLE
fix(library): harden activate --force and skip unchanged updates (#327)

### DIFF
--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import {
+  chmod,
   lstat,
   mkdir,
   mkdtemp,
@@ -270,6 +271,65 @@ describe("activateLibrarySkill", () => {
     );
 
     await expect(readlink(symlinkPath)).resolves.toBe(existingPath);
+  });
+
+  test("overwrites an existing symlink with force", async () => {
+    const symlinkPath = join(targetDir, "brainstorming");
+    const existingPath = join(tempDir, "existing");
+    await mkdir(targetDir, { recursive: true });
+    await mkdir(existingPath, { recursive: true });
+    await symlink(existingPath, symlinkPath, "dir");
+
+    const result = await activateLibrarySkill({
+      libraryPath,
+      targetDir,
+      activationName: "brainstorming",
+      force: true,
+    });
+
+    expect(result).toEqual({ symlinkPath, targetPath: libraryPath });
+    await expect(readlink(symlinkPath)).resolves.toBe(libraryPath);
+  });
+
+  test("refuses to overwrite a real directory with force", async () => {
+    const symlinkPath = join(targetDir, "brainstorming");
+    const sentinel = join(symlinkPath, "keep-me.txt");
+    await mkdir(symlinkPath, { recursive: true });
+    await writeFile(sentinel, "precious", "utf-8");
+
+    await expect(
+      activateLibrarySkill({
+        libraryPath,
+        targetDir,
+        activationName: "brainstorming",
+        force: true,
+      }),
+    ).rejects.toThrow(
+      `Refusing to overwrite non-symlink target: ${symlinkPath}.`,
+    );
+
+    await expect(readFile(sentinel, "utf-8")).resolves.toBe("precious");
+    await expect(lstat(symlinkPath)).resolves.toMatchObject({
+      isDirectory: expect.any(Function),
+    });
+    expect((await lstat(symlinkPath)).isDirectory()).toBe(true);
+  });
+
+  test("rethrows non-ENOENT lstat errors on the activation target", async () => {
+    await mkdir(targetDir, { recursive: true });
+    await chmod(targetDir, 0o000);
+    try {
+      await expect(
+        activateLibrarySkill({
+          libraryPath,
+          targetDir,
+          activationName: "brainstorming",
+          force: false,
+        }),
+      ).rejects.toMatchObject({ code: "EACCES" });
+    } finally {
+      await chmod(targetDir, 0o755);
+    }
   });
 
   test("rejects invalid activation names before touching filesystem targets", async () => {
@@ -1149,6 +1209,44 @@ describe("updateLibrarySkill", () => {
     await expect(
       readFile(join(externalDir, "brainstorming", "SKILL.md"), "utf-8"),
     ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("skips update when local commit hash is unchanged", async () => {
+    const first = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+    expect(first.status).toBe("updated");
+
+    const lockBefore = await readLibraryLock(lockPath);
+    const installedAtBefore = lockBefore.skills.brainstorming.installedAt;
+    const commitBefore = lockBefore.skills.brainstorming.commitHash;
+
+    const result = await updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+
+    expect(result).toMatchObject({
+      name: "brainstorming",
+      status: "skipped",
+      oldCommit: commitBefore,
+      newCommit: commitBefore,
+    });
+    const lockAfter = await readLibraryLock(lockPath);
+    expect(lockAfter.skills.brainstorming.installedAt).toBe(installedAtBefore);
+    expect(lockAfter.skills.brainstorming.commitHash).toBe(commitBefore);
+    await expect(
+      readFile(join(libraryPath, "SKILL.md"), "utf-8"),
+    ).resolves.toContain("# Old Source");
+  });
+
+  test("skippedCount reflects unchanged skills in update --all", async () => {
+    await updateLibrarySkill("brainstorming", { skillsDir, lockPath });
+    const summary = await updateLibrarySkills(null, { skillsDir, lockPath });
+    expect(summary.skippedCount).toBe(1);
+    expect(summary.updatedCount).toBe(0);
+    expect(summary.results[0].status).toBe("skipped");
   });
 
   test("includes non-SKILL.md files in local commit hash", async () => {

--- a/src/library.ts
+++ b/src/library.ts
@@ -583,6 +583,16 @@ export async function updateLibrarySkill(
     if (!nextCommitHash) {
       return libraryUpdateFailure(dirName, "Could not read new commit");
     }
+    if (entry.commitHash === nextCommitHash) {
+      return {
+        name: nameFromSource,
+        status: "skipped",
+        oldVersion: entry.version,
+        newVersion: versionFromSource,
+        oldCommit: entry.commitHash,
+        newCommit: nextCommitHash,
+      };
+    }
     const updatedLock = {
       ...lock,
       skills: {
@@ -756,15 +766,24 @@ export async function activateLibrarySkill(input: {
   const activationName = validateSkillDirectoryName(input.activationName);
   const symlinkPath = join(input.targetDir, activationName);
   try {
-    await lstat(symlinkPath);
+    const stat = await lstat(symlinkPath);
     if (!input.force) {
       throw new Error(
         `Target already exists: ${symlinkPath}. Use --force to overwrite.`,
       );
     }
-    await rm(symlinkPath, { recursive: true, force: true });
+    if (!stat.isSymbolicLink()) {
+      throw new Error(
+        `Refusing to overwrite non-symlink target: ${symlinkPath}.`,
+      );
+    }
+    await rm(symlinkPath, { force: true });
   } catch (err: any) {
-    if (err?.message?.includes("--force")) throw err;
+    if (err?.code === "ENOENT") {
+      // Target does not exist; proceed to create symlink.
+    } else {
+      throw err;
+    }
   }
 
   await mkdir(input.targetDir, { recursive: true });


### PR DESCRIPTION
## Summary

Batch follow-up from PR #320: harden `activateLibrarySkill` and implement the dead `skipped` path in `updateLibrarySkill`.

## Approach

- **#327**: On `--force`, `lstat` the target and remove only symlinks; refuse real directories with a clear error (aligned with deactivate).
- **#328**: Treat only `ENOENT` as missing target; propagate `EACCES`/`EPERM` and other errors.
- **#329**: After computing `nextCommitHash`, return `status: "skipped"` when it matches `entry.commitHash` — no directory swap, no `installedAt` bump.

## Changes

| File | Change |
|------|--------|
| `src/library.ts` | activate force/symlink guard; lstat error handling; update skip short-circuit |
| `src/library.test.ts` | Tests for force+symlink, force+real dir, EACCES, skipped update, skippedCount |

## Test Results

- `npx vitest run src/library.test.ts` — 45 passed

## Acceptance Criteria Verification

| Issue | Criterion | Status |
|-------|-----------|--------|
| #327 | `--force` only removes symlinks | ✓ |
| #327 | Real directory refused, not deleted | ✓ |
| #327 | Test for real directory + force | ✓ |
| #328 | Only ENOENT swallowed | ✓ |
| #328 | EACCES/EPERM rethrown | ✓ |
| #328 | Permission error test | ✓ |
| #329 | Compare commitHash, skip when equal | ✓ |
| #329 | No swap / no installedAt bump on skip | ✓ |
| #329 | skippedCount in update --all | ✓ |
| #329 | Test no-op update path | ✓ |

Closes #327
Closes #328
Closes #329