### PR TITLE
refactor(website): add author view, pie chart, and stats links (#351)

### DIFF
--- a/website-src/src/__tests__/skill-detail.test.jsx
+++ b/website-src/src/__tests__/skill-detail.test.jsx
@@ -1,6 +1,7 @@
 /** @vitest-environment jsdom */
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
+import { HashRouter } from "react-router-dom";
 import SkillDetail from "../components/SkillDetail.jsx";
 
 /**
@@ -34,7 +35,11 @@ const baseSkill = {
 };
 
 function renderDetail(props) {
-  return render(<SkillDetail slim={baseSkill} {...props} />);
+  return render(
+    <HashRouter>
+      <SkillDetail slim={baseSkill} {...props} />
+    </HashRouter>,
+  );
 }
 
 describe("SkillDetail — Quick Start section (issue #273)", () => {
@@ -90,7 +95,11 @@ describe("SkillDetail — Quick Start section (issue #273)", () => {
       ...baseSkill,
       installUrl: "github:custom/path:to/skill",
     };
-    render(<SkillDetail slim={customSkill} />);
+    render(
+      <HashRouter>
+        <SkillDetail slim={customSkill} />
+      </HashRouter>,
+    );
     expect(
       screen.getByText("asm audit security github:custom/path:to/skill"),
     ).toBeTruthy();
@@ -114,7 +123,11 @@ describe("SkillDetail — Quick Start section (issue #273)", () => {
       ...baseSkill,
       installUrl: undefined,
     };
-    render(<SkillDetail slim={skillWithoutUrl} />);
+    render(
+      <HashRouter>
+        <SkillDetail slim={skillWithoutUrl} />
+      </HashRouter>,
+    );
     expect(screen.queryByText("Quick Start")).toBeNull();
   });
 
@@ -123,7 +136,38 @@ describe("SkillDetail — Quick Start section (issue #273)", () => {
       ...baseSkill,
       installUrl: null,
     };
-    render(<SkillDetail slim={skillWithNullUrl} />);
+    render(
+      <HashRouter>
+        <SkillDetail slim={skillWithNullUrl} />
+      </HashRouter>,
+    );
     expect(screen.queryByText("Quick Start")).toBeNull();
+  });
+});
+
+describe("SkillDetail — author stats link (issue #351)", () => {
+  afterEach(() => cleanup());
+
+  it("renders a labeled link to the author stats page", () => {
+    renderDetail();
+    const link = screen.getByRole("link", { name: "View stats for test" });
+    expect(link.getAttribute("href")).toBe("#/profile/test");
+    expect(screen.getByText("Author stats")).toBeTruthy();
+  });
+
+  it("uses the skill owner in the profile link href", () => {
+    const customSkill = {
+      ...baseSkill,
+      owner: "custom-author",
+    };
+    render(
+      <HashRouter>
+        <SkillDetail slim={customSkill} />
+      </HashRouter>,
+    );
+    const link = screen.getByRole("link", {
+      name: "View stats for custom-author",
+    });
+    expect(link.getAttribute("href")).toBe("#/profile/custom-author");
   });
 });

--- a/website-src/src/__tests__/stats-page.test.jsx
+++ b/website-src/src/__tests__/stats-page.test.jsx
@@ -1,0 +1,153 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { HashRouter } from "react-router-dom";
+import MiniSearch from "minisearch";
+import StatsPage from "../pages/StatsPage.jsx";
+import { CatalogProvider } from "../hooks/useCatalog.jsx";
+import { MINISEARCH_OPTIONS } from "../lib/minisearch-options.js";
+
+const generatedAt = "2026-07-07T00:00:00.000Z";
+
+const catalog = {
+  generatedAt,
+  totalSkills: 3,
+  totalRepos: 2,
+  skills: [
+    {
+      id: "alice/repo::a::skill-a",
+      name: "skill-a",
+      description: "Skill A",
+      categories: ["dev", "docs"],
+      owner: "alice",
+      repo: "repo",
+    },
+    {
+      id: "alice/repo::b::skill-b",
+      name: "skill-b",
+      description: "Skill B",
+      categories: ["dev"],
+      owner: "alice",
+      repo: "repo",
+    },
+    {
+      id: "bob/other::c::skill-c",
+      name: "skill-c",
+      description: "Skill C",
+      categories: ["testing"],
+      owner: "bob",
+      repo: "other",
+    },
+  ],
+  categories: ["dev", "docs", "testing"],
+  repos: [],
+};
+
+const authorStats = {
+  stats: [
+    {
+      owner: "alice",
+      totalSkills: 2,
+      repos: [{ owner: "alice", repo: "repo" }],
+    },
+    { owner: "bob", totalSkills: 1, repos: [{ owner: "bob", repo: "other" }] },
+  ],
+};
+
+const indexStats = {
+  stats: {
+    totalRepos: 2,
+    totalSkills: 3,
+    totalAuthors: 2,
+    verifiedCount: 1,
+  },
+};
+
+function buildIndexJson() {
+  const ms = new MiniSearch(MINISEARCH_OPTIONS);
+  ms.addAll(
+    catalog.skills.map((s, i) => ({
+      id: i,
+      name: s.name,
+      description: s.description || "",
+      categoriesStr: (s.categories || []).join(" "),
+    })),
+  );
+  const payload = ms.toJSON();
+  payload.generatedAt = generatedAt;
+  return JSON.stringify(payload);
+}
+
+function mockFetch() {
+  global.fetch = vi.fn(async (url) => {
+    const path = String(url);
+    if (path.endsWith("skills.min.json")) {
+      return { ok: true, json: async () => catalog };
+    }
+    if (path.endsWith("search.idx.json")) {
+      return { ok: true, text: async () => buildIndexJson() };
+    }
+    if (path.endsWith("repo-stats.json")) {
+      return { ok: true, json: async () => ({ stats: [] }) };
+    }
+    if (path.endsWith("author-stats.json")) {
+      return { ok: true, json: async () => authorStats };
+    }
+    if (path.endsWith("index-stats.json")) {
+      return { ok: true, json: async () => indexStats };
+    }
+    return { ok: false, status: 404, json: async () => null };
+  });
+}
+
+function renderStatsPage() {
+  return render(
+    <HashRouter>
+      <CatalogProvider>
+        <StatsPage />
+      </CatalogProvider>
+    </HashRouter>,
+  );
+}
+
+describe("StatsPage — author view and pie chart (issue #351)", () => {
+  beforeEach(() => {
+    mockFetch();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders View buttons linking to author profile pages", async () => {
+    renderStatsPage();
+    await waitFor(() => {
+      expect(screen.getByText("alice")).toBeTruthy();
+    });
+
+    const aliceView = screen.getByRole("link", {
+      name: "View stats for alice",
+    });
+    const bobView = screen.getByRole("link", { name: "View stats for bob" });
+
+    expect(aliceView.getAttribute("href")).toBe("#/profile/alice");
+    expect(bobView.getAttribute("href")).toBe("#/profile/bob");
+  });
+
+  it("renders category pie chart with distribution data from catalog", async () => {
+    renderStatsPage();
+    await waitFor(() => {
+      expect(screen.getByText("Category Distribution")).toBeTruthy();
+    });
+
+    expect(
+      screen.getByRole("img", {
+        name: /Category distribution pie chart/i,
+      }),
+    ).toBeTruthy();
+    expect(screen.getByText("dev")).toBeTruthy();
+    expect(screen.getByText("docs")).toBeTruthy();
+    expect(screen.getByText("testing")).toBeTruthy();
+  });
+});

--- a/website-src/src/components/CategoryPieChart.jsx
+++ b/website-src/src/components/CategoryPieChart.jsx
@@ -67,7 +67,7 @@ export default function CategoryPieChart({ entries }) {
         viewBox="0 0 160 160"
         className="w-40 h-40 shrink-0"
         role="img"
-        aria-label={`Category distribution pie chart, ${total} skills total`}
+        aria-label={`Category distribution pie chart, ${total} category tags`}
       >
         {slices.map((slice) => (
           <path

--- a/website-src/src/components/CategoryPieChart.jsx
+++ b/website-src/src/components/CategoryPieChart.jsx
@@ -1,0 +1,110 @@
+/**
+ * Zero-dependency pie chart for category distribution data.
+ * Accepts entries as [label, value] tuples (same shape as StatsPage catEntries).
+ */
+
+const SLICE_COLORS = [
+  "#34d399",
+  "#60a5fa",
+  "#a78bfa",
+  "#f472b6",
+  "#fb923c",
+  "#facc15",
+  "#22d3ee",
+  "#94a3b8",
+  "#f87171",
+  "#4ade80",
+];
+
+function polarToCartesian(cx, cy, radius, angleDeg) {
+  const rad = ((angleDeg - 90) * Math.PI) / 180;
+  return {
+    x: cx + radius * Math.cos(rad),
+    y: cy + radius * Math.sin(rad),
+  };
+}
+
+function describeSlice(cx, cy, radius, startAngle, endAngle) {
+  const start = polarToCartesian(cx, cy, radius, endAngle);
+  const end = polarToCartesian(cx, cy, radius, startAngle);
+  const largeArc = endAngle - startAngle <= 180 ? 0 : 1;
+  return [
+    `M ${cx} ${cy}`,
+    `L ${start.x} ${start.y}`,
+    `A ${radius} ${radius} 0 ${largeArc} 0 ${end.x} ${end.y}`,
+    "Z",
+  ].join(" ");
+}
+
+export default function CategoryPieChart({ entries }) {
+  const total = entries.reduce((sum, [, value]) => sum + value, 0);
+  if (total === 0) return null;
+
+  const cx = 80;
+  const cy = 80;
+  const radius = 70;
+  let angle = 0;
+
+  const slices = entries.map(([label, value], index) => {
+    const sliceAngle = (value / total) * 360;
+    const startAngle = angle;
+    const endAngle = angle + sliceAngle;
+    angle = endAngle;
+    return {
+      label,
+      value,
+      color: SLICE_COLORS[index % SLICE_COLORS.length],
+      path:
+        sliceAngle >= 359.99
+          ? `M ${cx} ${cy - radius} A ${radius} ${radius} 0 1 1 ${cx - 0.01} ${cy - radius} Z`
+          : describeSlice(cx, cy, radius, startAngle, endAngle),
+    };
+  });
+
+  return (
+    <div className="flex flex-col sm:flex-row items-center sm:items-start gap-6">
+      <svg
+        viewBox="0 0 160 160"
+        className="w-40 h-40 shrink-0"
+        role="img"
+        aria-label={`Category distribution pie chart, ${total} skills total`}
+      >
+        {slices.map((slice) => (
+          <path
+            key={slice.label}
+            d={slice.path}
+            fill={slice.color}
+            stroke="var(--bg-card)"
+            strokeWidth="1"
+          />
+        ))}
+      </svg>
+      <ul className="flex-1 space-y-1.5 text-sm min-w-0">
+        {slices.map((slice) => {
+          const pct = Math.round((slice.value / total) * 100);
+          return (
+            <li
+              key={slice.label}
+              className="grid grid-cols-[0.75rem_minmax(0,1fr)_2.5rem_2.5rem] items-center gap-2"
+            >
+              <span
+                className="h-3 w-3 rounded-sm shrink-0"
+                style={{ backgroundColor: slice.color }}
+                aria-hidden="true"
+              />
+              <span className="truncate text-[var(--fg)]" title={slice.label}>
+                {slice.label}
+              </span>
+              <span className="text-right font-mono text-[var(--fg-dim)]">
+                {slice.value}
+              </span>
+              <span className="text-right text-[var(--fg-muted)] text-xs">
+                {pct}%
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/website-src/src/components/SkillDetail.jsx
+++ b/website-src/src/components/SkillDetail.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { evalScoreClass, formatTokens } from "../lib/utils.js";
 import CopyButton from "./CopyButton.jsx";
 import AddToBundleButton from "./AddToBundleButton.jsx";
@@ -110,6 +111,14 @@ export default function SkillDetail({ slim }) {
           >
             {skill.owner}/{skill.repo}
           </a>
+        </Row>
+        <Row label="Author stats">
+          <Link
+            to={`/profile/${encodeURIComponent(skill.owner)}`}
+            className="text-[var(--brand)] hover:underline"
+          >
+            View stats for {skill.owner}
+          </Link>
         </Row>
         <Row label="Categories">
           <div className="flex flex-wrap gap-1">

--- a/website-src/src/pages/StatsPage.jsx
+++ b/website-src/src/pages/StatsPage.jsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { Eye } from "lucide-react";
 import { useCatalog } from "../hooks/useCatalog.jsx";
 import { Badge } from "../components/ui/badge";
+import { Button } from "../components/ui/button";
+import CategoryPieChart from "../components/CategoryPieChart";
 import CopyButton from "../components/CopyButton";
 
 /**
@@ -11,23 +14,6 @@ import CopyButton from "../components/CopyButton";
  * Data comes from the build-time artifacts (repo-stats.json, author-stats.json,
  * index-stats.json) shipped alongside the catalog.
  */
-
-function cssBar(value, max) {
-  const pct = max > 0 ? Math.max(4, Math.round((value / max) * 100)) : 0;
-  return (
-    <span className="block h-2 min-w-0 rounded-full bg-[var(--bg-muted)]">
-      <span
-        className="block h-2 rounded-full bg-emerald-400"
-        style={{ width: `${pct}%` }}
-      />
-    </span>
-  );
-}
-
-function profileShareUrl(owner) {
-  if (typeof window === "undefined") return `#/profile/${owner}`;
-  return `${window.location.origin}${window.location.pathname}#/profile/${encodeURIComponent(owner)}`;
-}
 
 function SectionTitle({ children }) {
   return (
@@ -96,7 +82,6 @@ export default function StatsPage() {
     }
   }
   const catEntries = Object.entries(catCounts).sort((a, b) => b[1] - a[1]);
-  const maxCatCount = catEntries.length > 0 ? catEntries[0][1] : 1;
 
   return (
     <div className="max-w-4xl mx-auto">
@@ -124,25 +109,7 @@ export default function StatsPage() {
       {catEntries.length > 0 && (
         <section>
           <SectionTitle>Category Distribution</SectionTitle>
-          <div className="space-y-1">
-            {catEntries.map(([cat, count]) => (
-              <div
-                key={cat}
-                className="grid grid-cols-[minmax(5rem,8rem)_minmax(0,1fr)_2.5rem] items-center gap-3 text-sm"
-              >
-                <span
-                  className="text-right text-[var(--fg)] truncate"
-                  title={cat}
-                >
-                  {cat}
-                </span>
-                <span className="min-w-0">{cssBar(count, maxCatCount)}</span>
-                <span className="text-right font-mono text-[var(--fg-dim)]">
-                  {count}
-                </span>
-              </div>
-            ))}
-          </div>
+          <CategoryPieChart entries={catEntries} />
         </section>
       )}
 
@@ -210,7 +177,15 @@ export default function StatsPage() {
               <Badge variant="secondary" className="text-xs">
                 {a.totalSkills} skills
               </Badge>
-              <CopyButton text={profileShareUrl(a.owner)} size="sm" />
+              <Button variant="outline" size="sm" asChild>
+                <Link
+                  to={`/profile/${encodeURIComponent(a.owner)}`}
+                  aria-label={`View stats for ${a.owner}`}
+                >
+                  <Eye className="h-3 w-3 mr-1" aria-hidden="true" />
+                  View
+                </Link>
+              </Button>
             </div>
           ))}
           {authors.length === 0 && (


### PR DESCRIPTION
Closes #351

## Summary

Improves the stats page and skill detail page so users can explore author-level data more easily. Top Authors now has View buttons that navigate to profile pages, Category Distribution includes a pie chart visualization, and skill detail pages link to the author's stats page.

## Approach

Balanced approach: extracted a reusable zero-dependency `CategoryPieChart` component, replaced copy buttons with View navigation in Top Authors, added author stats links on skill detail, and added targeted vitest coverage.

## Decision Record

- **Root cause:** PR #349 delivered the base stats/profile feature but left copy buttons instead of navigation affordances, bar-only category charts, and no author profile link on skill detail pages.
- **Options considered:** Option 1 — Minimal fix (inline CSS pie); Option 2 — Balanced approach (extracted component + tests); Option 3 — Comprehensive refactor (chart library + shared primitives)
- **Options rejected:** Option 1 — pie logic inline, no StatsPage tests; Option 3 — adds dependency and scope beyond acceptance criteria
- **Selected option:** Option 2 — Balanced approach
- **Residual risk:** none identified — pie chart uses fixed color palette; many categories may crowd the legend but data remains readable

Analyzed at: `refactor/351-view-authors-pie-chart @ 666837d` (2026-07-07)

## Changes

| File | Change |
|------|--------|
| `website-src/src/components/CategoryPieChart.jsx` | New SVG pie chart with legend for category distribution |
| `website-src/src/pages/StatsPage.jsx` | View button replaces copy in Top Authors; pie chart in Category Distribution |
| `website-src/src/components/SkillDetail.jsx` | Author stats link row pointing to `/profile/:owner` |
| `website-src/src/__tests__/stats-page.test.jsx` | Tests for View links and pie chart rendering |
| `website-src/src/__tests__/skill-detail.test.jsx` | Tests for author stats link; HashRouter wrapper for Link |

## Test Results

- Unit tests: 4 new tests passed (2 stats-page, 2 skill-detail)
- Integration tests: skipped
- E2e tests: skipped
- Build: passed
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Each author in Top Authors shows View button instead of copy | pass | `StatsPage.jsx` Button+Link with Eye icon; `stats-page.test.jsx` |
| Clicking View navigates to author stats page | pass | Link to `/profile/:owner`; test asserts `#/profile/alice` |
| Category Distribution includes pie chart | pass | `CategoryPieChart.jsx`; test asserts pie chart role=img |
| Pie chart reflects same category data | pass | `CategoryPieChart` receives `catEntries` from catalog skills |
| Skill detail page includes author stats link | pass | `SkillDetail.jsx` Author stats row |
| Author stats link clearly labeled and accessible | pass | "View stats for {owner}" with aria-label on View buttons |
| Existing stats page content remains usable | pass | Index overview, Top Repos, Top Authors layout preserved |