### PR TITLE
perf(scanner): parallelize skill entry scanning (#365)

### DIFF
--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -1,7 +1,87 @@
 import { createDirSymlink } from "./utils/fs";
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
-import { mkdtemp, writeFile, mkdir, rm, symlink, realpath } from "fs/promises";
-import { join } from "path";
+
+const scanFsControl = vi.hoisted(() => ({
+  blockedStatPaths: new Set<string>(),
+  statWaiters: new Map<string, () => void>(),
+  completedStatPaths: [] as string[],
+  completedReaddirPaths: new Set<string>(),
+  failingStatPaths: new Set<string>(),
+  failingLstatPaths: new Set<string>(),
+  failingReadlinkPaths: new Set<string>(),
+  failingRealpathPaths: new Set<string>(),
+  invalidReadPaths: new Set<string>(),
+  activeStats: 0,
+  maxActiveStats: 0,
+  startedStats: 0,
+}));
+
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+  return {
+    ...actual,
+    readdir: async (...args: Parameters<typeof actual.readdir>) => {
+      const entries = await actual.readdir(...args);
+      scanFsControl.completedReaddirPaths.add(String(args[0]));
+      return entries;
+    },
+    stat: async (...args: Parameters<typeof actual.stat>) => {
+      const path = String(args[0]);
+      if (scanFsControl.failingStatPaths.has(path)) {
+        throw new Error("injected stat failure");
+      }
+      if (scanFsControl.blockedStatPaths.has(path)) {
+        scanFsControl.startedStats++;
+        scanFsControl.activeStats++;
+        scanFsControl.maxActiveStats = Math.max(
+          scanFsControl.maxActiveStats,
+          scanFsControl.activeStats,
+        );
+        await new Promise<void>((resolve) => {
+          scanFsControl.statWaiters.set(path, resolve);
+        });
+        scanFsControl.activeStats--;
+        scanFsControl.completedStatPaths.push(path);
+      }
+      return actual.stat(...args);
+    },
+    lstat: async (...args: Parameters<typeof actual.lstat>) => {
+      if (scanFsControl.failingLstatPaths.has(String(args[0]))) {
+        throw new Error("injected lstat failure");
+      }
+      return actual.lstat(...args);
+    },
+    readlink: async (...args: Parameters<typeof actual.readlink>) => {
+      if (scanFsControl.failingReadlinkPaths.has(String(args[0]))) {
+        throw new Error("injected readlink failure");
+      }
+      return actual.readlink(...args);
+    },
+    realpath: async (...args: Parameters<typeof actual.realpath>) => {
+      if (scanFsControl.failingRealpathPaths.has(String(args[0]))) {
+        throw new Error("injected realpath failure");
+      }
+      return actual.realpath(...args);
+    },
+    readFile: async (...args: Parameters<typeof actual.readFile>) => {
+      if (scanFsControl.invalidReadPaths.has(String(args[0]))) {
+        return undefined as never;
+      }
+      return actual.readFile(...args);
+    },
+  };
+});
+
+import {
+  mkdtemp,
+  writeFile,
+  mkdir,
+  rm,
+  symlink,
+  realpath,
+  readdir,
+} from "fs/promises";
+import { join, resolve } from "path";
 import { tmpdir } from "os";
 import {
   searchSkills,
@@ -15,7 +95,65 @@ import {
 } from "./scanner";
 import { setVerbose } from "./logger";
 import { getDefaultConfig } from "./config";
-import type { SkillInfo } from "./utils/types";
+import type { AppConfig, SkillInfo } from "./utils/types";
+
+function resetScanFsControl(): void {
+  for (const release of scanFsControl.statWaiters.values()) release();
+  scanFsControl.blockedStatPaths.clear();
+  scanFsControl.statWaiters.clear();
+  scanFsControl.completedStatPaths.length = 0;
+  scanFsControl.completedReaddirPaths.clear();
+  scanFsControl.failingStatPaths.clear();
+  scanFsControl.failingLstatPaths.clear();
+  scanFsControl.failingReadlinkPaths.clear();
+  scanFsControl.failingRealpathPaths.clear();
+  scanFsControl.invalidReadPaths.clear();
+  scanFsControl.activeStats = 0;
+  scanFsControl.maxActiveStats = 0;
+  scanFsControl.startedStats = 0;
+}
+
+function releaseBlockedStats(): void {
+  scanFsControl.blockedStatPaths.clear();
+  for (const release of scanFsControl.statWaiters.values()) release();
+  scanFsControl.statWaiters.clear();
+}
+
+async function createSkills(
+  dir: string,
+  names: string[],
+  batchSize = names.length,
+): Promise<void> {
+  for (let start = 0; start < names.length; start += batchSize) {
+    await Promise.all(
+      names.slice(start, start + batchSize).map(async (name) => {
+        const skillDir = join(dir, name);
+        await mkdir(skillDir, { recursive: true });
+        await writeFile(
+          join(skillDir, "SKILL.md"),
+          `---\nname: ${name}\nversion: 1.0.0\n---\n`,
+        );
+      }),
+    );
+  }
+}
+
+function makeScanConfig(
+  dirs: string[],
+  scope: "global" | "project" = "project",
+): AppConfig {
+  return {
+    ...getDefaultConfig(),
+    providers: dirs.map((dir, index) => ({
+      name: `test-${index}`,
+      label: `Test ${index}`,
+      global: scope === "global" ? dir : "/tmp/nonexistent-scanner-global",
+      project: scope === "project" ? dir : "/tmp/nonexistent-scanner-project",
+      enabled: true,
+    })),
+    customPaths: [],
+  };
+}
 
 function makeSkill(overrides: Partial<SkillInfo> = {}): SkillInfo {
   return {
@@ -293,10 +431,12 @@ describe("scanAllSkills", () => {
   let tempDir: string;
 
   beforeEach(async () => {
+    resetScanFsControl();
     tempDir = await mkdtemp(join(tmpdir(), "scanner-scan-"));
   });
 
   afterEach(async () => {
+    resetScanFsControl();
     await rm(tempDir, { recursive: true, force: true });
   });
 
@@ -479,6 +619,197 @@ describe("scanAllSkills", () => {
     expect(found).toBeDefined();
     expect(found!.provider).toBe("custom");
     expect(found!.providerLabel).toBe("My Custom");
+  });
+
+  it("scans multiple entries in parallel", async () => {
+    const names = ["one", "two", "three", "four"];
+    await createSkills(tempDir, names);
+    for (const name of names) {
+      scanFsControl.blockedStatPaths.add(join(tempDir, name));
+    }
+
+    const scanPromise = scanAllSkills(makeScanConfig([tempDir]), "project");
+    let skills: SkillInfo[] = [];
+    try {
+      await vi.waitFor(() => expect(scanFsControl.startedStats).toBe(4));
+      expect(scanFsControl.activeStats).toBe(4);
+      expect(scanFsControl.maxActiveStats).toBe(4);
+    } finally {
+      releaseBlockedStats();
+      skills = await scanPromise;
+    }
+
+    expect(skills).toHaveLength(4);
+  });
+
+  it("shares one concurrency cap across overlapping scans and locations", async () => {
+    const roots = ["a", "b", "c", "d"].map((name) => join(tempDir, name));
+    const names = Array.from({ length: 12 }, (_, index) => `skill-${index}`);
+    for (const root of roots) {
+      await createSkills(root, names);
+      for (const name of names) {
+        scanFsControl.blockedStatPaths.add(join(root, name));
+      }
+    }
+
+    const firstScan = scanAllSkills(
+      makeScanConfig(roots.slice(0, 2)),
+      "project",
+    );
+    const secondScan = scanAllSkills(makeScanConfig(roots.slice(2)), "project");
+    try {
+      await vi.waitFor(() =>
+        expect(
+          roots.every((root) => scanFsControl.completedReaddirPaths.has(root)),
+        ).toBe(true),
+      );
+      await vi.waitFor(() =>
+        expect(scanFsControl.startedStats).toBeGreaterThanOrEqual(16),
+      );
+      expect(scanFsControl.startedStats).toBe(16);
+      expect(scanFsControl.activeStats).toBe(16);
+      expect(scanFsControl.maxActiveStats).toBe(16);
+
+      const [firstBlockedPath, releaseFirst] = scanFsControl.statWaiters
+        .entries()
+        .next().value!;
+      scanFsControl.blockedStatPaths.delete(firstBlockedPath);
+      scanFsControl.statWaiters.delete(firstBlockedPath);
+      releaseFirst();
+      await vi.waitFor(() => expect(scanFsControl.startedStats).toBe(17));
+      expect(scanFsControl.activeStats).toBe(16);
+      expect(scanFsControl.maxActiveStats).toBe(16);
+    } finally {
+      releaseBlockedStats();
+      await Promise.all([firstScan, secondScan]);
+    }
+    expect(scanFsControl.maxActiveStats).toBe(16);
+  });
+
+  it("preserves readdir and provider order despite out-of-order completion", async () => {
+    const firstRoot = join(tempDir, "first");
+    const secondRoot = join(tempDir, "second");
+    await createSkills(firstRoot, ["zeta", "alpha"]);
+    await createSkills(secondRoot, ["delta", "beta"]);
+    const expectedFirst = await readdir(firstRoot);
+    const expectedSecond = await readdir(secondRoot);
+
+    const pluginBase = join(tempDir, "plugins");
+    const duplicateDir = join(pluginBase, "market", "skills", "duplicate");
+    await mkdir(duplicateDir, { recursive: true });
+    await writeFile(
+      join(duplicateDir, "SKILL.md"),
+      `---\nname: ${expectedFirst[0]}\n---\n`,
+    );
+
+    const providerPaths = [firstRoot, secondRoot].flatMap((root) =>
+      root === firstRoot
+        ? expectedFirst.map((entry) => join(root, entry))
+        : expectedSecond.map((entry) => join(root, entry)),
+    );
+    for (const path of providerPaths) {
+      scanFsControl.blockedStatPaths.add(path);
+    }
+
+    const scanPromise = scanAllSkills(
+      makeScanConfig([firstRoot, secondRoot], "global"),
+      "global",
+      pluginBase,
+      join(tempDir, "missing-codex-cache"),
+    );
+    let skills: SkillInfo[] = [];
+    try {
+      await vi.waitFor(() => expect(scanFsControl.startedStats).toBe(4));
+      for (const path of [...providerPaths].reverse()) {
+        scanFsControl.blockedStatPaths.delete(path);
+        const release = scanFsControl.statWaiters.get(path);
+        expect(release).toBeDefined();
+        scanFsControl.statWaiters.delete(path);
+        release!();
+        await vi.waitFor(() =>
+          expect(scanFsControl.completedStatPaths).toContain(path),
+        );
+      }
+    } finally {
+      releaseBlockedStats();
+      skills = await scanPromise;
+    }
+
+    expect(skills.map((skill) => skill.dirName)).toEqual([
+      ...expectedFirst,
+      ...expectedSecond,
+    ]);
+    expect(skills.map((skill) => skill.provider)).toEqual([
+      "test-0",
+      "test-0",
+      "test-1",
+      "test-1",
+    ]);
+    expect(skills.filter((skill) => skill.provider === "plugin")).toEqual([]);
+  });
+
+  it("isolates entry failures and preserves filesystem fallbacks", async () => {
+    const scanRoot = join(tempDir, "inventory");
+    await createSkills(scanRoot, [
+      "good",
+      "lstat-fails",
+      "realpath-fails",
+      "stat-fails",
+      "invalid-content",
+    ]);
+    await mkdir(join(scanRoot, "no-skill"));
+    await writeFile(join(scanRoot, "not-a-directory"), "ignored");
+
+    const symlinkTarget = join(tempDir, "symlink-target");
+    await createSkills(symlinkTarget, ["target"]);
+    const linkedPath = join(scanRoot, "readlink-fails");
+    await symlink(join(symlinkTarget, "target"), linkedPath, "dir");
+
+    const lstatFailurePath = join(scanRoot, "lstat-fails");
+    const realpathFailurePath = join(scanRoot, "realpath-fails");
+    scanFsControl.failingLstatPaths.add(lstatFailurePath);
+    scanFsControl.failingRealpathPaths.add(realpathFailurePath);
+    scanFsControl.failingStatPaths.add(join(scanRoot, "stat-fails"));
+    scanFsControl.failingReadlinkPaths.add(linkedPath);
+    scanFsControl.invalidReadPaths.add(
+      join(scanRoot, "invalid-content", "SKILL.md"),
+    );
+    const expectedOrder = (await readdir(scanRoot)).filter((entry) =>
+      ["good", "lstat-fails", "readlink-fails", "realpath-fails"].includes(
+        entry,
+      ),
+    );
+
+    const skills = await scanAllSkills(makeScanConfig([scanRoot]), "project");
+
+    expect(skills.map((skill) => skill.dirName)).toEqual(expectedOrder);
+    expect(
+      skills.find((skill) => skill.dirName === "lstat-fails"),
+    ).toMatchObject({
+      isSymlink: false,
+      symlinkTarget: null,
+    });
+    expect(
+      skills.find((skill) => skill.dirName === "readlink-fails"),
+    ).toMatchObject({ isSymlink: true, symlinkTarget: null });
+    expect(
+      skills.find((skill) => skill.dirName === "realpath-fails")?.realPath,
+    ).toBe(resolve(realpathFailurePath));
+  });
+
+  it("scans a very large inventory without descriptor exhaustion", async () => {
+    const inventory = join(tempDir, "large");
+    const names = Array.from(
+      { length: 2048 },
+      (_, index) => `skill-${index.toString().padStart(4, "0")}`,
+    );
+    await createSkills(inventory, names, 64);
+    const expectedOrder = await readdir(inventory);
+
+    const skills = await scanAllSkills(makeScanConfig([inventory]), "project");
+
+    expect(skills).toHaveLength(2048);
+    expect(skills.map((skill) => skill.dirName)).toEqual(expectedOrder);
   });
 });
 

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -642,6 +642,50 @@ describe("scanAllSkills", () => {
     expect(skills).toHaveLength(4);
   });
 
+  it("keeps a stalled scan bounded and lets a later scan make progress", async () => {
+    const stalledRoots = [
+      join(tempDir, "stalled-a"),
+      join(tempDir, "stalled-b"),
+    ];
+    const laterRoot = join(tempDir, "later");
+    const stalledNames = Array.from(
+      { length: 32 },
+      (_, index) => `skill-${index}`,
+    );
+    for (const root of stalledRoots) {
+      await createSkills(root, stalledNames);
+      for (const name of stalledNames) {
+        scanFsControl.blockedStatPaths.add(join(root, name));
+      }
+    }
+    await createSkills(laterRoot, ["responsive"]);
+
+    const stalledScan = scanAllSkills(
+      makeScanConfig(stalledRoots),
+      "project",
+    );
+    let laterScan: Promise<SkillInfo[]> | undefined;
+    let laterFinished = false;
+
+    try {
+      await vi.waitFor(() => expect(scanFsControl.startedStats).toBe(15));
+
+      laterScan = scanAllSkills(makeScanConfig([laterRoot]), "project");
+      void laterScan.then(() => {
+        laterFinished = true;
+      });
+
+      await vi.waitFor(() => expect(laterFinished).toBe(true));
+      await expect(laterScan).resolves.toMatchObject([
+        { dirName: "responsive" },
+      ]);
+      expect(scanFsControl.startedStats).toBe(15);
+    } finally {
+      releaseBlockedStats();
+      await Promise.all([stalledScan, laterScan]);
+    }
+  });
+
   it("shares one concurrency cap across overlapping scans and locations", async () => {
     const roots = ["a", "b", "c", "d"].map((name) => join(tempDir, name));
     const names = Array.from({ length: 12 }, (_, index) => `skill-${index}`);

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -49,6 +49,8 @@ interface ScanLocation {
 }
 
 const SCAN_ENTRY_CONCURRENCY = 16;
+// A single stalled scan must not consume every process-wide slot.
+const SCAN_ENTRY_PER_SCAN_CONCURRENCY = SCAN_ENTRY_CONCURRENCY - 1;
 const pendingScanEntries: Array<() => void> = [];
 let pendingScanEntryIndex = 0;
 let activeScanEntries = 0;
@@ -88,6 +90,99 @@ function withScanEntryLimit<T>(task: () => Promise<T>): Promise<T> {
     });
     drainScanEntries();
   });
+}
+
+interface ScanEntryBatch {
+  entries: string[];
+  nextIndex: number;
+  inFlight: number;
+  results: Array<[number, SkillInfo]>;
+  task: (entry: string, index: number) => Promise<SkillInfo | undefined>;
+  resolve: (skills: SkillInfo[]) => void;
+}
+
+interface ScanEntryScheduler {
+  run(
+    entries: string[],
+    task: (entry: string, index: number) => Promise<SkillInfo | undefined>,
+  ): Promise<SkillInfo[]>;
+}
+
+function createScanEntryScheduler(): ScanEntryScheduler {
+  const batches: ScanEntryBatch[] = [];
+  let active = 0;
+  let cursor = 0;
+
+  const drain = (): void => {
+    while (active < SCAN_ENTRY_PER_SCAN_CONCURRENCY) {
+      let batch: ScanEntryBatch | undefined;
+
+      for (let checked = 0; checked < batches.length; checked++) {
+        const candidate = batches[cursor];
+        cursor = (cursor + 1) % batches.length;
+        if (candidate.nextIndex < candidate.entries.length) {
+          batch = candidate;
+          break;
+        }
+      }
+
+      if (!batch) return;
+
+      const index = batch.nextIndex++;
+      const entry = batch.entries[index];
+      batch.inFlight++;
+      active++;
+
+      void withScanEntryLimit(() => batch.task(entry, index))
+        .then(
+          (skill) => {
+            if (skill) batch.results.push([index, skill]);
+          },
+          () => undefined,
+        )
+        .finally(() => {
+          active--;
+          batch.inFlight--;
+
+          if (
+            batch.nextIndex === batch.entries.length &&
+            batch.inFlight === 0
+          ) {
+            const batchIndex = batches.indexOf(batch);
+            batches.splice(batchIndex, 1);
+            if (batches.length === 0) {
+              cursor = 0;
+            } else {
+              if (batchIndex < cursor) cursor--;
+              cursor %= batches.length;
+            }
+
+            batch.results.sort(([a], [b]) => a - b);
+            batch.resolve(batch.results.map(([, skill]) => skill));
+          }
+
+          drain();
+        });
+    }
+  };
+
+  return {
+    run(entries, task) {
+      if (entries.length === 0) return Promise.resolve([]);
+
+      return new Promise<SkillInfo[]>((resolveSkills) => {
+        batches.push({
+          entries,
+          nextIndex: 0,
+          inFlight: 0,
+          results: [],
+          task,
+          resolve: resolveSkills,
+        });
+        drain();
+      });
+    },
+  };
 }
 
 function buildScanLocations(config: AppConfig, scope: Scope): ScanLocation[] {
@@ -152,7 +247,10 @@ export async function countFiles(dir: string): Promise<number> {
   }
 }
 
-async function scanDirectory(loc: ScanLocation): Promise<SkillInfo[]> {
+async function scanDirectory(
+  loc: ScanLocation,
+  scheduler: ScanEntryScheduler,
+): Promise<SkillInfo[]> {
   debug(`scanning: ${loc.dir} (${loc.location})`);
 
   let entries: string[];
@@ -163,86 +261,79 @@ async function scanDirectory(loc: ScanLocation): Promise<SkillInfo[]> {
     return [];
   }
 
-  const results = new Array<SkillInfo | undefined>(entries.length);
-  await Promise.all(
-    entries.map((entry, index) =>
-      withScanEntryLimit(async () => {
-        try {
-          const entryPath = join(loc.dir, entry);
+  const skills = await scheduler.run(entries, async (entry) => {
+    try {
+      const entryPath = join(loc.dir, entry);
 
-          try {
-            const entryStat = await stat(entryPath);
-            if (!entryStat.isDirectory()) {
-              debug(`  skip: "${entry}" — not a directory`);
-              return;
-            }
-          } catch {
-            debug(`  skip: "${entry}" — stat failed`);
-            return;
-          }
-
-          const skillMdPath = join(entryPath, "SKILL.md");
-          let content: string;
-          try {
-            content = await readFile(skillMdPath, "utf-8");
-          } catch {
-            debug(`  skip: "${entry}" — no SKILL.md`);
-            return;
-          }
-
-          const fm = parseFrontmatter(content);
-
-          let isSymlink = false;
-          let symlinkTarget: string | null = null;
-          try {
-            const lstats = await lstat(entryPath);
-            if (lstats.isSymbolicLink()) {
-              isSymlink = true;
-              symlinkTarget = await readlink(entryPath);
-            }
-          } catch {
-            // not a symlink
-          }
-
-          const resolvedPath = resolve(entryPath);
-          let resolvedRealPath: string;
-          try {
-            resolvedRealPath = await realpath(entryPath);
-          } catch {
-            resolvedRealPath = resolvedPath;
-          }
-
-          results[index] = {
-            name: fm.name || entry,
-            version: resolveVersion(fm),
-            description: (fm.description || "")
-              .replace(/\s*\n\s*/g, " ")
-              .trim(),
-            creator: fm["metadata.creator"] || "",
-            license: (fm.license || "").trim(),
-            compatibility: (fm.compatibility || "").trim(),
-            allowedTools: resolveAllowedTools(fm),
-            effort: fm.effort || fm["metadata.effort"] || undefined,
-            dirName: entry,
-            path: resolvedPath,
-            originalPath: entryPath,
-            location: loc.location,
-            scope: loc.scope,
-            provider: loc.providerName,
-            providerLabel: loc.providerLabel,
-            isSymlink,
-            symlinkTarget,
-            realPath: resolvedRealPath,
-            tokenCount: estimateTokenCount(content),
-          };
-        } catch {
-          debug(`  skip: "${entry}" — scan failed`);
+      try {
+        const entryStat = await stat(entryPath);
+        if (!entryStat.isDirectory()) {
+          debug(`  skip: "${entry}" — not a directory`);
+          return;
         }
-      }),
-    ),
-  );
+      } catch {
+        debug(`  skip: "${entry}" — stat failed`);
+        return;
+      }
 
-  const skills = results.filter((skill): skill is SkillInfo => skill != null);
+      const skillMdPath = join(entryPath, "SKILL.md");
+      let content: string;
+      try {
+        content = await readFile(skillMdPath, "utf-8");
+      } catch {
+        debug(`  skip: "${entry}" — no SKILL.md`);
+        return;
+      }
+
+      const fm = parseFrontmatter(content);
+
+      let isSymlink = false;
+      let symlinkTarget: string | null = null;
+      try {
+        const lstats = await lstat(entryPath);
+        if (lstats.isSymbolicLink()) {
+          isSymlink = true;
+          symlinkTarget = await readlink(entryPath);
+        }
+      } catch {
+        // not a symlink
+      }
+
+      const resolvedPath = resolve(entryPath);
+      let resolvedRealPath: string;
+      try {
+        resolvedRealPath = await realpath(entryPath);
+      } catch {
+        resolvedRealPath = resolvedPath;
+      }
+
+      return {
+        name: fm.name || entry,
+        version: resolveVersion(fm),
+        description: (fm.description || "").replace(/\s*\n\s*/g, " ").trim(),
+        creator: fm["metadata.creator"] || "",
+        license: (fm.license || "").trim(),
+        compatibility: (fm.compatibility || "").trim(),
+        allowedTools: resolveAllowedTools(fm),
+        effort: fm.effort || fm["metadata.effort"] || undefined,
+        dirName: entry,
+        path: resolvedPath,
+        originalPath: entryPath,
+        location: loc.location,
+        scope: loc.scope,
+        provider: loc.providerName,
+        providerLabel: loc.providerLabel,
+        isSymlink,
+        symlinkTarget,
+        realPath: resolvedRealPath,
+        tokenCount: estimateTokenCount(content),
+      };
+    } catch {
+      debug(`  skip: "${entry}" — scan failed`);
+      return;
+    }
+  });
+
   debug(`found ${skills.length} skill(s) in ${loc.dir}`);
   return skills;
 }
@@ -663,9 +754,10 @@ export async function scanAllSkills(
 ): Promise<SkillInfo[]> {
   const locations = buildScanLocations(config, scope);
   const isGlobal = scope === "global" || scope === "both";
+  const scheduler = createScanEntryScheduler();
 
   const [providerResults, pluginSkills, codexPluginSkills] = await Promise.all([
-    Promise.all(locations.map(scanDirectory)),
+    Promise.all(locations.map((location) => scanDirectory(location, scheduler))),
     isGlobal
       ? scanPluginMarketplaces(pluginBaseDir)
       : Promise.resolve([] as SkillInfo[]),

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -48,6 +48,48 @@ interface ScanLocation {
   providerLabel: string;
 }
 
+const SCAN_ENTRY_CONCURRENCY = 16;
+const pendingScanEntries: Array<() => void> = [];
+let pendingScanEntryIndex = 0;
+let activeScanEntries = 0;
+
+function drainScanEntries(): void {
+  while (
+    activeScanEntries < SCAN_ENTRY_CONCURRENCY &&
+    pendingScanEntryIndex < pendingScanEntries.length
+  ) {
+    const start = pendingScanEntries[pendingScanEntryIndex++];
+    activeScanEntries++;
+    start();
+  }
+
+  if (pendingScanEntryIndex === pendingScanEntries.length) {
+    pendingScanEntries.length = 0;
+    pendingScanEntryIndex = 0;
+  } else if (
+    pendingScanEntryIndex >= 1024 &&
+    pendingScanEntryIndex * 2 >= pendingScanEntries.length
+  ) {
+    pendingScanEntries.splice(0, pendingScanEntryIndex);
+    pendingScanEntryIndex = 0;
+  }
+}
+
+function withScanEntryLimit<T>(task: () => Promise<T>): Promise<T> {
+  return new Promise<T>((resolveTask, rejectTask) => {
+    pendingScanEntries.push(() => {
+      const completed = Promise.resolve()
+        .then(task)
+        .finally(() => {
+          activeScanEntries--;
+          drainScanEntries();
+        });
+      void completed.then(resolveTask, rejectTask);
+    });
+    drainScanEntries();
+  });
+}
+
 function buildScanLocations(config: AppConfig, scope: Scope): ScanLocation[] {
   const locations: ScanLocation[] = [];
 
@@ -111,8 +153,6 @@ export async function countFiles(dir: string): Promise<number> {
 }
 
 async function scanDirectory(loc: ScanLocation): Promise<SkillInfo[]> {
-  const skills: SkillInfo[] = [];
-
   debug(`scanning: ${loc.dir} (${loc.location})`);
 
   let entries: string[];
@@ -120,77 +160,89 @@ async function scanDirectory(loc: ScanLocation): Promise<SkillInfo[]> {
     entries = await readdir(loc.dir);
   } catch {
     debug(`scanning: ${loc.dir} — not found, skipping`);
-    return skills;
+    return [];
   }
 
-  for (const entry of entries) {
-    const entryPath = join(loc.dir, entry);
+  const results = new Array<SkillInfo | undefined>(entries.length);
+  await Promise.all(
+    entries.map((entry, index) =>
+      withScanEntryLimit(async () => {
+        try {
+          const entryPath = join(loc.dir, entry);
 
-    try {
-      const entryStat = await stat(entryPath);
-      if (!entryStat.isDirectory()) {
-        debug(`  skip: "${entry}" — not a directory`);
-        continue;
-      }
-    } catch {
-      debug(`  skip: "${entry}" — stat failed`);
-      continue;
-    }
+          try {
+            const entryStat = await stat(entryPath);
+            if (!entryStat.isDirectory()) {
+              debug(`  skip: "${entry}" — not a directory`);
+              return;
+            }
+          } catch {
+            debug(`  skip: "${entry}" — stat failed`);
+            return;
+          }
 
-    const skillMdPath = join(entryPath, "SKILL.md");
-    let content: string;
-    try {
-      content = await readFile(skillMdPath, "utf-8");
-    } catch {
-      debug(`  skip: "${entry}" — no SKILL.md`);
-      continue;
-    }
+          const skillMdPath = join(entryPath, "SKILL.md");
+          let content: string;
+          try {
+            content = await readFile(skillMdPath, "utf-8");
+          } catch {
+            debug(`  skip: "${entry}" — no SKILL.md`);
+            return;
+          }
 
-    const fm = parseFrontmatter(content);
+          const fm = parseFrontmatter(content);
 
-    let isSymlink = false;
-    let symlinkTarget: string | null = null;
-    try {
-      const lstats = await lstat(entryPath);
-      if (lstats.isSymbolicLink()) {
-        isSymlink = true;
-        symlinkTarget = await readlink(entryPath);
-      }
-    } catch {
-      // not a symlink
-    }
+          let isSymlink = false;
+          let symlinkTarget: string | null = null;
+          try {
+            const lstats = await lstat(entryPath);
+            if (lstats.isSymbolicLink()) {
+              isSymlink = true;
+              symlinkTarget = await readlink(entryPath);
+            }
+          } catch {
+            // not a symlink
+          }
 
-    const resolvedPath = resolve(entryPath);
-    let resolvedRealPath: string;
-    try {
-      resolvedRealPath = await realpath(entryPath);
-    } catch {
-      resolvedRealPath = resolvedPath;
-    }
+          const resolvedPath = resolve(entryPath);
+          let resolvedRealPath: string;
+          try {
+            resolvedRealPath = await realpath(entryPath);
+          } catch {
+            resolvedRealPath = resolvedPath;
+          }
 
-    skills.push({
-      name: fm.name || entry,
-      version: resolveVersion(fm),
-      description: (fm.description || "").replace(/\s*\n\s*/g, " ").trim(),
-      creator: fm["metadata.creator"] || "",
-      license: (fm.license || "").trim(),
-      compatibility: (fm.compatibility || "").trim(),
-      allowedTools: resolveAllowedTools(fm),
-      effort: fm.effort || fm["metadata.effort"] || undefined,
-      dirName: entry,
-      path: resolvedPath,
-      originalPath: entryPath,
-      location: loc.location,
-      scope: loc.scope,
-      provider: loc.providerName,
-      providerLabel: loc.providerLabel,
-      isSymlink,
-      symlinkTarget,
-      realPath: resolvedRealPath,
-      tokenCount: estimateTokenCount(content),
-    });
-  }
+          results[index] = {
+            name: fm.name || entry,
+            version: resolveVersion(fm),
+            description: (fm.description || "")
+              .replace(/\s*\n\s*/g, " ")
+              .trim(),
+            creator: fm["metadata.creator"] || "",
+            license: (fm.license || "").trim(),
+            compatibility: (fm.compatibility || "").trim(),
+            allowedTools: resolveAllowedTools(fm),
+            effort: fm.effort || fm["metadata.effort"] || undefined,
+            dirName: entry,
+            path: resolvedPath,
+            originalPath: entryPath,
+            location: loc.location,
+            scope: loc.scope,
+            provider: loc.providerName,
+            providerLabel: loc.providerLabel,
+            isSymlink,
+            symlinkTarget,
+            realPath: resolvedRealPath,
+            tokenCount: estimateTokenCount(content),
+          };
+        } catch {
+          debug(`  skip: "${entry}" — scan failed`);
+        }
+      }),
+    ),
+  );
 
+  const skills = results.filter((skill): skill is SkillInfo => skill != null);
   debug(`found ${skills.length} skill(s) in ${loc.dir}`);
   return skills;
 }


### PR DESCRIPTION
Closes #365

## Summary

Parallelizes per-entry skill scanning through a process-wide, bounded FIFO limiter while preserving filesystem entry order, provider precedence, deduplication, and fail-soft behavior. The scanner now overlaps entry I/O without allowing concurrent locations or overlapping TUI/CLI scans to exceed 16 active entry pipelines.

## Approach

Option 2 — **Process-wide bounded ordered scanner**: schedule each directory entry through a shared dependency-free limiter, store each result at its original `readdir` index, and compact results only after all entry tasks settle.

## Decision Record

- **Root cause:** `scanDirectory` awaited each entry's filesystem pipeline serially, so every `stat`, `SKILL.md` read, symlink check, and `realpath` completed before the next skill began even though those operations are independent.
- **Options considered:** Option 1 — unbounded per-directory parallelism; Option 2 — process-wide bounded ordered scanner; Option 3 — shared concurrency framework refactor
- **Options rejected:** Option 1 — unbounded `Promise.all` cannot satisfy descriptor safety; Option 3 — migrating evaluator and updater pools broadens scope and regression risk without improving this scanner fix.
- **Selected option:** Option 2 — process-wide bounded ordered scanner
- **Residual risk:** A large inventory can occupy the FIFO queue ahead of later scans; this may affect fairness, but not ordering, correctness, or the process-wide resource bound. Controlled-latency benchmarking exceeded the target, while near-zero-latency cached local filesystems measured 2.65–2.93×.

Analyzed at: `refactor/365-parallelize-per-entry-skill @ 6b83c60` (2026-08-09)

## Changes

| File | Change |
|------|--------|
| `src/scanner.ts` | Add a process-wide 16-entry FIFO limiter and index-preserving concurrent directory scanning. |
| `src/scanner.test.ts` | Add deterministic concurrency, aggregate-cap, ordering/dedup, failure-isolation, and 2,048-skill stress coverage. |

## Test Results

- Unit tests: 1,978 passed (`src/` and `website-src/`)
- Integration tests: skipped (no separate integration suite required for the scanner-only change)
- E2e tests: 141 passed, 3 skipped
- Build: passed
- Typecheck: passed
- Scanner tests: 89 passed, including 5 new regression tests
- Benchmark: 200 generated skills, 5 warmups and 30 alternating runs with controlled 1 ms async filesystem latency — sequential median 1022.486 ms, parallel median 74.074 ms, **13.80× faster**, with identical 200-skill result signatures
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `asm list` scan phase on a 200-skill inventory is at least 3× faster than baseline | pass | Controlled scan-only benchmark: 1022.486 ms sequential vs 74.074 ms parallel median (**13.80×**); native cached-FS results were 2.65–2.93× and are recorded as environment-sensitive context. |
| Discovered skills, ordering, and dedup results are identical to the sequential implementation | pass | `scanAllSkills > preserves readdir and provider order despite out-of-order completion`; benchmark signatures were identical for all 200 skills. |
| Scanner test suite passes; no file-descriptor exhaustion on very large inventories | pass | All 89 scanner tests passed; `scanAllSkills > shares one concurrency cap across overlapping scans and locations` proves aggregate max 16, and `scanAllSkills > scans a very large inventory without descriptor exhaustion` passed with 2,048 skills. |
