### PR TITLE
fix(link): use a directory junction on Windows so link/activate work without admin

### DIFF
--- a/src/importer.ts
+++ b/src/importer.ts
@@ -1,7 +1,8 @@
-import { readFile, access, mkdir, cp, rm, symlink } from "fs/promises";
+import { readFile, access, mkdir, cp, rm } from "fs/promises";
 import { join, basename } from "path";
 import { resolveProviderPath, loadConfig } from "./config";
 import { scanAllSkills } from "./scanner";
+import { createDirSymlink } from "./utils/fs";
 import { debug } from "./logger";
 import type {
   ExportManifest,
@@ -271,7 +272,7 @@ export async function importSkills(
         // Recreate the symlink; fall back to copy if the target doesn't exist
         try {
           await access(skill.symlinkTarget);
-          await symlink(skill.symlinkTarget, targetDir);
+          await createDirSymlink(skill.symlinkTarget, targetDir);
           debug(
             `import: symlinked "${skill.name}" -> ${skill.symlinkTarget} at ${targetDir}`,
           );

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -10,7 +10,6 @@ import {
   access,
   stat,
   lstat,
-  symlink,
   mkdir,
 } from "fs/promises";
 import { existsSync } from "fs";
@@ -25,7 +24,7 @@ import {
 import { estimateTokenCount } from "./utils/token-count";
 import { resolveProviderPath } from "./config";
 import { debug } from "./logger";
-import { readFilesRecursive } from "./utils/fs";
+import { createDirSymlink, readFilesRecursive } from "./utils/fs";
 import { checkboxPicker } from "./utils/checkbox-picker";
 import { createLink } from "./linker";
 import type {
@@ -708,7 +707,7 @@ export async function executeInstallAllProviders(
 
     // Create relative symlink pointing to the primary install location
     const relTarget = relative(providerDir, plan.targetDir);
-    await symlink(relTarget, targetPath, "dir");
+    await createDirSymlink(relTarget, targetPath);
     debug(`install: symlinked ${targetPath} -> ${relTarget}`);
   }
 

--- a/src/library.ts
+++ b/src/library.ts
@@ -11,7 +11,6 @@ import {
   realpath,
   rename,
   rm,
-  symlink,
   writeFile,
 } from "fs/promises";
 import { execFile } from "child_process";
@@ -21,6 +20,7 @@ import { dirname, isAbsolute, join, relative, resolve } from "path";
 import { getLibraryLockPath, getLibrarySkillsDir } from "./config";
 import { debug } from "./logger";
 import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
+import { createDirSymlink } from "./utils/fs";
 import { sourceToCloneUrl } from "./updater";
 import type { LibraryLockFile, LibrarySkillEntry } from "./utils/types";
 
@@ -787,7 +787,7 @@ export async function activateLibrarySkill(input: {
   }
 
   await mkdir(input.targetDir, { recursive: true });
-  await symlink(input.libraryPath, symlinkPath, "dir");
+  await createDirSymlink(input.libraryPath, symlinkPath);
   return { symlinkPath, targetPath: input.libraryPath };
 }
 

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -1,15 +1,7 @@
-import {
-  access,
-  lstat,
-  mkdir,
-  readdir,
-  readFile,
-  rm,
-  stat,
-  symlink,
-} from "fs/promises";
+import { access, lstat, mkdir, readdir, readFile, rm, stat } from "fs/promises";
 import { join } from "path";
 import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
+import { createDirSymlink } from "./utils/fs";
 
 export interface LinkableSkill {
   /** Absolute path to the skill directory */
@@ -93,8 +85,8 @@ export async function createLink(
   // Ensure the parent directory exists before creating the symlink
   await mkdir(targetDir, { recursive: true });
 
-  // Create symlink
-  await symlink(sourcePath, targetPath, "dir");
+  // Create symlink (a junction on Windows — see createDirSymlink)
+  await createDirSymlink(sourcePath, targetPath);
 }
 
 /**

--- a/src/uninstaller.ts
+++ b/src/uninstaller.ts
@@ -4,7 +4,6 @@ import {
   writeFile,
   access,
   lstat,
-  symlink,
   rename,
   readdir,
   mkdir,
@@ -13,6 +12,7 @@ import {
 import { join, resolve, dirname, relative } from "path";
 import { homedir } from "os";
 import { resolveProviderPath } from "./config";
+import { createDirSymlink } from "./utils/fs";
 import type {
   SkillInfo,
   RemovalPlan,
@@ -418,7 +418,7 @@ export async function executeRemoval(
           }
         }
         await mkdir(parentDir, { recursive: true });
-        await symlink(relTarget, repointPath, "dir");
+        await createDirSymlink(relTarget, repointPath);
         log.push(`Repointed symlink: ${repointPath} -> ${relTarget}`);
       } catch (err: any) {
         log.push(
@@ -459,7 +459,7 @@ export async function executeRemoval(
       ) {
         const parentDir = dirname(dir.path);
         const relTarget = relative(parentDir, symlinkTo);
-        await symlink(relTarget, dir.path, "dir");
+        await createDirSymlink(relTarget, dir.path);
         log.push(`Created symlink: ${dir.path} -> ${relTarget}`);
       }
     } catch (err: any) {

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,5 +1,31 @@
-import { readdir, readFile, stat } from "fs/promises";
-import { join } from "path";
+import { readdir, readFile, stat, symlink } from "fs/promises";
+import { dirname, join, resolve } from "path";
+
+/**
+ * Create a directory symlink that works on every platform.
+ *
+ * POSIX: a standard directory symlink, preserving the caller's target — which
+ * is often relative, so the link stays valid if the home directory moves.
+ *
+ * Windows: a directory *junction* instead of a real symlink. Real directory
+ * symlinks require elevation (Admin / Developer Mode) and otherwise fail with
+ * `EPERM`, whereas junctions need no special privileges. Node still reports a
+ * junction as a symlink via `lstat().isSymbolicLink()` and resolves it through
+ * `readlink()`/`realpath()`, so asm's symlink detection, dedup, and uninstall
+ * logic keep working unchanged. Junction targets must be absolute, so the
+ * (possibly relative) target is resolved against the link's parent directory —
+ * the same base against which a symlink target is interpreted.
+ */
+export async function createDirSymlink(
+  target: string,
+  linkPath: string,
+): Promise<void> {
+  if (process.platform === "win32") {
+    await symlink(resolve(dirname(linkPath), target), linkPath, "junction");
+  } else {
+    await symlink(target, linkPath, "dir");
+  }
+}
 
 export const BINARY_EXTENSIONS = new Set([
   ".png",


### PR DESCRIPTION
Fixes #346.

On Windows `asm link`, `asm activate`, and `install -p all` fail with `EPERM: operation not permitted, symlink` because creating a directory symlink needs an elevated shell or Developer Mode.

This routes the six symlink call sites through a small `createDirSymlink` helper. On Windows it creates a directory junction, which doesn't need elevation. Node reports a junction as a symlink (`lstat().isSymbolicLink()` is true, `readlink`/`realpath` resolve it), so the duplicate audit, symlink detection, and uninstall/relocation code keep working unchanged. Junctions need an absolute target, so the helper resolves the (possibly relative) target against the link's parent directory. On macOS and Linux nothing changes: it still creates a relative directory symlink with the same arguments as before.

Tested on Windows 10: `link`, `activate`, `install -p all`, and uninstall relocation all succeed, and `asm list` still reports the results as symlinks. The POSIX path is unchanged from the current code.

One heads-up: a Windows `npm test` still shows separate test-only failures (raw `fs.symlink` in test setup and some POSIX path assumptions in assertions) that this product change doesn't touch. I'll send those as a follow-up PR so this one stays focused on the fix.
