### PR TITLE
perf(health): reuse scanned SKILL.md content (#366)

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -719,6 +719,9 @@ describe("CLI integration: list", () => {
       expect(data[0]).toHaveProperty("version");
       expect(data[0]).toHaveProperty("path");
     }
+    for (const skill of data) {
+      expect(skill).not.toHaveProperty("_skillMdContent");
+    }
   });
 
   test("--scope global filters to global only", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -896,9 +896,11 @@ ${ansi.bold("Examples:")}
 // ─── Command Handlers ───────────────────────────────────────────────────────
 
 async function enrichWithHealth(skills: SkillInfo[]): Promise<void> {
-  for (const skill of skills) {
-    skill.warnings = await checkHealth(skill);
-  }
+  await Promise.all(
+    skills.map(async (skill) => {
+      skill.warnings = await checkHealth(skill);
+    }),
+  );
 }
 
 async function cmdList(args: ParsedArgs) {

--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -60,6 +60,78 @@ This skill does something useful.
     expect(warnings).toHaveLength(0);
   });
 
+  it("uses cached scanner content without reading SKILL.md from disk", async () => {
+    const skill = makeSkill({
+      path: join(tempDir, "missing-skill"),
+      _skillMdContent: `---
+name: test-skill
+version: 1.0.0
+description: A test skill
+---
+
+Cached body content.
+`,
+    });
+
+    await expect(checkHealth(skill)).resolves.toEqual([]);
+  });
+
+  it("treats empty cached content as present instead of falling back to disk", async () => {
+    await writeFile(
+      join(tempDir, "SKILL.md"),
+      `---
+name: test-skill
+version: 1.0.0
+description: A test skill
+---
+
+Healthy disk body.
+`,
+    );
+    const skill = makeSkill({ path: tempDir, _skillMdContent: "" });
+
+    await expect(checkHealth(skill)).resolves.toEqual([
+      {
+        category: "empty-body",
+        message: "SKILL.md contains only frontmatter with no body content",
+      },
+    ]);
+  });
+
+  it("produces identical warnings from cached content and disk fallback", async () => {
+    const content = `---
+name: test-skill
+description: Invalid: unquoted value
+---
+`;
+    await writeFile(join(tempDir, "SKILL.md"), content);
+    const overrides = {
+      description: "",
+      version: "0.0.0",
+      fileCount: 600,
+    };
+
+    const diskWarnings = await checkHealth(
+      makeSkill({ path: tempDir, ...overrides }),
+    );
+    const cachedWarnings = await checkHealth(
+      makeSkill({
+        path: join(tempDir, "missing-skill"),
+        _skillMdContent: content,
+        ...overrides,
+      }),
+    );
+
+    expect(cachedWarnings).toEqual(diskWarnings);
+    expect(cachedWarnings.map((warning) => warning.category)).toEqual([
+      "missing-description",
+      "missing-version",
+      "empty-body",
+      "invalid-yaml",
+      "high-file-count",
+    ]);
+  });
+
   it("warns on missing description", async () => {
     await writeFile(
       join(tempDir, "SKILL.md"),

--- a/src/health.ts
+++ b/src/health.ts
@@ -71,10 +71,12 @@ export async function checkHealth(skill: SkillInfo): Promise<SkillWarning[]> {
     });
   }
 
-  // Check SKILL.md content
+  // Check SKILL.md content, reusing the scanner's read when available.
   try {
-    const skillMdPath = join(skill.path, "SKILL.md");
-    const content = await readFile(skillMdPath, "utf-8");
+    const content =
+      skill._skillMdContent !== undefined
+        ? skill._skillMdContent
+        : await readFile(join(skill.path, "SKILL.md"), "utf-8");
     if (!hasBody(content)) {
       warnings.push({
         category: "empty-body",

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -444,10 +444,9 @@ describe("scanAllSkills", () => {
     // Create a fake skill directory
     const skillDir = join(tempDir, "my-skill");
     await mkdir(skillDir, { recursive: true });
-    await writeFile(
-      join(skillDir, "SKILL.md"),
-      "---\nname: My Skill\nversion: 1.0.0\ndescription: A test\n---\nBody",
-    );
+    const skillMdContent =
+      "---\nname: My Skill\nversion: 1.0.0\ndescription: A test\n---\nBody";
+    await writeFile(join(skillDir, "SKILL.md"), skillMdContent);
 
     const config = {
       ...getDefaultConfig(),
@@ -470,6 +469,8 @@ describe("scanAllSkills", () => {
     expect(found!.scope).toBe("global");
     expect(found!.provider).toBe("test");
     expect(found!.isSymlink).toBe(false);
+    expect(found!._skillMdContent).toBe(skillMdContent);
+    expect(JSON.stringify(found)).not.toContain("_skillMdContent");
     // Issue #188: scanner populates tokenCount for installed skills.
     expect(typeof found!.tokenCount).toBe("number");
     expect(found!.tokenCount!).toBeGreaterThan(0);
@@ -660,10 +661,7 @@ describe("scanAllSkills", () => {
     }
     await createSkills(laterRoot, ["responsive"]);
 
-    const stalledScan = scanAllSkills(
-      makeScanConfig(stalledRoots),
-      "project",
-    );
+    const stalledScan = scanAllSkills(makeScanConfig(stalledRoots), "project");
     let laterScan: Promise<SkillInfo[]> | undefined;
     let laterFinished = false;
 
@@ -881,10 +879,9 @@ describe("scanPluginMarketplaces", () => {
     // ~/.claude/plugins/marketplaces/my-marketplace/skills/my-skill/SKILL.md
     const skillDir = join(tempDir, "my-marketplace", "skills", "my-skill");
     await mkdir(skillDir, { recursive: true });
-    await writeFile(
-      join(skillDir, "SKILL.md"),
-      "---\nname: My Skill\nversion: 1.2.0\ndescription: A user-installed skill\n---\nBody",
-    );
+    const skillMdContent =
+      "---\nname: My Skill\nversion: 1.2.0\ndescription: A user-installed skill\n---\nBody";
+    await writeFile(join(skillDir, "SKILL.md"), skillMdContent);
 
     const skills = await scanPluginMarketplaces(tempDir);
     expect(skills).toHaveLength(1);
@@ -897,6 +894,8 @@ describe("scanPluginMarketplaces", () => {
     expect(skill.scope).toBe("global");
     expect(skill.location).toBe("global-plugin-my-marketplace");
     expect(skill.dirName).toBe("my-skill");
+    expect(skill._skillMdContent).toBe(skillMdContent);
+    expect(JSON.stringify(skill)).not.toContain("_skillMdContent");
     // Issue #188: scanPluginMarketplaces populates tokenCount for plugin
     // marketplace skills, matching the parallel scanDirectory codepath so
     // users with Claude plugin-marketplace skills also see Est. Tokens.

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -247,6 +247,15 @@ export async function countFiles(dir: string): Promise<number> {
   }
 }
 
+/** Retain scanned content without exposing it through JSON output. */
+function cacheSkillMdContent(skill: SkillInfo, content: string): void {
+  Object.defineProperty(skill, "_skillMdContent", {
+    value: content,
+    writable: true,
+    configurable: true,
+  });
+}
+
 async function scanDirectory(
   loc: ScanLocation,
   scheduler: ScanEntryScheduler,
@@ -307,7 +316,7 @@ async function scanDirectory(
         resolvedRealPath = resolvedPath;
       }
 
-      return {
+      const skill: SkillInfo = {
         name: fm.name || entry,
         version: resolveVersion(fm),
         description: (fm.description || "").replace(/\s*\n\s*/g, " ").trim(),
@@ -328,6 +337,8 @@ async function scanDirectory(
         realPath: resolvedRealPath,
         tokenCount: estimateTokenCount(content),
       };
+      cacheSkillMdContent(skill, content);
+      return skill;
     } catch {
       debug(`  skip: "${entry}" — scan failed`);
       return;
@@ -445,7 +456,7 @@ export async function scanPluginMarketplaces(
         resolvedRealPath = resolvedPath;
       }
 
-      skills.push({
+      const skill: SkillInfo = {
         name: fm.name || entry,
         version: resolveVersion(fm),
         description: (fm.description || "").replace(/\s*\n\s*/g, " ").trim(),
@@ -466,7 +477,9 @@ export async function scanPluginMarketplaces(
         realPath: resolvedRealPath,
         marketplace,
         tokenCount: estimateTokenCount(content),
-      });
+      };
+      cacheSkillMdContent(skill, content);
+      skills.push(skill);
     }
   }
 
@@ -757,7 +770,9 @@ export async function scanAllSkills(
   const scheduler = createScanEntryScheduler();
 
   const [providerResults, pluginSkills, codexPluginSkills] = await Promise.all([
-    Promise.all(locations.map((location) => scanDirectory(location, scheduler))),
+    Promise.all(
+      locations.map((location) => scanDirectory(location, scheduler)),
+    ),
     isGlobal
       ? scanPluginMarketplaces(pluginBaseDir)
       : Promise.resolve([] as SkillInfo[]),

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -27,6 +27,11 @@ export interface SkillInfo {
   effort?: string;
   warnings?: SkillWarning[];
   /**
+   * Exact SKILL.md text retained by filesystem scanners for downstream checks.
+   * @internal Consumers should tolerate this cache being absent.
+   */
+  _skillMdContent?: string;
+  /**
    * Estimated token cost for the skill's SKILL.md content.
    * Computed as `words + spaces` (issue #188 heuristic).
    * Always render as `~N tokens` to signal it is an approximation.


### PR DESCRIPTION
Closes #366

## Summary

Reuses the exact `SKILL.md` content already read by filesystem scanners during health checks and runs list health enrichment concurrently. This removes the redundant per-skill read pass while preserving existing warning behavior and keeping the cache out of JSON output.

## Approach

Direct cached-content enrichment (light profile): retain scanned content as an optional, non-enumerable `SkillInfo` property, prefer it in `checkHealth` with a disk fallback for non-scanner callers, and enrich skills concurrently with `Promise.all`.

## Decision Record

- **Root cause:** Filesystem scanners read and parsed each `SKILL.md` but discarded its raw text; `checkHealth` then read the same file again, and `enrichWithHealth` awaited every skill serially.
- **Options considered:** Direct cached-content enrichment — retain exact scanner-read content, preserve fallback compatibility, and parallelize enrichment (light profile; multi-option synthesis skipped).
- **Options rejected:** n/a — trivial change, direct plan (light profile)
- **Selected option:** Direct cached-content enrichment
- **Residual risk:** Retaining raw content increases transient list-process memory in proportion to scanned `SKILL.md` sizes; the cache is non-enumerable and exists only on in-memory skill objects.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `refactor/366-reuse-scanned-skill-md-content-in @ 6b83c60` (2026-08-09)

## Changes

| File | Change |
|------|--------|
| `src/utils/types.ts` | Add the optional internal scanned-content cache to `SkillInfo`. |
| `src/scanner.ts` | Retain exact `SKILL.md` text as a non-enumerable property for filesystem and marketplace scans. |
| `src/health.ts` | Prefer scanner-cached content and retain the existing disk fallback. |
| `src/cli.ts` | Enrich skill health concurrently while preserving result order. |
| `src/health.test.ts` | Cover cache reuse, empty-content presence semantics, fallback behavior, and warning parity. |
| `src/scanner.test.ts` | Verify exact scanner content retention without JSON exposure. |
| `src/cli.test.ts` | Verify internal cached content does not leak into CLI JSON output. |

## Test Results

- Unit tests: 1,906 passed (`src/`; health: 12, CLI: 364)
- Integration/site tests: 70 passed
- E2e tests: 141 passed, 3 skipped
- Typecheck: passed
- Build: passed
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Health enrichment performs no per-skill re-read of SKILL.md files already scanned | pass | `src/scanner.ts:114`, `src/health.ts:77`, and `src/health.test.ts:63` prove cached scanner content is used even without a readable disk file. |
| Health warnings produced are identical to the current implementation | pass | `src/health.test.ts:101` compares disk-fallback and cached-content warnings, including category order and messages. |
| health and cli test suites pass | pass | Final `npm run test:all`: 1,906 source tests passed, including 12 health and 364 CLI tests; typecheck and build also passed. |
