### PR TITLE
perf(version): resolve git commit lazily (#367)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -186,7 +186,7 @@ import {
   loadAllIndices,
 } from "./skill-index";
 import type { SearchFilters } from "./skill-index";
-import { VERSION_STRING } from "./utils/version";
+import { getVersionString } from "./utils/version";
 import { buildShadowingReport } from "./utils/path-shadowing";
 import { parseEditorCommand } from "./utils/editor";
 import {
@@ -564,7 +564,7 @@ function error(msg: string) {
 // ─── Help text ──────────────────────────────────────────────────────────────
 
 function printMainHelp() {
-  console.log(`${ansi.blueBold("agent-skill-manager")} (${ansi.bold("asm")}) ${VERSION_STRING}
+  console.log(`${ansi.blueBold("agent-skill-manager")} (${ansi.bold("asm")}) ${getVersionString()}
 
 Interactive TUI and CLI for managing installed skills for AI coding agents.
 
@@ -6765,7 +6765,7 @@ export async function runCLI(argv: string[]): Promise<void> {
 
   // --version at top level
   if (args.flags.version) {
-    console.log(`asm ${VERSION_STRING}`);
+    console.log(`asm ${getVersionString()}`);
     const report = await buildShadowingReport();
     if (args.flags.verbose && report.resolved) {
       console.log(`  path: ${report.resolved.path}`);

--- a/src/utils/version.test.ts
+++ b/src/utils/version.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const execSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("child_process", () => ({
+  execSync: execSyncMock,
+}));
+
+const originalInjectedCommit = process.env.__ASM_COMMIT__;
+
+describe("version utility", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    execSyncMock.mockReset();
+    delete process.env.__ASM_COMMIT__;
+  });
+
+  afterEach(() => {
+    if (originalInjectedCommit === undefined) {
+      delete process.env.__ASM_COMMIT__;
+    } else {
+      process.env.__ASM_COMMIT__ = originalInjectedCommit;
+    }
+  });
+
+  test("does not resolve git commit when imported", async () => {
+    await import("./version");
+
+    expect(execSyncMock).not.toHaveBeenCalled();
+  });
+
+  test("uses the injected commit without spawning git", async () => {
+    process.env.__ASM_COMMIT__ = "bundled123";
+    const version = await import("./version");
+
+    expect(version.getCommitHash()).toBe("bundled123");
+    expect(version.getVersionString()).toBe(
+      `v${version.VERSION} (bundled123)`,
+    );
+    expect(execSyncMock).not.toHaveBeenCalled();
+  });
+
+  test("resolves git lazily and memoizes the commit", async () => {
+    execSyncMock.mockReturnValue("dev123\n");
+    const version = await import("./version");
+
+    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(version.getCommitHash()).toBe("dev123");
+    expect(version.getVersionString()).toBe(`v${version.VERSION} (dev123)`);
+    expect(version.getCommitHash()).toBe("dev123");
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses unknown when git resolution fails", async () => {
+    execSyncMock.mockImplementation(() => {
+      throw new Error("git unavailable");
+    });
+    const version = await import("./version");
+
+    expect(version.getVersionString()).toBe(`v${version.VERSION} (unknown)`);
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/version.test.ts
+++ b/src/utils/version.test.ts
@@ -34,9 +34,7 @@ describe("version utility", () => {
     const version = await import("./version");
 
     expect(version.getCommitHash()).toBe("bundled123");
-    expect(version.getVersionString()).toBe(
-      `v${version.VERSION} (bundled123)`,
-    );
+    expect(version.getVersionString()).toBe(`v${version.VERSION} (bundled123)`);
     expect(execSyncMock).not.toHaveBeenCalled();
   });
 

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -14,17 +14,35 @@ try {
   // Bundled mode — use build-time injected version
 }
 
-let _commit: string = (process.env.__ASM_COMMIT__ as string) || "unknown";
-try {
-  _commit =
-    execSync("git rev-parse --short HEAD", {
-      encoding: "utf-8",
-      stdio: ["pipe", "pipe", "ignore"],
-    }).trim() || _commit;
-} catch {
-  // Not in a git repo or git not available
-}
+let _commit: string | undefined;
 
 export const VERSION = _version;
-export const COMMIT_HASH = _commit;
-export const VERSION_STRING = `v${VERSION} (${COMMIT_HASH})`;
+
+export function getCommitHash(): string {
+  if (_commit !== undefined) {
+    return _commit;
+  }
+
+  const injectedCommit = process.env.__ASM_COMMIT__;
+  if (injectedCommit !== undefined) {
+    _commit = injectedCommit;
+    return _commit;
+  }
+
+  _commit = "unknown";
+  try {
+    _commit =
+      execSync("git rev-parse --short HEAD", {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "ignore"],
+      }).trim() || _commit;
+  } catch {
+    // Not in a git repo or git not available
+  }
+
+  return _commit;
+}
+
+export function getVersionString(): string {
+  return `v${VERSION} (${getCommitHash()})`;
+}

--- a/src/views/help.tsx
+++ b/src/views/help.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Text } from "ink";
 import { theme } from "../utils/colors";
-import { VERSION_STRING } from "../utils/version";
+import { getVersionString } from "../utils/version";
 
 const KEYBINDINGS: Array<[string, string]> = [
   ["↑ / k", "Move up"],
@@ -44,7 +44,7 @@ export function HelpView() {
         <Text color={theme.fgDim}>Press ? or Esc to close</Text>
       </Box>
       <Box>
-        <Text color={theme.fgDim}>{VERSION_STRING}</Text>
+        <Text color={theme.fgDim}>{getVersionString()}</Text>
       </Box>
     </Box>
   );


### PR DESCRIPTION
Closes #367

## Summary

Defers git commit resolution until version text is actually requested and prefers the build-injected commit without spawning git. Development builds retain the existing git fallback and output format, with the lookup memoized after its first use.

## Approach

Lazy commit accessors (light profile): replace eager module-level commit/version-string constants with accessor functions, update internal display call sites, and add focused bundled/dev regression coverage.

## Decision Record

- **Root cause:** `src/utils/version.ts` initialized commit metadata by unconditionally invoking `git rev-parse --short HEAD` during module evaluation, even when `scripts/build.ts` had already injected a commit, adding startup cost and overwriting the build value.
- **Options considered:** Lazy commit accessors — prefer the injected commit and defer a memoized git fallback until version display is requested.
- **Options rejected:** n/a — trivial change, direct plan (light profile)
- **Selected option:** Lazy commit accessors
- **Residual risk:** Internal callers must use the accessor rather than an eager string constant; all current consumers were migrated and typechecking guards against stale imports.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `refactor/367-skip-git-execsync-at-cli-startup @ 6b83c60` (2026-08-09)

## Changes

| File | Change |
|------|--------|
| `src/utils/version.ts` | Add lazy, memoized commit and version-string accessors that prefer build injection. |
| `src/cli.ts` | Resolve version text only when help or version output is requested. |
| `src/views/help.tsx` | Resolve version text when the help view renders. |
| `src/utils/version.test.ts` | Cover import laziness, injected commits, dev fallback memoization, and git failure. |

## Test Results

- Unit/source tests: 1,907 passed
- Website tests: 70 passed
- E2e tests: 141 passed, 3 skipped
- Typecheck: passed
- Build: passed
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Bundled builds start without spawning git | pass | `src/utils/version.test.ts` — `does not resolve git commit when imported` and `uses the injected commit without spawning git`. |
| Version/commit output is unchanged in both bundled and dev contexts | pass | `src/utils/version.test.ts` — injected, lazy git, memoization, and `unknown` fallback assertions preserve `v<version> (<commit>)`; existing CLI and e2e version tests pass. |
| Existing tests pass | pass | Final `npm run test:all`: 1,907 source, 70 website, and 141 e2e tests passed (3 e2e skipped); build and typecheck passed. |
