### PR TITLE
fix(installer): run npx via node + npx-cli.js so Vercel install works on Windows

### DIFF
--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -8,7 +8,8 @@ import {
   lstat,
   symlink,
 } from "fs/promises";
-import { join, relative } from "path";
+import { existsSync } from "fs";
+import { join, relative, basename } from "path";
 import { tmpdir } from "os";
 import {
   parseSource,
@@ -30,6 +31,7 @@ import {
   findDuplicateInstallNames,
   buildRepoUrl,
   checkNpxAvailable,
+  resolveNpxCli,
   installScriptDependencies,
   checkCrossToolLink,
   linkExistingSkill,
@@ -1889,11 +1891,32 @@ describe("executeInstallAllProviders with project scope", () => {
   });
 });
 
+// ─── resolveNpxCli tests ────────────────────────────────────────────────────
+
+describe("resolveNpxCli", () => {
+  test("locates npm's npx-cli.js next to the running Node binary", () => {
+    // The test runner is launched by node, whose bundled npm ships npx-cli.js.
+    const cli = resolveNpxCli();
+    expect(cli).not.toBeNull();
+    expect(basename(cli as string)).toBe("npx-cli.js");
+    expect(existsSync(cli as string)).toBe(true);
+  });
+
+  test("returns a path under npm's bin directory", () => {
+    const cli = resolveNpxCli();
+    // Normalize separators so the assertion holds on Windows and POSIX alike.
+    const normalized = (cli as string).replace(/\\/g, "/");
+    expect(normalized).toContain("/npm/bin/npx-cli.js");
+  });
+});
+
 // ─── checkNpxAvailable tests ────────────────────────────────────────────────
 
 describe("checkNpxAvailable", () => {
   test("does not throw when npx is available", async () => {
-    // npx should be available in the test environment since node is present
+    // npx should be available in the test environment since node is present.
+    // On Windows this only passes because the runner invokes npx via node +
+    // npx-cli.js rather than the `npx.cmd` shim (which execFile cannot spawn).
     await expect(checkNpxAvailable()).resolves.toBeUndefined();
   });
 });

--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -9,7 +9,7 @@ import {
   symlink,
 } from "fs/promises";
 import { existsSync } from "fs";
-import { join, relative, basename } from "path";
+import { join, relative, basename, dirname } from "path";
 import { tmpdir } from "os";
 import {
   parseSource,
@@ -1894,19 +1894,66 @@ describe("executeInstallAllProviders with project scope", () => {
 // ─── resolveNpxCli tests ────────────────────────────────────────────────────
 
 describe("resolveNpxCli", () => {
-  test("locates npm's npx-cli.js next to the running Node binary", () => {
-    // The test runner is launched by node, whose bundled npm ships npx-cli.js.
-    const cli = resolveNpxCli();
-    expect(cli).not.toBeNull();
-    expect(basename(cli as string)).toBe("npx-cli.js");
-    expect(existsSync(cli as string)).toBe(true);
+  // Resolution is driven by the layout on disk relative to node's directory,
+  // which varies by installer. Test each known layout deterministically with a
+  // fixture tree and an injected nodeDir, so the result never depends on how
+  // the test runner's own Node happens to be installed (that env-dependence is
+  // what let a Homebrew-unversioned layout slip through — see issue #343).
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), "asm-npxcli-"));
   });
 
-  test("returns a path under npm's bin directory", () => {
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  // Create an npx-cli.js at `npxRel` under the fixture root and return the
+  // fake node-binary directory (what dirname(process.execPath) would yield).
+  async function layout(npxRel: string): Promise<string> {
+    const binDir = join(tmp, "bin");
+    await mkdir(binDir, { recursive: true });
+    const npxCli = join(tmp, npxRel);
+    await mkdir(dirname(npxCli), { recursive: true });
+    await writeFile(npxCli, "");
+    return binDir;
+  }
+
+  test("resolves the Windows layout (npm beside node)", async () => {
+    const binDir = await layout("bin/node_modules/npm/bin/npx-cli.js");
+    expect(resolveNpxCli(binDir)).toBe(
+      join(binDir, "node_modules", "npm", "bin", "npx-cli.js"),
+    );
+  });
+
+  test("resolves the standard POSIX layout (../lib/node_modules)", async () => {
+    const binDir = await layout("lib/node_modules/npm/bin/npx-cli.js");
+    expect(resolveNpxCli(binDir)).toBe(
+      join(tmp, "lib", "node_modules", "npm", "bin", "npx-cli.js"),
+    );
+  });
+
+  test("resolves Homebrew's unversioned layout (../libexec/lib) — issue #343", async () => {
+    const binDir = await layout("libexec/lib/node_modules/npm/bin/npx-cli.js");
+    expect(resolveNpxCli(binDir)).toBe(
+      join(tmp, "libexec", "lib", "node_modules", "npm", "bin", "npx-cli.js"),
+    );
+  });
+
+  test("returns null when no known layout matches (caller falls back to the shim)", async () => {
+    const binDir = join(tmp, "bin");
+    await mkdir(binDir, { recursive: true });
+    expect(resolveNpxCli(binDir)).toBeNull();
+  });
+
+  test("default nodeDir never throws: returns null or an existing npx-cli.js", () => {
+    // Contract check against the real runtime — must not assume a layout.
     const cli = resolveNpxCli();
-    // Normalize separators so the assertion holds on Windows and POSIX alike.
-    const normalized = (cli as string).replace(/\\/g, "/");
-    expect(normalized).toContain("/npm/bin/npx-cli.js");
+    if (cli !== null) {
+      expect(basename(cli)).toBe("npx-cli.js");
+      expect(existsSync(cli)).toBe(true);
+    }
   });
 });
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -13,7 +13,8 @@ import {
   symlink,
   mkdir,
 } from "fs/promises";
-import { join, resolve, relative, basename } from "path";
+import { existsSync } from "fs";
+import { join, resolve, relative, basename, dirname } from "path";
 import { homedir } from "os";
 import { tmpdir } from "os";
 import {
@@ -726,9 +727,61 @@ export async function cleanupTemp(tempDir: string): Promise<void> {
 
 // ─── Vercel npx skills add Support ──────────────────────────────────────────
 
+/**
+ * Resolve npm's bundled `npx-cli.js` so npx can be launched via the current
+ * Node binary (`process.execPath`) instead of the platform `npx` shim.
+ *
+ * On Windows the shim is `npx.cmd`, which `child_process.execFile`/`spawn`
+ * cannot launch without `shell: true`: a bare `npx` throws ENOENT (Node does
+ * not consult PATHEXT for the command name) and `npx.cmd` throws EINVAL under
+ * Node's CVE-2024-27980 hardening, which refuses to spawn `.cmd`/`.bat` files
+ * without a shell. Invoking `node <npx-cli.js> …` sidesteps the shim entirely
+ * and passes arguments as a verbatim argv, so paths with spaces and shell
+ * metacharacters stay safe (no shell interpolation, unlike `shell: true`).
+ *
+ * Returns the absolute path to `npx-cli.js`, or null when it cannot be located
+ * (exotic runtimes) — callers then fall back to the `npx` shim on PATH.
+ */
+export function resolveNpxCli(): string | null {
+  const nodeDir = dirname(process.execPath);
+  const candidates = [
+    // Windows installers, nvm-windows, fnm, Volta: npm sits beside node.
+    join(nodeDir, "node_modules", "npm", "bin", "npx-cli.js"),
+    // POSIX layouts (system packages, nvm, Homebrew): node in bin/, npm in lib/.
+    join(nodeDir, "..", "lib", "node_modules", "npm", "bin", "npx-cli.js"),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Cross-platform runner for the `npx` CLI. Prefers launching npm's bundled
+ * `npx-cli.js` through the current Node binary — this behaves identically on
+ * every OS and avoids the Windows `.cmd` shim problem (see `resolveNpxCli`).
+ * Falls back to the `npx` shim on PATH when the CLI script cannot be found.
+ */
+function runNpx(
+  args: string[],
+  opts: { timeout?: number } = {},
+): Promise<{ stdout: string; stderr: string }> {
+  // Only Windows needs the node + npx-cli.js indirection: there `npx` is a
+  // `.cmd` shim that execFile cannot launch (see resolveNpxCli). On POSIX the
+  // bare `npx` on PATH resolves correctly, so leave that path byte-for-byte
+  // unchanged to keep the blast radius of this fix on Windows alone.
+  if (process.platform === "win32") {
+    const npxCli = resolveNpxCli();
+    if (npxCli) {
+      return execFileAsync(process.execPath, [npxCli, ...args], opts);
+    }
+  }
+  return execFileAsync("npx", args, opts);
+}
+
 export async function checkNpxAvailable(): Promise<void> {
   try {
-    await execFileAsync("npx", ["--version"]);
+    await runNpx(["--version"]);
     debug("install: npx available");
   } catch {
     throw new Error(
@@ -752,7 +805,7 @@ export async function executeNpxSkillsAdd(
   debug(`install: running npx ${args.join(" ")}`);
 
   try {
-    const result = await execFileAsync("npx", args, { timeout: 120_000 });
+    const result = await runNpx(args, { timeout: 120_000 });
     return { stdout: result.stdout, stderr: result.stderr };
   } catch (err: any) {
     const stderr = err.stderr || err.message || "";

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -741,14 +741,33 @@ export async function cleanupTemp(tempDir: string): Promise<void> {
  *
  * Returns the absolute path to `npx-cli.js`, or null when it cannot be located
  * (exotic runtimes) — callers then fall back to the `npx` shim on PATH.
+ *
+ * `nodeDir` is injectable for testing; production always resolves it from the
+ * running Node binary.
  */
-export function resolveNpxCli(): string | null {
-  const nodeDir = dirname(process.execPath);
+export function resolveNpxCli(
+  nodeDir: string = dirname(process.execPath),
+): string | null {
   const candidates = [
-    // Windows installers, nvm-windows, fnm, Volta: npm sits beside node.
+    // Windows installers, nvm-windows, fnm, Volta, Chocolatey, Scoop: npm sits
+    // beside node under node_modules/.
     join(nodeDir, "node_modules", "npm", "bin", "npx-cli.js"),
-    // POSIX layouts (system packages, nvm, Homebrew): node in bin/, npm in lib/.
+    // Standard POSIX (system packages, nvm, CI toolcache, Homebrew node@NN):
+    // node in bin/, npm in ../lib/node_modules/.
     join(nodeDir, "..", "lib", "node_modules", "npm", "bin", "npx-cli.js"),
+    // Homebrew's *unversioned* `node` formula is keg-only and installs npm
+    // under libexec (bin/npx is only a symlink into it), so relative to the
+    // real node binary npm lives in ../libexec/lib/node_modules/.
+    join(
+      nodeDir,
+      "..",
+      "libexec",
+      "lib",
+      "node_modules",
+      "npm",
+      "bin",
+      "npx-cli.js",
+    ),
   ];
   for (const candidate of candidates) {
     if (existsSync(candidate)) return candidate;


### PR DESCRIPTION
Fixes #342.

## Problem
`asm install --method vercel` is unusable on Windows: it fails with `npx is required for Vercel method installation` even when npx works. On Windows `npx` is a `.cmd` shim, and `execFile("npx")` throws `ENOENT` (Node does not consult `PATHEXT`) while `execFile("npx.cmd")` throws `EINVAL` under Node's CVE-2024-27980 hardening (which refuses to spawn `.cmd`/`.bat` without a shell).

## Fix
- Add `resolveNpxCli()` to locate npm's bundled `npx-cli.js`, and `runNpx()` to launch it through the current Node binary (`process.execPath`).
- Shell-free: arguments pass as a verbatim argv, so paths with spaces and shell metacharacters stay safe (avoids the `shell: true` injection footgun and the DEP0190 deprecation).
- Preserves the existing `execFile` timeout and error semantics.
- **Windows-gated** — POSIX keeps launching the `npx` shim exactly as before, so Linux/macOS behavior is byte-for-byte unchanged.
- No new dependencies.

## Testing
- `tsc --noEmit` clean.
- New unit tests for `resolveNpxCli`; `checkNpxAvailable` now passes on Windows (it failed before this change).
- Verified end-to-end on Windows: `asm install github:... --method vercel` now actually runs `npx skills add` (clones, discovers, installs) instead of erroring at step 2.