### PR TITLE
feat(catalog): add top skill rankings and detail links (#398)

### DIFF
--- a/scripts/build-catalog.ts
+++ b/scripts/build-catalog.ts
@@ -689,6 +689,7 @@ for (const s of skills) {
 // ─── Bundles ─────────────────────────────────────────────────────────────────
 
 interface BundleSkill {
+  id?: string;
   name: string;
   installUrl: string;
   description: string;
@@ -730,9 +731,18 @@ const bundleMap = new Map<string, Bundle>();
 for (const bundle of bundles) {
   if (!bundleMap.has(bundle.name)) bundleMap.set(bundle.name, bundle);
 }
-const uniqueBundles = Array.from(bundleMap.values()).sort((a, b) =>
-  a.name.localeCompare(b.name),
+const skillIdByInstallUrl = new Map(
+  skills.map((skill) => [skill.installUrl, skill.id]),
 );
+const uniqueBundles = Array.from(bundleMap.values())
+  .map((bundle) => ({
+    ...bundle,
+    skills: bundle.skills.map((skill) => {
+      const id = skillIdByInstallUrl.get(skill.installUrl);
+      return id ? { ...skill, id } : skill;
+    }),
+  }))
+  .sort((a, b) => a.name.localeCompare(b.name));
 
 const bundlesData: BundlesData = {
   generatedAt: new Date().toISOString(),
@@ -833,7 +843,15 @@ interface AuthorStatsEntry {
   verifiedCount: number;
   totalTokens: number;
   avgEvalScore?: number;
-  topSkills: Array<{ name: string; repo: string }>;
+  topSkills: Array<{ id: string; name: string; repo: string }>;
+}
+
+interface CategoryTopSkill {
+  id: string;
+  name: string;
+  owner: string;
+  repo: string;
+  evalSummary: SkillEvalSummary;
 }
 
 interface IndexStatsEntry {
@@ -841,6 +859,7 @@ interface IndexStatsEntry {
   totalSkills: number;
   totalAuthors: number;
   categoryDistribution: Record<string, number>;
+  categoryTopSkills: Record<string, CategoryTopSkill[]>;
   verifiedCount: number;
   totalTokens: number;
   avgTokensPerSkill: number;
@@ -915,7 +934,11 @@ for (const r of repos) {
     }
     if (s.verified) author.verifiedCount++;
     author.totalTokens += s.tokenCount ?? 0;
-    author.topSkills.push({ name: s.name, repo: `${r.owner}/${r.repo}` });
+    author.topSkills.push({
+      id: s.id,
+      name: s.name,
+      repo: `${r.owner}/${r.repo}`,
+    });
   }
 }
 
@@ -935,11 +958,31 @@ for (const s of skills) {
     indexCatDist[c] = (indexCatDist[c] || 0) + 1;
   }
 }
+const categoryTopSkills: Record<string, CategoryTopSkill[]> = {};
+for (const category of categories) {
+  categoryTopSkills[category] = skills
+    .filter((skill) => skill.categories.includes(category) && skill.evalSummary)
+    .sort(
+      (a, b) =>
+        b.evalSummary!.overallScore - a.evalSummary!.overallScore ||
+        a.id.localeCompare(b.id),
+    )
+    .slice(0, 10)
+    .map((skill) => ({
+      id: skill.id,
+      name: skill.name,
+      owner: skill.owner,
+      repo: skill.repo,
+      evalSummary: skill.evalSummary!,
+    }));
+}
+
 const indexStats: IndexStatsEntry = {
   totalRepos: repos.length,
   totalSkills: skills.length,
   totalAuthors: authorMap.size,
   categoryDistribution: indexCatDist,
+  categoryTopSkills,
   verifiedCount: skills.filter((s) => s.verified).length,
   totalTokens: skills.reduce((sum, s) => sum + (s.tokenCount ?? 0), 0),
   avgTokensPerSkill:

--- a/tests/e2e/build-verification.test.ts
+++ b/tests/e2e/build-verification.test.ts
@@ -269,6 +269,9 @@ describe("website: token count + eval surfaces", () => {
 const SKILLS_MIN_PATH = join(WEBSITE_DIR, "skills.min.json");
 const SEARCH_IDX_PATH = join(WEBSITE_DIR, "search.idx.json");
 const SKILLS_DETAIL_DIR = join(WEBSITE_DIR, "skills");
+const AUTHOR_STATS_PATH = join(WEBSITE_DIR, "author-stats.json");
+const INDEX_STATS_PATH = join(WEBSITE_DIR, "index-stats.json");
+const BUNDLES_PATH = join(WEBSITE_DIR, "bundles.json");
 
 describe("catalog: split artifacts (issue #214)", () => {
   if (!catalogExists || !existsSync(SKILLS_MIN_PATH)) {
@@ -348,6 +351,8 @@ describe("catalog: split artifacts (issue #214)", () => {
         expect(slim.evalSummary?.overallScore).toBe(
           full.evalSummary.overallScore,
         );
+        expect(slim.evalSummary?.categories).toBeUndefined();
+        expect(slim.evalSummary?.evaluatedAt).toBeUndefined();
       }
     }
   });
@@ -420,6 +425,98 @@ describe("catalog: split artifacts (issue #214)", () => {
     // ever regresses, either the slim shape drifted or catalog.json shrunk
     // for other reasons; either way, worth looking at.
     expect(slimSize).toBeLessThan(catalogSize * 0.75);
+  });
+});
+
+// ─── category rankings + stable skill links (issue #398) ──────────────────
+
+describe("catalog: category rankings and stable skill links (issue #398)", () => {
+  const artifactsExist = [
+    CATALOG_PATH,
+    AUTHOR_STATS_PATH,
+    INDEX_STATS_PATH,
+    BUNDLES_PATH,
+  ].every(existsSync);
+
+  if (!artifactsExist) {
+    test.skip("ranking artifacts not present — run `npx tsx scripts/build-catalog.ts` to generate them", () => {});
+    return;
+  }
+
+  const catalog = JSON.parse(readFileSync(CATALOG_PATH, "utf-8"));
+  const indexStats = JSON.parse(readFileSync(INDEX_STATS_PATH, "utf-8")).stats;
+  const authorStats = JSON.parse(
+    readFileSync(AUTHOR_STATS_PATH, "utf-8"),
+  ).stats;
+  const bundles = JSON.parse(readFileSync(BUNDLES_PATH, "utf-8")).bundles;
+  const catalogById = new Map(
+    catalog.skills.map((skill: any) => [skill.id, skill]),
+  );
+
+  test("emits up to ten deterministically ordered skills for every category", () => {
+    expect(Object.keys(indexStats.categoryTopSkills)).toEqual(
+      catalog.categories,
+    );
+
+    for (const category of catalog.categories) {
+      const expected = catalog.skills
+        .filter(
+          (skill: any) =>
+            skill.categories.includes(category) && skill.evalSummary,
+        )
+        .sort(
+          (a: any, b: any) =>
+            b.evalSummary.overallScore - a.evalSummary.overallScore ||
+            a.id.localeCompare(b.id),
+        )
+        .slice(0, 10)
+        .map((skill: any) => skill.id);
+      const actual = indexStats.categoryTopSkills[category];
+      expect(actual).toHaveLength(expected.length);
+      expect(actual.map((skill: any) => skill.id)).toEqual(expected);
+    }
+  });
+
+  test("every ranked skill resolves and carries its full canonical breakdown", () => {
+    for (const rankedSkills of Object.values(
+      indexStats.categoryTopSkills,
+    ) as any[][]) {
+      for (const rankedSkill of rankedSkills) {
+        const source = catalogById.get(rankedSkill.id) as any;
+        expect(source).toBeDefined();
+        expect(rankedSkill.evalSummary).toEqual(source.evalSummary);
+        expect(rankedSkill.evalSummary.categories.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("every author top skill carries a catalog-resolvable id", () => {
+    for (const author of authorStats) {
+      for (const skill of author.topSkills) {
+        expect(catalogById.has(skill.id)).toBe(true);
+      }
+    }
+  });
+
+  test("bundle skills receive ids exactly when their install URL resolves", () => {
+    const catalogByInstallUrl = new Map(
+      catalog.skills.map((skill: any) => [skill.installUrl, skill]),
+    );
+    let linked = 0;
+
+    for (const bundle of bundles) {
+      for (const skill of bundle.skills) {
+        const source = catalogByInstallUrl.get(skill.installUrl) as any;
+        if (source) {
+          expect(skill.id).toBe(source.id);
+          linked++;
+        } else {
+          expect(skill.id).toBeUndefined();
+        }
+      }
+    }
+
+    expect(linked).toBeGreaterThan(0);
   });
 });
 

--- a/website-src/src/__tests__/app-smoke.test.jsx
+++ b/website-src/src/__tests__/app-smoke.test.jsx
@@ -308,6 +308,7 @@ describe("App smoke", () => {
     expect(skillLink.getAttribute("href")).toBe(
       `#/skills/${encodeSkillId(BUNDLES.bundles[0].skills[0].id)}`,
     );
+    expect(skillLink.className).toContain("min-h-11");
   });
 
   it("root path renders the marketing landing page, not the catalog", async () => {

--- a/website-src/src/__tests__/app-smoke.test.jsx
+++ b/website-src/src/__tests__/app-smoke.test.jsx
@@ -23,6 +23,7 @@ import { HashRouter } from "react-router-dom";
 import MiniSearch from "minisearch";
 import App from "../App.jsx";
 import { MINISEARCH_OPTIONS } from "../lib/minisearch-options.js";
+import { encodeSkillId } from "../lib/utils.js";
 
 /**
  * End-to-end smoke tests for the React app.
@@ -120,6 +121,7 @@ const BUNDLES = {
       tags: ["demo"],
       skills: [
         {
+          id: "owner/repo::a::hello-world",
           name: "hello-world",
           installUrl: "github:owner/repo:skills/hello-world",
           description: "A friendly greeting skill.",
@@ -302,6 +304,10 @@ describe("App smoke", () => {
     await waitFor(() => {
       expect(screen.getByText(/asm bundle install starter/)).toBeTruthy();
     });
+    const skillLink = screen.getByRole("link", { name: "hello-world" });
+    expect(skillLink.getAttribute("href")).toBe(
+      `#/skills/${encodeSkillId(BUNDLES.bundles[0].skills[0].id)}`,
+    );
   });
 
   it("root path renders the marketing landing page, not the catalog", async () => {

--- a/website-src/src/__tests__/app-smoke.test.jsx
+++ b/website-src/src/__tests__/app-smoke.test.jsx
@@ -309,6 +309,7 @@ describe("App smoke", () => {
       `#/skills/${encodeSkillId(BUNDLES.bundles[0].skills[0].id)}`,
     );
     expect(skillLink.className).toContain("min-h-11");
+    expect(skillLink.className).toContain("min-w-11");
   });
 
   it("root path renders the marketing landing page, not the catalog", async () => {

--- a/website-src/src/__tests__/bundle-cart.test.jsx
+++ b/website-src/src/__tests__/bundle-cart.test.jsx
@@ -231,6 +231,7 @@ describe("Bundle cart flow", () => {
     expect(skillLink?.getAttribute("href")).toBe(
       `#/skills/${encodeSkillId(catalog.skills[0].id)}`,
     );
+    expect(skillLink?.className).toContain("min-h-11");
 
     // Export button is enabled (there's ≥1 skill) but the name is blank,
     // so clicking should show a validation error message

--- a/website-src/src/__tests__/bundle-cart.test.jsx
+++ b/website-src/src/__tests__/bundle-cart.test.jsx
@@ -49,6 +49,7 @@ import { HashRouter } from "react-router-dom";
 import MiniSearch from "minisearch";
 import App from "../App.jsx";
 import { MINISEARCH_OPTIONS } from "../lib/minisearch-options.js";
+import { encodeSkillId } from "../lib/utils.js";
 
 /**
  * Bundle cart flow (#238). Covers:
@@ -225,6 +226,11 @@ describe("Bundle cart flow", () => {
     // The skill name should appear in the dialog item list
     const withinDialog = dialog.querySelectorAll("li");
     expect(withinDialog.length).toBe(1);
+    const skillLink = dialog.querySelector("a[href*='/skills/']");
+    expect(skillLink?.textContent).toContain("hello-world");
+    expect(skillLink?.getAttribute("href")).toBe(
+      `#/skills/${encodeSkillId(catalog.skills[0].id)}`,
+    );
 
     // Export button is enabled (there's ≥1 skill) but the name is blank,
     // so clicking should show a validation error message

--- a/website-src/src/__tests__/bundle-cart.test.jsx
+++ b/website-src/src/__tests__/bundle-cart.test.jsx
@@ -232,6 +232,7 @@ describe("Bundle cart flow", () => {
       `#/skills/${encodeSkillId(catalog.skills[0].id)}`,
     );
     expect(skillLink?.className).toContain("min-h-11");
+    expect(skillLink?.className).toContain("min-w-11");
 
     // Export button is enabled (there's ≥1 skill) but the name is blank,
     // so clicking should show a validation error message

--- a/website-src/src/__tests__/profile-page.test.jsx
+++ b/website-src/src/__tests__/profile-page.test.jsx
@@ -57,6 +57,7 @@ describe("ProfilePage — skill detail links (issue #398)", () => {
         `#/skills/${encodeSkillId(skill.id)}`,
       );
       expect(link.className).toContain("min-h-11");
+      expect(link.className).toContain("min-w-11");
     }
   });
 });

--- a/website-src/src/__tests__/profile-page.test.jsx
+++ b/website-src/src/__tests__/profile-page.test.jsx
@@ -43,7 +43,7 @@ describe("ProfilePage — skill detail links (issue #398)", () => {
   });
 
   it("links every listed skill to its canonically encoded detail route", async () => {
-    render(
+    const { container } = render(
       <HashRouter>
         <Routes>
           <Route path="/profile/:owner" element={<ProfilePage />} />
@@ -59,5 +59,9 @@ describe("ProfilePage — skill detail links (issue #398)", () => {
       expect(link.className).toContain("min-h-11");
       expect(link.className).toContain("min-w-11");
     }
+
+    expect(container.querySelector("span.w-6").className).toContain(
+      "text-[var(--fg-dim)]",
+    );
   });
 });

--- a/website-src/src/__tests__/profile-page.test.jsx
+++ b/website-src/src/__tests__/profile-page.test.jsx
@@ -56,6 +56,7 @@ describe("ProfilePage — skill detail links (issue #398)", () => {
       expect(link.getAttribute("href")).toBe(
         `#/skills/${encodeSkillId(skill.id)}`,
       );
+      expect(link.className).toContain("min-h-11");
     }
   });
 });

--- a/website-src/src/__tests__/profile-page.test.jsx
+++ b/website-src/src/__tests__/profile-page.test.jsx
@@ -1,0 +1,61 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { HashRouter, Route, Routes } from "react-router-dom";
+import ProfilePage from "../pages/ProfilePage.jsx";
+import { encodeSkillId } from "../lib/utils.js";
+
+const topSkills = [
+  {
+    id: "alice/tools::skills/alpha::alpha",
+    name: "alpha",
+    repo: "alice/tools",
+  },
+  {
+    id: "alice/tools::skills/beta::beta",
+    name: "beta",
+    repo: "alice/tools",
+  },
+];
+
+const author = {
+  owner: "alice",
+  totalSkills: 2,
+  repos: ["alice/tools"],
+  categories: { coding: 2 },
+  verifiedCount: 2,
+  totalTokens: 400,
+  topSkills,
+};
+
+describe("ProfilePage — skill detail links (issue #398)", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/#/profile/alice");
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ stats: [author] }),
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("links every listed skill to its canonically encoded detail route", async () => {
+    render(
+      <HashRouter>
+        <Routes>
+          <Route path="/profile/:owner" element={<ProfilePage />} />
+        </Routes>
+      </HashRouter>,
+    );
+
+    for (const skill of topSkills) {
+      const link = await screen.findByRole("link", { name: skill.name });
+      expect(link.getAttribute("href")).toBe(
+        `#/skills/${encodeSkillId(skill.id)}`,
+      );
+    }
+  });
+});

--- a/website-src/src/__tests__/stats-page.test.jsx
+++ b/website-src/src/__tests__/stats-page.test.jsx
@@ -192,6 +192,7 @@ describe("StatsPage — author view and pie chart (issue #351)", () => {
       `#/skills/${encodeSkillId(categoryRanking[0].id)}`,
     );
     expect(firstLink.className).toContain("min-h-11");
+    expect(firstLink.className).toContain("min-w-11");
   });
 
   it("shows the complete score breakdown for every ranked skill", async () => {
@@ -214,6 +215,16 @@ describe("StatsPage — author view and pie chart (issue #351)", () => {
     expect(
       firstBreakdown.querySelectorAll('tbody th[scope="row"]'),
     ).toHaveLength(2);
+
+    const firstArticle = firstBreakdown.closest("article");
+    const scoreSuffix = screen.getAllByText("/100")[0];
+    const evaluatedAt = screen.getAllByText(/^Evaluated /)[0];
+    const ranking = firstArticle.querySelector("div > span");
+    const repository = screen.getAllByText("alice/repo")[0];
+    for (const metadata of [scoreSuffix, evaluatedAt, ranking, repository]) {
+      expect(metadata.className).toContain("text-[var(--fg-dim)]");
+      expect(metadata.className).not.toContain("text-[var(--fg-muted)]");
+    }
 
     const score = firstBreakdown
       .closest("article")

--- a/website-src/src/__tests__/stats-page.test.jsx
+++ b/website-src/src/__tests__/stats-page.test.jsx
@@ -191,6 +191,7 @@ describe("StatsPage — author view and pie chart (issue #351)", () => {
     expect(firstLink.getAttribute("href")).toBe(
       `#/skills/${encodeSkillId(categoryRanking[0].id)}`,
     );
+    expect(firstLink.className).toContain("min-h-11");
   });
 
   it("shows the complete score breakdown for every ranked skill", async () => {
@@ -201,5 +202,23 @@ describe("StatsPage — author view and pie chart (issue #351)", () => {
     expect(screen.getAllByText("Safety")).toHaveLength(10);
     expect(screen.getAllByText("30/30")).toHaveLength(10);
     expect(screen.getAllByText("20/20")).toHaveLength(10);
+
+    const firstBreakdown = screen.getAllByRole("table", {
+      name: "Evaluation score breakdown",
+    })[0];
+    expect(
+      Array.from(firstBreakdown.querySelectorAll('thead th[scope="col"]')).map(
+        (header) => header.textContent,
+      ),
+    ).toEqual(["Category", "Percentage", "Points"]);
+    expect(
+      firstBreakdown.querySelectorAll('tbody th[scope="row"]'),
+    ).toHaveLength(2);
+
+    const score = firstBreakdown
+      .closest("article")
+      .querySelector(".text-3xl").parentElement;
+    expect(score.className).toContain("text-emerald-700");
+    expect(score.className).toContain("dark:text-emerald-400");
   });
 });

--- a/website-src/src/__tests__/stats-page.test.jsx
+++ b/website-src/src/__tests__/stats-page.test.jsx
@@ -6,6 +6,7 @@ import MiniSearch from "minisearch";
 import StatsPage from "../pages/StatsPage.jsx";
 import { CatalogProvider } from "../hooks/useCatalog.jsx";
 import { MINISEARCH_OPTIONS } from "../lib/minisearch-options.js";
+import { encodeSkillId } from "../lib/utils.js";
 
 const generatedAt = "2026-07-07T00:00:00.000Z";
 
@@ -54,12 +55,35 @@ const authorStats = {
   ],
 };
 
+function rankedSkill(index) {
+  return {
+    id: `alice/repo::skills/ranked-${index}::ranked-${index}`,
+    name: `ranked-${index}`,
+    owner: "alice",
+    repo: "repo",
+    evalSummary: {
+      overallScore: 100 - index,
+      grade: index < 10 ? "A" : "B",
+      evaluatedAt: "2026-07-07T00:00:00.000Z",
+      categories: [
+        { id: "instructions", name: "Instructions", score: 30, max: 30 },
+        { id: "safety", name: "Safety", score: 20, max: 20 },
+      ],
+    },
+  };
+}
+
+const categoryRanking = Array.from({ length: 11 }, (_, index) =>
+  rankedSkill(index),
+);
+
 const indexStats = {
   stats: {
     totalRepos: 2,
     totalSkills: 3,
     totalAuthors: 2,
     verifiedCount: 1,
+    categoryTopSkills: { dev: categoryRanking },
   },
 };
 
@@ -146,8 +170,36 @@ describe("StatsPage — author view and pie chart (issue #351)", () => {
         name: /Category distribution pie chart/i,
       }),
     ).toBeTruthy();
-    expect(screen.getByText("dev")).toBeTruthy();
+    expect(screen.getAllByText("dev").length).toBeGreaterThan(0);
     expect(screen.getByText("docs")).toBeTruthy();
     expect(screen.getByText("testing")).toBeTruthy();
+  });
+
+  it("renders at most ten ranked skills in artifact order with detail links", async () => {
+    renderStatsPage();
+    await screen.findByText("Top Skills by Category");
+
+    const breakdowns = screen.getAllByRole("article", {
+      name: /score breakdown/i,
+    });
+    expect(breakdowns).toHaveLength(10);
+    expect(breakdowns[0].textContent).toContain("ranked-0");
+    expect(breakdowns[9].textContent).toContain("ranked-9");
+    expect(screen.queryByText("ranked-10")).toBeNull();
+
+    const firstLink = screen.getByRole("link", { name: "ranked-0" });
+    expect(firstLink.getAttribute("href")).toBe(
+      `#/skills/${encodeSkillId(categoryRanking[0].id)}`,
+    );
+  });
+
+  it("shows the complete score breakdown for every ranked skill", async () => {
+    renderStatsPage();
+    await screen.findByText("Top Skills by Category");
+
+    expect(screen.getAllByText("Instructions")).toHaveLength(10);
+    expect(screen.getAllByText("Safety")).toHaveLength(10);
+    expect(screen.getAllByText("30/30")).toHaveLength(10);
+    expect(screen.getAllByText("20/20")).toHaveLength(10);
   });
 });

--- a/website-src/src/components/BundleBuilderDialog.jsx
+++ b/website-src/src/components/BundleBuilderDialog.jsx
@@ -264,7 +264,7 @@ export default function BundleBuilderDialog({ open, onClose }) {
                       <div className="flex items-center gap-2">
                         <Link
                           to={`/skills/${encodeSkillId(sk.id)}`}
-                          className="min-h-11 -my-2 -ml-2 px-2 inline-flex items-center font-mono text-sm text-[var(--fg)] hover:text-[var(--brand)] transition-colors truncate"
+                          className="min-h-11 min-w-11 -my-2 -ml-2 px-2 inline-flex items-center font-mono text-sm text-[var(--fg)] hover:text-[var(--brand)] transition-colors truncate"
                           onClick={onClose}
                         >
                           {sk.name}

--- a/website-src/src/components/BundleBuilderDialog.jsx
+++ b/website-src/src/components/BundleBuilderDialog.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { X, Download, Github, Trash2, ExternalLink } from "lucide-react";
+import { Link } from "react-router-dom";
 import { useBundleCart } from "../hooks/useBundleCart.jsx";
 import {
   buildBundleJson,
@@ -10,6 +11,7 @@ import {
 import { Button } from "./ui/button.jsx";
 import { Input } from "./ui/input.jsx";
 import { cn } from "../lib/cn.js";
+import { encodeSkillId } from "../lib/utils.js";
 
 /**
  * Bundle builder dialog (#238). Opens from the header cart button
@@ -260,9 +262,13 @@ export default function BundleBuilderDialog({ open, onClose }) {
                   >
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
-                        <span className="font-mono text-sm text-[var(--fg)] truncate">
+                        <Link
+                          to={`/skills/${encodeSkillId(sk.id)}`}
+                          className="font-mono text-sm text-[var(--fg)] hover:text-[var(--brand)] transition-colors truncate"
+                          onClick={onClose}
+                        >
                           {sk.name}
-                        </span>
+                        </Link>
                         {sk.owner && sk.repo && (
                           <span className="text-[10px] text-[var(--fg-muted)] truncate">
                             {sk.owner}/{sk.repo}

--- a/website-src/src/components/BundleBuilderDialog.jsx
+++ b/website-src/src/components/BundleBuilderDialog.jsx
@@ -264,7 +264,7 @@ export default function BundleBuilderDialog({ open, onClose }) {
                       <div className="flex items-center gap-2">
                         <Link
                           to={`/skills/${encodeSkillId(sk.id)}`}
-                          className="font-mono text-sm text-[var(--fg)] hover:text-[var(--brand)] transition-colors truncate"
+                          className="min-h-11 -my-2 -ml-2 px-2 inline-flex items-center font-mono text-sm text-[var(--fg)] hover:text-[var(--brand)] transition-colors truncate"
                           onClick={onClose}
                         >
                           {sk.name}

--- a/website-src/src/components/BundleDetail.jsx
+++ b/website-src/src/components/BundleDetail.jsx
@@ -72,7 +72,7 @@ export default function BundleDetail({ bundle }) {
                     {sk.id ? (
                       <Link
                         to={`/skills/${encodeSkillId(sk.id)}`}
-                        className="min-h-11 -m-2 px-2 inline-flex items-center font-mono text-sm text-[var(--fg)] hover:text-[var(--brand)] transition-colors"
+                        className="min-h-11 min-w-11 -m-2 px-2 inline-flex items-center font-mono text-sm text-[var(--fg)] hover:text-[var(--brand)] transition-colors"
                       >
                         {sk.name}
                       </Link>

--- a/website-src/src/components/BundleDetail.jsx
+++ b/website-src/src/components/BundleDetail.jsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+import { encodeSkillId } from "../lib/utils.js";
 import CopyButton from "./CopyButton.jsx";
 import { Card } from "./ui/card.jsx";
 import { Badge } from "./ui/badge.jsx";
@@ -63,13 +65,22 @@ export default function BundleDetail({ bundle }) {
                 sk.installUrl && "asm install " + sk.installUrl;
               return (
                 <li
-                  key={sk.name}
+                  key={sk.id || sk.installUrl || sk.name}
                   className="rounded-md border border-[var(--border)] bg-[var(--bg-card)] p-3"
                 >
                   <div className="flex items-start justify-between gap-2">
-                    <span className="font-mono text-sm text-[var(--fg)]">
-                      {sk.name}
-                    </span>
+                    {sk.id ? (
+                      <Link
+                        to={`/skills/${encodeSkillId(sk.id)}`}
+                        className="font-mono text-sm text-[var(--fg)] hover:text-[var(--brand)] transition-colors"
+                      >
+                        {sk.name}
+                      </Link>
+                    ) : (
+                      <span className="font-mono text-sm text-[var(--fg)]">
+                        {sk.name}
+                      </span>
+                    )}
                     {skillInstall && (
                       <CopyButton
                         text={skillInstall}

--- a/website-src/src/components/BundleDetail.jsx
+++ b/website-src/src/components/BundleDetail.jsx
@@ -72,7 +72,7 @@ export default function BundleDetail({ bundle }) {
                     {sk.id ? (
                       <Link
                         to={`/skills/${encodeSkillId(sk.id)}`}
-                        className="font-mono text-sm text-[var(--fg)] hover:text-[var(--brand)] transition-colors"
+                        className="min-h-11 -m-2 px-2 inline-flex items-center font-mono text-sm text-[var(--fg)] hover:text-[var(--brand)] transition-colors"
                       >
                         {sk.name}
                       </Link>

--- a/website-src/src/components/EvalScoreBreakdown.jsx
+++ b/website-src/src/components/EvalScoreBreakdown.jsx
@@ -26,14 +26,14 @@ export default function EvalScoreBreakdown({ summary }) {
       <div className={`flex items-center gap-3 ${scoreColor(overallTone)}`}>
         <span className="text-3xl font-semibold">
           {summary.overallScore}
-          <span className="text-base text-[var(--fg-muted)]">/100</span>
+          <span className="text-base text-[var(--fg-dim)]">/100</span>
         </span>
         <span className="text-sm text-[var(--fg-dim)]">
           grade {summary.grade}
         </span>
       </div>
       {summary.evaluatedAt && (
-        <div className="text-xs text-[var(--fg-muted)]">
+        <div className="text-xs text-[var(--fg-dim)]">
           Evaluated {new Date(summary.evaluatedAt).toLocaleDateString()}
           {summary.evaluatedVersion ? ` · v${summary.evaluatedVersion}` : ""}
         </div>

--- a/website-src/src/components/EvalScoreBreakdown.jsx
+++ b/website-src/src/components/EvalScoreBreakdown.jsx
@@ -1,0 +1,73 @@
+import { evalScoreClass } from "../lib/utils.js";
+
+function scoreColor(scoreClass) {
+  if (scoreClass === "eval-a") return "text-emerald-400";
+  if (scoreClass === "eval-b") return "text-lime-400";
+  if (scoreClass === "eval-c") return "text-yellow-400";
+  if (scoreClass === "eval-d") return "text-orange-400";
+  return "text-red-400";
+}
+
+function barColor(scoreClass) {
+  if (scoreClass === "eval-a") return "bg-emerald-500";
+  if (scoreClass === "eval-b") return "bg-lime-500";
+  if (scoreClass === "eval-c") return "bg-yellow-500";
+  if (scoreClass === "eval-d") return "bg-orange-500";
+  return "bg-red-500";
+}
+
+/** Render the canonical overall score and complete per-category breakdown. */
+export default function EvalScoreBreakdown({ summary }) {
+  if (!summary) return null;
+  const overallTone = evalScoreClass(summary.overallScore);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className={`flex items-center gap-3 ${scoreColor(overallTone)}`}>
+        <span className="text-3xl font-semibold">
+          {summary.overallScore}
+          <span className="text-base text-[var(--fg-muted)]">/100</span>
+        </span>
+        <span className="text-sm text-[var(--fg-dim)]">
+          grade {summary.grade}
+        </span>
+      </div>
+      {summary.evaluatedAt && (
+        <div className="text-xs text-[var(--fg-muted)]">
+          Evaluated {new Date(summary.evaluatedAt).toLocaleDateString()}
+          {summary.evaluatedVersion ? ` · v${summary.evaluatedVersion}` : ""}
+        </div>
+      )}
+      {summary.categories?.length > 0 && (
+        <table className="w-full text-xs">
+          <tbody>
+            {summary.categories.map((category) => {
+              const percent =
+                category.max > 0
+                  ? Math.round((category.score / category.max) * 100)
+                  : 0;
+              return (
+                <tr key={category.id}>
+                  <td className="py-1 text-[var(--fg-dim)] pr-2 align-middle">
+                    {category.name}
+                  </td>
+                  <td className="w-full align-middle">
+                    <div className="h-1.5 rounded bg-[var(--bg-input)] overflow-hidden">
+                      <div
+                        className={`h-full ${barColor(evalScoreClass(percent))}`}
+                        style={{ width: `${percent}%` }}
+                      />
+                    </div>
+                  </td>
+                  <td className="pl-2 text-right text-[var(--fg-dim)] whitespace-nowrap align-middle">
+                    {category.score}/{category.max}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/website-src/src/components/EvalScoreBreakdown.jsx
+++ b/website-src/src/components/EvalScoreBreakdown.jsx
@@ -1,11 +1,11 @@
 import { evalScoreClass } from "../lib/utils.js";
 
 function scoreColor(scoreClass) {
-  if (scoreClass === "eval-a") return "text-emerald-400";
-  if (scoreClass === "eval-b") return "text-lime-400";
-  if (scoreClass === "eval-c") return "text-yellow-400";
-  if (scoreClass === "eval-d") return "text-orange-400";
-  return "text-red-400";
+  if (scoreClass === "eval-a") return "text-emerald-700 dark:text-emerald-400";
+  if (scoreClass === "eval-b") return "text-lime-700 dark:text-lime-400";
+  if (scoreClass === "eval-c") return "text-yellow-700 dark:text-yellow-400";
+  if (scoreClass === "eval-d") return "text-orange-700 dark:text-orange-400";
+  return "text-red-700 dark:text-red-400";
 }
 
 function barColor(scoreClass) {
@@ -40,6 +40,14 @@ export default function EvalScoreBreakdown({ summary }) {
       )}
       {summary.categories?.length > 0 && (
         <table className="w-full text-xs">
+          <caption className="sr-only">Evaluation score breakdown</caption>
+          <thead className="sr-only">
+            <tr>
+              <th scope="col">Category</th>
+              <th scope="col">Percentage</th>
+              <th scope="col">Points</th>
+            </tr>
+          </thead>
           <tbody>
             {summary.categories.map((category) => {
               const percent =
@@ -48,11 +56,18 @@ export default function EvalScoreBreakdown({ summary }) {
                   : 0;
               return (
                 <tr key={category.id}>
-                  <td className="py-1 text-[var(--fg-dim)] pr-2 align-middle">
+                  <th
+                    scope="row"
+                    className="py-1 text-left font-normal text-[var(--fg-dim)] pr-2 align-middle"
+                  >
                     {category.name}
-                  </td>
+                  </th>
                   <td className="w-full align-middle">
-                    <div className="h-1.5 rounded bg-[var(--bg-input)] overflow-hidden">
+                    <span className="sr-only">{percent}%</span>
+                    <div
+                      aria-hidden="true"
+                      className="h-1.5 rounded bg-[var(--bg-input)] overflow-hidden"
+                    >
                       <div
                         className={`h-full ${barColor(evalScoreClass(percent))}`}
                         style={{ width: `${percent}%` }}

--- a/website-src/src/components/SkillDetail.jsx
+++ b/website-src/src/components/SkillDetail.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { evalScoreClass, formatTokens } from "../lib/utils.js";
+import { formatTokens } from "../lib/utils.js";
 import CopyButton from "./CopyButton.jsx";
+import EvalScoreBreakdown from "./EvalScoreBreakdown.jsx";
 import AddToBundleButton from "./AddToBundleButton.jsx";
 import { Badge } from "./ui/badge.jsx";
 import { Card } from "./ui/card.jsx";
@@ -53,10 +54,6 @@ export default function SkillDetail({ slim }) {
 
   const skill = useMemo(() => detail.data || slim, [detail.data, slim]);
   if (!skill) return null;
-
-  const evalScoreCls = skill.evalSummary
-    ? evalScoreClass(skill.evalSummary.overallScore)
-    : "";
 
   return (
     <div className="flex flex-col gap-4">
@@ -136,78 +133,7 @@ export default function SkillDetail({ slim }) {
           asm eval score
         </h2>
         {skill.evalSummary ? (
-          <div className="flex flex-col gap-3">
-            <div
-              className={
-                "flex items-center gap-3 " +
-                (evalScoreCls === "eval-a"
-                  ? "text-emerald-400"
-                  : evalScoreCls === "eval-b"
-                    ? "text-lime-400"
-                    : evalScoreCls === "eval-c"
-                      ? "text-yellow-400"
-                      : evalScoreCls === "eval-d"
-                        ? "text-orange-400"
-                        : "text-red-400")
-              }
-            >
-              <span className="text-3xl font-semibold">
-                {skill.evalSummary.overallScore}
-                <span className="text-base text-[var(--fg-muted)]">/100</span>
-              </span>
-              <span className="text-sm text-[var(--fg-dim)]">
-                grade {skill.evalSummary.grade}
-              </span>
-            </div>
-            {skill.evalSummary.evaluatedAt && (
-              <div className="text-xs text-[var(--fg-muted)]">
-                Evaluated{" "}
-                {new Date(skill.evalSummary.evaluatedAt).toLocaleDateString()}
-                {skill.evalSummary.evaluatedVersion
-                  ? " · v" + skill.evalSummary.evaluatedVersion
-                  : ""}
-              </div>
-            )}
-            {skill.evalSummary.categories?.length > 0 && (
-              <table className="w-full text-xs">
-                <tbody>
-                  {skill.evalSummary.categories.map((c) => {
-                    const pct =
-                      c.max > 0 ? Math.round((c.score / c.max) * 100) : 0;
-                    const tone = evalScoreClass(pct);
-                    const toneColor =
-                      tone === "eval-a"
-                        ? "bg-emerald-500"
-                        : tone === "eval-b"
-                          ? "bg-lime-500"
-                          : tone === "eval-c"
-                            ? "bg-yellow-500"
-                            : tone === "eval-d"
-                              ? "bg-orange-500"
-                              : "bg-red-500";
-                    return (
-                      <tr key={c.id}>
-                        <td className="py-1 text-[var(--fg-dim)] pr-2 align-middle">
-                          {c.name}
-                        </td>
-                        <td className="w-full align-middle">
-                          <div className="h-1.5 rounded bg-[var(--bg-input)] overflow-hidden">
-                            <div
-                              className={"h-full " + toneColor}
-                              style={{ width: pct + "%" }}
-                            />
-                          </div>
-                        </td>
-                        <td className="pl-2 text-right text-[var(--fg-dim)] whitespace-nowrap align-middle">
-                          {c.score}/{c.max}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            )}
-          </div>
+          <EvalScoreBreakdown summary={skill.evalSummary} />
         ) : (
           <p className="text-xs text-[var(--fg-dim)]">
             No <code>asm eval</code> data is available for this skill yet. Run{" "}

--- a/website-src/src/pages/ProfilePage.jsx
+++ b/website-src/src/pages/ProfilePage.jsx
@@ -161,7 +161,7 @@ export default function ProfilePage() {
                 {s.id ? (
                   <Link
                     to={`/skills/${encodeSkillId(s.id)}`}
-                    className="min-w-0 min-h-11 -mx-2 px-2 inline-flex items-center font-medium text-[var(--fg)] hover:text-[var(--brand)] transition-colors truncate"
+                    className="min-w-11 min-h-11 -mx-2 px-2 inline-flex items-center font-medium text-[var(--fg)] hover:text-[var(--brand)] transition-colors truncate"
                   >
                     {s.name}
                   </Link>

--- a/website-src/src/pages/ProfilePage.jsx
+++ b/website-src/src/pages/ProfilePage.jsx
@@ -3,6 +3,7 @@ import { useParams, Link } from "react-router-dom";
 import CopyButton from "../components/CopyButton";
 import CategoryPieChart from "../components/CategoryPieChart";
 import { Badge } from "../components/ui/badge";
+import { encodeSkillId } from "../lib/utils.js";
 
 /**
  * Author profile page — shows an author's skills across all indexed repos,
@@ -38,7 +39,6 @@ export default function ProfilePage() {
   const { owner } = useParams();
   const [author, setAuthor] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     fetch("author-stats.json")
@@ -158,9 +158,18 @@ export default function ProfilePage() {
                 <span className="w-6 text-right font-mono text-[var(--fg-muted)]">
                   {i + 1}
                 </span>
-                <span className="min-w-0 font-medium text-[var(--fg)] truncate">
-                  {s.name}
-                </span>
+                {s.id ? (
+                  <Link
+                    to={`/skills/${encodeSkillId(s.id)}`}
+                    className="min-w-0 font-medium text-[var(--fg)] hover:text-[var(--brand)] transition-colors truncate"
+                  >
+                    {s.name}
+                  </Link>
+                ) : (
+                  <span className="min-w-0 font-medium text-[var(--fg)] truncate">
+                    {s.name}
+                  </span>
+                )}
                 <span className="hidden sm:inline text-[var(--fg-dim)] text-xs truncate">
                   {s.repo}
                 </span>

--- a/website-src/src/pages/ProfilePage.jsx
+++ b/website-src/src/pages/ProfilePage.jsx
@@ -161,7 +161,7 @@ export default function ProfilePage() {
                 {s.id ? (
                   <Link
                     to={`/skills/${encodeSkillId(s.id)}`}
-                    className="min-w-0 font-medium text-[var(--fg)] hover:text-[var(--brand)] transition-colors truncate"
+                    className="min-w-0 min-h-11 -mx-2 px-2 inline-flex items-center font-medium text-[var(--fg)] hover:text-[var(--brand)] transition-colors truncate"
                   >
                     {s.name}
                   </Link>

--- a/website-src/src/pages/ProfilePage.jsx
+++ b/website-src/src/pages/ProfilePage.jsx
@@ -155,7 +155,7 @@ export default function ProfilePage() {
                 key={`${s.name}-${s.repo}`}
                 className="grid grid-cols-[1.5rem_minmax(0,1fr)] sm:grid-cols-[1.5rem_minmax(0,1fr)_minmax(6rem,auto)] items-center gap-3 text-sm py-2 border-b border-[var(--border)] last:border-0"
               >
-                <span className="w-6 text-right font-mono text-[var(--fg-muted)]">
+                <span className="w-6 text-right font-mono text-[var(--fg-dim)]">
                   {i + 1}
                 </span>
                 {s.id ? (

--- a/website-src/src/pages/StatsPage.jsx
+++ b/website-src/src/pages/StatsPage.jsx
@@ -146,7 +146,7 @@ export default function StatsPage() {
                         <div className="min-w-0">
                           <Link
                             to={`/skills/${encodeSkillId(skill.id)}`}
-                            className="block font-medium text-[var(--fg)] hover:text-[var(--brand)] transition-colors truncate"
+                            className="flex min-h-11 items-center -mx-2 px-2 font-medium text-[var(--fg)] hover:text-[var(--brand)] transition-colors truncate"
                           >
                             {skill.name}
                           </Link>

--- a/website-src/src/pages/StatsPage.jsx
+++ b/website-src/src/pages/StatsPage.jsx
@@ -4,8 +4,10 @@ import { Eye } from "lucide-react";
 import { useCatalog } from "../hooks/useCatalog.jsx";
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
-import CategoryPieChart from "../components/CategoryPieChart";
-import CopyButton from "../components/CopyButton";
+import CategoryPieChart from "../components/CategoryPieChart.jsx";
+import CopyButton from "../components/CopyButton.jsx";
+import EvalScoreBreakdown from "../components/EvalScoreBreakdown.jsx";
+import { encodeSkillId } from "../lib/utils.js";
 
 /**
  * Stats overview page — shows top repos by skill count, top authors,
@@ -82,6 +84,7 @@ export default function StatsPage() {
     }
   }
   const catEntries = Object.entries(catCounts).sort((a, b) => b[1] - a[1]);
+  const categoryTopSkills = Object.entries(idx?.categoryTopSkills || {});
 
   return (
     <div className="max-w-4xl mx-auto">
@@ -110,6 +113,55 @@ export default function StatsPage() {
         <section>
           <SectionTitle>Category Distribution</SectionTitle>
           <CategoryPieChart entries={catEntries} />
+        </section>
+      )}
+
+      {/* Top Skills by Category */}
+      {categoryTopSkills.length > 0 && (
+        <section className="mt-8">
+          <SectionTitle>Top Skills by Category</SectionTitle>
+          <div className="space-y-8">
+            {categoryTopSkills.map(([category, rankedSkills]) => (
+              <section
+                key={category}
+                aria-labelledby={`category-ranking-${category}`}
+              >
+                <h3
+                  id={`category-ranking-${category}`}
+                  className="text-base font-semibold text-[var(--fg)] mb-3"
+                >
+                  {category}
+                </h3>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {rankedSkills.slice(0, 10).map((skill, index) => (
+                    <article
+                      key={skill.id}
+                      aria-label={`${skill.name} score breakdown`}
+                      className="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-4"
+                    >
+                      <div className="flex items-start gap-3 mb-3">
+                        <span className="w-6 text-right font-mono text-[var(--fg-muted)]">
+                          {index + 1}
+                        </span>
+                        <div className="min-w-0">
+                          <Link
+                            to={`/skills/${encodeSkillId(skill.id)}`}
+                            className="block font-medium text-[var(--fg)] hover:text-[var(--brand)] transition-colors truncate"
+                          >
+                            {skill.name}
+                          </Link>
+                          <span className="block text-xs text-[var(--fg-muted)] truncate">
+                            {skill.owner}/{skill.repo}
+                          </span>
+                        </div>
+                      </div>
+                      <EvalScoreBreakdown summary={skill.evalSummary} />
+                    </article>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
         </section>
       )}
 

--- a/website-src/src/pages/StatsPage.jsx
+++ b/website-src/src/pages/StatsPage.jsx
@@ -140,17 +140,17 @@ export default function StatsPage() {
                       className="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-4"
                     >
                       <div className="flex items-start gap-3 mb-3">
-                        <span className="w-6 text-right font-mono text-[var(--fg-muted)]">
+                        <span className="w-6 text-right font-mono text-[var(--fg-dim)]">
                           {index + 1}
                         </span>
                         <div className="min-w-0">
                           <Link
                             to={`/skills/${encodeSkillId(skill.id)}`}
-                            className="flex min-h-11 items-center -mx-2 px-2 font-medium text-[var(--fg)] hover:text-[var(--brand)] transition-colors truncate"
+                            className="flex min-h-11 min-w-11 items-center -mx-2 px-2 font-medium text-[var(--fg)] hover:text-[var(--brand)] transition-colors truncate"
                           >
                             {skill.name}
                           </Link>
-                          <span className="block text-xs text-[var(--fg-muted)] truncate">
+                          <span className="block text-xs text-[var(--fg-dim)] truncate">
                             {skill.owner}/{skill.repo}
                           </span>
                         </div>
@@ -174,7 +174,7 @@ export default function StatsPage() {
               key={`${r.owner}/${r.repo}`}
               className="grid grid-cols-[1.5rem_minmax(0,1fr)_auto] sm:grid-cols-[1.5rem_minmax(0,1fr)_6rem_auto] items-center gap-3 text-sm py-2 border-b border-[var(--border)] last:border-0"
             >
-              <span className="w-6 text-right font-mono text-[var(--fg-muted)]">
+              <span className="w-6 text-right font-mono text-[var(--fg-dim)]">
                 {i + 1}
               </span>
               <a
@@ -214,7 +214,7 @@ export default function StatsPage() {
               key={a.owner}
               className="grid grid-cols-[1.5rem_minmax(0,1fr)_auto_auto] sm:grid-cols-[1.5rem_minmax(0,1fr)_auto_auto_auto] items-center gap-3 text-sm py-2 border-b border-[var(--border)] last:border-0"
             >
-              <span className="w-6 text-right font-mono text-[var(--fg-muted)]">
+              <span className="w-6 text-right font-mono text-[var(--fg-dim)]">
                 {i + 1}
               </span>
               <Link


### PR DESCRIPTION
Closes #398

## Summary

Adds deterministic top-10 skill rankings for every catalog category, including complete evaluation score breakdowns, and makes catalog-backed skill mentions open their canonical skill detail pages across rankings, author profiles, predefined bundles, and the bundle builder.

## Approach

**Option 2 — Build-time rankings and stable-link enrichment.** The catalog builder now computes category rankings while complete evaluation data and stable skill IDs are available. The React catalog consumes this compact stats data, reuses one accessible score-breakdown component, and routes skill mentions through the existing encoded detail URL convention.

## Decision Record

- **Root cause:** The catalog build discarded category-level ranking data and stable IDs at key output boundaries: stats had no per-category top skills, author `topSkills` retained only names/repos, and bundle entries were not enriched with resolvable IDs. The UI therefore could neither show deterministic category rankings with full scores nor construct canonical detail links for those mentions.
- **Options considered:** Option 1 — Minimal client-side integration; Option 2 — Build-time rankings and stable-link enrichment; Option 3 — Unified enriched catalog and reusable skill links.
- **Options rejected:** Option 1 — runtime detail loading and indirect identity lookups add request fan-out and partial-failure states; Option 3 — enriching every slim catalog record would increase payload size and broaden the refactor beyond this issue.
- **Selected option:** Option 2 — Build-time rankings and stable-link enrichment.
- **Residual risk:** Bundle entries without a deterministic match to an indexed catalog skill remain plain text because no corresponding detail page can be identified safely; no IDs are guessed.
- **Design-confirm:** Confirmed Option 2 at the interactive design-confirm checkpoint (complexity: L).

Analyzed at: `refactor/398-improve-top-skills-rankings @ fa8bf21` (2026-08-05)

## Changes

| File | Change |
|------|--------|
| `scripts/build-catalog.ts` | Generates deterministic top-10 rankings with full scores and enriches author/bundle entries with stable IDs. |
| `website-src/src/components/EvalScoreBreakdown.jsx` | Adds reusable, semantic, theme-accessible score breakdown rendering. |
| `website-src/src/components/SkillDetail.jsx` | Reuses the shared score-breakdown component. |
| `website-src/src/pages/StatsPage.jsx` | Displays category rankings, complete scores, and canonical detail links. |
| `website-src/src/pages/ProfilePage.jsx` | Links author top skills and improves ranking accessibility. |
| `website-src/src/components/BundleDetail.jsx` | Links resolvable predefined-bundle skills. |
| `website-src/src/components/BundleBuilderDialog.jsx` | Links selected bundle-builder skills. |
| `tests/e2e/build-verification.test.ts` | Verifies limits, ordering, full breakdowns, and stable-ID enrichment. |
| `website-src/src/__tests__/stats-page.test.jsx` | Covers ranking display, links, score semantics, contrast tokens, and touch targets. |
| `website-src/src/__tests__/profile-page.test.jsx` | Covers author skill routes and accessible ranking metadata. |
| `website-src/src/__tests__/app-smoke.test.jsx` | Covers predefined-bundle skill links. |
| `website-src/src/__tests__/bundle-cart.test.jsx` | Covers bundle-builder skill links. |

## Test Results

- Unit tests: 1,898 passed
- Website component tests: 66 passed
- E2e tests: 159 passed
- Build, typecheck, lint, and pre-push hooks: passed
- Code review and code-level UI/UX review: passed
- Browser review: skipped because Playwright was unavailable; code UI review completed
- QA cycles: 4

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| The Top Skills experience shows the top 10 skills for each category. | pass | `scripts/build-catalog.ts:961`, `website-src/src/pages/StatsPage.jsx:120`, and deterministic limit/order assertions in `tests/e2e/build-verification.test.ts:457`. |
| Every skill in a category's top 10 displays its detailed score breakdown. | pass | `website-src/src/pages/StatsPage.jsx:158`, `website-src/src/components/EvalScoreBreakdown.jsx:20`, and full-breakdown assertions in `tests/e2e/build-verification.test.ts:480`. |
| Every skill mention across catalog pages links to the corresponding skill detail page. | pass | Canonical encoded links in `StatsPage.jsx:148`, `ProfilePage.jsx:163`, `BundleDetail.jsx:74`, and `BundleBuilderDialog.jsx:266`; covered by site component tests. |
| Skills listed on author profile pages can be opened through their skill detail links. | pass | `website-src/src/pages/ProfilePage.jsx:163` and `website-src/src/__tests__/profile-page.test.jsx:54`. |

