### PR TITLE
fix(import): clarify conflict diff behavior (#359)

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -8,7 +8,13 @@ import {
   beforeAll,
   afterAll,
 } from "vitest";
-import { parseArgs, isCLIMode } from "./cli";
+import {
+  parseArgs,
+  isCLIMode,
+  printImportConflictDiffs,
+  promptForImportConflict,
+} from "./cli";
+import type { ImportConflict, ImportResult } from "./utils/types";
 import { compareSemver } from "./scanner";
 import { join, dirname } from "path";
 import {
@@ -2577,6 +2583,8 @@ describe("CLI integration: per-command --help (new commands)", () => {
     expect(stdout).toContain("asm import");
     expect(stdout).toContain("--scope");
     expect(stdout).toContain("--force");
+    expect(stdout).toContain("--diff");
+    expect(stdout).toContain("cannot be combined with --force");
     expect(stdout).toContain("--json");
   });
 
@@ -3103,6 +3111,131 @@ describe("CLI integration: export", () => {
   });
 });
 
+// ─── Import conflict CLI behavior ──────────────────────────────────────────
+
+function makeImportConflict(
+  newer: ImportConflict["newer"] = "local",
+): ImportConflict {
+  return {
+    skillName: "test-skill",
+    provider: "claude",
+    scope: "global",
+    targetDir: "/tmp/local",
+    sourcePath: "/tmp/imported",
+    localModified: "2026-01-02T00:00:00.000Z",
+    importedModified: "2026-01-01T00:00:00.000Z",
+    newer,
+  };
+}
+
+describe("import conflict prompt", () => {
+  test.each([
+    ["k", "keep-local"],
+    ["u", "use-imported"],
+    ["s", "skip"],
+  ] as const)("maps %s to %s", async (answer, expected) => {
+    const choice = await promptForImportConflict(makeImportConflict(), {
+      readAnswer: async () => answer,
+      writeLine: () => {},
+      writePrompt: () => {},
+    });
+
+    expect(choice).toBe(expected);
+  });
+
+  test("shows a diff for d, then prompts again for a resolution", async () => {
+    const answers = ["d", "k"];
+    const lines: string[] = [];
+    const prompts: string[] = [];
+    let renders = 0;
+
+    const choice = await promptForImportConflict(makeImportConflict(), {
+      readAnswer: async () => answers.shift() ?? "s",
+      renderDiff: async () => {
+        renders += 1;
+        return "--- local/SKILL.md\n+++ imported/SKILL.md";
+      },
+      writeLine: (line) => lines.push(line),
+      writePrompt: (prompt) => prompts.push(prompt),
+    });
+
+    expect(choice).toBe("keep-local");
+    expect(renders).toBe(1);
+    expect(lines.join("\n")).toContain("--- local/SKILL.md");
+    expect(prompts).toHaveLength(2);
+    expect(prompts[0]).toContain("[d] show diff");
+    expect(prompts[1]).not.toContain("[d] show diff");
+  });
+
+  test.each([
+    ["local", "local:", "imported:"],
+    ["imported", "imported:", "local:"],
+  ] as const)(
+    "marks the %s side newer and the other side older",
+    async (newer, newerLabel, olderLabel) => {
+      const lines: string[] = [];
+      await promptForImportConflict(makeImportConflict(newer), {
+        readAnswer: async () => "s",
+        writeLine: (line) => lines.push(line),
+        writePrompt: () => {},
+      });
+
+      const newerLine = lines.find((line) => line.includes(newerLabel));
+      const olderLine = lines.find((line) => line.includes(olderLabel));
+      expect(newerLine).toContain("(newer)");
+      expect(olderLine).toContain("(older)");
+    },
+  );
+
+  test("--diff renders before prompting and hides the d choice", async () => {
+    const lines: string[] = [];
+    const prompts: string[] = [];
+    await promptForImportConflict(makeImportConflict(), {
+      showDiff: true,
+      readAnswer: async () => "s",
+      renderDiff: async () => "conflict diff",
+      writeLine: (line) => lines.push(line),
+      writePrompt: (prompt) => prompts.push(prompt),
+    });
+
+    expect(lines.join("\n")).toContain("conflict diff");
+    expect(prompts[0]).not.toContain("[d] show diff");
+  });
+});
+
+describe("non-interactive import conflict diffs", () => {
+  test("prints every collected conflict and skips non-conflict results", async () => {
+    const conflict = makeImportConflict();
+    const results: ImportResult[] = [
+      {
+        skillName: "test-skill",
+        provider: "claude",
+        scope: "global",
+        status: "skipped",
+        conflict,
+      },
+      {
+        skillName: "unchanged-skill",
+        provider: "claude",
+        scope: "global",
+        status: "skipped",
+      },
+    ];
+    const lines: string[] = [];
+
+    await printImportConflictDiffs(
+      results,
+      async () => "--- local/SKILL.md\n+++ imported/SKILL.md",
+      (line) => lines.push(line),
+    );
+
+    expect(lines.join("\n")).toContain("Conflict diff: test-skill");
+    expect(lines.join("\n")).toContain("local -> imported");
+    expect(lines.join("\n")).toContain("+++ imported/SKILL.md");
+    expect(lines.join("\n")).not.toContain("unchanged-skill");
+  });
+});
+
 // ─── CLI integration: import ────────────────────────────────────────────────
 
 describe("CLI integration: import", () => {
@@ -3130,6 +3263,80 @@ describe("CLI integration: import", () => {
     );
     expect(exitCode).toBe(1);
     expect(stderr).toContain("Manifest file not found");
+  });
+
+  test("import rejects --force with --diff before reading the manifest", async () => {
+    const { stderr, exitCode } = await runCLI(
+      "import",
+      "/tmp/nonexistent-manifest-xyz.json",
+      "--force",
+      "--diff",
+    );
+
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("--force and --diff cannot be used together");
+    expect(stderr).toContain("Run without --force to inspect conflicts");
+    expect(stderr).not.toContain("Manifest file not found");
+  });
+
+  test("import --diff prints a collected conflict in non-interactive mode", async () => {
+    const homeDir = join(tempDir, "home");
+    const sourceDir = join(homeDir, ".claude", "skills", "diff-skill");
+    const targetDir = join(tempDir, ".claude", "skills", "diff-skill");
+    await mkdir(sourceDir, { recursive: true });
+    await mkdir(targetDir, { recursive: true });
+    await writeFile(
+      join(sourceDir, "SKILL.md"),
+      "---\nname: diff-skill\ndescription: imported\n---\n# Imported\n",
+    );
+    await writeFile(
+      join(targetDir, "SKILL.md"),
+      "---\nname: diff-skill\ndescription: local\n---\n# Local\n",
+    );
+    const manifestPath = join(tempDir, "manifest.json");
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        version: 1,
+        exportedAt: new Date().toISOString(),
+        skills: [
+          {
+            name: "diff-skill",
+            version: "1.0.0",
+            dirName: "diff-skill",
+            provider: "claude",
+            scope: "project",
+            path: sourceDir,
+            isSymlink: false,
+            symlinkTarget: null,
+          },
+        ],
+      }),
+    );
+
+    const result = await spawnCollect(
+      [
+        join(process.cwd(), "node_modules", ".bin", "tsx"),
+        CLI_BIN,
+        "import",
+        manifestPath,
+        "--yes",
+        "--diff",
+      ],
+      {
+        cwd: tempDir,
+        env: { ...process.env, HOME: homeDir, NO_COLOR: "1" },
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("Conflict diff: diff-skill");
+    expect(result.stderr).toContain("local -> imported");
+    expect(result.stderr).toContain("-# Local");
+    expect(result.stderr).toContain("+# Imported");
+    expect(await readFile(join(targetDir, "SKILL.md"), "utf-8")).toContain(
+      "# Local",
+    );
   });
 
   test("import invalid JSON shows error", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,7 +88,11 @@ import {
 import type { RegistryManifest, ResolutionSource } from "./registry";
 import { buildManifest } from "./exporter";
 import { readManifestFile, importSkills, renderConflictDiff } from "./importer";
-import type { ImportConflict, ImportConflictChoice } from "./utils/types";
+import type {
+  ImportConflict,
+  ImportConflictChoice,
+  ImportResult,
+} from "./utils/types";
 import { scaffoldSkill, directoryExists } from "./initializer";
 import {
   computeStats,
@@ -3721,7 +3725,7 @@ be found locally are reported as failed — install them first with
 ${ansi.bold("Options:")}
   -s, --scope <s>    Filter: global, project, or both (default: both)
   -f, --force        Overwrite existing skills without conflict prompts
-  --diff             Show unified diffs for conflicting skills
+  --diff             Show unified diffs (cannot be combined with --force)
   -y, --yes          Skip prompts (conflicts are skipped and reported)
   --json             Output results as JSON (includes conflict details)
   --no-color         Disable ANSI colors
@@ -3736,6 +3740,80 @@ ${ansi.bold("Examples:")}
   asm import backup.json              ${ansi.dim("Restore from backup")}`);
 }
 
+type ImportConflictPromptOptions = {
+  showDiff?: boolean;
+  readAnswer?: () => Promise<string>;
+  renderDiff?: (conflict: ImportConflict) => Promise<string>;
+  writeLine?: (text: string) => void;
+  writePrompt?: (text: string) => void;
+};
+
+/** Prompt for one import conflict. Dependencies are injectable for CLI tests. */
+export async function promptForImportConflict(
+  conflict: ImportConflict,
+  options: ImportConflictPromptOptions = {},
+): Promise<ImportConflictChoice> {
+  const {
+    showDiff = false,
+    readAnswer = readLine,
+    renderDiff = renderConflictDiff,
+    writeLine = console.error,
+    writePrompt = (text) => process.stderr.write(text),
+  } = options;
+  const mark = (side: "local" | "imported") =>
+    conflict.newer === side
+      ? ` ${ansi.green("(newer)")}`
+      : conflict.newer === "same"
+        ? ""
+        : ` ${ansi.dim("(older)")}`;
+  writeLine("");
+  writeLine(
+    `${ansi.bold("Conflict:")} ${conflict.skillName} (${conflict.provider}/${conflict.scope})`,
+  );
+  writeLine(`  local:    ${conflict.localModified}${mark("local")}`);
+  writeLine(`  imported: ${conflict.importedModified}${mark("imported")}`);
+
+  let diffShown = false;
+  if (showDiff) {
+    const diff = await renderDiff(conflict);
+    writeLine(diff ? `\n${diff}\n` : "  (no textual differences found)");
+    diffShown = true;
+  }
+
+  for (;;) {
+    writePrompt(
+      `  [k] keep local  [u] use imported  [s] skip${diffShown ? "" : "  [d] show diff"}  ${ansi.dim("[s]")} `,
+    );
+    const answer = (await readAnswer()).trim().toLowerCase();
+    if (answer === "k" || answer === "keep") return "keep-local";
+    if (answer === "u" || answer === "use") return "use-imported";
+    if (answer === "" || answer === "s" || answer === "skip") return "skip";
+    if (answer === "d" || answer === "diff") {
+      const diff = await renderDiff(conflict);
+      writeLine(diff ? `\n${diff}\n` : "  (no textual differences found)");
+      diffShown = true;
+    }
+  }
+}
+
+/** Print conflict diffs collected by a non-interactive import. */
+export async function printImportConflictDiffs(
+  results: ImportResult[],
+  renderDiff: (
+    conflict: ImportConflict,
+  ) => Promise<string> = renderConflictDiff,
+  writeLine: (text: string) => void = console.error,
+): Promise<void> {
+  for (const result of results) {
+    if (!result.conflict) continue;
+    const diff = await renderDiff(result.conflict);
+    writeLine(
+      `\n${ansi.bold(`Conflict diff: ${result.skillName} (${result.provider}/${result.scope})`)} ${ansi.dim("local -> imported")}`,
+    );
+    writeLine(diff || "  (no textual differences found)");
+  }
+}
+
 async function cmdImport(args: ParsedArgs) {
   if (args.flags.help) {
     printImportHelp();
@@ -3746,6 +3824,12 @@ async function cmdImport(args: ParsedArgs) {
   if (!filePath) {
     error("Missing required argument: <file>");
     console.error(`Run "asm import --help" for usage.`);
+    process.exit(2);
+  }
+  if (args.flags.force && args.flags.diff) {
+    error(
+      "--force and --diff cannot be used together. Run without --force to inspect conflicts, or omit --diff to overwrite them.",
+    );
     process.exit(2);
   }
 
@@ -3815,68 +3899,20 @@ async function cmdImport(args: ParsedArgs) {
     !args.flags.force && !args.flags.yes && !!process.stdin.isTTY;
   const showDiff = args.flags.diff;
 
-  async function promptForConflict(
-    conflict: ImportConflict,
-  ): Promise<ImportConflictChoice> {
-    const mark = (side: "local" | "imported") =>
-      conflict.newer === side
-        ? ` ${ansi.green("(newer)")}`
-        : conflict.newer === "same"
-          ? ""
-          : ` ${ansi.dim("(older)")}`;
-    console.error("");
-    console.error(
-      `${ansi.bold("Conflict:")} ${conflict.skillName} (${conflict.provider}/${conflict.scope})`,
-    );
-    console.error(`  local:    ${conflict.localModified}${mark("local")}`);
-    console.error(
-      `  imported: ${conflict.importedModified}${mark("imported")}`,
-    );
-
-    let diffShown = false;
-    if (showDiff) {
-      const diff = await renderConflictDiff(conflict);
-      console.error(diff ? `\n${diff}\n` : "  (no textual differences found)");
-      diffShown = true;
-    }
-
-    for (;;) {
-      process.stderr.write(
-        `  [k] keep local  [u] use imported  [s] skip${diffShown ? "" : "  [d] show diff"}  ${ansi.dim("[s]")} `,
-      );
-      const answer = (await readLine()).trim().toLowerCase();
-      if (answer === "k" || answer === "keep") return "keep-local";
-      if (answer === "u" || answer === "use") return "use-imported";
-      if (answer === "" || answer === "s" || answer === "skip") return "skip";
-      if (answer === "d" || answer === "diff") {
-        const diff = await renderConflictDiff(conflict);
-        console.error(
-          diff ? `\n${diff}\n` : "  (no textual differences found)",
-        );
-        diffShown = true;
-      }
-    }
-  }
-
   // Run import
   const summary = await importSkills(manifest, {
     force: args.flags.force,
     dryRun: false,
     scopeFilter: args.flags.scope,
-    onConflict: interactive ? promptForConflict : undefined,
+    onConflict: interactive
+      ? (conflict) => promptForImportConflict(conflict, { showDiff })
+      : undefined,
   });
 
   // Non-interactive --diff: print the diff for each detected conflict so the
-  // user can inspect before deciding on --force or an interactive run.
+  // user can inspect before deciding on an interactive run.
   if (showDiff && !interactive) {
-    for (const result of summary.results) {
-      if (!result.conflict) continue;
-      const diff = await renderConflictDiff(result.conflict);
-      console.error(
-        `\n${ansi.bold(`Conflict diff: ${result.skillName} (${result.provider}/${result.scope})`)} ${ansi.dim("local -> imported")}`,
-      );
-      console.error(diff || "  (no textual differences found)");
-    }
+    await printImportConflictDiffs(summary.results);
   }
 
   // Output results


### PR DESCRIPTION
Closes #359
Closes #360

## Summary

Make import conflict behavior explicit and testable: `asm import --force --diff` now fails before reading or modifying a manifest, while the interactive and non-interactive conflict display paths have focused regression coverage.

## Approach

Selected the minimum-risk validation approach. `--force` remains an unconditional overwrite mode with no conflict construction, and `--diff` remains a conflict-inspection mode; combining them is rejected as invalid CLI usage rather than changing importer contracts or silently ignoring `--diff`. The prompt and non-interactive renderer were extracted with injectable I/O seams so their existing behavior can be tested without a real TTY.

## Decision Record

- **Root cause:** Force imports bypass conflict construction, so the later non-interactive diff loop receives no conflict records and silently renders nothing; the prompt and rendering glue were nested inside `cmdImport`, leaving no practical unit-test seam.
- **Options considered:** Option 1 — document that `--diff` is ignored with `--force`; Option 2 — reject the incompatible flags before import work; Option 3 — construct reporting conflicts during forced overwrites.
- **Options rejected:** Option 1 preserves a surprising silent no-op; Option 3 changes importer behavior and risks rendering only after destructive writes.
- **Selected option:** Option 2 — reject the incompatible flags and extract focused conflict UI seams.
- **Residual risk:** A real pseudoterminal interaction is not exercised; prompt parsing, rendering, and callbacks are covered through the same functions used by `cmdImport`.

Analyzed at: `feat/359-import-force-diff @ 1cdee2b` (2026-07-11)

## Changes

| File | Change |
|------|--------|
| `src/cli.ts` | Reject `--force --diff` before manifest I/O, document the incompatibility, and expose testable prompt/diff helpers. |
| `src/cli.test.ts` | Cover k/u/s/d prompt choices, newer/older labels, interactive diff display, real non-interactive conflict diff output, and early incompatible-flag rejection. |

## Test Results

- Unit/integration tests: 1,895 passed (`npm test`)
- Focused CLI tests: 364 passed
- Typecheck: passed
- Build: passed
- E2e node tests: passed in pre-push hook
- Formatting: passed
- QA cycles: 2

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `--force --diff` no longer silently renders nothing | pass | `CLI integration: import > import rejects --force with --diff before reading the manifest` |
| Rejection occurs before import side effects | pass | The regression uses a nonexistent manifest and asserts the incompatibility error precedes file reading. |
| k/u/s prompt choices map to keep-local/use-imported/skip | pass | `import conflict prompt > maps ...` parameterized tests in `src/cli.test.ts` |
| d prints a diff and re-prompts | pass | `import conflict prompt > shows a diff for d, then prompts again for a resolution` |
| Newer/older sides are marked correctly | pass | `import conflict prompt > marks the ... side newer and the other side older` |
| Non-interactive `--diff` prints actual conflict output without overwriting | pass | `CLI integration: import > import --diff prints a collected conflict in non-interactive mode` |
