### PR TITLE
fix(tui): keep raw mode held while removing duplicates

### DIFF
--- a/src/views/duplicates.test.tsx
+++ b/src/views/duplicates.test.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { DuplicatesView } from "./duplicates";
+import type { AuditReport, SkillInfo } from "../utils/types";
+
+const ARROW_DOWN = "\u001B[B";
+const ENTER = "\r";
+
+function makeSkill(over: Partial<SkillInfo> & { path: string }): SkillInfo {
+  return {
+    name: "dupe",
+    version: "1.0.0",
+    description: "",
+    creator: "",
+    license: "",
+    compatibility: "",
+    allowedTools: [],
+    dirName: "dupe",
+    originalPath: over.path,
+    location: "global",
+    scope: "global",
+    provider: "claude",
+    providerLabel: "claude",
+    isSymlink: false,
+    symlinkTarget: null,
+    realPath: over.path,
+    ...over,
+  };
+}
+
+function makeReport(): AuditReport {
+  const instances = [
+    makeSkill({ path: "/a/dupe", location: "a" }),
+    makeSkill({ path: "/b/dupe", location: "b" }),
+  ];
+  return {
+    scannedAt: new Date().toISOString(),
+    totalSkills: 2,
+    duplicateGroups: [{ key: "dupe", reason: "same-dirName", instances }],
+    totalDuplicateInstances: 2,
+  };
+}
+
+const tick = async (ms = 50) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+describe("DuplicatesView raw-mode lifetime", () => {
+  // Regression test for the TUI freeze after removing duplicates.
+  //
+  // ink reference-counts raw mode: when the last active `useInput` releases it,
+  // App.handleSetRawMode drops to 0 and runs the full teardown —
+  // `stdin.setRawMode(false)`, removing the 'readable' listener and
+  // `stdin.unref()`. On Windows, re-enabling raw mode after that teardown has
+  // spanned event-loop turns leaves stdin permanently silent: the process stays
+  // alive and idle but never receives another keypress.
+  //
+  // That is exactly what happened here. While the removal was awaited, the
+  // parent App had already disabled its own `useInput` (`isActive: view !==
+  // "audit"`), so gating this view's `useInput` on `!busy` left ZERO holders of
+  // raw mode for the whole duration of the await.
+  //
+  // The view must therefore keep its `useInput` mounted while busy and ignore
+  // keystrokes inside the handler instead (the handler's `if (busy) return`
+  // guard already does this).
+  it("never releases raw mode while the removal is in flight", async () => {
+    let resolveRemoval: (() => void) | undefined;
+    const onRemove = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRemoval = resolve;
+        }),
+    );
+
+    const { stdin, lastFrame, unmount } = render(
+      <DuplicatesView
+        report={makeReport()}
+        onRemove={onRemove}
+        onClose={() => {}}
+      />,
+    );
+
+    // Let ink mount and subscribe to stdin before driving any keys.
+    await tick();
+
+    const setRawMode = vi.spyOn(
+      stdin as unknown as { setRawMode: (v: boolean) => void },
+      "setRawMode",
+    );
+
+    // groups phase → Enter opens the group (pre-marks every instance but the
+    // first), instances phase starts with the cursor on instance 0.
+    stdin.write(ENTER);
+    await tick();
+
+    // Move onto the ">>> Remove N marked instance(s) <<<" action row: two
+    // instances means the action row sits at index 2.
+    stdin.write(ARROW_DOWN);
+    await tick();
+    stdin.write(ARROW_DOWN);
+    await tick();
+    expect(lastFrame()).toContain("Remove 1 marked instance(s)");
+
+    // Enter triggers the removal and flips `busy`.
+    stdin.write(ENTER);
+    await tick();
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(resolveRemoval).toBeDefined();
+
+    // The removal is still pending here — this is the window in which the real
+    // app hung. Raw mode must still be held.
+    expect(setRawMode).not.toHaveBeenCalledWith(false);
+
+    resolveRemoval!();
+    await tick();
+
+    setRawMode.mockRestore();
+    unmount();
+  });
+});

--- a/src/views/duplicates.tsx
+++ b/src/views/duplicates.tsx
@@ -31,78 +31,84 @@ export function DuplicatesView({ report, onRemove, onClose }: DuplicatesProps) {
   const optionCount =
     phase === "groups" ? groups.length : sortedInstances.length + 1;
 
-  useInput(
-    async (_input, key) => {
-      if (busy) return;
-      if (key.escape) {
-        if (phase === "instances") {
-          setPhase("groups");
-          setCursor(0);
-          setMarkedForRemoval(new Set());
-          return;
-        }
-        onClose();
+  // NOTE: this handler must stay mounted while `busy` — do NOT gate it with
+  // `{ isActive: !busy }`. ink reference-counts raw mode, and the parent App
+  // disables its own `useInput` while the audit view is open. Releasing this
+  // one too would drop the count to zero for the whole duration of the await,
+  // making ink run its full stdin teardown (`setRawMode(false)`, drop the
+  // 'readable' listener, `unref()`). On Windows, re-enabling raw mode after
+  // that teardown has spanned event-loop turns leaves stdin permanently
+  // silent: the process stays alive and idle but never sees another keypress.
+  // The `if (busy) return` guard below is what ignores keys during removal.
+  useInput(async (_input, key) => {
+    if (busy) return;
+    if (key.escape) {
+      if (phase === "instances") {
+        setPhase("groups");
+        setCursor(0);
+        setMarkedForRemoval(new Set());
         return;
       }
-      if (optionCount === 0) return;
-      if (key.upArrow) {
-        setCursor((i) => (i <= 0 ? optionCount - 1 : i - 1));
-        return;
-      }
-      if (key.downArrow) {
-        setCursor((i) => (i >= optionCount - 1 ? 0 : i + 1));
-        return;
-      }
-      if (key.return) {
-        if (phase === "groups") {
-          if (groups[cursor]) {
-            const group = groups[cursor];
-            const sorted = sortInstancesForKeep(group.instances);
-            const preMarked = new Set<string>();
-            for (let i = 1; i < sorted.length; i++) {
-              preMarked.add(sorted[i].path);
-            }
-            setGroupIndex(cursor);
-            setMarkedForRemoval(preMarked);
-            setCursor(0);
-            setPhase("instances");
+      onClose();
+      return;
+    }
+    if (optionCount === 0) return;
+    if (key.upArrow) {
+      setCursor((i) => (i <= 0 ? optionCount - 1 : i - 1));
+      return;
+    }
+    if (key.downArrow) {
+      setCursor((i) => (i >= optionCount - 1 ? 0 : i + 1));
+      return;
+    }
+    if (key.return) {
+      if (phase === "groups") {
+        if (groups[cursor]) {
+          const group = groups[cursor];
+          const sorted = sortInstancesForKeep(group.instances);
+          const preMarked = new Set<string>();
+          for (let i = 1; i < sorted.length; i++) {
+            preMarked.add(sorted[i].path);
           }
-          return;
+          setGroupIndex(cursor);
+          setMarkedForRemoval(preMarked);
+          setCursor(0);
+          setPhase("instances");
         }
-        // Phase: instances
-        if (cursor < sortedInstances.length) {
-          // Toggle checkbox
-          const skillPath = sortedInstances[cursor].path;
-          setMarkedForRemoval((prev) => {
-            const next = new Set(prev);
-            if (next.has(skillPath)) {
-              next.delete(skillPath);
-            } else {
-              // Guard: don't allow marking ALL instances
-              if (next.size >= sortedInstances.length - 1) return prev;
-              next.add(skillPath);
-            }
-            return next;
-          });
-          return;
-        }
-        // Action row → execute removal
-        if (markedForRemoval.size === 0) return;
-        const toRemove = sortedInstances.filter((s) =>
-          markedForRemoval.has(s.path),
-        );
-        const kept = sortedInstances.find((s) => !markedForRemoval.has(s.path));
-        if (!kept) return;
-        setBusy(true);
-        try {
-          await onRemove(toRemove, kept);
-        } finally {
-          setBusy(false);
-        }
+        return;
       }
-    },
-    { isActive: !busy },
-  );
+      // Phase: instances
+      if (cursor < sortedInstances.length) {
+        // Toggle checkbox
+        const skillPath = sortedInstances[cursor].path;
+        setMarkedForRemoval((prev) => {
+          const next = new Set(prev);
+          if (next.has(skillPath)) {
+            next.delete(skillPath);
+          } else {
+            // Guard: don't allow marking ALL instances
+            if (next.size >= sortedInstances.length - 1) return prev;
+            next.add(skillPath);
+          }
+          return next;
+        });
+        return;
+      }
+      // Action row → execute removal
+      if (markedForRemoval.size === 0) return;
+      const toRemove = sortedInstances.filter((s) =>
+        markedForRemoval.has(s.path),
+      );
+      const kept = sortedInstances.find((s) => !markedForRemoval.has(s.path));
+      if (!kept) return;
+      setBusy(true);
+      try {
+        await onRemove(toRemove, kept);
+      } finally {
+        setBusy(false);
+      }
+    }
+  });
 
   return (
     <Box


### PR DESCRIPTION
## Description

Removing marked instances from **Audit: Duplicates** leaves the TUI alive but permanently deaf. The dashboard comes back, and from then on no keystroke is ever delivered again — not arrows, not `Esc`, not `q`. The process idles forever and has to be killed.

The cause is ink's raw-mode reference counting. When the count reaches zero, `App.handleSetRawMode` runs a full stdin teardown: `stdin.setRawMode(false)`, remove the `'readable'` listener, `stdin.unref()`. The duplicates flow drives that count to zero:

1. `App` disables its own `useInput` while the audit view is open — `{ isActive: view !== "config" && view !== "audit" }` (`src/index.tsx`).
2. `DuplicatesView` disabled its `useInput` for the entire `await` — `{ isActive: !busy }`.

So for the whole duration of the removal, **nobody holds raw mode** and the teardown runs. Re-enabling raw mode afterwards does not restore input delivery on Windows, so stdin stays silent for good.

Entering the audit view also passes through zero, but within a single tick, and that survives — the damage needs the teardown to span event-loop turns, which is exactly what the `await` introduces.

### The fix

Stop gating the hook. The handler's first line is already `if (busy) return`, so `{ isActive: !busy }` was redundant for behaviour and served only to drop the refcount. A comment records why it must not come back.

### How it was diagnosed

Three hypotheses were ruled out with instrumentation before touching anything:

- **Slow removal** — a file trace showed the handler completing in 177–244 ms end to end (`buildRemovalPlan` 0 ms, `executeRemoval` 2–8 ms per instance, `refreshSkills` ~150 ms).
- **Render overflow** — a 250 ms heartbeat recording render counts and wrapped `stdout.write` timings showed ~16 KB written in 2 ms across 3 renders after the handler returned, then complete silence: no blocked event loop, no re-render storm.
- **Node version** — reproduced identically under a pinned Node 22 and under Node 24.

The process was simply idle and no longer receiving input, which pointed at stdin rather than at CPU.

## Related Issue

None. Related but **not** a duplicate of #375: that one is the ad-hoc registry-disambiguation prompt leaving `stdin` flowing because `pause()` is never called, so the process refuses to exit. Different code path, opposite symptom (won't exit vs. won't respond). Both are stdin-lifecycle bugs, so the maintainer may want to look at them together.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

`src/views/duplicates.test.tsx` drives the view with `ink-testing-library` and asserts `stdin.setRawMode(false)` is never called while the removal is in flight. It fails on `main` with `Number of calls: 1` and passes with the fix.

The diff on `duplicates.tsx` looks larger than it is: removing the second argument to `useInput` dedents the handler body by one level. The behavioural change is the deleted `{ isActive: !busy }`.

Verified interactively on Windows 11 / Node 22: after the fix the dashboard comes back and keeps responding.

Reported and verified by a user hitting this on a config with 11 custom paths and ~25 duplicate groups.
