### PR TITLE
feat(import): detect conflicts, show diffs, and make overwrites safe

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1150,6 +1150,13 @@ describe("parseArgs: install", () => {
     expect(result.flags.library).toBe(true);
   });
 
+  test("parses import --diff", () => {
+    const result = parse("import", "skills.json", "--diff");
+    expect(result.command).toBe("import");
+    expect(result.subcommand).toBe("skills.json");
+    expect(result.flags.diff).toBe(true);
+  });
+
   test("parses --provider flag", () => {
     const result = parse("install", "github:user/repo", "--provider", "claude");
     expect(result.flags.provider).toBe("claude");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,7 +87,8 @@ import {
 } from "./registry";
 import type { RegistryManifest, ResolutionSource } from "./registry";
 import { buildManifest } from "./exporter";
-import { readManifestFile, importSkills } from "./importer";
+import { readManifestFile, importSkills, renderConflictDiff } from "./importer";
+import type { ImportConflict, ImportConflictChoice } from "./utils/types";
 import { scaffoldSkill, directoryExists } from "./initializer";
 import {
   computeStats,
@@ -279,6 +280,8 @@ interface ParsedArgs {
     has: string[];
     missing: string[];
     dryRun: boolean;
+    /** `asm import --diff` — show unified diffs for conflicts. */
+    diff: boolean;
     machine: boolean;
     noCache: boolean;
     fix: boolean;
@@ -352,6 +355,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
       has: [],
       missing: [],
       dryRun: false,
+      diff: false,
       machine: false,
       noCache: false,
       fix: false,
@@ -494,6 +498,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       result.flags.path = args[i] || null;
     } else if (arg === "--dry-run") {
       result.flags.dryRun = true;
+    } else if (arg === "--diff") {
+      result.flags.diff = true;
     } else if (arg === "--fix") {
       result.flags.fix = true;
     } else if (arg === "--machine") {
@@ -3704,20 +3710,26 @@ function printImportHelp() {
 Import skills from a previously exported JSON manifest. Recreates skill
 installations based on the manifest metadata.
 
-Skills that already exist at the target location are skipped unless --force
-is used. Skills whose source files cannot be found locally are reported as
-failed — install them first with "asm install".
+Skills that already exist with identical content are skipped. When an
+existing skill differs from the imported version, the conflict is reported
+with which side is newer; in a terminal you can resolve each conflict
+(keep local, use imported, or skip), optionally viewing a diff. --force
+overwrites all conflicts without asking. Skills whose source files cannot
+be found locally are reported as failed — install them first with
+"asm install".
 
 ${ansi.bold("Options:")}
   -s, --scope <s>    Filter: global, project, or both (default: both)
-  -f, --force        Overwrite existing skills
-  -y, --yes          Skip confirmation prompt
-  --json             Output results as JSON
+  -f, --force        Overwrite existing skills without conflict prompts
+  --diff             Show unified diffs for conflicting skills
+  -y, --yes          Skip prompts (conflicts are skipped and reported)
+  --json             Output results as JSON (includes conflict details)
   --no-color         Disable ANSI colors
   -V, --verbose      Show debug output
 
 ${ansi.bold("Examples:")}
   asm import skills.json              ${ansi.dim("Import from manifest")}
+  asm import skills.json --diff       ${ansi.dim("Show diffs for conflicting skills")}
   asm import skills.json --force      ${ansi.dim("Overwrite existing skills")}
   asm import skills.json -s global    ${ansi.dim("Import only global skills")}
   asm export > backup.json            ${ansi.dim("Export first, then import later")}
@@ -3755,7 +3767,14 @@ async function cmdImport(args: ParsedArgs) {
     if (args.flags.json) {
       console.log(
         JSON.stringify(
-          { total: 0, installed: 0, skipped: 0, failed: 0, results: [] },
+          {
+            total: 0,
+            installed: 0,
+            skipped: 0,
+            failed: 0,
+            conflicts: 0,
+            results: [],
+          },
           null,
           2,
         ),
@@ -3789,12 +3808,76 @@ async function cmdImport(args: ParsedArgs) {
     }
   }
 
+  // Conflicts (existing skill with different content) are resolved
+  // interactively on a TTY unless --force or --yes was given; otherwise
+  // they are skipped and reported.
+  const interactive =
+    !args.flags.force && !args.flags.yes && !!process.stdin.isTTY;
+  const showDiff = args.flags.diff;
+
+  async function promptForConflict(
+    conflict: ImportConflict,
+  ): Promise<ImportConflictChoice> {
+    const mark = (side: "local" | "imported") =>
+      conflict.newer === side
+        ? ` ${ansi.green("(newer)")}`
+        : conflict.newer === "same"
+          ? ""
+          : ` ${ansi.dim("(older)")}`;
+    console.error("");
+    console.error(
+      `${ansi.bold("Conflict:")} ${conflict.skillName} (${conflict.provider}/${conflict.scope})`,
+    );
+    console.error(`  local:    ${conflict.localModified}${mark("local")}`);
+    console.error(
+      `  imported: ${conflict.importedModified}${mark("imported")}`,
+    );
+
+    let diffShown = false;
+    if (showDiff) {
+      const diff = await renderConflictDiff(conflict);
+      console.error(diff ? `\n${diff}\n` : "  (no textual differences found)");
+      diffShown = true;
+    }
+
+    for (;;) {
+      process.stderr.write(
+        `  [k] keep local  [u] use imported  [s] skip${diffShown ? "" : "  [d] show diff"}  ${ansi.dim("[s]")} `,
+      );
+      const answer = (await readLine()).trim().toLowerCase();
+      if (answer === "k" || answer === "keep") return "keep-local";
+      if (answer === "u" || answer === "use") return "use-imported";
+      if (answer === "" || answer === "s" || answer === "skip") return "skip";
+      if (answer === "d" || answer === "diff") {
+        const diff = await renderConflictDiff(conflict);
+        console.error(
+          diff ? `\n${diff}\n` : "  (no textual differences found)",
+        );
+        diffShown = true;
+      }
+    }
+  }
+
   // Run import
   const summary = await importSkills(manifest, {
     force: args.flags.force,
     dryRun: false,
     scopeFilter: args.flags.scope,
+    onConflict: interactive ? promptForConflict : undefined,
   });
+
+  // Non-interactive --diff: print the diff for each detected conflict so the
+  // user can inspect before deciding on --force or an interactive run.
+  if (showDiff && !interactive) {
+    for (const result of summary.results) {
+      if (!result.conflict) continue;
+      const diff = await renderConflictDiff(result.conflict);
+      console.error(
+        `\n${ansi.bold(`Conflict diff: ${result.skillName} (${result.provider}/${result.scope})`)} ${ansi.dim("local -> imported")}`,
+      );
+      console.error(diff || "  (no textual differences found)");
+    }
+  }
 
   // Output results
   if (args.flags.json) {
@@ -3827,12 +3910,24 @@ async function cmdImport(args: ParsedArgs) {
   }
 
   console.error("");
+  const conflictsPart =
+    summary.conflicts > 0
+      ? `, ${ansi.yellow(String(summary.conflicts))} conflicts`
+      : "";
   console.error(
     `${ansi.bold("Summary:")} ${summary.total} total, ` +
       `${ansi.green(String(summary.installed))} installed, ` +
       `${ansi.yellow(String(summary.skipped))} skipped, ` +
-      `${ansi.red(String(summary.failed))} failed`,
+      `${ansi.red(String(summary.failed))} failed${conflictsPart}`,
   );
+
+  if (summary.conflicts > 0 && !interactive && !args.flags.force) {
+    console.error(
+      ansi.dim(
+        "Conflicts were skipped. Re-run in a terminal to resolve each one, add --diff to inspect, or --force to overwrite all.",
+      ),
+    );
+  }
 
   if (summary.failed > 0) {
     process.exitCode = 1;

--- a/src/import-skills.test.ts
+++ b/src/import-skills.test.ts
@@ -6,17 +6,25 @@ import {
   rm,
   readdir,
   readlink,
+  readFile,
   lstat,
+  utimes,
 } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
-import { importSkills } from "./importer";
+import {
+  importSkills,
+  skillDirsIdentical,
+  buildImportConflict,
+  renderConflictDiff,
+} from "./importer";
 import type {
   ExportManifest,
   ExportedSkill,
   AppConfig,
   ProviderConfig,
   SkillInfo,
+  ImportConflict,
 } from "./utils/types";
 
 // ─── Shared test temp dir ────────────────────────────────────────────────────
@@ -451,5 +459,365 @@ describe("importSkills", () => {
     expect(stat.isDirectory()).toBe(true);
     const files = await readdir(targetPath);
     expect(files).toContain("skill.md");
+  });
+});
+
+// ─── Conflict detection & safe overwrite ────────────────────────
+
+describe("importSkills conflicts", () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "importer-conflict-"));
+    globalSkillsDir = join(tempDir, "global-skills");
+    projectSkillsDir = join(tempDir, "project-skills");
+    sourceSkillsDir = join(tempDir, "source-skills");
+    await mkdir(globalSkillsDir, { recursive: true });
+    await mkdir(projectSkillsDir, { recursive: true });
+    await mkdir(sourceSkillsDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function makeSkillDir(dir: string, content: string): Promise<void> {
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "SKILL.md"), content);
+  }
+
+  const HOUR = 60 * 60 * 1000;
+
+  it("does not delete the skill when the manifest source is the target itself (self-import regression)", async () => {
+    // `asm export` then `asm import --force` on the same machine resolves the
+    // copy source to the install being overwritten. The old remove-then-copy
+    // deleted the only copy and then failed with ENOENT.
+    const targetDir = join(globalSkillsDir, "test-skill");
+    await makeSkillDir(targetDir, "# Precious content");
+
+    const deps = makeDeps({
+      installedSkills: [
+        makeSkillInfo({
+          realPath: targetDir,
+          path: targetDir,
+          originalPath: targetDir,
+        }),
+      ],
+    });
+
+    const summary = await importSkills(
+      makeManifest(),
+      { force: true, dryRun: false, scopeFilter: "both" },
+      deps,
+    );
+
+    expect(summary.failed).toBe(0);
+    expect(summary.results[0].status).toBe("skipped");
+    await expect(readFile(join(targetDir, "SKILL.md"), "utf-8")).resolves.toBe(
+      "# Precious content",
+    );
+  });
+
+  it("skips without a conflict when existing content is identical", async () => {
+    const targetDir = join(globalSkillsDir, "test-skill");
+    const srcDir = join(sourceSkillsDir, "test-skill");
+    await makeSkillDir(targetDir, "# Same");
+    await makeSkillDir(srcDir, "# Same");
+
+    const deps = makeDeps({
+      installedSkills: [makeSkillInfo({ realPath: srcDir })],
+    });
+
+    const summary = await importSkills(
+      makeManifest(),
+      { force: false, dryRun: false, scopeFilter: "both" },
+      deps,
+    );
+
+    expect(summary.conflicts).toBe(0);
+    expect(summary.results[0].status).toBe("skipped");
+    expect(summary.results[0].reason).toContain("Already installed");
+    expect(summary.results[0].conflict).toBeUndefined();
+  });
+
+  it("reports a conflict with the newer side when contents differ (local newer)", async () => {
+    const targetDir = join(globalSkillsDir, "test-skill");
+    const srcDir = join(sourceSkillsDir, "test-skill");
+    await makeSkillDir(targetDir, "# Local edit");
+    await makeSkillDir(srcDir, "# Imported edit");
+    const now = new Date();
+    const earlier = new Date(now.getTime() - HOUR);
+    await utimes(join(targetDir, "SKILL.md"), now, now);
+    await utimes(join(srcDir, "SKILL.md"), earlier, earlier);
+
+    const deps = makeDeps({
+      installedSkills: [makeSkillInfo({ realPath: srcDir })],
+    });
+
+    const summary = await importSkills(
+      makeManifest(),
+      { force: false, dryRun: false, scopeFilter: "both" },
+      deps,
+    );
+
+    expect(summary.conflicts).toBe(1);
+    const result = summary.results[0];
+    expect(result.status).toBe("skipped");
+    expect(result.reason).toContain("Conflict");
+    expect(result.reason).toContain("local version is newer");
+    expect(result.conflict?.newer).toBe("local");
+    // Local content untouched
+    await expect(readFile(join(targetDir, "SKILL.md"), "utf-8")).resolves.toBe(
+      "# Local edit",
+    );
+  });
+
+  it("reports the imported side as newer when the source was modified later", async () => {
+    const targetDir = join(globalSkillsDir, "test-skill");
+    const srcDir = join(sourceSkillsDir, "test-skill");
+    await makeSkillDir(targetDir, "# Local");
+    await makeSkillDir(srcDir, "# Imported");
+    const now = new Date();
+    const earlier = new Date(now.getTime() - HOUR);
+    await utimes(join(targetDir, "SKILL.md"), earlier, earlier);
+    await utimes(join(srcDir, "SKILL.md"), now, now);
+
+    const deps = makeDeps({
+      installedSkills: [makeSkillInfo({ realPath: srcDir })],
+    });
+
+    const summary = await importSkills(
+      makeManifest(),
+      { force: false, dryRun: false, scopeFilter: "both" },
+      deps,
+    );
+
+    expect(summary.results[0].reason).toContain("imported version is newer");
+    expect(summary.results[0].conflict?.newer).toBe("imported");
+  });
+
+  it("resolves a conflict with use-imported via the onConflict callback", async () => {
+    const targetDir = join(globalSkillsDir, "test-skill");
+    const srcDir = join(sourceSkillsDir, "test-skill");
+    await makeSkillDir(targetDir, "# Local");
+    await makeSkillDir(srcDir, "# Imported");
+
+    const seen: ImportConflict[] = [];
+    const deps = makeDeps({
+      installedSkills: [makeSkillInfo({ realPath: srcDir })],
+    });
+
+    const summary = await importSkills(
+      makeManifest(),
+      {
+        force: false,
+        dryRun: false,
+        scopeFilter: "both",
+        onConflict: async (c) => {
+          seen.push(c);
+          return "use-imported";
+        },
+      },
+      deps,
+    );
+
+    expect(seen).toHaveLength(1);
+    expect(summary.installed).toBe(1);
+    expect(summary.conflicts).toBe(1);
+    expect(summary.results[0].status).toBe("installed");
+    await expect(readFile(join(targetDir, "SKILL.md"), "utf-8")).resolves.toBe(
+      "# Imported",
+    );
+  });
+
+  it("keeps the local version when the callback answers keep-local", async () => {
+    const targetDir = join(globalSkillsDir, "test-skill");
+    const srcDir = join(sourceSkillsDir, "test-skill");
+    await makeSkillDir(targetDir, "# Local");
+    await makeSkillDir(srcDir, "# Imported");
+
+    const deps = makeDeps({
+      installedSkills: [makeSkillInfo({ realPath: srcDir })],
+    });
+
+    const summary = await importSkills(
+      makeManifest(),
+      {
+        force: false,
+        dryRun: false,
+        scopeFilter: "both",
+        onConflict: async () => "keep-local",
+      },
+      deps,
+    );
+
+    expect(summary.results[0].status).toBe("skipped");
+    expect(summary.results[0].reason).toContain("kept local");
+    await expect(readFile(join(targetDir, "SKILL.md"), "utf-8")).resolves.toBe(
+      "# Local",
+    );
+  });
+
+  it("skips the skill when the callback answers skip", async () => {
+    const targetDir = join(globalSkillsDir, "test-skill");
+    const srcDir = join(sourceSkillsDir, "test-skill");
+    await makeSkillDir(targetDir, "# Local");
+    await makeSkillDir(srcDir, "# Imported");
+
+    const deps = makeDeps({
+      installedSkills: [makeSkillInfo({ realPath: srcDir })],
+    });
+
+    const summary = await importSkills(
+      makeManifest(),
+      {
+        force: false,
+        dryRun: false,
+        scopeFilter: "both",
+        onConflict: async () => "skip",
+      },
+      deps,
+    );
+
+    expect(summary.results[0].status).toBe("skipped");
+    expect(summary.results[0].reason).toContain("Conflict: skipped");
+    await expect(readFile(join(targetDir, "SKILL.md"), "utf-8")).resolves.toBe(
+      "# Local",
+    );
+  });
+
+  it("force still overwrites a differing skill (existing escape hatch)", async () => {
+    const targetDir = join(globalSkillsDir, "test-skill");
+    const srcDir = join(sourceSkillsDir, "test-skill");
+    await makeSkillDir(targetDir, "# Local");
+    await makeSkillDir(srcDir, "# Imported");
+
+    const deps = makeDeps({
+      installedSkills: [makeSkillInfo({ realPath: srcDir })],
+    });
+
+    const summary = await importSkills(
+      makeManifest(),
+      { force: true, dryRun: false, scopeFilter: "both" },
+      deps,
+    );
+
+    expect(summary.installed).toBe(1);
+    await expect(readFile(join(targetDir, "SKILL.md"), "utf-8")).resolves.toBe(
+      "# Imported",
+    );
+  });
+});
+
+describe("skillDirsIdentical", () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "dirs-identical-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns true for identical trees including nested directories", async () => {
+    const a = join(tempDir, "a");
+    const b = join(tempDir, "b");
+    await mkdir(join(a, "nested"), { recursive: true });
+    await mkdir(join(b, "nested"), { recursive: true });
+    await writeFile(join(a, "SKILL.md"), "# Same");
+    await writeFile(join(b, "SKILL.md"), "# Same");
+    await writeFile(join(a, "nested", "ref.md"), "ref");
+    await writeFile(join(b, "nested", "ref.md"), "ref");
+
+    await expect(skillDirsIdentical(a, b)).resolves.toBe(true);
+  });
+
+  it("returns false when file contents differ", async () => {
+    const a = join(tempDir, "a");
+    const b = join(tempDir, "b");
+    await mkdir(a, { recursive: true });
+    await mkdir(b, { recursive: true });
+    await writeFile(join(a, "SKILL.md"), "# One");
+    await writeFile(join(b, "SKILL.md"), "# Two");
+
+    await expect(skillDirsIdentical(a, b)).resolves.toBe(false);
+  });
+
+  it("returns false when one tree has an extra file", async () => {
+    const a = join(tempDir, "a");
+    const b = join(tempDir, "b");
+    await mkdir(a, { recursive: true });
+    await mkdir(b, { recursive: true });
+    await writeFile(join(a, "SKILL.md"), "# Same");
+    await writeFile(join(b, "SKILL.md"), "# Same");
+    await writeFile(join(b, "extra.txt"), "surplus");
+
+    await expect(skillDirsIdentical(a, b)).resolves.toBe(false);
+  });
+
+  it("ignores .git directories", async () => {
+    const a = join(tempDir, "a");
+    const b = join(tempDir, "b");
+    await mkdir(join(a, ".git"), { recursive: true });
+    await mkdir(b, { recursive: true });
+    await writeFile(join(a, "SKILL.md"), "# Same");
+    await writeFile(join(b, "SKILL.md"), "# Same");
+    await writeFile(join(a, ".git", "HEAD"), "ref: refs/heads/main");
+
+    await expect(skillDirsIdentical(a, b)).resolves.toBe(true);
+  });
+});
+
+describe("buildImportConflict / renderConflictDiff", () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "conflict-diff-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("reports same-age trees as 'same' within the mtime epsilon", async () => {
+    const local = join(tempDir, "local");
+    const imported = join(tempDir, "imported");
+    await mkdir(local, { recursive: true });
+    await mkdir(imported, { recursive: true });
+    await writeFile(join(local, "SKILL.md"), "# A");
+    await writeFile(join(imported, "SKILL.md"), "# B");
+    const when = new Date();
+    await utimes(join(local, "SKILL.md"), when, when);
+    await utimes(join(imported, "SKILL.md"), when, when);
+
+    const conflict = await buildImportConflict(
+      makeExportedSkill(),
+      imported,
+      local,
+    );
+    expect(conflict.newer).toBe("same");
+  });
+
+  it("renders per-file unified diffs and added/removed notes", async () => {
+    const local = join(tempDir, "local");
+    const imported = join(tempDir, "imported");
+    await mkdir(local, { recursive: true });
+    await mkdir(imported, { recursive: true });
+    await writeFile(join(local, "SKILL.md"), "shared\nlocal line\n");
+    await writeFile(join(imported, "SKILL.md"), "shared\nimported line\n");
+    await writeFile(join(local, "only-local.md"), "x");
+    await writeFile(join(imported, "only-imported.md"), "y");
+
+    const conflict: ImportConflict = {
+      skillName: "test-skill",
+      provider: "claude",
+      scope: "global",
+      targetDir: local,
+      sourcePath: imported,
+      localModified: new Date().toISOString(),
+      importedModified: new Date().toISOString(),
+      newer: "same",
+    };
+
+    const diff = await renderConflictDiff(conflict);
+    expect(diff).toContain("-local line");
+    expect(diff).toContain("+imported line");
+    expect(diff).toContain("only in local: only-local.md");
+    expect(diff).toContain("only in imported: only-imported.md");
   });
 });

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -1,12 +1,25 @@
-import { readFile, access, mkdir, cp, rm } from "fs/promises";
-import { join, basename } from "path";
+import {
+  readFile,
+  readdir,
+  access,
+  mkdir,
+  cp,
+  rm,
+  rename,
+  realpath,
+  stat,
+} from "fs/promises";
+import { join, basename, resolve } from "path";
 import { resolveProviderPath, loadConfig } from "./config";
 import { scanAllSkills } from "./scanner";
-import { createDirSymlink } from "./utils/fs";
+import { unifiedDiff } from "./evaluator";
+import { BINARY_EXTENSIONS, MAX_FILE_SIZE, createDirSymlink } from "./utils/fs";
 import { debug } from "./logger";
 import type {
   ExportManifest,
   ExportedSkill,
+  ImportConflict,
+  ImportConflictChoice,
   ImportResult,
   ImportSummary,
   AppConfig,
@@ -115,6 +128,253 @@ async function skillExists(targetDir: string): Promise<boolean> {
 }
 
 /**
+ * True when two on-disk paths refer to the same directory. Compares realpaths
+ * so symlinked locations match, and compares case-insensitively on Windows.
+ * Used to guard self-imports: a manifest exported on this machine resolves its
+ * "source" to the very install it is about to overwrite, and removing the
+ * target first would destroy the only copy.
+ */
+async function isSameDir(a: string, b: string): Promise<boolean> {
+  let ra: string;
+  let rb: string;
+  try {
+    [ra, rb] = await Promise.all([realpath(a), realpath(b)]);
+  } catch {
+    ra = resolve(a);
+    rb = resolve(b);
+  }
+  if (process.platform === "win32") {
+    return ra.toLowerCase() === rb.toLowerCase();
+  }
+  return ra === rb;
+}
+
+/**
+ * Map of relative path (posix separators) -> absolute path for every file in
+ * the tree, skipping `.git`. Directory symlinks are followed; broken entries
+ * are recorded so a missing counterpart still registers as a difference.
+ */
+async function collectFiles(dir: string): Promise<Map<string, string>> {
+  const files = new Map<string, string>();
+
+  async function walk(currentDir: string, prefix: string): Promise<void> {
+    const entries = await readdir(currentDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === ".git") continue;
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      const full = join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full, rel);
+      } else if (entry.isFile()) {
+        files.set(rel, full);
+      } else {
+        // Symlink or other: classify via stat (follows links).
+        try {
+          const s = await stat(full);
+          if (s.isDirectory()) {
+            await walk(full, rel);
+          } else {
+            files.set(rel, full);
+          }
+        } catch {
+          files.set(rel, full);
+        }
+      }
+    }
+  }
+
+  await walk(dir, "");
+  return files;
+}
+
+/**
+ * Compare two skill directories file-by-file. Returns true only when both
+ * trees contain the same relative paths with byte-identical contents. Any
+ * read error is treated as "different" — the conservative answer, since a
+ * difference only surfaces a conflict rather than touching data.
+ */
+export async function skillDirsIdentical(
+  dirA: string,
+  dirB: string,
+): Promise<boolean> {
+  try {
+    const [filesA, filesB] = await Promise.all([
+      collectFiles(dirA),
+      collectFiles(dirB),
+    ]);
+    if (filesA.size !== filesB.size) return false;
+    for (const [rel, fullA] of filesA) {
+      const fullB = filesB.get(rel);
+      if (!fullB) return false;
+      const [bufA, bufB] = await Promise.all([
+        readFile(fullA),
+        readFile(fullB),
+      ]);
+      if (!bufA.equals(bufB)) return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Latest file mtime (ms) in a tree — the timestamp of the most recent edit.
+ * Falls back to the directory's own mtime for empty trees, and to 0 when the
+ * tree cannot be read at all (callers treat 0 as "no reliable timestamp").
+ */
+async function latestMtimeMs(dir: string): Promise<number> {
+  try {
+    const files = await collectFiles(dir);
+    let latest = 0;
+    for (const full of files.values()) {
+      try {
+        const s = await stat(full);
+        if (s.mtimeMs > latest) latest = s.mtimeMs;
+      } catch {
+        // unreadable entry — ignore for timestamp purposes
+      }
+    }
+    if (latest === 0) {
+      const s = await stat(dir);
+      latest = s.mtimeMs;
+    }
+    return latest;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Build the conflict record for a skill that exists locally with different
+ * content than the imported source. Timestamps within 2s are
+ * reported as "same" to absorb filesystem mtime granularity.
+ */
+export async function buildImportConflict(
+  skill: ExportedSkill,
+  sourcePath: string,
+  targetDir: string,
+): Promise<ImportConflict> {
+  const [localMs, importedMs] = await Promise.all([
+    latestMtimeMs(targetDir),
+    latestMtimeMs(sourcePath),
+  ]);
+  const EPSILON_MS = 2000;
+  // A 0 from latestMtimeMs means the tree could not be read — don't claim
+  // either side is newer on unreliable data.
+  const newer =
+    localMs === 0 ||
+    importedMs === 0 ||
+    Math.abs(localMs - importedMs) <= EPSILON_MS
+      ? "same"
+      : localMs > importedMs
+        ? "local"
+        : "imported";
+  return {
+    skillName: skill.name,
+    provider: skill.provider,
+    scope: skill.scope,
+    targetDir,
+    sourcePath,
+    localModified: new Date(localMs).toISOString(),
+    importedModified: new Date(importedMs).toISOString(),
+    newer,
+  };
+}
+
+/**
+ * Render a unified diff between the local and imported versions of a
+ * conflicting skill: per-file hunks for changed text files, one-line notes
+ * for added/removed/binary/oversized files. Direction is local -> imported,
+ * i.e. the change that choosing "use imported" would apply.
+ */
+export async function renderConflictDiff(
+  conflict: ImportConflict,
+): Promise<string> {
+  const [localFiles, importedFiles] = await Promise.all([
+    collectFiles(conflict.targetDir),
+    collectFiles(conflict.sourcePath),
+  ]);
+  const allPaths = Array.from(
+    new Set([...localFiles.keys(), ...importedFiles.keys()]),
+  ).sort();
+
+  const sections: string[] = [];
+  for (const rel of allPaths) {
+    const localPath = localFiles.get(rel);
+    const importedPath = importedFiles.get(rel);
+    if (!importedPath) {
+      sections.push(`only in local: ${rel}`);
+      continue;
+    }
+    if (!localPath) {
+      sections.push(`only in imported: ${rel}`);
+      continue;
+    }
+
+    const ext = rel.includes(".")
+      ? `.${rel.split(".").pop()!.toLowerCase()}`
+      : "";
+    try {
+      const [bufLocal, bufImported] = await Promise.all([
+        readFile(localPath),
+        readFile(importedPath),
+      ]);
+      if (bufLocal.equals(bufImported)) continue;
+      if (BINARY_EXTENSIONS.has(ext)) {
+        sections.push(`differs (binary): ${rel}`);
+        continue;
+      }
+      if (
+        bufLocal.length > MAX_FILE_SIZE ||
+        bufImported.length > MAX_FILE_SIZE
+      ) {
+        sections.push(`differs (too large to diff): ${rel}`);
+        continue;
+      }
+      const diff = unifiedDiff(
+        bufLocal.toString("utf-8"),
+        bufImported.toString("utf-8"),
+        rel,
+      );
+      if (diff) sections.push(diff);
+    } catch {
+      sections.push(`differs (unreadable): ${rel}`);
+    }
+  }
+  return sections.join("\n");
+}
+
+/**
+ * Replace the existing target directory via backup-and-swap: rename the
+ * current version aside, run `apply` to produce the replacement, then drop
+ * the backup. On any failure the backup is restored, so the previous install
+ * survives. This replaces the old remove-then-copy sequence, which deleted
+ * the target before knowing the copy could succeed — and destroyed the skill
+ * outright when the copy source was the target itself.
+ */
+async function replaceTarget(
+  targetDir: string,
+  apply: () => Promise<void>,
+): Promise<void> {
+  const backupDir = `${targetDir}.import-backup-${Date.now()}`;
+  await rename(targetDir, backupDir);
+  try {
+    await apply();
+    await rm(backupDir, { recursive: true, force: true });
+  } catch (err) {
+    try {
+      await rm(targetDir, { recursive: true, force: true });
+      await rename(backupDir, targetDir);
+    } catch {
+      // Rollback failed — surface the original error; the backup dir still
+      // holds the previous version for manual recovery.
+    }
+    throw err;
+  }
+}
+
+/**
  * Find a provider config by name from the app config.
  */
 function findProvider(config: AppConfig, providerName: string) {
@@ -170,7 +430,13 @@ function findInstalledSkill(
  *
  * Strategy:
  * - For each skill in the manifest, check if it already exists at the target location.
- * - If it exists, skip (unless force=true).
+ * - If it exists with identical content (or the manifest resolves to this very
+ *   install), skip — nothing to do.
+ * - If it exists with different content, that is a conflict:
+ *   ask `onConflict` when provided, otherwise skip and report which side is
+ *   newer. `force` overwrites without asking.
+ * - Overwrites go through a backup-and-swap so a failed copy never destroys
+ *   the existing install.
  * - If a matching skill is found in any installed location, copy it to the target.
  * - If no source is found, report as failed with guidance.
  */
@@ -180,6 +446,11 @@ export async function importSkills(
     force: boolean;
     dryRun: boolean;
     scopeFilter: "global" | "project" | "both";
+    /**
+     * Called for each conflict (existing target with different content).
+     * Absent -> conflicts are skipped and reported.
+     */
+    onConflict?: (conflict: ImportConflict) => Promise<ImportConflictChoice>;
   },
   /** @internal – dependency overrides for testing */
   _deps?: {
@@ -221,6 +492,92 @@ export async function importSkills(
 
     // Check if already installed at target
     const exists = await skillExists(targetDir);
+
+    // Existing target without --force: compare against the resolved source
+    // to distinguish "same skill, nothing to do" from a real conflict
+    //. Dry-run keeps the legacy skip below unchanged.
+    if (exists && !options.force && !options.dryRun) {
+      const source = findInstalledSkill(installedSkills, skill);
+      // Nothing to compare against (no source), the manifest resolves to
+      // this very install (self-import), or contents are identical: the
+      // skill is already here — skip as before.
+      if (
+        !source ||
+        (await isSameDir(source.realPath, targetDir)) ||
+        (await skillDirsIdentical(source.realPath, targetDir))
+      ) {
+        results.push({
+          skillName: skill.name,
+          provider: skill.provider,
+          scope: skill.scope,
+          status: "skipped",
+          reason: "Already installed.",
+          path: targetDir,
+        });
+        continue;
+      }
+
+      // Same skill, different content — a conflict.
+      const conflict = await buildImportConflict(
+        skill,
+        source.realPath,
+        targetDir,
+      );
+      const choice: ImportConflictChoice = options.onConflict
+        ? await options.onConflict(conflict)
+        : "skip";
+
+      if (choice === "use-imported") {
+        try {
+          await replaceTarget(targetDir, () =>
+            cp(source.realPath, targetDir, { recursive: true }),
+          );
+          debug(
+            `import: conflict resolved, copied "${skill.name}" from ${source.realPath} to ${targetDir}`,
+          );
+          results.push({
+            skillName: skill.name,
+            provider: skill.provider,
+            scope: skill.scope,
+            status: "installed",
+            reason: "Conflict resolved: used imported version.",
+            path: targetDir,
+            conflict,
+          });
+        } catch (err: any) {
+          results.push({
+            skillName: skill.name,
+            provider: skill.provider,
+            scope: skill.scope,
+            status: "failed",
+            reason: `Copy failed: ${err.message}`,
+            conflict,
+          });
+        }
+      } else {
+        const reason =
+          choice === "keep-local"
+            ? "Conflict: kept local version."
+            : options.onConflict
+              ? "Conflict: skipped."
+              : conflict.newer === "local"
+                ? "Conflict: local version is newer. Use --force to overwrite."
+                : conflict.newer === "imported"
+                  ? "Conflict: imported version is newer. Use --force to overwrite."
+                  : "Conflict: contents differ. Use --force to overwrite.";
+        results.push({
+          skillName: skill.name,
+          provider: skill.provider,
+          scope: skill.scope,
+          status: "skipped",
+          reason,
+          path: targetDir,
+          conflict,
+        });
+      }
+      continue;
+    }
+
     if (exists && !options.force) {
       results.push({
         skillName: skill.name,
@@ -260,34 +617,54 @@ export async function importSkills(
       continue;
     }
 
+    // Self-import guard: the manifest's source is the target itself.
+    // The old remove-then-copy sequence deleted the only copy here.
+    if (exists && (await isSameDir(source.realPath, targetDir))) {
+      results.push({
+        skillName: skill.name,
+        provider: skill.provider,
+        scope: skill.scope,
+        status: "skipped",
+        reason: "Already installed.",
+        path: targetDir,
+      });
+      continue;
+    }
+
     // Copy skill to target (or recreate symlink)
     try {
       await mkdir(join(targetDir, ".."), { recursive: true });
-      if (exists) {
-        // Force mode: remove existing and re-copy
-        await rm(targetDir, { recursive: true, force: true });
-      }
 
-      if (skill.isSymlink && skill.symlinkTarget) {
-        // Recreate the symlink; fall back to copy if the target doesn't exist
-        try {
-          await access(skill.symlinkTarget);
-          await createDirSymlink(skill.symlinkTarget, targetDir);
-          debug(
-            `import: symlinked "${skill.name}" -> ${skill.symlinkTarget} at ${targetDir}`,
-          );
-        } catch {
-          // Symlink target unreachable on this machine – fall back to copy
+      const apply = async () => {
+        if (skill.isSymlink && skill.symlinkTarget) {
+          // Recreate the symlink; fall back to copy if the target doesn't exist
+          try {
+            await access(skill.symlinkTarget);
+            await createDirSymlink(skill.symlinkTarget, targetDir);
+            debug(
+              `import: symlinked "${skill.name}" -> ${skill.symlinkTarget} at ${targetDir}`,
+            );
+          } catch {
+            // Symlink target unreachable on this machine – fall back to copy
+            await cp(source.realPath, targetDir, { recursive: true });
+            debug(
+              `import: symlink target unreachable, copied "${skill.name}" from ${source.realPath} to ${targetDir}`,
+            );
+          }
+        } else {
           await cp(source.realPath, targetDir, { recursive: true });
           debug(
-            `import: symlink target unreachable, copied "${skill.name}" from ${source.realPath} to ${targetDir}`,
+            `import: copied "${skill.name}" from ${source.realPath} to ${targetDir}`,
           );
         }
+      };
+
+      if (exists) {
+        // Overwrite via backup-and-swap so a failed copy can't destroy the
+        // existing install (the old code removed it first).
+        await replaceTarget(targetDir, apply);
       } else {
-        await cp(source.realPath, targetDir, { recursive: true });
-        debug(
-          `import: copied "${skill.name}" from ${source.realPath} to ${targetDir}`,
-        );
+        await apply();
       }
 
       results.push({
@@ -311,12 +688,14 @@ export async function importSkills(
   const installed = results.filter((r) => r.status === "installed").length;
   const skipped = results.filter((r) => r.status === "skipped").length;
   const failed = results.filter((r) => r.status === "failed").length;
+  const conflicts = results.filter((r) => r.conflict !== undefined).length;
 
   return {
     total: results.length,
     installed,
     skipped,
     failed,
+    conflicts,
     results,
   };
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -189,6 +189,28 @@ export interface ExportManifest {
 
 // ─── Import Types ──────────────────────────────────────────────────────────
 
+/**
+ * A skill that exists both locally (at the import target) and in the manifest
+ * source, with differing content. Timestamps are the latest file
+ * mtime found in each tree, so "newer" reflects the most recent edit.
+ */
+export interface ImportConflict {
+  skillName: string;
+  provider: string;
+  scope: "global" | "project";
+  /** The local version — the directory the import would overwrite. */
+  targetDir: string;
+  /** The imported version — the source install the manifest resolves to. */
+  sourcePath: string;
+  /** ISO timestamp of the last modification in the local tree. */
+  localModified: string;
+  /** ISO timestamp of the last modification in the imported tree. */
+  importedModified: string;
+  newer: "local" | "imported" | "same";
+}
+
+export type ImportConflictChoice = "keep-local" | "use-imported" | "skip";
+
 export interface ImportResult {
   skillName: string;
   provider: string;
@@ -196,6 +218,8 @@ export interface ImportResult {
   status: "installed" | "skipped" | "failed" | "dry-run";
   reason?: string;
   path?: string;
+  /** Present when this skill was detected as a conflict. */
+  conflict?: ImportConflict;
 }
 
 export interface ImportSummary {
@@ -203,6 +227,8 @@ export interface ImportSummary {
   installed: number;
   skipped: number;
   failed: number;
+  /** Number of results that carried conflict information. */
+  conflicts: number;
   results: ImportResult[];
 }
 


### PR DESCRIPTION
Resolves #102.

When an imported skill already exists locally with different content, `asm import` currently just prints "Already installed" and skips — there's no way to see that the two versions differ, which one is newer, or what changed. This adds conflict detection and resolution:

- The existing target is compared file-by-file against the install the manifest resolves to. Identical content skips exactly as before.
- A conflict reports which side is newer (latest file mtime in each tree, 2s epsilon for filesystem timestamp granularity).
- In a terminal, each conflict is resolved per skill: keep local, use imported, skip, or show a diff first. `--yes` and non-TTY runs skip conflicts and report them, so scripts never hang. `--json` carries the conflict details.
- `asm import --diff` prints per-file unified diffs (reusing the evaluator's `unifiedDiff`), with notes for added/removed/binary/oversized files.
- `--force` still overwrites without asking.

While building this I found and fixed a data-loss bug in the existing overwrite path. Import removes the target directory before copying, and the copy source is an install already on this machine — so for a same-machine `asm export` then `asm import --force`, the source is the target itself: the skill gets deleted, then the copy fails with ENOENT. Reproducible on main with any installed skill. Overwrites now go through a backup-and-swap (rename aside, copy, drop backup; restore on failure), and self-imports are detected via realpath comparison and skipped. There's a regression test for the exact roundtrip.

One scope note: manifests carry metadata only, so "the imported version" is whatever install the manifest resolves to on this machine. Entries whose source resolves to the target itself are a no-op by definition. Comparing actual content from the exporting host would need the manifest format to carry file hashes or contents — happy to discuss that as a follow-up; the conflict machinery here (resolver callback, diff rendering, safe swap) is the base it would build on.

Tested: 12 new unit tests (conflict detection, newer/older via controlled mtimes, all three resolutions, safe-overwrite regression, dir comparison, diff rendering) plus a flag-parsing test; existing import behavior and messages are unchanged for the no-conflict paths, and the new summary field is additive.
