### PR TITLE
test(windows): make the test suite pass on Windows

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,3 +1,4 @@
+import { createDirSymlink } from "./utils/fs";
 import { fileURLToPath } from "url";
 import {
   describe,
@@ -3671,7 +3672,7 @@ metadata:
       `---\nname: link-via-symlink\nversion: 1.0.0\n---\n# Body\n`,
     );
     const linkedSrc = join(tempDir, "linked-src");
-    await symlink(realDir, linkedSrc, "dir");
+    await createDirSymlink(realDir, linkedSrc);
     // The link name comes from the source directory basename, not the SKILL.md
     // name field, so the resulting symlink lives under "linked-src".
     const providerLink = join(homedir(), ".claude", "skills", "linked-src");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -199,6 +199,7 @@ import {
 } from "./library";
 import { setVerbose } from "./logger";
 import { join as joinPath, resolve, relative as relativePath } from "path";
+import { toPortableRelativePath } from "./utils/fs";
 import type {
   Scope,
   SortBy,
@@ -2739,7 +2740,9 @@ async function installSelectedLibrarySkill(input: {
     : resolutionSource === "registry"
       ? ("registry" as const)
       : ("github" as const);
-  const skillPath = relativePath(scanBaseDir, inspection.plan.sourceDir);
+  const skillPath = toPortableRelativePath(
+    relativePath(scanBaseDir, inspection.plan.sourceDir),
+  );
   const installed = await installLibrarySkill({
     sourceDir: inspection.plan.sourceDir,
     libraryName: inspection.skillName,
@@ -3560,9 +3563,11 @@ async function cmdInstall(args: ParsedArgs) {
               installedAt: new Date().toISOString(),
               provider: inspection.plan.providerName,
               scope: inspection.plan.scope,
-              skillPath: relativePath(
-                inspection.plan.tempDir,
-                inspection.plan.sourceDir,
+              skillPath: toPortableRelativePath(
+                relativePath(
+                  inspection.plan.tempDir,
+                  inspection.plan.sourceDir,
+                ),
               ),
               targetDir: inspection.plan.targetDir,
               sourceType,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -79,9 +79,11 @@ describe("getDefaultConfig", () => {
 });
 
 describe("resolveProviderPath", () => {
+  // Expectations are built with join() rather than "/" templates:
+  // resolveProviderPath returns native separators, i.e. backslashes on Windows.
   it("resolves ~ paths to home directory", () => {
     const result = resolveProviderPath("~/.claude/skills");
-    expect(result).toBe(`${HOME}/.claude/skills`);
+    expect(result).toBe(join(HOME, ".claude", "skills"));
   });
 
   it("preserves absolute paths", () => {
@@ -96,7 +98,7 @@ describe("resolveProviderPath", () => {
 
   it("handles ~/path with deeper nesting", () => {
     const result = resolveProviderPath("~/a/b/c/d");
-    expect(result).toBe(`${HOME}/a/b/c/d`);
+    expect(result).toBe(join(HOME, "a", "b", "c", "d"));
   });
 
   it("handles ~ alone as prefix", () => {
@@ -108,7 +110,9 @@ describe("resolveProviderPath", () => {
 describe("getConfigPath", () => {
   it("returns a path under ~/.config/agent-skill-manager", () => {
     const path = getConfigPath();
-    expect(path).toContain(".config/agent-skill-manager/config.json");
+    expect(path).toContain(
+      join(".config", "agent-skill-manager", "config.json"),
+    );
   });
 });
 

--- a/src/evaluator.test.ts
+++ b/src/evaluator.test.ts
@@ -22,7 +22,7 @@ import {
   type EvalProvenance,
 } from "./evaluator";
 import { mkdtemp, rm, readFile, writeFile, access } from "fs/promises";
-import { join } from "path";
+import { basename, join } from "path";
 import { tmpdir } from "os";
 
 let tempDir: string;
@@ -737,7 +737,7 @@ describe("classifyEvalDirectory", () => {
     const r = await classifyEvalDirectory(root);
     expect(r.kind).toBe("collection");
     expect(r.skillDirs.length).toBe(2);
-    expect(r.skillDirs.map((d) => d.split("/").pop()).sort()).toEqual([
+    expect(r.skillDirs.map((d) => basename(d)).sort()).toEqual([
       "alpha",
       "beta",
     ]);
@@ -761,7 +761,7 @@ describe("classifyEvalDirectory", () => {
     const r = await classifyEvalDirectory(root);
     expect(r.kind).toBe("collection");
     expect(r.skillDirs.length).toBe(1);
-    expect(r.skillDirs[0].endsWith("/real")).toBe(true);
+    expect(basename(r.skillDirs[0]) === "real").toBe(true);
   });
 });
 
@@ -779,7 +779,7 @@ describe("findChildSkillDirs", () => {
     await writeSkillMd(join(root, "a"), MINI_SKILL);
     await writeSkillMd(join(root, "b"), MINI_SKILL);
     const r = await findChildSkillDirs(root);
-    expect(r.map((d) => d.split("/").pop())).toEqual(["a", "b", "c"]);
+    expect(r.map((d) => basename(d))).toEqual(["a", "b", "c"]);
   });
 });
 

--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -1,3 +1,4 @@
+import { createDirSymlink } from "./utils/fs";
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   mkdtemp,
@@ -9,7 +10,7 @@ import {
   symlink,
 } from "fs/promises";
 import { existsSync } from "fs";
-import { join, relative, basename, dirname } from "path";
+import { join, relative, resolve, isAbsolute, basename, dirname } from "path";
 import { tmpdir } from "os";
 import {
   parseSource,
@@ -1157,14 +1158,20 @@ describe("executeInstallAllProviders", () => {
       const stats = await lstat(linkPath);
       expect(stats.isSymbolicLink()).toBe(true);
 
-      // Verify symlink is relative, not absolute
       const target = await readlink(linkPath);
-      expect(target.startsWith("/")).toBe(false);
-
-      // Verify relative path resolves correctly
       const providerDir = join(tempDir, "providers", name, "skills");
-      const expectedRel = relative(providerDir, plan.targetDir);
-      expect(target).toBe(expectedRel);
+
+      // The link must resolve to the primary install on every platform.
+      expect(resolve(providerDir, target)).toBe(resolve(plan.targetDir));
+
+      // POSIX keeps the target relative so the link survives a moved home.
+      // Windows gets a junction instead, and junction targets are always
+      // absolute — see createDirSymlink in src/utils/fs.ts.
+      if (process.platform === "win32") {
+        expect(isAbsolute(target)).toBe(true);
+      } else {
+        expect(target).toBe(relative(providerDir, plan.targetDir));
+      }
     }
   });
 
@@ -1174,10 +1181,9 @@ describe("executeInstallAllProviders", () => {
     // Pre-create a stale symlink in the claude provider dir
     const claudeDir = join(tempDir, "providers", "claude", "skills");
     await mkdir(claudeDir, { recursive: true });
-    await symlink(
+    await createDirSymlink(
       "/nonexistent/old-target",
       join(claudeDir, "my-skill"),
-      "dir",
     );
 
     const result = await executeInstallAllProviders(plan, providers);
@@ -1185,8 +1191,10 @@ describe("executeInstallAllProviders", () => {
 
     // Symlink should now point to the primary install, not the old target
     const target = await readlink(join(claudeDir, "my-skill"));
-    const expectedRel = relative(claudeDir, plan.targetDir);
-    expect(target).toBe(expectedRel);
+    expect(resolve(claudeDir, target)).toBe(resolve(plan.targetDir));
+    if (process.platform !== "win32") {
+      expect(target).toBe(relative(claudeDir, plan.targetDir));
+    }
   });
 
   test("skips existing real directories instead of deleting them", async () => {
@@ -1373,11 +1381,18 @@ describe("isLocalPath", () => {
 
 // ─── parseLocalSource tests ─────────────────────────────────────────────────
 
+// An absolute path in the platform's own shape: "/…" is not absolute on
+// Windows, where parseLocalSource would resolve it onto the current drive.
+const ABS_SKILL_PATH =
+  process.platform === "win32"
+    ? "C:\\home\\user\\my-skill"
+    : "/home/user/my-skill";
+
 describe("parseLocalSource", () => {
   test("parses absolute path", () => {
-    const result = parseLocalSource("/home/user/my-skill");
+    const result = parseLocalSource(ABS_SKILL_PATH);
     expect(result.isLocal).toBe(true);
-    expect(result.localPath).toBe("/home/user/my-skill");
+    expect(result.localPath).toBe(ABS_SKILL_PATH);
     expect(result.owner).toBe("local");
     expect(result.repo).toBe("my-skill");
     expect(result.ref).toBeNull();
@@ -1391,21 +1406,21 @@ describe("parseLocalSource", () => {
     expect(result.isLocal).toBe(true);
     expect(result.localPath).toBeTruthy();
     // Should resolve to an absolute path
-    expect(result.localPath!.startsWith("/")).toBe(true);
+    expect(isAbsolute(result.localPath!)).toBe(true);
     expect(result.repo).toBe("my-skill");
   });
 
   test("parses parent-relative path", () => {
     const result = parseLocalSource("../sibling-skill");
     expect(result.isLocal).toBe(true);
-    expect(result.localPath!.startsWith("/")).toBe(true);
+    expect(isAbsolute(result.localPath!)).toBe(true);
     expect(result.repo).toBe("sibling-skill");
   });
 
   test("parses tilde path", () => {
     const result = parseLocalSource("~/skills/my-skill");
     expect(result.isLocal).toBe(true);
-    expect(result.localPath!.startsWith("/")).toBe(true);
+    expect(isAbsolute(result.localPath!)).toBe(true);
     expect(result.repo).toBe("my-skill");
     // Should NOT contain tilde in resolved path
     expect(result.localPath).not.toContain("~");
@@ -1550,9 +1565,13 @@ describe("buildRepoUrl", () => {
   });
 
   test("returns local path for local source", () => {
-    const source = parseSource("/home/user/skills/my-skill");
+    const local =
+      process.platform === "win32"
+        ? "C:\\home\\user\\skills\\my-skill"
+        : "/home/user/skills/my-skill";
+    const source = parseSource(local);
     const url = buildRepoUrl(source);
-    expect(url).toBe("/home/user/skills/my-skill");
+    expect(url).toBe(local);
   });
 });
 
@@ -1586,7 +1605,7 @@ describe("buildInstallPlan", () => {
       "global",
     );
     expect(plan.scope).toBe("global");
-    expect(plan.targetDir).toContain(".claude/skills/my-skill");
+    expect(plan.targetDir).toContain(join(".claude", "skills", "my-skill"));
     expect(plan.targetDir).not.toMatch(/^\.\//);
   });
 
@@ -1601,7 +1620,7 @@ describe("buildInstallPlan", () => {
       "project",
     );
     expect(plan.scope).toBe("project");
-    expect(plan.targetDir).toContain(".claude/skills/my-skill");
+    expect(plan.targetDir).toContain(join(".claude", "skills", "my-skill"));
   });
 
   test("defaults to global scope when scope is omitted", () => {
@@ -1647,7 +1666,7 @@ describe("buildInstallPlan scope - target directory resolution", () => {
       "global",
     );
     // Global path should resolve ~ to homedir, resulting in an absolute path
-    expect(plan.targetDir.startsWith("/")).toBe(true);
+    expect(isAbsolute(plan.targetDir)).toBe(true);
     expect(plan.targetDir).toContain("my-skill");
   });
 
@@ -1668,7 +1687,7 @@ describe("buildInstallPlan scope - target directory resolution", () => {
       false,
       "project",
     );
-    expect(plan.targetDir).toContain(".claude/skills/my-skill");
+    expect(plan.targetDir).toContain(join(".claude", "skills", "my-skill"));
   });
 
   test("force flag is preserved in plan", () => {

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -1,3 +1,4 @@
+import { createDirSymlink } from "./utils/fs";
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import {
   chmod,
@@ -257,7 +258,7 @@ describe("activateLibrarySkill", () => {
     const existingPath = join(tempDir, "existing");
     await mkdir(targetDir, { recursive: true });
     await mkdir(existingPath, { recursive: true });
-    await symlink(existingPath, symlinkPath, "dir");
+    await createDirSymlink(existingPath, symlinkPath);
 
     await expect(
       activateLibrarySkill({
@@ -278,7 +279,7 @@ describe("activateLibrarySkill", () => {
     const existingPath = join(tempDir, "existing");
     await mkdir(targetDir, { recursive: true });
     await mkdir(existingPath, { recursive: true });
-    await symlink(existingPath, symlinkPath, "dir");
+    await createDirSymlink(existingPath, symlinkPath);
 
     const result = await activateLibrarySkill({
       libraryPath,
@@ -315,22 +316,28 @@ describe("activateLibrarySkill", () => {
     expect((await lstat(symlinkPath)).isDirectory()).toBe(true);
   });
 
-  test("rethrows non-ENOENT lstat errors on the activation target", async () => {
-    await mkdir(targetDir, { recursive: true });
-    await chmod(targetDir, 0o000);
-    try {
-      await expect(
-        activateLibrarySkill({
-          libraryPath,
-          targetDir,
-          activationName: "brainstorming",
-          force: false,
-        }),
-      ).rejects.toMatchObject({ code: "EACCES" });
-    } finally {
-      await chmod(targetDir, 0o755);
-    }
-  });
+  // POSIX-only: the EACCES is provoked with `chmod 000`, and Windows ignores
+  // POSIX mode bits on directories — lstat succeeds there, so there is nothing
+  // to rethrow and the call resolves normally.
+  test.skipIf(process.platform === "win32")(
+    "rethrows non-ENOENT lstat errors on the activation target",
+    async () => {
+      await mkdir(targetDir, { recursive: true });
+      await chmod(targetDir, 0o000);
+      try {
+        await expect(
+          activateLibrarySkill({
+            libraryPath,
+            targetDir,
+            activationName: "brainstorming",
+            force: false,
+          }),
+        ).rejects.toMatchObject({ code: "EACCES" });
+      } finally {
+        await chmod(targetDir, 0o755);
+      }
+    },
+  );
 
   test("rejects invalid activation names before touching filesystem targets", async () => {
     const outsideDir = join(tempDir, "provider", "outside");
@@ -387,7 +394,7 @@ describe("deactivateLibrarySkill", () => {
 
   test("removes a provider symlink pointing into the library", async () => {
     const symlinkPath = join(targetDir, "brainstorming");
-    await symlink(libraryPath, symlinkPath, "dir");
+    await createDirSymlink(libraryPath, symlinkPath);
     const target = await realpath(libraryPath);
 
     const result = await deactivateLibrarySkill({
@@ -414,7 +421,7 @@ describe("deactivateLibrarySkill", () => {
   test("removes a provider symlink with a relative target into the library", async () => {
     const symlinkPath = join(targetDir, "brainstorming");
     const relativeTarget = relative(targetDir, libraryPath);
-    await symlink(relativeTarget, symlinkPath, "dir");
+    await createDirSymlink(relativeTarget, symlinkPath);
     const target = await realpath(libraryPath);
 
     const result = await deactivateLibrarySkill({
@@ -442,7 +449,7 @@ describe("deactivateLibrarySkill", () => {
     const symlinkPath = join(targetDir, "brainstorming");
     const relativeTarget = relative(targetDir, libraryPath);
     const expectedTarget = resolve(targetDir, relativeTarget);
-    await symlink(relativeTarget, symlinkPath, "dir");
+    await createDirSymlink(relativeTarget, symlinkPath);
     await rm(libraryPath, { recursive: true, force: true });
 
     const result = await deactivateLibrarySkill({
@@ -466,7 +473,7 @@ describe("deactivateLibrarySkill", () => {
   test("removes a symlink into the library when the library dir was deleted", async () => {
     const symlinkPath = join(targetDir, "brainstorming");
     const expectedTarget = libraryPath;
-    await symlink(libraryPath, symlinkPath, "dir");
+    await createDirSymlink(libraryPath, symlinkPath);
     await rm(join(tempDir, "library"), { recursive: true, force: true });
 
     const result = await deactivateLibrarySkill({
@@ -492,7 +499,7 @@ describe("deactivateLibrarySkill", () => {
     const symlinkPath = join(targetDir, "brainstorming");
     const relativeTarget = relative(targetDir, externalDir);
     await mkdir(externalDir, { recursive: true });
-    await symlink(relativeTarget, symlinkPath, "dir");
+    await createDirSymlink(relativeTarget, symlinkPath);
     await rm(externalDir, { recursive: true, force: true });
 
     await expect(
@@ -506,7 +513,15 @@ describe("deactivateLibrarySkill", () => {
     ).rejects.toThrow(
       `Refusing to deactivate symlink outside the ASM library: ${symlinkPath}.`,
     );
-    await expect(readlink(symlinkPath)).resolves.toBe(relativeTarget);
+    // The link is left untouched. POSIX stores the relative target verbatim;
+    // Windows uses a junction, whose target is always absolute (see
+    // createDirSymlink), so compare the resolved location there.
+    const storedTarget = await readlink(symlinkPath);
+    if (process.platform === "win32") {
+      expect(resolve(storedTarget)).toBe(resolve(targetDir, relativeTarget));
+    } else {
+      expect(storedTarget).toBe(relativeTarget);
+    }
   });
 
   test("refuses to deactivate a real directory", async () => {
@@ -531,7 +546,7 @@ describe("deactivateLibrarySkill", () => {
     const externalDir = join(tempDir, "external");
     const symlinkPath = join(targetDir, "brainstorming");
     await mkdir(externalDir, { recursive: true });
-    await symlink(externalDir, symlinkPath, "dir");
+    await createDirSymlink(externalDir, symlinkPath);
 
     await expect(
       deactivateLibrarySkill({
@@ -1129,7 +1144,10 @@ describe("updateLibrarySkill", () => {
       join(externalSkillDir, "SKILL.md"),
       "---\nname: brainstorming\nversion: 2.0.0\n---\n# Escaped Source\n",
     );
-    await symlink(join(tempDir, "external"), join(sourceRoot, "skills"), "dir");
+    await createDirSymlink(
+      join(tempDir, "external"),
+      join(sourceRoot, "skills"),
+    );
 
     const originalLock = await readLibraryLock(lockPath);
 
@@ -1184,7 +1202,7 @@ describe("updateLibrarySkill", () => {
     const externalDir = join(tempDir, "external-library");
     const linkPath = join(skillsDir, "link");
     await mkdir(externalDir, { recursive: true });
-    await symlink(externalDir, linkPath, "dir");
+    await createDirSymlink(externalDir, linkPath);
 
     const lock = await readLibraryLock(lockPath);
     lock.skills.brainstorming.libraryPath = join(linkPath, "brainstorming");

--- a/src/linker.test.ts
+++ b/src/linker.test.ts
@@ -1,3 +1,4 @@
+import { createDirSymlink } from "./utils/fs";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import {
   validateLinkSource,
@@ -109,7 +110,7 @@ Body.
 `,
     );
     const linkPath = join(tempDir, "linked-skill");
-    await symlink(realDir, linkPath, "dir");
+    await createDirSymlink(realDir, linkPath);
     const result = await validateLinkSource(linkPath);
     expect(result.name).toBe("real-skill");
   });
@@ -279,7 +280,7 @@ describe("discoverLinkableSkills", () => {
       `---\nname: skill-c\nversion: 1.0.0\n---\nBody.\n`,
     );
     const linkedDir = join(tempDir, "linked");
-    await symlink(realDir, linkedDir, "dir");
+    await createDirSymlink(realDir, linkedDir);
     const skills = await discoverLinkableSkills(linkedDir);
     expect(skills.length).toBe(1);
     expect(skills[0].name).toBe("skill-c");

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -1,3 +1,4 @@
+import { createDirSymlink } from "./utils/fs";
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { mkdtemp, writeFile, mkdir, rm, symlink, realpath } from "fs/promises";
 import { join } from "path";
@@ -432,7 +433,7 @@ describe("scanAllSkills", () => {
     // Create a separate scan dir with symlink
     const scanDir = join(tempDir, "scan");
     await mkdir(scanDir);
-    await symlink(realDir, join(scanDir, "linked-skill"), "dir");
+    await createDirSymlink(realDir, join(scanDir, "linked-skill"));
 
     const config = {
       ...getDefaultConfig(),
@@ -703,7 +704,7 @@ describe("scanPluginMarketplaces", () => {
 
     // Symlink inside the marketplace pointing at the real skill dir
     const symlinkPath = join(marketplaceDir, "linked-skill");
-    await symlink(realSkillDir, symlinkPath);
+    await createDirSymlink(realSkillDir, symlinkPath);
 
     const skills = await scanPluginMarketplaces(tempDir);
     // The symlinked entry is skipped — result must be empty

--- a/src/skill-state.test.ts
+++ b/src/skill-state.test.ts
@@ -1,3 +1,4 @@
+import { createDirSymlink } from "./utils/fs";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   mkdtemp,
@@ -361,7 +362,7 @@ describe("symlinked-sibling topology (real install layout, issue #91)", () => {
     );
     // codex's directory is a relative symlink at the claude copy, exactly as
     // the installer creates it.
-    await symlink(relative(codexProvider, canonicalDir), symlinkDir, "dir");
+    await createDirSymlink(relative(codexProvider, canonicalDir), symlinkDir);
   });
 
   afterEach(async () => {

--- a/src/uninstaller.test.ts
+++ b/src/uninstaller.test.ts
@@ -1,3 +1,4 @@
+import { createDirSymlink } from "./utils/fs";
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 
 // ─── Module mocks for EXDEV cp fallback test (issue #283) ────────────────────
@@ -341,10 +342,15 @@ describe("executeRemoval with symlinkTo", () => {
       const stats = await lstat(dupDir);
       expect(stats.isSymbolicLink()).toBe(true);
 
-      // Should point to the kept directory via relative path
+      // Should point to the kept directory. POSIX stores a relative target;
+      // Windows uses a junction, whose target is always absolute (see
+      // createDirSymlink), so only the resolved location is comparable there.
       const target = await readlink(dupDir);
-      const expectedRel = relative(join(base, "provider-b"), keptDir);
-      expect(target).toBe(expectedRel);
+      const linkDir = join(base, "provider-b");
+      expect(resolve(linkDir, target)).toBe(resolve(keptDir));
+      if (process.platform !== "win32") {
+        expect(target).toBe(relative(linkDir, keptDir));
+      }
 
       // Should resolve to the kept directory
       const resolved = await realpath(dupDir);
@@ -366,7 +372,7 @@ describe("executeRemoval with symlinkTo", () => {
       const dupLink = join(base, "dup-link");
       await mkdir(keptDir, { recursive: true });
       await mkdir(oldTarget, { recursive: true });
-      await symlink(oldTarget, dupLink, "dir");
+      await createDirSymlink(oldTarget, dupLink);
 
       const plan: RemovalPlan = {
         directories: [{ path: dupLink, isSymlink: true }],
@@ -606,7 +612,7 @@ describe("getExistingTargets", () => {
       const realDir = join(base, "real");
       const linkDir = join(base, "link");
       await mkdir(realDir);
-      await symlink(realDir, linkDir, "dir");
+      await createDirSymlink(realDir, linkDir);
 
       const plan: RemovalPlan = {
         directories: [{ path: linkDir, isSymlink: true }],
@@ -1032,7 +1038,7 @@ describe("executeRemoval with relocation", () => {
       await mkdir(realDir, { recursive: true });
       await mkdir(dirname(linkDir), { recursive: true });
       await writeFile(join(realDir, "SKILL.md"), "real content");
-      await symlink(realDir, linkDir, "dir");
+      await createDirSymlink(realDir, linkDir);
 
       // Sanity: the symlink resolves to the real content
       const preResolve = await realpath(linkDir);
@@ -1089,8 +1095,8 @@ describe("executeRemoval with relocation", () => {
       await mkdir(dirname(linkA), { recursive: true });
       await mkdir(dirname(linkB), { recursive: true });
       await writeFile(join(realDir, "SKILL.md"), "shared content");
-      await symlink(realDir, linkA, "dir");
-      await symlink(realDir, linkB, "dir");
+      await createDirSymlink(realDir, linkA);
+      await createDirSymlink(realDir, linkB);
 
       const plan: RemovalPlan = {
         directories: [{ path: realDir, isSymlink: false }],
@@ -1145,7 +1151,7 @@ describe("executeRemoval with relocation", () => {
       await mkdir(dirname(agentsLink), { recursive: true });
       await writeFile(join(claudeReal, "SKILL.md"), "claude content");
       await writeFile(join(codexReal, "SKILL.md"), "codex content");
-      await symlink(claudeReal, agentsLink, "dir");
+      await createDirSymlink(claudeReal, agentsLink);
 
       const plan: RemovalPlan = {
         directories: [{ path: claudeReal, isSymlink: false }],
@@ -1205,7 +1211,7 @@ describe("executeRemoval with relocation", () => {
       await mkdir(dirname(blockedParent), { recursive: true });
       await writeFile(blockedParent, "not a directory");
       await writeFile(join(realDir, "SKILL.md"), "content");
-      await symlink(realDir, goodLink, "dir");
+      await createDirSymlink(realDir, goodLink);
 
       const plan: RemovalPlan = {
         directories: [{ path: realDir, isSymlink: false }],
@@ -1252,7 +1258,7 @@ describe("executeRemoval with relocation", () => {
       const linkDir = join(base, "codex", "skills", "my-skill");
       await mkdir(realDir, { recursive: true });
       await mkdir(dirname(linkDir), { recursive: true });
-      await symlink(realDir, linkDir, "dir");
+      await createDirSymlink(realDir, linkDir);
 
       const plan: RemovalPlan = {
         directories: [{ path: realDir, isSymlink: false }],
@@ -1302,7 +1308,7 @@ describe("executeRemoval with relocation", () => {
       await mkdir(realDir, { recursive: true });
       await writeFile(join(realDir, "SKILL.md"), "source content");
       await mkdir(dirname(linkDir), { recursive: true });
-      await symlink(realDir, linkDir, "dir");
+      await createDirSymlink(realDir, linkDir);
 
       // Force rename to report EXDEV so the cp fallback is exercised, then
       // have cp create a partial copy at toPath before throwing — this

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -27,6 +27,23 @@ export async function createDirSymlink(
   }
 }
 
+/**
+ * Normalize a *relative* path for storage in on-disk metadata.
+ *
+ * `path.relative()` returns backslashes on Windows, so persisting its result
+ * verbatim (library manifest `skillPath`, lock entries) writes machine-specific
+ * separators into files that are meant to be portable — a manifest written on
+ * Windows then fails to resolve on POSIX, where `\` is a legal filename char
+ * rather than a separator. Storing POSIX separators is safe in both directions:
+ * `path.join()` on Windows accepts `/` transparently.
+ *
+ * Only for relative paths; absolute Windows paths keep their drive prefix and
+ * are not portable anyway.
+ */
+export function toPortableRelativePath(relPath: string): string {
+  return relPath.split("\\").join("/");
+}
+
 export const BINARY_EXTENSIONS = new Set([
   ".png",
   ".jpg",

--- a/src/utils/path-shadowing.test.ts
+++ b/src/utils/path-shadowing.test.ts
@@ -5,12 +5,21 @@ import { join, delimiter } from "path";
 
 import { detectAsmBinaries, buildShadowingReport } from "./path-shadowing";
 
+// POSIX-only suite. detectAsmBinaries looks for an extensionless `asm` file and
+// gates on the X_OK access bit; on Windows the shim is `asm.cmd`/`asm.ps1` and
+// `access(X_OK)` is a no-op, so the module under test simply does not apply.
+// The fixtures also need a real *file* symlink, which Windows refuses without
+// Developer Mode or elevation — that EPERM used to blow up the beforeAll hook
+// and fail the whole file instead of skipping it.
+const POSIX_ONLY = process.platform !== "win32";
+
 let tmpRoot: string;
 let dirA: string;
 let dirB: string;
 let dirC: string;
 
 beforeAll(async () => {
+  if (!POSIX_ONLY) return;
   tmpRoot = await mkdtemp(join(tmpdir(), "asm-shadow-test-"));
   dirA = join(tmpRoot, "a");
   dirB = join(tmpRoot, "b");
@@ -37,7 +46,7 @@ afterAll(async () => {
   if (tmpRoot) await rm(tmpRoot, { recursive: true, force: true });
 });
 
-describe("detectAsmBinaries", () => {
+describe.skipIf(!POSIX_ONLY)("detectAsmBinaries", () => {
   test("returns empty list when PATH has no asm", async () => {
     const fakeDir = join(tmpRoot, "empty");
     await mkdir(fakeDir);
@@ -82,7 +91,7 @@ describe("detectAsmBinaries", () => {
   });
 });
 
-describe("buildShadowingReport", () => {
+describe.skipIf(!POSIX_ONLY)("buildShadowingReport", () => {
   test("no binaries → resolved null, shadowed empty", async () => {
     const emptyDir = join(tmpRoot, "emptyreport");
     await mkdir(emptyDir);

--- a/src/utils/spawn.test.ts
+++ b/src/utils/spawn.test.ts
@@ -1,24 +1,36 @@
 import { describe, expect, it } from "vitest";
+import { realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { runCommand } from "./spawn";
+
+// The child process is the running `node` binary rather than shell builtins
+// (`echo`, `false`, `sh -c`, `pwd`): those either don't exist as standalone
+// executables on Windows or need a shell, which would test the platform rather
+// than `runCommand`'s contract. `process.execPath` exercises the same contract
+// — stdout capture, stderr separation, exit codes, cwd — on every platform.
+const node = process.execPath;
 
 describe("runCommand", () => {
   it("captures stdout from a successful command", async () => {
-    const { stdout, exitCode } = await runCommand(["echo", "hello"]);
+    const { stdout, exitCode } = await runCommand([
+      node,
+      "-e",
+      "console.log('hello')",
+    ]);
     expect(exitCode).toBe(0);
     expect(stdout.trim()).toBe("hello");
   });
 
   it("returns non-zero exit code on failure", async () => {
-    // `false` is a POSIX command that always exits with code 1
-    const { exitCode } = await runCommand(["false"]);
+    const { exitCode } = await runCommand([node, "-e", "process.exit(1)"]);
     expect(exitCode).not.toBe(0);
   });
 
   it("captures stderr separately from stdout", async () => {
     const { stdout, stderr, exitCode } = await runCommand([
-      "sh",
-      "-c",
-      "echo out; echo err >&2",
+      node,
+      "-e",
+      "console.log('out'); console.error('err')",
     ]);
     expect(exitCode).toBe(0);
     expect(stdout.trim()).toBe("out");
@@ -26,10 +38,15 @@ describe("runCommand", () => {
   });
 
   it("respects the cwd option", async () => {
-    const { stdout, exitCode } = await runCommand(["pwd"], { cwd: "/tmp" });
+    // macOS resolves /tmp to /private/tmp and Windows returns the short 8.3
+    // form for some temp paths, so compare resolved paths, not literals.
+    const dir = await realpath(tmpdir());
+    const { stdout, exitCode } = await runCommand(
+      [node, "-e", "console.log(process.cwd())"],
+      { cwd: dir },
+    );
     expect(exitCode).toBe(0);
-    // macOS resolves /tmp to /private/tmp; accept either.
-    expect(stdout.trim()).toMatch(/^(\/tmp|\/private\/tmp)$/);
+    expect(await realpath(stdout.trim())).toBe(dir);
   });
 
   it("rejects when argv is empty", async () => {

--- a/src/utils/test-spawn.ts
+++ b/src/utils/test-spawn.ts
@@ -5,12 +5,81 @@ import {
 import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { createRequire } from "node:module";
 import type {
   SpawnSyncOptions,
   SpawnOptions,
   SpawnSyncReturns,
   ChildProcess,
 } from "node:child_process";
+
+const requireFromHere = createRequire(import.meta.url);
+
+let cachedTsxCli: string | null | undefined;
+function resolveTsxCli(): string | null {
+  if (cachedTsxCli === undefined) {
+    try {
+      cachedTsxCli = requireFromHere.resolve("tsx/cli");
+    } catch {
+      cachedTsxCli = null;
+    }
+  }
+  return cachedTsxCli;
+}
+
+/**
+ * Rewrite `npx tsx <file> …` to `<node> <tsx-cli> <file> …`.
+ *
+ * On Windows `npx` is `npx.cmd`, and Node's `spawn()` refuses to resolve
+ * `.cmd`/`.bat` without `shell: true` — every `npx`-based test spawn dies with
+ * ENOENT, which `spawnCollect` reports as exit code 127. Invoking tsx's own CLI
+ * with the running `node` binary sidesteps the shim entirely; it is also faster
+ * on every platform because it skips the npx package lookup.
+ *
+ * Falls back to the original argv when tsx can't be resolved, so the failure
+ * mode stays the same as before instead of turning into a confusing error.
+ */
+function isBinShimForTsx(cmd: string): boolean {
+  // `node_modules/.bin/tsx` (extensionless) is a shell script; on Windows the
+  // real entry points are the sibling `tsx.cmd` / `tsx.ps1` shims, so spawning
+  // the extensionless path fails with ENOENT there.
+  return /(^|[\\/])node_modules[\\/]\.bin[\\/]tsx$/.test(cmd);
+}
+
+function normalizeArgv(argv: readonly string[]): string[] {
+  const usesTsx =
+    (argv[0] === "npx" && argv[1] === "tsx") || isBinShimForTsx(argv[0] ?? "");
+  if (usesTsx) {
+    const tsxCli = resolveTsxCli();
+    if (tsxCli) {
+      const rest = argv[0] === "npx" ? argv.slice(2) : argv.slice(1);
+      return [process.execPath, tsxCli, ...rest];
+    }
+  }
+  return [...argv];
+}
+
+/**
+ * Keep a redirected `HOME` effective on Windows.
+ *
+ * Tests sandbox the CLI by spawning it with `env: { ...process.env, HOME: tmp }`,
+ * but the product resolves its paths through `os.homedir()`, which on Windows
+ * reads `USERPROFILE` and ignores `HOME` entirely. Without this, every such test
+ * runs against the developer's REAL home directory: assertions fail, and worse,
+ * `asm install` fixtures get written into `~/.claude/skills` for real.
+ *
+ * Mirroring `HOME` onto `USERPROFILE` (only when the caller actually redirected
+ * it) makes the sandbox hold on Windows and changes nothing on POSIX.
+ */
+function normalizeEnv<T extends { env?: NodeJS.ProcessEnv }>(opts: T): T {
+  if (process.platform !== "win32") return opts;
+  const env = opts.env;
+  if (!env?.HOME || env.HOME === process.env.HOME) return opts;
+  if (env.USERPROFILE && env.USERPROFILE !== process.env.USERPROFILE) {
+    return opts;
+  }
+  return { ...opts, env: { ...env, USERPROFILE: env.HOME } };
+}
 
 /**
  * Thin argv-first wrapper around `child_process.spawnSync` for tests. Takes an
@@ -20,8 +89,8 @@ export function spawnSyncArgv(
   argv: readonly string[],
   opts: SpawnSyncOptions = {},
 ): SpawnSyncReturns<string | Buffer> {
-  const [cmd, ...args] = argv;
-  return nodeSpawnSync(cmd, args, opts);
+  const [cmd, ...args] = normalizeArgv(argv);
+  return nodeSpawnSync(cmd, args, normalizeEnv(opts));
 }
 
 /**
@@ -33,8 +102,8 @@ export function spawnArgv(
   argv: readonly string[],
   opts: SpawnOptions = {},
 ): ChildProcess {
-  const [cmd, ...args] = argv;
-  return nodeSpawn(cmd, args, opts);
+  const [cmd, ...args] = normalizeArgv(argv);
+  return nodeSpawn(cmd, args, normalizeEnv(opts));
 }
 
 /**


### PR DESCRIPTION
## Description

`npm test` on Windows fails **272 of 1886 tests**. None of them are product defects — they are two harness assumptions plus a set of POSIX-only assertions. This PR takes the suite to **1886 passed, 10 skipped, 0 failed** on Windows, with no change to POSIX behaviour.

### Two root causes, both in `src/utils/test-spawn.ts`

**1. `spawn()` cannot resolve `.cmd` (~211 failures).** `npm` and `npx` are `.cmd` shims on Windows and Node refuses to spawn them without a shell, so every `npx tsx`-based test spawn died with `ENOENT` — surfaced by `spawnCollect` as exit code 127, which then cascaded into empty-stdout and `JSON.parse` assertions. `normalizeArgv()` rewrites `npx tsx <file>` — and the `node_modules/.bin/tsx` shim — to `<node> <tsx/cli> <file>`, resolving `tsx/cli` through `createRequire`. It falls back to the original argv if `tsx` can't be resolved. This is also faster on every platform, since it skips the npx lookup.

**2. `HOME` does not sandbox anything on Windows.** Tests isolate the CLI with `env: { ...process.env, HOME: tmp }`, but the product resolves paths through `os.homedir()`, which reads `USERPROFILE` on Windows and ignores `HOME` entirely.

> ⚠️ This one is worth flagging beyond the red CI: those tests were running against the **developer's real home directory**, and `asm install` fixtures were written into a real `~/.claude/skills`. Running the suite on Windows today leaves skills named `foo`, `bar`, `src`, `nested-one` and `widget` installed on the machine.

`normalizeEnv()` mirrors a redirected `HOME` onto `USERPROFILE`, only when the caller actually redirected it. POSIX is unaffected. Verified: after the change, full suite runs create nothing under the real home.

### One product fix

`path.relative()` returns backslashes on Windows, and that value was persisted verbatim as `skillPath` in the library manifest and the lock entry. A manifest written on Windows then fails to resolve on POSIX, where `\` is a legal filename character rather than a separator. New `toPortableRelativePath()` in `src/utils/fs.ts`, applied at the two sites that write `skillPath`. `path.join()` accepts `/` transparently on Windows, so the stored form works in both directions.

Happy to split this into its own PR if you'd prefer to keep this one purely test-side.

### Platform-aware assertions — nothing weakened

Every POSIX-specific guarantee is **kept**, under an explicit `process.platform !== "win32"` branch, with the Windows equivalent asserted alongside:

- 25 `symlink(..., "dir")` fixtures across 7 files now use the project's own `createDirSymlink()`, which already creates a junction on Windows. Real directory symlinks need Developer Mode or elevation and otherwise fail with `EPERM`. This also makes the fixtures create the same kind of link the product creates. Confirmed junctions behave correctly for both dangling cases the tests rely on (target missing at creation; target deleted afterwards).
- Link-target assertions compare `resolve(linkDir, target)` on all platforms; the "target is relative" check stays POSIX-only, because junction targets are always absolute by design.
- `startsWith("/")` → `isAbsolute()`, `split("/").pop()` → `basename()`, `"/"`-joined expectations → `join()`.
- `utils/spawn.test.ts` drives `process.execPath -e ...` instead of `echo` / `false` / `sh -c` / `pwd`, so it tests `runCommand`'s contract — stdout capture, stderr separation, exit codes, cwd — rather than the availability of a POSIX shell.

### Two suites marked POSIX-only (the 10 skipped)

- `utils/path-shadowing.test.ts` (9): the module looks for an extensionless `asm` binary and gates on `access(X_OK)`, which is a no-op on Windows where the shim is `asm.cmd`/`.ps1` — the module simply does not apply. Its fixtures also need a real *file* symlink, which a junction cannot substitute. Previously the `beforeAll` hook threw `EPERM` and failed the whole file instead of skipping it.
- `library.test.ts` (1): provokes `EACCES` with `chmod 000` on a directory, which Windows ignores.

## Related Issue

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

```
Windows 11, Node 22        before          after
npm test          12 files / 272 fail    0 fail / 1886 pass / 10 skip
tsc --noEmit               exit 0         exit 0
```

Baseline confirmed by stashing the changes and re-running on a clean tree, so the 272 are genuinely pre-existing rather than introduced here.

I don't have a POSIX machine to hand for a cross-check — CI should cover that, and every platform-specific branch is guarded so the POSIX path is byte-identical to before. Worth considering a Windows job in the CI matrix to keep this from regressing.
