### PR TITLE
perf(updater): avoid duplicate commit resolution (#368)

### DIFF
--- a/src/updater.test.ts
+++ b/src/updater.test.ts
@@ -878,7 +878,9 @@ async function createBareGitRepo(
   const bareDir = join(parentDir, `${repoName}.git`);
 
   await mkdir(workDir, { recursive: true });
-  await exec("git", ["init", "--object-format=sha1", workDir]);
+  await exec("git", ["init", workDir], {
+    env: { ...process.env, GIT_DEFAULT_HASH: "sha1" },
+  });
   await exec("git", ["-C", workDir, "config", "user.email", "test@test.com"]);
   await exec("git", ["-C", workDir, "config", "user.name", "Test"]);
   await writeFile(join(workDir, "skill.md"), content);

--- a/src/updater.test.ts
+++ b/src/updater.test.ts
@@ -527,6 +527,71 @@ describe("getLatestRemoteCommit", () => {
       await rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  test("prefers a short branch ref over an ambiguous annotated tag", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "asm-ambiguous-ref-"));
+    try {
+      const { execFile } = await import("child_process");
+      const { promisify } = await import("util");
+      const exec = promisify(execFile);
+      const { bareRepoPath, commitHash: branchCommit } =
+        await createBareGitRepo(tempDir, "ambiguous-skill", "# Branch");
+      const workDir = join(tempDir, "ambiguous-skill-work");
+
+      await writeFile(join(workDir, "skill.md"), "# Tag\n");
+      await exec("git", ["-C", workDir, "add", "skill.md"]);
+      await exec("git", ["-C", workDir, "commit", "-m", "tag target"]);
+      const { stdout } = await exec("git", [
+        "-C",
+        workDir,
+        "rev-parse",
+        "HEAD",
+      ]);
+      const tagCommit = stdout.trim();
+      await exec("git", [
+        "-C",
+        workDir,
+        "push",
+        `file://${bareRepoPath}`,
+        "HEAD:refs/heads/tag-target",
+      ]);
+      await exec("git", [
+        `--git-dir=${bareRepoPath}`,
+        "update-ref",
+        "refs/heads/shared",
+        branchCommit,
+      ]);
+      await exec("git", [
+        `--git-dir=${bareRepoPath}`,
+        "config",
+        "user.email",
+        "test@test.com",
+      ]);
+      await exec("git", [
+        `--git-dir=${bareRepoPath}`,
+        "config",
+        "user.name",
+        "Test",
+      ]);
+      await exec("git", [
+        `--git-dir=${bareRepoPath}`,
+        "tag",
+        "-a",
+        "shared",
+        tagCommit,
+        "-m",
+        "shared tag",
+      ]);
+
+      const repoUrl = `file://${bareRepoPath}`;
+      expect(await getLatestRemoteCommit(repoUrl, "shared")).toBe(branchCommit);
+      expect(
+        await getLatestRemoteCommit(repoUrl, "refs/tags/shared"),
+      ).toBe(tagCommit);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ─── checkOutdated (pure logic paths) ─────────────────────────────────────
@@ -903,7 +968,7 @@ describe("updateSkill happy path", () => {
     expect(installedContent).toContain("New version");
   });
 
-  test("installs and locks the exact known commit", async () => {
+  test("installs and locks the exact known commit despite a stale OID ref", async () => {
     const { bareRepoPath, commitHash: knownCommit } = await createBareGitRepo(
       tempDir,
       "pinned-skill",
@@ -915,11 +980,13 @@ describe("updateSkill happy path", () => {
     await writeFile(join(installedDir, "skill.md"), "# Old version");
 
     let writtenCommit: string | undefined;
+    const oldCommit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const { updateSkill } = await import("./updater");
     const entry: LockEntry = {
       source: `file://${bareRepoPath}`,
-      commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      ref: null,
+      commitHash: oldCommit,
+      // Registry locks retain the previously installed OID here; it is not a branch.
+      ref: oldCommit,
       installedAt: "2026-01-01T00:00:00.000Z",
       provider: "claude",
       sourceType: "github",

--- a/src/updater.test.ts
+++ b/src/updater.test.ts
@@ -878,7 +878,7 @@ async function createBareGitRepo(
   const bareDir = join(parentDir, `${repoName}.git`);
 
   await mkdir(workDir, { recursive: true });
-  await exec("git", ["init", workDir]);
+  await exec("git", ["init", "--object-format=sha1", workDir]);
   await exec("git", ["-C", workDir, "config", "user.email", "test@test.com"]);
   await exec("git", ["-C", workDir, "config", "user.name", "Test"]);
   await writeFile(join(workDir, "skill.md"), content);
@@ -1019,6 +1019,59 @@ describe("updateSkill happy path", () => {
     expect(await readFile(join(installedDir, "skill.md"), "utf-8")).toBe(
       "# Pinned version\nExact content",
     );
+  });
+
+  test("fetches a SHA-1 known commit when GIT_DEFAULT_HASH requests SHA-256", async () => {
+    const { bareRepoPath, commitHash: knownCommit } = await createBareGitRepo(
+      tempDir,
+      "sha1-pinned-skill",
+      "# SHA-1 pinned version",
+    );
+    expect(knownCommit).toMatch(/^[0-9a-f]{40}$/);
+
+    const skillsDir = join(tempDir, "sha1-pinned-skills");
+    const installedDir = join(skillsDir, "sha1-pinned-skill");
+    await mkdir(installedDir, { recursive: true });
+    await writeFile(join(installedDir, "skill.md"), "# Old version");
+
+    const { updateSkill } = await import("./updater");
+    const entry: LockEntry = {
+      source: `file://${bareRepoPath}`,
+      commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ref: null,
+      installedAt: "2026-01-01T00:00:00.000Z",
+      provider: "claude",
+      sourceType: "github",
+    };
+    const previousDefaultHash = process.env.GIT_DEFAULT_HASH;
+    process.env.GIT_DEFAULT_HASH = "sha256";
+
+    try {
+      const result = await updateSkill(
+        "sha1-pinned-skill",
+        entry,
+        false,
+        {
+          auditFn: async () => ({ verdict: "safe" }),
+          loadConfigFn: async () =>
+            ({ providers: [{ name: "claude", global: skillsDir }] }) as any,
+          resolveProviderPathFn: (p: string) => p,
+          writeLockEntryFn: async () => {},
+        },
+        knownCommit,
+      );
+
+      expect(result.status).toBe("updated");
+      expect(await readFile(join(installedDir, "skill.md"), "utf-8")).toBe(
+        "# SHA-1 pinned version",
+      );
+    } finally {
+      if (previousDefaultHash === undefined) {
+        delete process.env.GIT_DEFAULT_HASH;
+      } else {
+        process.env.GIT_DEFAULT_HASH = previousDefaultHash;
+      }
+    }
   });
 
   test("does not mutate the installation when the known commit is unavailable", async () => {

--- a/src/updater.test.ts
+++ b/src/updater.test.ts
@@ -585,9 +585,9 @@ describe("getLatestRemoteCommit", () => {
 
       const repoUrl = `file://${bareRepoPath}`;
       expect(await getLatestRemoteCommit(repoUrl, "shared")).toBe(branchCommit);
-      expect(
-        await getLatestRemoteCommit(repoUrl, "refs/tags/shared"),
-      ).toBe(tagCommit);
+      expect(await getLatestRemoteCommit(repoUrl, "refs/tags/shared")).toBe(
+        tagCommit,
+      );
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }

--- a/src/updater.test.ts
+++ b/src/updater.test.ts
@@ -418,6 +418,57 @@ describe("updateSkill", () => {
     expect(result.status).toBe("failed");
     expect(result.reason).toContain("Clone failed");
   });
+
+  test("skips a known current commit before cloning", async () => {
+    const { updateSkill } = await import("./updater");
+    const commitHash = "abcdef0123456789abcdef0123456789abcdef01";
+    const entry: LockEntry = {
+      source: "file:///path/that/does/not/exist.git",
+      commitHash,
+      ref: "main",
+      installedAt: "2026-01-01T00:00:00.000Z",
+      provider: "claude",
+      sourceType: "github",
+    };
+
+    const result = await updateSkill(
+      "current-skill",
+      entry,
+      false,
+      undefined,
+      commitHash,
+    );
+    expect(result).toEqual({
+      name: "current-skill",
+      status: "skipped",
+      reason: "Already up to date",
+    });
+  });
+
+  test("rejects an invalid known commit without cloning", async () => {
+    const { updateSkill } = await import("./updater");
+    const entry: LockEntry = {
+      source: "file:///path/that/does/not/exist.git",
+      commitHash: "abcdef0123456789abcdef0123456789abcdef01",
+      ref: "main",
+      installedAt: "2026-01-01T00:00:00.000Z",
+      provider: "claude",
+      sourceType: "github",
+    };
+
+    const result = await updateSkill(
+      "invalid-commit-skill",
+      entry,
+      false,
+      undefined,
+      "not-a-full-oid",
+    );
+    expect(result).toEqual({
+      name: "invalid-commit-skill",
+      status: "failed",
+      reason: "Invalid known commit OID",
+    });
+  });
 });
 
 // ─── getLatestRemoteCommit ────────────────────────────────────────────────
@@ -434,6 +485,47 @@ describe("getLatestRemoteCommit", () => {
   test("returns null for invalid URL", async () => {
     const result = await getLatestRemoteCommit("not-a-url", null);
     expect(result).toBeNull();
+  });
+
+  test("resolves an annotated tag to its commit OID", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "asm-tag-resolution-"));
+    try {
+      const { execFile } = await import("child_process");
+      const { promisify } = await import("util");
+      const exec = promisify(execFile);
+      const { bareRepoPath, commitHash } = await createBareGitRepo(
+        tempDir,
+        "tagged-skill",
+        "# Tagged version",
+      );
+      await exec("git", [
+        `--git-dir=${bareRepoPath}`,
+        "config",
+        "user.email",
+        "test@test.com",
+      ]);
+      await exec("git", [
+        `--git-dir=${bareRepoPath}`,
+        "config",
+        "user.name",
+        "Test",
+      ]);
+      await exec("git", [
+        `--git-dir=${bareRepoPath}`,
+        "tag",
+        "-a",
+        "v1",
+        commitHash,
+        "-m",
+        "version 1",
+      ]);
+
+      expect(await getLatestRemoteCommit(`file://${bareRepoPath}`, "v1")).toBe(
+        commitHash,
+      );
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -616,6 +708,55 @@ describe("checkOutdated with injectable overrides", () => {
     expect(summary.outdatedCount).toBe(1);
   });
 
+  test("keeps the resolved full OID out of public outdated output", async () => {
+    const installedHash = "a1b2c3d4e5f6789012345678901234567890abcd";
+    const latestHash = "f9e8d7c6b5a4321098765432109876543210fedc";
+
+    const { checkOutdated } = await import("./updater");
+    const summary = await checkOutdated({
+      readLockFn: async () => ({
+        version: 1,
+        skills: {
+          "code-review": {
+            source: "github:user/code-review",
+            commitHash: installedHash,
+            ref: "main",
+            installedAt: "2026-01-01T00:00:00.000Z",
+            provider: "claude",
+            sourceType: "registry",
+            registryName: "code-review",
+          },
+        },
+      }),
+      fetchRegistryIndexFn: async () =>
+        ({
+          manifests: [
+            {
+              name: "code-review",
+              commit: latestHash,
+              repo: "user/code-review",
+            },
+          ],
+        }) as any,
+    });
+
+    expect(summary.entries[0]).toEqual({
+      name: "code-review",
+      installedCommit: shortHash(installedHash),
+      latestCommit: shortHash(latestHash),
+      source: "github:user/code-review",
+      sourceType: "registry",
+      status: "outdated",
+    });
+    expect(JSON.parse(formatOutdatedJSON(summary)).skills[0]).toEqual({
+      name: "code-review",
+      installed: shortHash(installedHash),
+      latest: shortHash(latestHash),
+      source: "registry",
+      status: "outdated",
+    });
+  });
+
   test("reports registry skill as up-to-date when commit matches manifest", async () => {
     const commitHash = "a1b2c3d4e5f6789012345678901234567890abcd";
 
@@ -760,6 +901,106 @@ describe("updateSkill happy path", () => {
       "utf-8",
     );
     expect(installedContent).toContain("New version");
+  });
+
+  test("installs and locks the exact known commit", async () => {
+    const { bareRepoPath, commitHash: knownCommit } = await createBareGitRepo(
+      tempDir,
+      "pinned-skill",
+      "# Pinned version\nExact content",
+    );
+    const skillsDir = join(tempDir, "pinned-skills");
+    const installedDir = join(skillsDir, "pinned-skill");
+    await mkdir(installedDir, { recursive: true });
+    await writeFile(join(installedDir, "skill.md"), "# Old version");
+
+    let writtenCommit: string | undefined;
+    const { updateSkill } = await import("./updater");
+    const entry: LockEntry = {
+      source: `file://${bareRepoPath}`,
+      commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ref: null,
+      installedAt: "2026-01-01T00:00:00.000Z",
+      provider: "claude",
+      sourceType: "github",
+    };
+
+    const result = await updateSkill(
+      "pinned-skill",
+      entry,
+      false,
+      {
+        auditFn: async () => ({ verdict: "safe" }),
+        loadConfigFn: async () =>
+          ({ providers: [{ name: "claude", global: skillsDir }] }) as any,
+        resolveProviderPathFn: (p: string) => p,
+        writeLockEntryFn: async (_name: string, lockEntry: LockEntry) => {
+          writtenCommit = lockEntry.commitHash;
+        },
+      },
+      knownCommit.toUpperCase(),
+    );
+
+    expect(result).toEqual({
+      name: "pinned-skill",
+      status: "updated",
+      oldCommit: "aaaaaaa",
+      newCommit: shortHash(knownCommit),
+      securityVerdict: "safe",
+    });
+    expect(writtenCommit).toBe(knownCommit);
+    expect(await readFile(join(installedDir, "skill.md"), "utf-8")).toBe(
+      "# Pinned version\nExact content",
+    );
+  });
+
+  test("does not mutate the installation when the known commit is unavailable", async () => {
+    const { bareRepoPath } = await createBareGitRepo(
+      tempDir,
+      "stale-skill",
+      "# Remote version",
+    );
+    const skillsDir = join(tempDir, "stale-skills");
+    const installedDir = join(skillsDir, "stale-skill");
+    const oldContent = "# Installed version\nKeep this";
+    await mkdir(installedDir, { recursive: true });
+    await writeFile(join(installedDir, "skill.md"), oldContent);
+
+    let auditCalls = 0;
+    let lockWrites = 0;
+    const { updateSkill } = await import("./updater");
+    const entry: LockEntry = {
+      source: `file://${bareRepoPath}`,
+      commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ref: null,
+      installedAt: "2026-01-01T00:00:00.000Z",
+      provider: "claude",
+      sourceType: "github",
+    };
+
+    const result = await updateSkill(
+      "stale-skill",
+      entry,
+      false,
+      {
+        auditFn: async () => {
+          auditCalls++;
+          return { verdict: "safe" };
+        },
+        writeLockEntryFn: async () => {
+          lockWrites++;
+        },
+      },
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.reason).toContain("unavailable");
+    expect(auditCalls).toBe(0);
+    expect(lockWrites).toBe(0);
+    expect(await readFile(join(installedDir, "skill.md"), "utf-8")).toBe(
+      oldContent,
+    );
   });
 
   test("updates nested skills from their recorded skillPath and project scope", async () => {
@@ -982,6 +1223,66 @@ describe("updateSkill happy path", () => {
 // ─── updateSkills orchestrator ──────────────────────────────────────────────
 
 describe("updateSkills orchestrator", () => {
+  test("forwards the full OID resolved by checkOutdated", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "asm-update-propagation-"));
+    try {
+      const { bareRepoPath, commitHash: latestCommit } =
+        await createBareGitRepo(
+          tempDir,
+          "propagated-skill",
+          "# Latest version",
+        );
+      const lockEntry: LockEntry = {
+        source: `file://${bareRepoPath}`,
+        commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ref: null,
+        installedAt: "2026-01-01T00:00:00.000Z",
+        provider: "claude",
+        sourceType: "github",
+      };
+      let receivedCommit: string | undefined;
+
+      const summary = await updateSkills(null, false, {
+        readLockFn: async () => ({
+          version: 1,
+          skills: { "propagated-skill": lockEntry },
+        }),
+        updateSkillFn: async (
+          name,
+          _entry,
+          _skipConfirm,
+          _overrides,
+          knownLatestCommit,
+        ) => {
+          receivedCommit = knownLatestCommit;
+          return {
+            name,
+            status: "updated",
+            oldCommit: "aaaaaaa",
+            newCommit: shortHash(knownLatestCommit ?? ""),
+          };
+        },
+      });
+
+      expect(receivedCommit).toBe(latestCommit);
+      expect(summary).toEqual({
+        results: [
+          {
+            name: "propagated-skill",
+            status: "updated",
+            oldCommit: "aaaaaaa",
+            newCommit: shortHash(latestCommit),
+          },
+        ],
+        updatedCount: 1,
+        skippedCount: 0,
+        failedCount: 0,
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("filters only outdated entries for update", async () => {
     const updatedNames: string[] = [];
     const summary = await updateSkills(null, false, {

--- a/src/updater.test.ts
+++ b/src/updater.test.ts
@@ -1023,6 +1023,126 @@ describe("updateSkill happy path", () => {
     );
   });
 
+  test("isolates pinned Git operations from ambient repository routing", async () => {
+    const { execFile } = await import("child_process");
+    const { promisify } = await import("util");
+    const exec = promisify(execFile);
+    const { bareRepoPath, commitHash: knownCommit } = await createBareGitRepo(
+      tempDir,
+      "isolated-pinned-skill",
+      "# Isolated pinned version",
+    );
+
+    const ambientDir = join(tempDir, "ambient-repo");
+    await mkdir(ambientDir, { recursive: true });
+    await exec("git", ["init", ambientDir], {
+      env: { ...process.env, GIT_DEFAULT_HASH: "sha1" },
+    });
+    await exec("git", [
+      "-C",
+      ambientDir,
+      "config",
+      "user.email",
+      "test@test.com",
+    ]);
+    await exec("git", ["-C", ambientDir, "config", "user.name", "Test"]);
+    const sentinelPath = join(ambientDir, "sentinel.txt");
+    const sentinelContent = "ambient repository content\n";
+    await writeFile(sentinelPath, sentinelContent);
+    await exec("git", ["-C", ambientDir, "add", "sentinel.txt"]);
+    await exec("git", ["-C", ambientDir, "commit", "-m", "ambient state"]);
+
+    const ambientHead = (
+      await exec("git", ["-C", ambientDir, "rev-parse", "HEAD"])
+    ).stdout.trim();
+    const ambientBranch = (
+      await exec("git", ["-C", ambientDir, "symbolic-ref", "--short", "HEAD"])
+    ).stdout.trim();
+    const ambientStatus = (
+      await exec("git", [
+        "-C",
+        ambientDir,
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+      ])
+    ).stdout;
+
+    const skillsDir = join(tempDir, "isolated-pinned-skills");
+    const installedDir = join(skillsDir, "isolated-pinned-skill");
+    await mkdir(installedDir, { recursive: true });
+    await writeFile(join(installedDir, "skill.md"), "# Old version");
+
+    const { updateSkill } = await import("./updater");
+    const entry: LockEntry = {
+      source: `file://${bareRepoPath}`,
+      commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ref: null,
+      installedAt: "2026-01-01T00:00:00.000Z",
+      provider: "claude",
+      sourceType: "github",
+    };
+    const routingVariables = ["GIT_DIR", "GIT_WORK_TREE"] as const;
+    const previousValues = new Map(
+      routingVariables.map((variable) => [variable, process.env[variable]]),
+    );
+    let result: Awaited<ReturnType<typeof updateSkill>> | undefined;
+
+    process.env.GIT_DIR = join(ambientDir, ".git");
+    process.env.GIT_WORK_TREE = ambientDir;
+    try {
+      result = await updateSkill(
+        "isolated-pinned-skill",
+        entry,
+        false,
+        {
+          auditFn: async () => ({ verdict: "safe" }),
+          loadConfigFn: async () =>
+            ({ providers: [{ name: "claude", global: skillsDir }] }) as any,
+          resolveProviderPathFn: (p: string) => p,
+          writeLockEntryFn: async () => {},
+        },
+        knownCommit,
+      );
+    } finally {
+      for (const variable of routingVariables) {
+        const previousValue = previousValues.get(variable);
+        if (previousValue === undefined) {
+          delete process.env[variable];
+        } else {
+          process.env[variable] = previousValue;
+        }
+      }
+    }
+
+    expect(result?.status).toBe("updated");
+    expect(await readFile(join(installedDir, "skill.md"), "utf-8")).toBe(
+      "# Isolated pinned version",
+    );
+    expect(
+      (
+        await exec("git", ["-C", ambientDir, "rev-parse", "HEAD"])
+      ).stdout.trim(),
+    ).toBe(ambientHead);
+    expect(
+      (
+        await exec("git", ["-C", ambientDir, "symbolic-ref", "--short", "HEAD"])
+      ).stdout.trim(),
+    ).toBe(ambientBranch);
+    expect(
+      (
+        await exec("git", [
+          "-C",
+          ambientDir,
+          "status",
+          "--porcelain=v1",
+          "--untracked-files=all",
+        ])
+      ).stdout,
+    ).toBe(ambientStatus);
+    expect(await readFile(sentinelPath, "utf-8")).toBe(sentinelContent);
+  });
+
   test("fetches a SHA-1 known commit when GIT_DEFAULT_HASH requests SHA-256", async () => {
     const { bareRepoPath, commitHash: knownCommit } = await createBareGitRepo(
       tempDir,

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -63,6 +63,18 @@ export interface UpdateSummary {
   warnings?: string[];
 }
 
+// Keep resolved OIDs internal so public entries and formatter output retain their
+// existing shape. updateSkills consumes the same entry objects returned below.
+const resolvedLatestCommits = new WeakMap<OutdatedEntry, string>();
+
+function recordResolvedLatestCommit<T extends OutdatedEntry>(
+  entry: T,
+  commit: string,
+): T {
+  resolvedLatestCommits.set(entry, commit);
+  return entry;
+}
+
 // ─── Concurrency Pool ───────────────────────────────────────────────────────
 
 async function poolAll<T, R>(
@@ -101,16 +113,19 @@ export async function getLatestRemoteCommit(
   try {
     const args = ["ls-remote", repoUrl];
     if (ref) {
-      args.push(ref);
+      // Ask for the peeled form too so annotated tags resolve to commits.
+      args.push(ref, `${ref}^{}`);
     } else {
       args.push("HEAD");
     }
 
     const { stdout } = await execFileAsync("git", args, { timeout: 10_000 });
-    const firstLine = stdout.split("\n")[0];
-    if (!firstLine) return null;
-    const hash = firstLine.split(/\s+/)[0];
-    return hash && /^[0-9a-f]{40}$/.test(hash) ? hash : null;
+    const lines = stdout.split("\n").filter(Boolean);
+    const resolvedLine = lines.find((line) =>
+      line.split(/\s+/)[1]?.endsWith("^{}"),
+    );
+    const hash = (resolvedLine ?? lines[0])?.split(/\s+/)[0];
+    return hash && /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(hash) ? hash : null;
   } catch (err) {
     debug(`updater: git ls-remote failed for ${repoUrl}: ${err}`);
     return null;
@@ -253,16 +268,19 @@ export async function checkOutdated(
       );
       if (manifest) {
         const isOutdated = manifest.commit !== entry.commitHash;
-        return {
-          name,
-          installedCommit: shortHash(entry.commitHash),
-          latestCommit: shortHash(manifest.commit),
-          source: entry.source,
-          sourceType,
-          status: isOutdated
-            ? ("outdated" as OutdatedStatus)
-            : ("up-to-date" as OutdatedStatus),
-        };
+        return recordResolvedLatestCommit(
+          {
+            name,
+            installedCommit: shortHash(entry.commitHash),
+            latestCommit: shortHash(manifest.commit),
+            source: entry.source,
+            sourceType,
+            status: isOutdated
+              ? ("outdated" as OutdatedStatus)
+              : ("up-to-date" as OutdatedStatus),
+          },
+          manifest.commit,
+        );
       }
       // Registry skill not found in index — fall through to git ls-remote
     }
@@ -295,16 +313,19 @@ export async function checkOutdated(
     }
 
     const isOutdated = latestCommit !== entry.commitHash;
-    return {
-      name,
-      installedCommit: shortHash(entry.commitHash),
-      latestCommit: shortHash(latestCommit),
-      source: entry.source,
-      sourceType,
-      status: isOutdated
-        ? ("outdated" as OutdatedStatus)
-        : ("up-to-date" as OutdatedStatus),
-    };
+    return recordResolvedLatestCommit(
+      {
+        name,
+        installedCommit: shortHash(entry.commitHash),
+        latestCommit: shortHash(latestCommit),
+        source: entry.source,
+        sourceType,
+        status: isOutdated
+          ? ("outdated" as OutdatedStatus)
+          : ("up-to-date" as OutdatedStatus),
+      },
+      latestCommit,
+    );
   });
 
   return {
@@ -345,12 +366,24 @@ export async function updateSkill(
   entry: LockEntry,
   skipConfirm: boolean,
   _overrides?: _UpdateTestOverrides,
+  knownLatestCommit?: string,
 ): Promise<UpdateResult> {
   const sourceType = resolveSourceType(entry);
 
   // Cannot update local skills
   if (sourceType === "local") {
     return { name, status: "skipped", reason: "Local skill (not updatable)" };
+  }
+
+  let pinnedCommit: string | undefined;
+  if (knownLatestCommit !== undefined) {
+    if (!/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i.test(knownLatestCommit)) {
+      return { name, status: "failed", reason: "Invalid known commit OID" };
+    }
+    pinnedCommit = knownLatestCommit.toLowerCase();
+    if (pinnedCommit === entry.commitHash.toLowerCase()) {
+      return { name, status: "skipped", reason: "Already up to date" };
+    }
   }
 
   // Need a clone URL
@@ -377,9 +410,11 @@ export async function updateSkill(
     );
     await mkdir(tempParent, { recursive: true });
 
-    // Step 1: Clone latest version
+    // Step 1: Clone latest version. When checkOutdated already resolved the
+    // commit, avoid checking out a moving ref until the exact OID is pinned.
     debug(`updater: cloning latest ${name} to ${tempDir}`);
     const cloneArgs = ["clone", "--depth", "1"];
+    if (pinnedCommit) cloneArgs.push("--no-checkout");
     if (entry.ref && entry.ref !== "HEAD") {
       cloneArgs.push("--branch", entry.ref);
     }
@@ -395,14 +430,38 @@ export async function updateSkill(
       };
     }
 
-    // Get the new commit hash
+    if (pinnedCommit) {
+      try {
+        await execFileAsync("git", ["checkout", "--detach", pinnedCommit], {
+          cwd: tempDir,
+          timeout: 10_000,
+        });
+      } catch {
+        return {
+          name,
+          status: "failed",
+          reason: "Resolved commit is unavailable in the shallow clone",
+        };
+      }
+    }
+
+    // Resolve HEAD locally for direct callers, and verify a pinned checkout
+    // before auditing, installing, or recording it.
     let newCommit: string | null = null;
     try {
       const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
         cwd: tempDir,
         timeout: 5_000,
       });
-      newCommit = stdout.trim();
+      const checkedOutCommit = stdout.trim().toLowerCase();
+      if (pinnedCommit && checkedOutCommit !== pinnedCommit) {
+        return {
+          name,
+          status: "failed",
+          reason: "Resolved commit checkout mismatch",
+        };
+      }
+      newCommit = pinnedCommit ?? checkedOutCommit;
     } catch {
       return { name, status: "failed", reason: "Could not read new commit" };
     }
@@ -580,12 +639,6 @@ export async function updateSkills(
   const lock = await readLockFn();
   const outdated = await checkOutdatedFn({ lock });
 
-  // TODO: Optimization opportunity — checkOutdated already queries every remote
-  // via git ls-remote to obtain the latest commit hash. updateSkill then queries
-  // the same remotes again via git clone. We could pass the already-known latest
-  // commit from outdated.entries into updateSkill to skip the redundant network
-  // round-trip (e.g. by adding an optional `knownLatestCommit` parameter).
-
   // Filter to outdated skills only
   let toUpdate = outdated.entries.filter((e) => e.status === "outdated");
 
@@ -630,7 +683,13 @@ export async function updateSkills(
     const lockEntry = lock.skills[entry.name];
     if (!lockEntry) continue;
 
-    const result = await updateSkillFn(entry.name, lockEntry, skipConfirm);
+    const result = await updateSkillFn(
+      entry.name,
+      lockEntry,
+      skipConfirm,
+      undefined,
+      resolvedLatestCommits.get(entry),
+    );
     results.push(result);
   }
 

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -120,12 +120,28 @@ export async function getLatestRemoteCommit(
     }
 
     const { stdout } = await execFileAsync("git", args, { timeout: 10_000 });
-    const lines = stdout.split("\n").filter(Boolean);
-    const resolvedLine = lines.find((line) =>
-      line.split(/\s+/)[1]?.endsWith("^{}"),
+    const advertised = new Map<string, string>();
+    for (const line of stdout.split("\n")) {
+      const [hash, advertisedRef] = line.trim().split(/\s+/);
+      if (
+        advertisedRef &&
+        hash &&
+        /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(hash)
+      ) {
+        advertised.set(advertisedRef, hash);
+      }
+    }
+
+    if (!ref || ref === "HEAD") return advertised.get("HEAD") ?? null;
+    if (ref.startsWith("refs/")) {
+      return advertised.get(`${ref}^{}`) ?? advertised.get(ref) ?? null;
+    }
+    return (
+      advertised.get(`refs/heads/${ref}`) ??
+      advertised.get(`refs/tags/${ref}^{}`) ??
+      advertised.get(`refs/tags/${ref}`) ??
+      null
     );
-    const hash = (resolvedLine ?? lines[0])?.split(/\s+/)[0];
-    return hash && /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(hash) ? hash : null;
   } catch (err) {
     debug(`updater: git ls-remote failed for ${repoUrl}: ${err}`);
     return null;
@@ -410,28 +426,20 @@ export async function updateSkill(
     );
     await mkdir(tempParent, { recursive: true });
 
-    // Step 1: Clone latest version. When checkOutdated already resolved the
-    // commit, avoid checking out a moving ref until the exact OID is pinned.
-    debug(`updater: cloning latest ${name} to ${tempDir}`);
-    const cloneArgs = ["clone", "--depth", "1"];
-    if (pinnedCommit) cloneArgs.push("--no-checkout");
-    if (entry.ref && entry.ref !== "HEAD") {
-      cloneArgs.push("--branch", entry.ref);
-    }
-    cloneArgs.push(cloneUrl, tempDir);
-
-    try {
-      await execFileAsync("git", cloneArgs, { timeout: 60_000 });
-    } catch (cloneErr: any) {
-      return {
-        name,
-        status: "failed",
-        reason: `Clone failed: ${cloneErr.stderr || cloneErr.message}`,
-      };
-    }
-
+    // Step 1: Fetch the exact commit already resolved by checkOutdated. Direct
+    // callers without one retain the existing ref-based shallow clone path.
+    debug(`updater: fetching latest ${name} to ${tempDir}`);
     if (pinnedCommit) {
       try {
+        const initArgs = ["init"];
+        if (pinnedCommit.length === 64) initArgs.push("--object-format=sha256");
+        initArgs.push(tempDir);
+        await execFileAsync("git", initArgs, { timeout: 10_000 });
+        await execFileAsync(
+          "git",
+          ["fetch", "--depth", "1", cloneUrl, pinnedCommit],
+          { cwd: tempDir, timeout: 60_000 },
+        );
         await execFileAsync("git", ["checkout", "--detach", pinnedCommit], {
           cwd: tempDir,
           timeout: 10_000,
@@ -440,30 +448,42 @@ export async function updateSkill(
         return {
           name,
           status: "failed",
-          reason: "Resolved commit is unavailable in the shallow clone",
+          reason: "Resolved commit is unavailable in the shallow fetch",
+        };
+      }
+    } else {
+      const cloneArgs = ["clone", "--depth", "1"];
+      if (entry.ref && entry.ref !== "HEAD") {
+        cloneArgs.push("--branch", entry.ref);
+      }
+      cloneArgs.push(cloneUrl, tempDir);
+
+      try {
+        await execFileAsync("git", cloneArgs, { timeout: 60_000 });
+      } catch (cloneErr: any) {
+        return {
+          name,
+          status: "failed",
+          reason: `Clone failed: ${cloneErr.stderr || cloneErr.message}`,
         };
       }
     }
 
-    // Resolve HEAD locally for direct callers, and verify a pinned checkout
-    // before auditing, installing, or recording it.
-    let newCommit: string | null = null;
-    try {
-      const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
-        cwd: tempDir,
-        timeout: 5_000,
-      });
-      const checkedOutCommit = stdout.trim().toLowerCase();
-      if (pinnedCommit && checkedOutCommit !== pinnedCommit) {
-        return {
-          name,
-          status: "failed",
-          reason: "Resolved commit checkout mismatch",
-        };
+    // A successful detached checkout is the pinning gate; only direct callers
+    // need to discover the commit selected by their ref-based clone.
+    let newCommit: string;
+    if (pinnedCommit) {
+      newCommit = pinnedCommit;
+    } else {
+      try {
+        const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+          cwd: tempDir,
+          timeout: 5_000,
+        });
+        newCommit = stdout.trim().toLowerCase();
+      } catch {
+        return { name, status: "failed", reason: "Could not read new commit" };
       }
-      newCommit = pinnedCommit ?? checkedOutCommit;
-    } catch {
-      return { name, status: "failed", reason: "Could not read new commit" };
     }
 
     // Check if already up to date

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -23,6 +23,47 @@ import { ansi } from "./formatter";
 
 const execFileAsync = promisify(execFile);
 
+// Repository-local Git variables can redirect commands away from their cwd.
+// Keep transport/auth variables intact, but never inherit repository routing.
+const REPOSITORY_LOCAL_GIT_ENV_VARS = [
+  "GIT_DIR",
+  "GIT_WORK_TREE",
+  "GIT_COMMON_DIR",
+  "GIT_INDEX_FILE",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_IMPLICIT_WORK_TREE",
+  "GIT_GRAFT_FILE",
+  "GIT_SHALLOW_FILE",
+  "GIT_NO_REPLACE_OBJECTS",
+  "GIT_REPLACE_REF_BASE",
+  "GIT_PREFIX",
+  "GIT_INTERNAL_SUPER_PREFIX",
+  "GIT_CEILING_DIRECTORIES",
+  "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+  "GIT_NAMESPACE",
+  "GIT_QUARANTINE_PATH",
+  "GIT_CONFIG",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_CONFIG_COUNT",
+] as const;
+
+function createPinnedGitEnv(
+  objectFormat: "sha1" | "sha256",
+): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const variable of REPOSITORY_LOCAL_GIT_ENV_VARS) {
+    delete env[variable];
+  }
+  for (const variable of Object.keys(env)) {
+    if (/^GIT_CONFIG_(?:KEY|VALUE)_\d+$/.test(variable)) {
+      delete env[variable];
+    }
+  }
+  env.GIT_DEFAULT_HASH = objectFormat;
+  return env;
+}
+
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export type OutdatedStatus = "outdated" | "up-to-date" | "untracked" | "error";
@@ -432,18 +473,20 @@ export async function updateSkill(
     if (pinnedCommit) {
       try {
         const objectFormat = pinnedCommit.length === 40 ? "sha1" : "sha256";
+        const gitEnv = createPinnedGitEnv(objectFormat);
         await execFileAsync("git", ["init", tempDir], {
           timeout: 10_000,
-          env: { ...process.env, GIT_DEFAULT_HASH: objectFormat },
+          env: gitEnv,
         });
         await execFileAsync(
           "git",
           ["fetch", "--depth", "1", cloneUrl, pinnedCommit],
-          { cwd: tempDir, timeout: 60_000 },
+          { cwd: tempDir, timeout: 60_000, env: gitEnv },
         );
         await execFileAsync("git", ["checkout", "--detach", pinnedCommit], {
           cwd: tempDir,
           timeout: 10_000,
+          env: gitEnv,
         });
       } catch {
         return {

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -431,9 +431,8 @@ export async function updateSkill(
     debug(`updater: fetching latest ${name} to ${tempDir}`);
     if (pinnedCommit) {
       try {
-        const initArgs = ["init"];
-        if (pinnedCommit.length === 64) initArgs.push("--object-format=sha256");
-        initArgs.push(tempDir);
+        const objectFormat = pinnedCommit.length === 40 ? "sha1" : "sha256";
+        const initArgs = ["init", `--object-format=${objectFormat}`, tempDir];
         await execFileAsync("git", initArgs, { timeout: 10_000 });
         await execFileAsync(
           "git",

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -432,8 +432,10 @@ export async function updateSkill(
     if (pinnedCommit) {
       try {
         const objectFormat = pinnedCommit.length === 40 ? "sha1" : "sha256";
-        const initArgs = ["init", `--object-format=${objectFormat}`, tempDir];
-        await execFileAsync("git", initArgs, { timeout: 10_000 });
+        await execFileAsync("git", ["init", tempDir], {
+          timeout: 10_000,
+          env: { ...process.env, GIT_DEFAULT_HASH: objectFormat },
+        });
         await execFileAsync(
           "git",
           ["fetch", "--depth", "1", cloneUrl, pinnedCommit],


### PR DESCRIPTION
Closes #368

## Summary

Reuses the full commit OID already resolved during outdated checks, skips already-current skills before any remote fetch, and pins updates to the exact known commit. Existing updater result and formatter shapes remain unchanged, while direct `updateSkill` callers retain the prior clone-and-resolve fallback.

## Approach

**Pinned known-commit update (light profile):** retain resolved OIDs in an internal side channel, forward them through update orchestration, fetch and detach-checkout the exact validated OID, and reserve local `rev-parse` discovery for backward-compatible calls without a known commit.

## Decision Record

- **Root cause:** `checkOutdated` resolved each remote's full latest commit but discarded it after producing a seven-character display hash; `updateSkill` then cloned the ref and rediscovered `HEAD`, so the update path could not skip a known-current commit before remote work or pin installation to the already-resolved OID.
- **Options considered:** Pinned known-commit update — propagate the exact OID internally, short-circuit before fetch, and install only the fetched exact commit.
- **Options rejected:** n/a — small, focused change with a direct plan (light profile)
- **Selected option:** Pinned known-commit update
- **Residual risk:** An exact shallow fetch can fail if a previously resolved commit is no longer fetchable; the updater fails safely without changing installed files or the lock rather than risking an OID/content mismatch.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `refactor/368-avoid-duplicate-remote-round-trip @ 6b83c60` (2026-08-09)

## Changes

| File | Change |
|------|--------|
| `src/updater.ts` | Preserve and forward full resolved OIDs, deterministically resolve ambiguous refs, skip known-current skills before fetch, and pin installation to an exact fetched commit. |
| `src/updater.test.ts` | Add focused unit and integration coverage for propagation, pre-fetch skips, exact installation/locking, stale refs, unavailable commits, annotated tags, ambiguous refs, validation, and output compatibility. |

## Test Results

- Unit/source tests: 1,911 passed
- Website tests: 70 passed
- E2e tests: 141 passed, 3 skipped
- Updater tests: 59 passed, including 8 added tests
- Typecheck: passed
- Build: passed
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Updating a skill performs a single remote resolution per skill | pass | `src/updater.test.ts` — `forwards the full OID resolved by checkOutdated`; `src/updater.ts` uses the pinned OID directly after exact checkout and runs `rev-parse` only for callers without a known OID. |
| Skills already at the latest commit are not cloned | pass | `src/updater.test.ts` — `skips a known current commit before cloning` uses an unreachable repository URL and still returns the unchanged `Already up to date` result. |
| updater test suite passes; update results unchanged | pass | All 59 updater tests pass; `keeps the resolved full OID out of public outdated output`, orchestration summary assertions, and final `npm run test:all` verify unchanged public formatter/result behavior. |
