### PR TITLE
feat(website): landing page scroll reveals and motion

### DIFF
--- a/website-src/src/components/Reveal.jsx
+++ b/website-src/src/components/Reveal.jsx
@@ -1,0 +1,30 @@
+import { cn } from "../lib/cn.js";
+import { useInViewReveal } from "../hooks/useInViewReveal.js";
+
+/**
+ * Scroll-triggered section reveal. Children in `.lp-stagger` get a short cascade.
+ */
+export default function Reveal({
+  children,
+  className,
+  stagger = false,
+  immediate = false,
+  delay = 0,
+  as: Component = "div",
+}) {
+  const { ref, visible } = useInViewReveal({ immediate });
+  return (
+    <Component
+      ref={ref}
+      className={cn(
+        "lp-reveal",
+        stagger && "lp-stagger",
+        visible && "is-visible",
+        className,
+      )}
+      style={delay ? { "--lp-reveal-delay": `${delay}ms` } : undefined}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/website-src/src/hooks/useInViewReveal.js
+++ b/website-src/src/hooks/useInViewReveal.js
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  canUseIntersectionObserver,
+  prefersReducedMotion,
+} from "../lib/motion.js";
+
+/**
+ * Fires once when the element enters the viewport. Used for scroll-triggered
+ * landing-page reveals (opacity + translate only — GPU-friendly).
+ */
+export function useInViewReveal({
+  immediate = false,
+  rootMargin = "-8% 0px",
+} = {}) {
+  const ref = useRef(null);
+  const [visible, setVisible] = useState(immediate);
+
+  useEffect(() => {
+    if (immediate) {
+      setVisible(true);
+      return undefined;
+    }
+    if (prefersReducedMotion() || !canUseIntersectionObserver()) {
+      setVisible(true);
+      return undefined;
+    }
+    const el = ref.current;
+    if (!el) return undefined;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin, threshold: 0.08 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [immediate, rootMargin]);
+
+  return { ref, visible };
+}

--- a/website-src/src/index.css
+++ b/website-src/src/index.css
@@ -627,6 +627,8 @@ mark.hl {
 .lp {
   --lp-serif: "Fraunces", "Instrument Serif", ui-serif, Georgia, serif;
   --lp-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --lp-ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+  --lp-ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
 }
 
 /* Monospace eyebrow / kicker shared by every section */
@@ -740,6 +742,17 @@ mark.hl {
   color: var(--fg-dim);
   white-space: pre-wrap;
 }
+.lp-term-line {
+  opacity: 0;
+  transform: translateY(4px);
+  transition:
+    opacity 320ms var(--lp-ease-out),
+    transform 320ms var(--lp-ease-out);
+}
+.lp-term-line.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
 .lp-term-body .c {
   color: var(--brand);
 }
@@ -760,12 +773,14 @@ mark.hl {
   border-radius: 12px;
   padding: 22px 22px 24px;
   transition:
-    border-color 180ms ease,
-    transform 180ms ease;
+    border-color 200ms var(--lp-ease-out),
+    transform 200ms var(--lp-ease-out);
 }
-.lp-card:hover {
-  border-color: color-mix(in srgb, var(--brand) 45%, var(--border));
-  transform: translateY(-2px);
+@media (hover: hover) and (pointer: fine) {
+  .lp-card:hover {
+    border-color: color-mix(in srgb, var(--brand) 45%, var(--border));
+    transform: translateY(-2px);
+  }
 }
 .lp-card-icon {
   font-family: var(--lp-mono);
@@ -829,12 +844,20 @@ mark.hl {
   color: #06120a;
   border: 1px solid var(--brand);
   transition:
-    filter 160ms ease,
-    transform 160ms ease;
+    filter 160ms var(--lp-ease-out),
+    transform 160ms var(--lp-ease-out);
 }
-.lp-cta:hover {
-  filter: brightness(1.08);
-  transform: translateY(-1px);
+.lp-cta:active {
+  transform: scale(0.97);
+}
+@media (hover: hover) and (pointer: fine) {
+  .lp-cta:hover {
+    filter: brightness(1.08);
+    transform: translateY(-1px);
+  }
+  .lp-cta:active {
+    transform: scale(0.97);
+  }
 }
 .lp-cta-ghost {
   display: inline-flex;
@@ -848,12 +871,18 @@ mark.hl {
   color: var(--fg);
   border: 1px solid var(--border);
   transition:
-    border-color 160ms ease,
-    color 160ms ease;
+    border-color 160ms var(--lp-ease-out),
+    color 160ms var(--lp-ease-out),
+    transform 160ms var(--lp-ease-out);
 }
-.lp-cta-ghost:hover {
-  border-color: var(--brand);
-  color: var(--brand);
+.lp-cta-ghost:active {
+  transform: scale(0.97);
+}
+@media (hover: hover) and (pointer: fine) {
+  .lp-cta-ghost:hover {
+    border-color: var(--brand);
+    color: var(--brand);
+  }
 }
 
 /* Section divider rule with a node */
@@ -871,9 +900,112 @@ mark.hl {
   height: 7px;
   border-radius: 50%;
   background: var(--brand);
+  transform: scale(0.85);
+  opacity: 0.6;
+  transition:
+    transform 400ms var(--lp-ease-out),
+    opacity 400ms var(--lp-ease-out);
+}
+
+/* Scroll reveal — transform + opacity only */
+.lp-reveal {
+  opacity: 0;
+  transform: translateY(14px);
+  transition:
+    opacity 520ms var(--lp-ease-out),
+    transform 520ms var(--lp-ease-out);
+  transition-delay: var(--lp-reveal-delay, 0ms);
+}
+.lp-reveal.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+.lp-stagger > * {
+  opacity: 0;
+  transform: translateY(10px);
+  transition:
+    opacity 420ms var(--lp-ease-out),
+    transform 420ms var(--lp-ease-out);
+}
+.lp-reveal.is-visible.lp-stagger > * {
+  opacity: 1;
+  transform: translateY(0);
+}
+.lp-stagger > *:nth-child(1) {
+  transition-delay: calc(var(--lp-reveal-delay, 0ms) + 0ms);
+}
+.lp-stagger > *:nth-child(2) {
+  transition-delay: calc(var(--lp-reveal-delay, 0ms) + 55ms);
+}
+.lp-stagger > *:nth-child(3) {
+  transition-delay: calc(var(--lp-reveal-delay, 0ms) + 110ms);
+}
+.lp-stagger > *:nth-child(4) {
+  transition-delay: calc(var(--lp-reveal-delay, 0ms) + 165ms);
+}
+.lp-stagger > *:nth-child(5) {
+  transition-delay: calc(var(--lp-reveal-delay, 0ms) + 220ms);
+}
+.lp-stagger > *:nth-child(6) {
+  transition-delay: calc(var(--lp-reveal-delay, 0ms) + 275ms);
+}
+.lp-stagger > *:nth-child(n + 7) {
+  transition-delay: calc(var(--lp-reveal-delay, 0ms) + 330ms);
+}
+
+.lp-term-hero {
+  opacity: 0;
+  transform: translateY(12px) scale(0.98);
+  transition:
+    opacity 600ms var(--lp-ease-out),
+    transform 600ms var(--lp-ease-out);
+}
+.lp-term-hero.is-visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.lp-cursor {
+  display: inline-block;
+  color: var(--brand);
+  animation: lp-cursor-blink 1.05s step-end infinite;
+}
+
+@keyframes lp-cursor-blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
+.lp-rule.is-visible::before {
+  transform: scale(1);
+  opacity: 1;
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .lp-reveal,
+  .lp-stagger > * {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+  .lp-term-hero {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+  .lp-cursor {
+    animation: none;
+  }
+  .lp-term-line {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
   .lp-card:hover,
   .lp-cta:hover,
   .lp-cta-ghost:hover {
@@ -881,5 +1013,9 @@ mark.hl {
   }
   .lp-kicker .dot {
     animation: none;
+  }
+  .lp-rule::before {
+    transform: none;
+    opacity: 1;
   }
 }

--- a/website-src/src/lib/motion.js
+++ b/website-src/src/lib/motion.js
@@ -1,0 +1,12 @@
+/** Safe in SSR and jsdom (no matchMedia / IntersectionObserver). */
+export function prefersReducedMotion() {
+  if (typeof window === "undefined") return false;
+  if (typeof window.matchMedia !== "function") return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export function canUseIntersectionObserver() {
+  return (
+    typeof window !== "undefined" && typeof IntersectionObserver === "function"
+  );
+}

--- a/website-src/src/pages/LandingPage.jsx
+++ b/website-src/src/pages/LandingPage.jsx
@@ -1,7 +1,12 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { ArrowRight, Github } from "lucide-react";
 import { useCatalog } from "../hooks/useCatalog.jsx";
 import CopyButton from "../components/CopyButton.jsx";
+import Reveal from "../components/Reveal.jsx";
+import { useInViewReveal } from "../hooks/useInViewReveal.js";
+import { cn } from "../lib/cn.js";
+import { prefersReducedMotion } from "../lib/motion.js";
 
 const REPO_URL = "https://github.com/luongnv89/asm";
 const NPM_CMD = "npm install -g agent-skill-manager";
@@ -9,14 +14,6 @@ const PROVIDER_COUNT = 19;
 
 /**
  * Marketing landing page (route `/`). The catalog lives at `/skills`.
- *
- * Copy follows a Problem → Agitate → Solution arc mirroring the README:
- * "your skills are a mess" → "asm brings order". Visual language reuses
- * the editorial/terminal system already established on the changelog
- * page (Fraunces serif headlines, JetBrains Mono accents, hacker-green
- * `--brand`). Headline stats (`skills`, `repos`, `categories`) are read
- * live from the loaded catalog so they never drift from reality, with
- * static fallbacks for the brief window before the catalog hydrates.
  */
 export default function LandingPage() {
   const { catalog } = useCatalog();
@@ -75,7 +72,11 @@ function WhatsNew() {
     },
   ];
   return (
-    <section className="flex flex-col gap-8" aria-label="What's new in v2.14">
+    <Reveal
+      as="section"
+      className="flex flex-col gap-8"
+      aria-label="What's new in v2.14"
+    >
       <header className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
         <div className="flex flex-col gap-3 max-w-[680px]">
           <span className="lp-kicker">
@@ -98,7 +99,7 @@ function WhatsNew() {
           <ArrowRight className="h-4 w-4" aria-hidden="true" />
         </Link>
       </header>
-      <div className="grid sm:grid-cols-2 gap-5">
+      <Reveal stagger className="grid sm:grid-cols-2 gap-5">
         {highlights.map((h) => (
           <article key={h.head} className="lp-card">
             <span className="text-[10px] font-[var(--lp-mono)] uppercase tracking-wider text-[var(--brand)]">
@@ -108,8 +109,8 @@ function WhatsNew() {
             <p>{h.body}</p>
           </article>
         ))}
-      </div>
-    </section>
+      </Reveal>
+    </Reveal>
   );
 }
 
@@ -118,7 +119,7 @@ function WhatsNew() {
 function Hero({ skillsLabel, repoCount, providerCount }) {
   return (
     <section className="grid lg:grid-cols-[1.05fr_0.95fr] gap-12 lg:gap-16 items-center pt-2 sm:pt-6">
-      <div className="flex flex-col gap-7">
+      <Reveal immediate className="flex flex-col gap-7">
         <span className="lp-kicker">
           <span className="dot" aria-hidden="true" />
           agent-skill-manager
@@ -166,7 +167,7 @@ function Hero({ skillsLabel, repoCount, providerCount }) {
             no tracking
           </p>
         </div>
-      </div>
+      </Reveal>
 
       <HeroTerminal repoCount={repoCount} />
     </section>
@@ -174,8 +175,65 @@ function Hero({ skillsLabel, repoCount, providerCount }) {
 }
 
 function HeroTerminal({ repoCount }) {
+  const reducedMotion = prefersReducedMotion();
+  const [linesLive, setLinesLive] = useState(() => prefersReducedMotion());
+
+  useEffect(() => {
+    if (reducedMotion) {
+      setLinesLive(true);
+      return undefined;
+    }
+    const t = window.setTimeout(() => setLinesLive(true), 280);
+    return () => window.clearTimeout(t);
+  }, [reducedMotion]);
+
+  const lines = [
+    <span key="install">
+      <span className="c">$</span> <span className="fg">asm install</span>{" "}
+      github:anthropics/skills
+    </span>,
+    <span key="clone" className="dim">
+      {" "}
+      ↳ cloning anthropics/skills…
+    </span>,
+    <span key="scan">
+      <span className="dim"> ↳ </span>
+      <span className="c">✓ security scan passed</span>
+      <span className="dim"> — no risky patterns</span>
+    </span>,
+    <span key="link">
+      <span className="dim"> ↳ </span>
+      <span className="c">✓ linked 7 skills</span>
+      <span className="dim"> → claude, codex (cross-tool link)</span>
+    </span>,
+    null,
+    <span key="audit-cmd">
+      <span className="c">$</span> <span className="fg">asm audit</span>{" "}
+      duplicates
+    </span>,
+    <span key="dups">
+      <span className="dim"> ↳ </span>
+      <span className="warn">⚠ 3 duplicates</span>
+      <span className="dim"> across claude / cursor — </span>
+      <span className="fg">asm clean</span>
+    </span>,
+    null,
+    <span key="stats-cmd">
+      <span className="c">$</span> <span className="fg">asm stats</span>
+    </span>,
+    <span key="stats-out" className="dim">
+      {" "}
+      142 skills · {repoCount} repos · 6 providers
+    </span>,
+  ];
+
   return (
-    <div className="lp-term shadow-xl shadow-black/10">
+    <div
+      className={cn(
+        "lp-term lp-term-hero shadow-xl shadow-black/10",
+        linesLive && "is-visible",
+      )}
+    >
       <div className="lp-term-bar">
         <span className="tdot" aria-hidden="true" />
         <span className="tdot" aria-hidden="true" />
@@ -183,35 +241,26 @@ function HeroTerminal({ repoCount }) {
         <span className="tlabel">asm — ~/projects</span>
       </div>
       <div className="lp-term-body">
-        <span className="c">$</span> <span className="fg">asm install</span>{" "}
-        github:anthropics/skills
-        {"\n"}
-        <span className="dim"> ↳ cloning anthropics/skills…</span>
-        {"\n"}
-        <span className="dim"> ↳ </span>
-        <span className="c">✓ security scan passed</span>
-        <span className="dim"> — no risky patterns</span>
-        {"\n"}
-        <span className="dim"> ↳ </span>
-        <span className="c">✓ linked 7 skills</span>
-        <span className="dim"> → claude, codex (cross-tool link)</span>
-        {"\n\n"}
-        <span className="c">$</span> <span className="fg">asm audit</span>{" "}
-        duplicates
-        {"\n"}
-        <span className="dim"> ↳ </span>
-        <span className="warn">⚠ 3 duplicates</span>
-        <span className="dim"> across claude / cursor — </span>
-        <span className="fg">asm clean</span>
-        {"\n\n"}
-        <span className="c">$</span> <span className="fg">asm stats</span>
-        {"\n"}
-        <span className="dim">
-          {" "}
-          142 skills · {repoCount} repos · 6 providers
+        {lines.map((line, i) =>
+          line === null ? (
+            <br key={`br-${i}`} />
+          ) : (
+            <div
+              key={i}
+              className={cn("lp-term-line", linesLive && "is-visible")}
+              style={
+                reducedMotion
+                  ? undefined
+                  : { transitionDelay: `${120 + i * 65}ms` }
+              }
+            >
+              {line}
+            </div>
+          ),
+        )}
+        <span className="lp-cursor" aria-hidden="true">
+          ▍
         </span>
-        {"\n"}
-        <span className="c">▍</span>
       </div>
     </div>
   );
@@ -227,7 +276,9 @@ function Stats({ skillsLabel, repoCount, categoryCount, providerCount }) {
     { num: providerCount, label: "agents supported" },
   ];
   return (
-    <section
+    <Reveal
+      as="section"
+      stagger
       aria-label="Catalog at a glance"
       className="grid grid-cols-2 sm:grid-cols-4 gap-y-8 gap-x-4 py-2"
     >
@@ -237,7 +288,7 @@ function Stats({ skillsLabel, repoCount, categoryCount, providerCount }) {
           <span className="lp-stat-label">{it.label}</span>
         </div>
       ))}
-    </section>
+    </Reveal>
   );
 }
 
@@ -259,7 +310,7 @@ function Problem() {
     },
   ];
   return (
-    <section className="flex flex-col gap-10">
+    <Reveal as="section" className="flex flex-col gap-10">
       <header className="flex flex-col gap-4 max-w-[680px]">
         <span className="lp-kicker">
           <span className="dot" aria-hidden="true" />
@@ -275,11 +326,11 @@ function Problem() {
           one is another folder to babysit.
         </p>
       </header>
-      <div className="grid sm:grid-cols-3 gap-5">
+      <Reveal stagger className="grid sm:grid-cols-3 gap-5">
         {pains.map((p) => (
           <div
             key={p.head}
-            className="border-l-2 border-[var(--warn)] pl-5 py-1 flex flex-col gap-2"
+            className="lp-pain border-l-2 border-[var(--warn)] pl-5 py-1 flex flex-col gap-2"
           >
             <h3 className="text-[var(--fg)] font-semibold text-base">
               {p.head}
@@ -289,8 +340,8 @@ function Problem() {
             </p>
           </div>
         ))}
-      </div>
-    </section>
+      </Reveal>
+    </Reveal>
   );
 }
 
@@ -330,7 +381,7 @@ function Solution() {
     },
   ];
   return (
-    <section className="flex flex-col gap-10">
+    <Reveal as="section" className="flex flex-col gap-10">
       <header className="flex flex-col gap-4 max-w-[680px]">
         <span className="lp-kicker">
           <span className="dot" aria-hidden="true" />
@@ -347,7 +398,7 @@ function Solution() {
           One TUI. One CLI. Every agent.
         </p>
       </header>
-      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
+      <Reveal stagger className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
         {features.map((f) => (
           <article key={f.icon} className="lp-card">
             <span className="lp-card-icon">{f.icon}</span>
@@ -355,8 +406,8 @@ function Solution() {
             <p>{f.body}</p>
           </article>
         ))}
-      </div>
-    </section>
+      </Reveal>
+    </Reveal>
   );
 }
 
@@ -386,7 +437,7 @@ function HowItWorks() {
     },
   ];
   return (
-    <section className="flex flex-col gap-10">
+    <Reveal as="section" className="flex flex-col gap-10">
       <header className="flex flex-col gap-4 max-w-[680px]">
         <span className="lp-kicker">
           <span className="dot" aria-hidden="true" />
@@ -394,11 +445,14 @@ function HowItWorks() {
         </span>
         <h2 className="lp-section-title">From chaos to clean in four steps.</h2>
       </header>
-      <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-x-6 gap-y-10">
+      <Reveal
+        stagger
+        className="grid sm:grid-cols-2 lg:grid-cols-4 gap-x-6 gap-y-10"
+      >
         {steps.map((s) => (
           <div key={s.n} className="flex flex-col gap-3">
             <span className="lp-step-num">{s.n}</span>
-            <div className="lp-rule" />
+            <StepRule />
             <h3 className="text-[var(--fg)] font-semibold text-base mt-1">
               {s.head}
             </h3>
@@ -407,9 +461,14 @@ function HowItWorks() {
             </p>
           </div>
         ))}
-      </div>
-    </section>
+      </Reveal>
+    </Reveal>
   );
+}
+
+function StepRule() {
+  const { ref, visible } = useInViewReveal();
+  return <div ref={ref} className={cn("lp-rule", visible && "is-visible")} />;
 }
 
 /* ─── Build your own ────────────────────────────────────────────────── */
@@ -417,7 +476,7 @@ function HowItWorks() {
 function Build() {
   return (
     <section className="grid lg:grid-cols-[0.95fr_1.05fr] gap-12 lg:gap-16 items-center">
-      <div className="flex flex-col gap-5 max-w-[560px]">
+      <Reveal className="flex flex-col gap-5 max-w-[560px]">
         <span className="lp-kicker">
           <span className="dot" aria-hidden="true" />
           for skill authors
@@ -449,9 +508,9 @@ function Build() {
             Explore bundles →
           </Link>
         </div>
-      </div>
+      </Reveal>
 
-      <div className="lp-term">
+      <Reveal delay={80} className="lp-term">
         <div className="lp-term-bar">
           <span className="tdot" aria-hidden="true" />
           <span className="tdot" aria-hidden="true" />
@@ -495,7 +554,7 @@ function Build() {
           <span className="c">✓ PR opened</span>
           <span className="dim"> — installable by name once merged</span>
         </div>
-      </div>
+      </Reveal>
     </section>
   );
 }
@@ -504,7 +563,10 @@ function Build() {
 
 function FinalCta({ skillsLabel }) {
   return (
-    <section className="flex flex-col items-center text-center gap-7 py-6 sm:py-10 border-t border-[var(--border)]">
+    <Reveal
+      as="section"
+      className="flex flex-col items-center text-center gap-7 py-6 sm:py-10 border-t border-[var(--border)]"
+    >
       <span className="lp-kicker">
         <span className="dot" aria-hidden="true" />
         get started in 30 seconds
@@ -549,6 +611,6 @@ function FinalCta({ skillsLabel }) {
           </a>
         </div>
       </div>
-    </section>
+    </Reveal>
   );
 }


### PR DESCRIPTION
## Summary

Adds polished, GPU-friendly motion to the marketing landing page (`/`):

- **Hero**: immediate fade-in for copy; terminal panel enters with subtle scale + staggered command lines and blinking cursor
- **Sections**: scroll-triggered reveals via `IntersectionObserver` (`Reveal` + `useInViewReveal`)
- **Grids**: 55ms stagger on stats, cards, pain columns, and steps
- **Interactions**: CTA `:active` press feedback, hover lifts gated to fine pointers, stronger ease-out curves
- **A11y**: `prefers-reduced-motion` disables motion; `motion.js` guards missing `matchMedia` / `IntersectionObserver` in jsdom tests

## Test plan

- [x] `npm run test:site`
- [x] pre-commit (unit + e2e node + build)
- [ ] Manual: `npm run dev:site` — scroll landing page, toggle OS reduced motion if available