### PR TITLE
refactor(lock): make lock writes atomic and serialized (#369)

### DIFF
--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -1563,14 +1563,12 @@ describe("updateLibrarySkill", () => {
     ).resolves.toContain("# New Outline");
   });
 
-  test("rejects a stale staged update after force reinstall commits newer metadata", async () => {
-    const reinstallRoot = join(tempDir, "reinstall");
-    const reinstallSourceDir = join(reinstallRoot, "brainstorming");
-    await mkdir(reinstallSourceDir, { recursive: true });
-    await writeFile(
-      join(reinstallSourceDir, "SKILL.md"),
-      "---\nname: brainstorming\nversion: 3.0.0\n---\n# Reinstalled Source\n",
-    );
+  test("rejects a stale staged update after force reinstall publishes a new generation with unchanged metadata", async () => {
+    const initialInstalledAt = "2000-01-01T00:00:00.000Z";
+    const initialLock = await readLibraryLock(lockPath);
+    initialLock.skills.brainstorming.installedAt = initialInstalledAt;
+    await writeLibraryLock(initialLock, lockPath);
+
     await writeFile(
       join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
       "---\nname: brainstorming\nversion: 2.0.0\n---\n# Updated Source\n",
@@ -1597,6 +1595,11 @@ describe("updateLibrarySkill", () => {
     });
     await updateStageReady.promise;
 
+    await writeFile(
+      join(updateSourceDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 3.0.0\n---\n# Reinstalled Source\n",
+    );
+
     let reinstallResult: Awaited<ReturnType<typeof installLibrarySkill>>;
     let reinstallEntry: Awaited<
       ReturnType<typeof readLibraryLock>
@@ -1604,13 +1607,13 @@ describe("updateLibrarySkill", () => {
     try {
       reinstallResult = await installLibrarySkill(
         {
-          sourceDir: reinstallSourceDir,
+          sourceDir: updateSourceDir,
           libraryName: "brainstorming",
-          source: `local:${reinstallRoot}`,
+          source: `local:${sourceRoot}`,
           sourceType: "local",
-          commitHash: "reinstall",
+          commitHash: "local",
           ref: null,
-          skillPath: "brainstorming",
+          skillPath: "skills/brainstorming",
           force: true,
         },
         { skillsDir, lockPath },
@@ -1647,10 +1650,14 @@ describe("updateLibrarySkill", () => {
     });
     const finalLock = await readLibraryLock(lockPath);
     expect(finalLock.skills.brainstorming).toEqual(reinstallEntry);
-    expect(finalLock.skills.brainstorming.source).toBe(
-      `local:${reinstallRoot}`,
+    expect(finalLock.skills.brainstorming.source).toBe(`local:${sourceRoot}`);
+    expect(finalLock.skills.brainstorming.skillPath).toBe(
+      "skills/brainstorming",
     );
-    expect(finalLock.skills.brainstorming.skillPath).toBe("brainstorming");
+    expect(finalLock.skills.brainstorming.commitHash).toBe("local");
+    expect(finalLock.skills.brainstorming.installedAt).not.toBe(
+      initialInstalledAt,
+    );
   });
 
   test("accepts equivalent local source spellings during stale-update revalidation", async () => {

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -1562,6 +1562,124 @@ describe("updateLibrarySkill", () => {
     expect(finalLock.skills.brainstorming.skillPath).toBe("brainstorming");
   });
 
+  test("accepts equivalent local source spellings during stale-update revalidation", async () => {
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 2.0.0\n---\n# Updated Source\n",
+    );
+
+    const updateStageReady = deferred<void>();
+    const releaseUpdateStage = deferred<void>();
+    let blockedUpdateStage = false;
+    const updateSourceDir = join(sourceRoot, "skills", "brainstorming");
+
+    fspMocks.cpOverride = async (realCp, from, to, ...rest) => {
+      const result = await realCp(from, to, ...rest);
+      if (!blockedUpdateStage && String(from) === updateSourceDir) {
+        blockedUpdateStage = true;
+        updateStageReady.resolve();
+        await releaseUpdateStage.promise;
+      }
+      return result;
+    };
+
+    const updatePromise = updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+    await updateStageReady.promise;
+
+    const lock = await readLibraryLock(lockPath);
+    const equivalentSource = sourceRoot.endsWith("/")
+      ? `${sourceRoot}.`
+      : `${sourceRoot}/.`;
+    lock.skills.brainstorming = {
+      ...lock.skills.brainstorming,
+      source: `local:${equivalentSource}`,
+      ref: "HEAD",
+      skillPath: "skills/brainstorming/.",
+    };
+    await writeLibraryLock(lock, lockPath);
+    releaseUpdateStage.resolve();
+
+    const result = await updatePromise;
+
+    expect(result).toMatchObject({
+      name: "brainstorming",
+      status: "updated",
+      oldVersion: "1.0.0",
+      newVersion: "2.0.0",
+    });
+    await expect(
+      readFile(join(libraryPath, "SKILL.md"), "utf-8"),
+    ).resolves.toContain("# Updated Source");
+    const finalLock = await readLibraryLock(lockPath);
+    expect(finalLock.skills.brainstorming.source).toBe(`local:${equivalentSource}`);
+    expect(finalLock.skills.brainstorming.ref).toBe("HEAD");
+    expect(finalLock.skills.brainstorming.skillPath).toBe("skills/brainstorming/.");
+  });
+
+  test("rejects changed local sources during stale-update revalidation", async () => {
+    const movedSourceRoot = join(tempDir, "moved-source");
+    await mkdir(join(movedSourceRoot, "skills", "brainstorming"), {
+      recursive: true,
+    });
+    await writeFile(
+      join(movedSourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 9.9.0\n---\n# Moved Source\n",
+    );
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 2.0.0\n---\n# Updated Source\n",
+    );
+
+    const updateStageReady = deferred<void>();
+    const releaseUpdateStage = deferred<void>();
+    let blockedUpdateStage = false;
+    const updateSourceDir = join(sourceRoot, "skills", "brainstorming");
+
+    fspMocks.cpOverride = async (realCp, from, to, ...rest) => {
+      const result = await realCp(from, to, ...rest);
+      if (!blockedUpdateStage && String(from) === updateSourceDir) {
+        blockedUpdateStage = true;
+        updateStageReady.resolve();
+        await releaseUpdateStage.promise;
+      }
+      return result;
+    };
+
+    const updatePromise = updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+    await updateStageReady.promise;
+
+    const lock = await readLibraryLock(lockPath);
+    lock.skills.brainstorming = {
+      ...lock.skills.brainstorming,
+      source: `local:${movedSourceRoot}`,
+    };
+    await writeLibraryLock(lock, lockPath);
+    releaseUpdateStage.resolve();
+
+    const result = await updatePromise;
+
+    expect(result).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason:
+        'Library skill "brainstorming" changed while update was in progress. Run "asm library update brainstorming" again.',
+    });
+    await expect(
+      readFile(join(libraryPath, "SKILL.md"), "utf-8"),
+    ).resolves.toContain("# Old Source");
+    await expect(
+      readFile(join(libraryPath, "SKILL.md"), "utf-8"),
+    ).resolves.not.toContain("# Updated Source");
+    const finalLock = await readLibraryLock(lockPath);
+    expect(finalLock.skills.brainstorming.source).toBe(`local:${movedSourceRoot}`);
+  });
+
   test("serializes force reinstall with failing update rollback so disk and lock stay aligned", async () => {
     const reinstallSourceDir = join(tempDir, "reinstall", "brainstorming");
     await mkdir(reinstallSourceDir, { recursive: true });

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -2,18 +2,24 @@ import { createDirSymlink } from "./utils/fs";
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 
 const fspMocks = vi.hoisted(() => ({
-  renameOverride: null as null | ((
-    realRename: typeof import("fs/promises").rename,
-    ...args: Parameters<typeof import("fs/promises").rename>
-  ) => Promise<void>),
-  readFileOverride: null as null | ((
-    realReadFile: typeof import("fs/promises").readFile,
-    ...args: Parameters<typeof import("fs/promises").readFile>
-  ) => ReturnType<typeof import("fs/promises").readFile>),
-  cpOverride: null as null | ((
-    realCp: typeof import("fs/promises").cp,
-    ...args: Parameters<typeof import("fs/promises").cp>
-  ) => ReturnType<typeof import("fs/promises").cp>),
+  renameOverride: null as
+    | null
+    | ((
+        realRename: typeof import("fs/promises").rename,
+        ...args: Parameters<typeof import("fs/promises").rename>
+      ) => Promise<void>),
+  readFileOverride: null as
+    | null
+    | ((
+        realReadFile: typeof import("fs/promises").readFile,
+        ...args: Parameters<typeof import("fs/promises").readFile>
+      ) => ReturnType<typeof import("fs/promises").readFile>),
+  cpOverride: null as
+    | null
+    | ((
+        realCp: typeof import("fs/promises").cp,
+        ...args: Parameters<typeof import("fs/promises").cp>
+      ) => ReturnType<typeof import("fs/promises").cp>),
 }));
 vi.mock("fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("fs/promises")>();
@@ -137,26 +143,27 @@ describe("library lock", () => {
   });
 
   test("writeLibraryLock preserves the previous lock when atomic rename fails", async () => {
-    const original = JSON.stringify(
-      {
-        version: 1,
-        skills: {
-          brainstorming: {
-            name: "brainstorming",
-            version: "1.0.0",
-            source: "github:obra/superpowers",
-            sourceType: "github",
-            commitHash: "abc123",
-            ref: "main",
-            skillPath: "skills/brainstorming",
-            libraryPath: join(tempDir, "skills", "brainstorming"),
-            installedAt: "2026-06-18T00:00:00.000Z",
+    const original =
+      JSON.stringify(
+        {
+          version: 1,
+          skills: {
+            brainstorming: {
+              name: "brainstorming",
+              version: "1.0.0",
+              source: "github:obra/superpowers",
+              sourceType: "github",
+              commitHash: "abc123",
+              ref: "main",
+              skillPath: "skills/brainstorming",
+              libraryPath: join(tempDir, "skills", "brainstorming"),
+              installedAt: "2026-06-18T00:00:00.000Z",
+            },
           },
         },
-      },
-      null,
-      2,
-    ) + "\n";
+        null,
+        2,
+      ) + "\n";
     await writeFile(lockPath, original, "utf-8");
 
     fspMocks.renameOverride = async (_realRename, _from, to) => {
@@ -1511,7 +1518,9 @@ describe("updateLibrarySkill", () => {
     await updateStageReady.promise;
 
     let reinstallResult: Awaited<ReturnType<typeof installLibrarySkill>>;
-    let reinstallEntry: Awaited<ReturnType<typeof readLibraryLock>>["skills"][string];
+    let reinstallEntry: Awaited<
+      ReturnType<typeof readLibraryLock>
+    >["skills"][string];
     try {
       reinstallResult = await installLibrarySkill(
         {
@@ -1558,7 +1567,9 @@ describe("updateLibrarySkill", () => {
     });
     const finalLock = await readLibraryLock(lockPath);
     expect(finalLock.skills.brainstorming).toEqual(reinstallEntry);
-    expect(finalLock.skills.brainstorming.source).toBe(`local:${reinstallRoot}`);
+    expect(finalLock.skills.brainstorming.source).toBe(
+      `local:${reinstallRoot}`,
+    );
     expect(finalLock.skills.brainstorming.skillPath).toBe("brainstorming");
   });
 
@@ -1614,9 +1625,13 @@ describe("updateLibrarySkill", () => {
       readFile(join(libraryPath, "SKILL.md"), "utf-8"),
     ).resolves.toContain("# Updated Source");
     const finalLock = await readLibraryLock(lockPath);
-    expect(finalLock.skills.brainstorming.source).toBe(`local:${equivalentSource}`);
+    expect(finalLock.skills.brainstorming.source).toBe(
+      `local:${equivalentSource}`,
+    );
     expect(finalLock.skills.brainstorming.ref).toBe("HEAD");
-    expect(finalLock.skills.brainstorming.skillPath).toBe("skills/brainstorming/.");
+    expect(finalLock.skills.brainstorming.skillPath).toBe(
+      "skills/brainstorming/.",
+    );
   });
 
   test("rejects changed local sources during stale-update revalidation", async () => {
@@ -1677,7 +1692,9 @@ describe("updateLibrarySkill", () => {
       readFile(join(libraryPath, "SKILL.md"), "utf-8"),
     ).resolves.not.toContain("# Updated Source");
     const finalLock = await readLibraryLock(lockPath);
-    expect(finalLock.skills.brainstorming.source).toBe(`local:${movedSourceRoot}`);
+    expect(finalLock.skills.brainstorming.source).toBe(
+      `local:${movedSourceRoot}`,
+    );
   });
 
   test("serializes force reinstall with failing update rollback so disk and lock stay aligned", async () => {

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -6,6 +6,10 @@ const fspMocks = vi.hoisted(() => ({
     realRename: typeof import("fs/promises").rename,
     ...args: Parameters<typeof import("fs/promises").rename>
   ) => Promise<void>),
+  readFileOverride: null as null | ((
+    realReadFile: typeof import("fs/promises").readFile,
+    ...args: Parameters<typeof import("fs/promises").readFile>
+  ) => ReturnType<typeof import("fs/promises").readFile>),
 }));
 vi.mock("fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("fs/promises")>();
@@ -15,6 +19,10 @@ vi.mock("fs/promises", async (importOriginal) => {
       fspMocks.renameOverride
         ? fspMocks.renameOverride(actual.rename, ...args)
         : actual.rename(...args),
+    readFile: (...args: Parameters<typeof actual.readFile>) =>
+      fspMocks.readFileOverride
+        ? fspMocks.readFileOverride(actual.readFile, ...args)
+        : actual.readFile(...args),
   };
 });
 
@@ -57,10 +65,12 @@ function deferred<T = void>() {
 
 beforeEach(() => {
   fspMocks.renameOverride = null;
+  fspMocks.readFileOverride = null;
 });
 
 afterEach(() => {
   fspMocks.renameOverride = null;
+  fspMocks.readFileOverride = null;
 });
 
 describe("library lock", () => {
@@ -1454,6 +1464,91 @@ describe("updateLibrarySkill", () => {
     await expect(
       readFile(join(outliningLibraryPath, "SKILL.md"), "utf-8"),
     ).resolves.toContain("# New Outline");
+  });
+
+  test("serializes force reinstall with failing update rollback so disk and lock stay aligned", async () => {
+    const reinstallSourceDir = join(tempDir, "reinstall", "brainstorming");
+    await mkdir(reinstallSourceDir, { recursive: true });
+    await writeFile(
+      join(reinstallSourceDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 3.0.0\n---\n# Reinstalled Source\n",
+    );
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 2.0.0\n---\n# Updated Source\n",
+    );
+
+    const updateWriteStarted = deferred<void>();
+    const releaseUpdateWrite = deferred<void>();
+    const installMetadataRead = deferred<void>();
+    let watchInstallRead = false;
+    let installMetadataCaptured = false;
+
+    fspMocks.readFileOverride = async (realReadFile, path, ...rest) => {
+      const result = await realReadFile(path, ...rest);
+      if (
+        watchInstallRead &&
+        !installMetadataCaptured &&
+        String(path).endsWith("SKILL.md")
+      ) {
+        installMetadataCaptured = true;
+        installMetadataRead.resolve();
+      }
+      return result;
+    };
+
+    const updatePromise = updateLibrarySkill(
+      "brainstorming",
+      { skillsDir, lockPath },
+      {
+        writeLibraryLockFn: async () => {
+          updateWriteStarted.resolve();
+          await releaseUpdateWrite.promise;
+          throw new Error("lock write boom");
+        },
+      },
+    );
+    await updateWriteStarted.promise;
+
+    watchInstallRead = true;
+    const reinstallPromise = installLibrarySkill(
+      {
+        sourceDir: reinstallSourceDir,
+        libraryName: "brainstorming",
+        source: `local:${join(tempDir, "reinstall")}`,
+        sourceType: "local",
+        commitHash: "reinstall",
+        ref: null,
+        skillPath: "brainstorming",
+        force: true,
+      },
+      { skillsDir, lockPath },
+    );
+    await installMetadataRead.promise;
+    releaseUpdateWrite.resolve();
+
+    const [updateResult, reinstallResult] = await Promise.all([
+      updatePromise,
+      reinstallPromise,
+    ]);
+
+    expect(updateResult).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason:
+        "Updated library copy, but failed to write lock file: lock write boom",
+    });
+    expect(reinstallResult).toMatchObject({
+      name: "brainstorming",
+      version: "3.0.0",
+      libraryPath,
+    });
+    await expect(
+      readFile(join(libraryPath, "SKILL.md"), "utf-8"),
+    ).resolves.toContain("# Reinstalled Source");
+    const lock = await readLibraryLock(lockPath);
+    expect(lock.skills.brainstorming.version).toBe("3.0.0");
+    expect(lock.skills.brainstorming.commitHash).toBe("reinstall");
   });
 
   test("restores old library copy when lock write fails after swap", async () => {

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -1,5 +1,23 @@
 import { createDirSymlink } from "./utils/fs";
-import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+
+const fspMocks = vi.hoisted(() => ({
+  renameOverride: null as null | ((
+    realRename: typeof import("fs/promises").rename,
+    ...args: Parameters<typeof import("fs/promises").rename>
+  ) => Promise<void>),
+}));
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+  return {
+    ...actual,
+    rename: (...args: Parameters<typeof actual.rename>) =>
+      fspMocks.renameOverride
+        ? fspMocks.renameOverride(actual.rename, ...args)
+        : actual.rename(...args),
+  };
+});
+
 import {
   chmod,
   lstat,
@@ -12,6 +30,7 @@ import {
   rm,
   symlink,
   writeFile,
+  readdir,
 } from "fs/promises";
 import { tmpdir } from "os";
 import { join, relative, resolve } from "path";
@@ -25,6 +44,24 @@ import {
   updateLibrarySkills,
   writeLibraryLock,
 } from "./library";
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  fspMocks.renameOverride = null;
+});
+
+afterEach(() => {
+  fspMocks.renameOverride = null;
+});
 
 describe("library lock", () => {
   let tempDir: string;
@@ -77,6 +114,55 @@ describe("library lock", () => {
     await expect(readFile(lockPath + ".bak", "utf-8")).resolves.toBe(
       invalidLock,
     );
+  });
+
+  test("writeLibraryLock preserves the previous lock when atomic rename fails", async () => {
+    const original = JSON.stringify(
+      {
+        version: 1,
+        skills: {
+          brainstorming: {
+            name: "brainstorming",
+            version: "1.0.0",
+            source: "github:obra/superpowers",
+            sourceType: "github",
+            commitHash: "abc123",
+            ref: "main",
+            skillPath: "skills/brainstorming",
+            libraryPath: join(tempDir, "skills", "brainstorming"),
+            installedAt: "2026-06-18T00:00:00.000Z",
+          },
+        },
+      },
+      null,
+      2,
+    ) + "\n";
+    await writeFile(lockPath, original, "utf-8");
+
+    fspMocks.renameOverride = async (_realRename, _from, to) => {
+      if (to === lockPath) {
+        throw new Error("rename boom");
+      }
+    };
+
+    const updatedLock = emptyLibraryLock();
+    updatedLock.skills.brainstorming = {
+      name: "brainstorming",
+      version: "2.0.0",
+      source: "github:obra/superpowers",
+      sourceType: "github",
+      commitHash: "def456",
+      ref: "main",
+      skillPath: "skills/brainstorming",
+      libraryPath: join(tempDir, "skills", "brainstorming"),
+      installedAt: "2026-06-19T00:00:00.000Z",
+    };
+
+    await expect(writeLibraryLock(updatedLock, lockPath)).rejects.toThrow(
+      "rename boom",
+    );
+    await expect(readFile(lockPath, "utf-8")).resolves.toBe(original);
+    await expect(readdir(tempDir)).resolves.toEqual(["library-lock.json"]);
   });
 });
 
@@ -1296,6 +1382,78 @@ describe("updateLibrarySkill", () => {
     await expect(
       readFile(join(libraryPath, "notes.txt"), "utf-8"),
     ).resolves.toBe("bravo");
+  });
+
+  test("serializes overlapping updates so later writes keep earlier lock deltas", async () => {
+    const outliningSourceDir = join(sourceRoot, "skills", "outlining");
+    const outliningLibraryPath = join(skillsDir, "outlining");
+    await mkdir(outliningSourceDir, { recursive: true });
+    await writeFile(
+      join(outliningSourceDir, "SKILL.md"),
+      "---\nname: outlining\nversion: 1.0.0\n---\n# Old Outline\n",
+    );
+    await installLibrarySkill(
+      {
+        sourceDir: outliningSourceDir,
+        libraryName: "outlining",
+        source: `local:${sourceRoot}`,
+        sourceType: "local",
+        commitHash: "local-outline",
+        ref: null,
+        skillPath: "skills/outlining",
+        force: false,
+      },
+      { skillsDir, lockPath },
+    );
+
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 2.0.0\n---\n# New Brainstorming\n",
+    );
+    await writeFile(
+      join(outliningSourceDir, "SKILL.md"),
+      "---\nname: outlining\nversion: 2.0.0\n---\n# New Outline\n",
+    );
+
+    const firstLockRenameStarted = deferred<void>();
+    const releaseFirstLockRename = deferred<void>();
+    let blockedFirstLockRename = false;
+    fspMocks.renameOverride = async (realRename, from, to) => {
+      if (to === lockPath && !blockedFirstLockRename) {
+        blockedFirstLockRename = true;
+        firstLockRenameStarted.resolve();
+        await releaseFirstLockRename.promise;
+      }
+      await realRename(from, to);
+    };
+
+    const firstUpdate = updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+    await firstLockRenameStarted.promise;
+
+    const secondUpdate = updateLibrarySkill("outlining", {
+      skillsDir,
+      lockPath,
+    });
+
+    releaseFirstLockRename.resolve();
+
+    await expect(Promise.all([firstUpdate, secondUpdate])).resolves.toEqual([
+      expect.objectContaining({ name: "brainstorming", status: "updated" }),
+      expect.objectContaining({ name: "outlining", status: "updated" }),
+    ]);
+
+    const updatedLock = await readLibraryLock(lockPath);
+    expect(updatedLock.skills.brainstorming.version).toBe("2.0.0");
+    expect(updatedLock.skills.outlining.version).toBe("2.0.0");
+    await expect(
+      readFile(join(libraryPath, "SKILL.md"), "utf-8"),
+    ).resolves.toContain("# New Brainstorming");
+    await expect(
+      readFile(join(outliningLibraryPath, "SKILL.md"), "utf-8"),
+    ).resolves.toContain("# New Outline");
   });
 
   test("restores old library copy when lock write fails after swap", async () => {

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -1564,7 +1564,7 @@ describe("updateLibrarySkill", () => {
   });
 
   test("rejects a stale staged update after force reinstall publishes a new generation with unchanged metadata", async () => {
-    const initialInstalledAt = "2000-01-01T00:00:00.000Z";
+    const initialInstalledAt = "2999-01-01T00:00:00.000Z";
     const initialLock = await readLibraryLock(lockPath);
     initialLock.skills.brainstorming.installedAt = initialInstalledAt;
     await writeLibraryLock(initialLock, lockPath);
@@ -1655,9 +1655,9 @@ describe("updateLibrarySkill", () => {
       "skills/brainstorming",
     );
     expect(finalLock.skills.brainstorming.commitHash).toBe("local");
-    expect(finalLock.skills.brainstorming.installedAt).not.toBe(
-      initialInstalledAt,
-    );
+    expect(
+      Date.parse(finalLock.skills.brainstorming.installedAt),
+    ).toBeGreaterThan(Date.parse(initialInstalledAt));
   });
 
   test("accepts equivalent local source spellings during stale-update revalidation", async () => {

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -2,6 +2,12 @@ import { createDirSymlink } from "./utils/fs";
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 
 const fspMocks = vi.hoisted(() => ({
+  openOverride: null as
+    | null
+    | ((
+        realOpen: typeof import("fs/promises").open,
+        ...args: Parameters<typeof import("fs/promises").open>
+      ) => ReturnType<typeof import("fs/promises").open>),
   renameOverride: null as
     | null
     | ((
@@ -25,6 +31,10 @@ vi.mock("fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("fs/promises")>();
   return {
     ...actual,
+    open: (...args: Parameters<typeof actual.open>) =>
+      fspMocks.openOverride
+        ? fspMocks.openOverride(actual.open, ...args)
+        : actual.open(...args),
     rename: (...args: Parameters<typeof actual.rename>) =>
       fspMocks.renameOverride
         ? fspMocks.renameOverride(actual.rename, ...args)
@@ -55,7 +65,7 @@ import {
   readdir,
 } from "fs/promises";
 import { tmpdir } from "os";
-import { join, relative, resolve } from "path";
+import { dirname, join, relative, resolve } from "path";
 import {
   emptyLibraryLock,
   activateLibrarySkill,
@@ -77,13 +87,43 @@ function deferred<T = void>() {
   return { promise, resolve, reject };
 }
 
+function failDirectoryDurability(
+  directoryPath: string,
+  phase: "open" | "sync" | "close",
+  error: Error,
+): void {
+  fspMocks.openOverride = async (realOpen, ...args) => {
+    if (
+      args[1] !== "r" ||
+      resolve(String(args[0])) !== resolve(directoryPath)
+    ) {
+      return realOpen(...args);
+    }
+    if (phase === "open") throw error;
+
+    const handle = await realOpen(...args);
+    return {
+      sync: async () => {
+        if (phase === "sync") throw error;
+        await handle.sync();
+      },
+      close: async () => {
+        await handle.close();
+        if (phase === "close") throw error;
+      },
+    } as Awaited<ReturnType<typeof realOpen>>;
+  };
+}
+
 beforeEach(() => {
+  fspMocks.openOverride = null;
   fspMocks.renameOverride = null;
   fspMocks.readFileOverride = null;
   fspMocks.cpOverride = null;
 });
 
 afterEach(() => {
+  fspMocks.openOverride = null;
   fspMocks.renameOverride = null;
   fspMocks.readFileOverride = null;
   fspMocks.cpOverride = null;
@@ -253,6 +293,46 @@ describe("installLibrarySkill", () => {
       libraryPath: result.libraryPath,
     });
   });
+
+  test.each(["open", "sync", "close"] as const)(
+    "keeps fresh-install lock metadata and files aligned after directory %s fails post-rename",
+    async (phase) => {
+      failDirectoryDurability(
+        dirname(lockPath),
+        phase,
+        new Error(`directory ${phase} boom`),
+      );
+
+      await expect(
+        installLibrarySkill(
+          {
+            sourceDir,
+            libraryName: "brainstorming",
+            source: "github:obra/superpowers",
+            sourceType: "github",
+            commitHash: "abc123",
+            ref: "main",
+            skillPath: "skills/brainstorming",
+            force: false,
+          },
+          { skillsDir, lockPath },
+        ),
+      ).rejects.toThrow(
+        "Lock metadata and library files were published as the new generation, but parent-directory durability could not be confirmed",
+      );
+
+      const lock = await readLibraryLock(lockPath);
+      expect(lock.skills.brainstorming).toMatchObject({
+        name: "brainstorming",
+        version: "1.0.0",
+        commitHash: "abc123",
+      });
+      await expect(
+        readFile(join(skillsDir, "brainstorming", "SKILL.md"), "utf-8"),
+      ).resolves.toContain("# Body");
+      await expect(readdir(skillsDir)).resolves.toEqual(["brainstorming"]);
+    },
+  );
 
   test("refuses to overwrite an existing library skill without force", async () => {
     await installLibrarySkill(
@@ -1781,6 +1861,41 @@ describe("updateLibrarySkill", () => {
     expect(lock.skills.brainstorming.version).toBe("3.0.0");
     expect(lock.skills.brainstorming.commitHash).toBe("reinstall");
   });
+
+  test.each(["open", "sync", "close"] as const)(
+    "keeps updated lock metadata and files aligned after directory %s fails post-rename",
+    async (phase) => {
+      await writeFile(
+        join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+        "---\nname: brainstorming\nversion: 2.0.0\n---\n# New Source\n",
+      );
+      failDirectoryDurability(
+        dirname(lockPath),
+        phase,
+        new Error(`directory ${phase} boom`),
+      );
+
+      const result = await updateLibrarySkill("brainstorming", {
+        skillsDir,
+        lockPath,
+      });
+
+      expect(result).toMatchObject({
+        name: "brainstorming",
+        status: "failed",
+        reason: expect.stringContaining(
+          "Lock metadata and library files were published as the new generation, but parent-directory durability could not be confirmed",
+        ),
+      });
+      const lock = await readLibraryLock(lockPath);
+      expect(lock.skills.brainstorming.version).toBe("2.0.0");
+      expect(lock.skills.brainstorming.commitHash).not.toBe("local");
+      await expect(
+        readFile(join(libraryPath, "SKILL.md"), "utf-8"),
+      ).resolves.toContain("# New Source");
+      await expect(readdir(skillsDir)).resolves.toEqual(["brainstorming"]);
+    },
+  );
 
   test("restores old library copy when lock write fails after swap", async () => {
     await writeFile(

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -10,6 +10,10 @@ const fspMocks = vi.hoisted(() => ({
     realReadFile: typeof import("fs/promises").readFile,
     ...args: Parameters<typeof import("fs/promises").readFile>
   ) => ReturnType<typeof import("fs/promises").readFile>),
+  cpOverride: null as null | ((
+    realCp: typeof import("fs/promises").cp,
+    ...args: Parameters<typeof import("fs/promises").cp>
+  ) => ReturnType<typeof import("fs/promises").cp>),
 }));
 vi.mock("fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("fs/promises")>();
@@ -23,6 +27,10 @@ vi.mock("fs/promises", async (importOriginal) => {
       fspMocks.readFileOverride
         ? fspMocks.readFileOverride(actual.readFile, ...args)
         : actual.readFile(...args),
+    cp: (...args: Parameters<typeof actual.cp>) =>
+      fspMocks.cpOverride
+        ? fspMocks.cpOverride(actual.cp, ...args)
+        : actual.cp(...args),
   };
 });
 
@@ -66,11 +74,13 @@ function deferred<T = void>() {
 beforeEach(() => {
   fspMocks.renameOverride = null;
   fspMocks.readFileOverride = null;
+  fspMocks.cpOverride = null;
 });
 
 afterEach(() => {
   fspMocks.renameOverride = null;
   fspMocks.readFileOverride = null;
+  fspMocks.cpOverride = null;
 });
 
 describe("library lock", () => {
@@ -1464,6 +1474,92 @@ describe("updateLibrarySkill", () => {
     await expect(
       readFile(join(outliningLibraryPath, "SKILL.md"), "utf-8"),
     ).resolves.toContain("# New Outline");
+  });
+
+  test("rejects a stale staged update after force reinstall commits newer metadata", async () => {
+    const reinstallRoot = join(tempDir, "reinstall");
+    const reinstallSourceDir = join(reinstallRoot, "brainstorming");
+    await mkdir(reinstallSourceDir, { recursive: true });
+    await writeFile(
+      join(reinstallSourceDir, "SKILL.md"),
+      "---\nname: brainstorming\nversion: 3.0.0\n---\n# Reinstalled Source\n",
+    );
+    await writeFile(
+      join(sourceRoot, "skills", "brainstorming", "SKILL.md"),
+      "---\nname: brainstorming\nversion: 2.0.0\n---\n# Updated Source\n",
+    );
+
+    const updateStageReady = deferred<void>();
+    const releaseUpdateStage = deferred<void>();
+    let blockedUpdateStage = false;
+    const updateSourceDir = join(sourceRoot, "skills", "brainstorming");
+
+    fspMocks.cpOverride = async (realCp, from, to, ...rest) => {
+      const result = await realCp(from, to, ...rest);
+      if (!blockedUpdateStage && String(from) === updateSourceDir) {
+        blockedUpdateStage = true;
+        updateStageReady.resolve();
+        await releaseUpdateStage.promise;
+      }
+      return result;
+    };
+
+    const updatePromise = updateLibrarySkill("brainstorming", {
+      skillsDir,
+      lockPath,
+    });
+    await updateStageReady.promise;
+
+    let reinstallResult: Awaited<ReturnType<typeof installLibrarySkill>>;
+    let reinstallEntry: Awaited<ReturnType<typeof readLibraryLock>>["skills"][string];
+    try {
+      reinstallResult = await installLibrarySkill(
+        {
+          sourceDir: reinstallSourceDir,
+          libraryName: "brainstorming",
+          source: `local:${reinstallRoot}`,
+          sourceType: "local",
+          commitHash: "reinstall",
+          ref: null,
+          skillPath: "brainstorming",
+          force: true,
+        },
+        { skillsDir, lockPath },
+      );
+      reinstallEntry = (await readLibraryLock(lockPath)).skills.brainstorming;
+    } finally {
+      releaseUpdateStage.resolve();
+    }
+
+    const updateResult = await updatePromise;
+
+    expect(reinstallResult).toMatchObject({
+      name: "brainstorming",
+      version: "3.0.0",
+      libraryPath,
+    });
+    expect(updateResult).toEqual({
+      name: "brainstorming",
+      status: "failed",
+      reason:
+        'Library skill "brainstorming" changed while update was in progress. Run "asm library update brainstorming" again.',
+    });
+    await expect(
+      readFile(join(libraryPath, "SKILL.md"), "utf-8"),
+    ).resolves.toContain("# Reinstalled Source");
+    await expect(
+      readFile(join(libraryPath, "SKILL.md"), "utf-8"),
+    ).resolves.not.toContain("# Updated Source");
+    await expect(readLibraryLock(lockPath)).resolves.toEqual({
+      version: 1,
+      skills: {
+        brainstorming: reinstallEntry,
+      },
+    });
+    const finalLock = await readLibraryLock(lockPath);
+    expect(finalLock.skills.brainstorming).toEqual(reinstallEntry);
+    expect(finalLock.skills.brainstorming.source).toBe(`local:${reinstallRoot}`);
+    expect(finalLock.skills.brainstorming.skillPath).toBe("brainstorming");
   });
 
   test("serializes force reinstall with failing update rollback so disk and lock stay aligned", async () => {

--- a/src/library.ts
+++ b/src/library.ts
@@ -21,6 +21,7 @@ import { debug } from "./logger";
 import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
 import { createDirSymlink } from "./utils/fs";
 import {
+  AtomicWritePostRenameError,
   withFileMutationLock,
   writeTextFileAtomically,
 } from "./utils/atomic-file";
@@ -486,6 +487,16 @@ async function replaceDirectoryAtomically(input: {
         await input.writeLock();
         return null;
       } catch (err: any) {
+        if (err instanceof AtomicWritePostRenameError) {
+          return {
+            name: "",
+            status: "failed",
+            reason: `Lock metadata and library files were published as the new generation, but parent-directory durability could not be confirmed: ${
+              err.cause instanceof Error ? err.cause.message : String(err.cause)
+            }`,
+          };
+        }
+
         await rm(input.targetDir, { recursive: true, force: true });
         if (backupDir) {
           try {

--- a/src/library.ts
+++ b/src/library.ts
@@ -176,9 +176,11 @@ function libraryEntryChangedDuringUpdate(name: string): LibraryUpdateResult {
 }
 
 function nextInstalledAt(previousInstalledAt?: string): string {
-  const installedAt = new Date().toISOString();
-  if (installedAt !== previousInstalledAt) return installedAt;
-  return new Date(Date.parse(installedAt) + 1).toISOString();
+  const previousTime = Date.parse(previousInstalledAt ?? "");
+  const installedAt = Number.isFinite(previousTime)
+    ? Math.max(Date.now(), previousTime + 1)
+    : Date.now();
+  return new Date(installedAt).toISOString();
 }
 
 function librarySourceRoot(entry: LibrarySkillEntry): string | null {

--- a/src/library.ts
+++ b/src/library.ts
@@ -135,6 +135,28 @@ function libraryUpdateFailure(
   return { name, status: "failed", reason };
 }
 
+function libraryEntryMatchesUpdateSource(
+  currentEntry: LibrarySkillEntry,
+  expectedEntry: LibrarySkillEntry,
+): boolean {
+  return (
+    currentEntry.source === expectedEntry.source &&
+    currentEntry.sourceType === expectedEntry.sourceType &&
+    currentEntry.ref === expectedEntry.ref &&
+    currentEntry.skillPath === expectedEntry.skillPath &&
+    currentEntry.libraryPath === expectedEntry.libraryPath
+  );
+}
+
+function libraryEntryChangedDuringUpdate(
+  name: string,
+): LibraryUpdateResult {
+  return libraryUpdateFailure(
+    name,
+    `Library skill "${name}" changed while update was in progress. Run "asm library update ${name}" again.`,
+  );
+}
+
 function librarySourceRoot(entry: LibrarySkillEntry): string | null {
   if (!entry.source.startsWith("local:")) {
     return null;
@@ -496,6 +518,7 @@ export async function updateLibrarySkill(
   }
 
   const [dirName, entry] = selected;
+  const expectedEntry = { ...entry };
 
   if (!entry.source || !entry.source.trim()) {
     return libraryUpdateFailure(dirName, "Missing update metadata: source");
@@ -648,7 +671,11 @@ export async function updateLibrarySkill(
           );
         }
 
-        if (currentEntry.commitHash === nextCommitHash) {
+        const updateSourceStillMatches = libraryEntryMatchesUpdateSource(
+          currentEntry,
+          expectedEntry,
+        );
+        if (updateSourceStillMatches && currentEntry.commitHash === nextCommitHash) {
           return {
             name: currentEntry.name,
             status: "skipped" as const,
@@ -657,6 +684,13 @@ export async function updateLibrarySkill(
             oldCommit: currentEntry.commitHash,
             newCommit: nextCommitHash,
           };
+        }
+
+        if (
+          !updateSourceStillMatches ||
+          currentEntry.commitHash !== expectedEntry.commitHash
+        ) {
+          return libraryEntryChangedDuringUpdate(dirName);
         }
 
         const updatedLock = {

--- a/src/library.ts
+++ b/src/library.ts
@@ -11,7 +11,6 @@ import {
   realpath,
   rename,
   rm,
-  writeFile,
 } from "fs/promises";
 import { execFile } from "child_process";
 import { createHash } from "crypto";
@@ -21,6 +20,7 @@ import { getLibraryLockPath, getLibrarySkillsDir } from "./config";
 import { debug } from "./logger";
 import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
 import { createDirSymlink } from "./utils/fs";
+import { withFileMutationLock, writeTextFileAtomically } from "./utils/atomic-file";
 import { sourceToCloneUrl } from "./updater";
 import type { LibraryLockFile, LibrarySkillEntry } from "./utils/types";
 
@@ -86,51 +86,16 @@ export function emptyLibraryLock(): LibraryLockFile {
 export async function readLibraryLock(
   path: string = getLibraryLockPath(),
 ): Promise<LibraryLockFile> {
-  let raw: string;
-  try {
-    raw = await readFile(path, "utf-8");
-  } catch (err: any) {
-    if (err?.code === "ENOENT") {
-      debug("library: lock file not found, returning empty lock");
-      return emptyLibraryLock();
-    }
-    throw err;
-  }
-
-  try {
-    const parsed = JSON.parse(raw);
-    if (
-      !parsed ||
-      typeof parsed !== "object" ||
-      Array.isArray(parsed) ||
-      parsed.version !== 1 ||
-      typeof parsed.skills !== "object" ||
-      parsed.skills === null ||
-      Array.isArray(parsed.skills)
-    ) {
-      throw new Error("invalid schema");
-    }
-    return parsed as LibraryLockFile;
-  } catch {
-    const backupPath = path + ".bak";
-    try {
-      await copyFile(path, backupPath);
-    } catch {
-      // best effort backup
-    }
-    console.error(
-      `Warning: library-lock.json was corrupted. Backup saved to ${backupPath}. Starting fresh.`,
-    );
-    return emptyLibraryLock();
-  }
+  return readLibraryLockFile(path);
 }
 
 export async function writeLibraryLock(
   lock: LibraryLockFile,
   path: string = getLibraryLockPath(),
 ): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(lock, null, 2) + "\n", "utf-8");
+  await withFileMutationLock(path, async () => {
+    await persistLibraryLock(lock, path);
+  });
 }
 
 export async function listLibrarySkills(
@@ -179,6 +144,71 @@ function librarySourceRoot(entry: LibrarySkillEntry): string | null {
     return null;
   }
   return resolve(basePath);
+}
+
+async function readLibraryLockFile(path: string): Promise<LibraryLockFile> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf-8");
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      debug("library: lock file not found, returning empty lock");
+      return emptyLibraryLock();
+    }
+    throw err;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed) ||
+      parsed.version !== 1 ||
+      typeof parsed.skills !== "object" ||
+      parsed.skills === null ||
+      Array.isArray(parsed.skills)
+    ) {
+      throw new Error("invalid schema");
+    }
+    return parsed as LibraryLockFile;
+  } catch {
+    const backupPath = path + ".bak";
+    try {
+      await copyFile(path, backupPath);
+    } catch {
+      // best effort backup
+    }
+    console.error(
+      `Warning: library-lock.json was corrupted. Backup saved to ${backupPath}. Starting fresh.`,
+    );
+    return emptyLibraryLock();
+  }
+}
+
+async function persistLibraryLock(
+  lock: LibraryLockFile,
+  path: string,
+): Promise<void> {
+  await writeTextFileAtomically(path, JSON.stringify(lock, null, 2) + "\n");
+}
+
+async function mutateLibraryLock<T>(
+  path: string,
+  mutate: (
+    lock: LibraryLockFile,
+  ) =>
+    | Promise<{ changed: boolean; result?: T }>
+    | { changed: boolean; result?: T },
+): Promise<T | undefined> {
+  return withFileMutationLock(path, async () => {
+    const lock = await readLibraryLockFile(path);
+    const { changed, result } = await mutate(lock);
+    if (changed) {
+      await persistLibraryLock(lock, path);
+    }
+    return result;
+  });
 }
 
 function validateSourceSkillFrontmatter(
@@ -352,27 +382,39 @@ async function cloneRemoteLibrarySource(
   }
 }
 
+async function stageLibraryDirectory(
+  sourceDir: string,
+  targetDir: string,
+): Promise<string> {
+  const stagedDir = await mkdtemp(join(dirname(targetDir), ".library-update-"));
+
+  try {
+    await cp(sourceDir, stagedDir, { recursive: true });
+    await rm(join(stagedDir, ".git"), { recursive: true, force: true });
+    return stagedDir;
+  } catch (err) {
+    await rm(stagedDir, { recursive: true, force: true });
+    throw err;
+  }
+}
+
 async function replaceDirectoryAtomically(input: {
-  sourceDir: string;
+  stagedDir: string;
   targetDir: string;
   writeLock: () => Promise<void>;
 }): Promise<LibraryUpdateResult | null> {
   const parentDir = dirname(input.targetDir);
-  const stagedDir = await mkdtemp(join(parentDir, ".library-update-"));
   let backupDir: string | null = null;
   let preserveBackup = false;
 
   try {
     try {
-      await cp(input.sourceDir, stagedDir, { recursive: true });
-      await rm(join(stagedDir, ".git"), { recursive: true, force: true });
-
       if (await pathExists(input.targetDir)) {
         backupDir = join(parentDir, `.library-update-backup-${Date.now()}`);
         await rename(input.targetDir, backupDir);
       }
 
-      await rename(stagedDir, input.targetDir);
+      await rename(input.stagedDir, input.targetDir);
 
       try {
         await input.writeLock();
@@ -418,7 +460,7 @@ async function replaceDirectoryAtomically(input: {
       };
     }
   } finally {
-    await rm(stagedDir, { recursive: true, force: true });
+    await rm(input.stagedDir, { recursive: true, force: true });
     if (backupDir && !preserveBackup) {
       await rm(backupDir, { recursive: true, force: true });
     }
@@ -434,7 +476,8 @@ export async function updateLibrarySkill(
 ): Promise<LibraryUpdateResult> {
   const lockPath = paths.lockPath ?? getLibraryLockPath();
   const skillsDir = paths.skillsDir ?? getLibrarySkillsDir();
-  const writeLibraryLockFn = _overrides?.writeLibraryLockFn ?? writeLibraryLock;
+  const persistLibraryLockFn =
+    _overrides?.writeLibraryLockFn ?? persistLibraryLock;
   const lock = await readLibraryLock(lockPath);
   const directEntry = lock.skills[name] ?? null;
   const nameMatch =
@@ -543,20 +586,6 @@ export async function updateLibrarySkill(
       );
     }
 
-    const libraryPath = resolveContainedPath(skillsDir, entry.libraryPath);
-    if (!libraryPath) {
-      return libraryUpdateFailure(
-        dirName,
-        "Invalid update metadata: libraryPath escapes library skills directory",
-      );
-    }
-    if (!(await libraryPathRealpathIsContained(skillsDir, libraryPath))) {
-      return libraryUpdateFailure(
-        dirName,
-        "Invalid update metadata: libraryPath escapes library skills directory",
-      );
-    }
-
     let sourceMarkdown: string;
     try {
       sourceMarkdown = await readFile(sourceSkillPath, "utf-8");
@@ -583,50 +612,91 @@ export async function updateLibrarySkill(
     if (!nextCommitHash) {
       return libraryUpdateFailure(dirName, "Could not read new commit");
     }
-    if (entry.commitHash === nextCommitHash) {
-      return {
-        name: nameFromSource,
-        status: "skipped",
-        oldVersion: entry.version,
-        newVersion: versionFromSource,
-        oldCommit: entry.commitHash,
-        newCommit: nextCommitHash,
-      };
-    }
-    const updatedLock = {
-      ...lock,
-      skills: {
-        ...lock.skills,
-        [dirName]: {
-          ...entry,
-          name: nameFromSource,
-          version: versionFromSource,
-          commitHash: nextCommitHash,
-          installedAt: new Date().toISOString(),
-        },
-      },
-    };
 
-    const swapResult = await replaceDirectoryAtomically({
+    const stagedDir = await stageLibraryDirectory(
       sourceDir,
-      targetDir: libraryPath,
-      writeLock: () => writeLibraryLockFn(updatedLock, lockPath),
-    });
-    if (swapResult) {
-      return libraryUpdateFailure(
-        dirName,
-        swapResult.reason ?? "Failed to update library skill",
-      );
-    }
+      join(skillsDir, dirName),
+    );
 
-    return {
-      name: nameFromSource,
-      status: "updated",
-      oldVersion: entry.version,
-      newVersion: versionFromSource,
-      oldCommit: entry.commitHash,
-      newCommit: nextCommitHash,
-    };
+    try {
+      return await withFileMutationLock(lockPath, async () => {
+        const currentLock = await readLibraryLockFile(lockPath);
+        const currentEntry = currentLock.skills[dirName];
+        if (!currentEntry) {
+          return libraryUpdateFailure(
+            dirName,
+            `Library skill "${dirName}" not found. Run "asm library list".`,
+          );
+        }
+
+        const currentLibraryPath = resolveContainedPath(
+          skillsDir,
+          currentEntry.libraryPath,
+        );
+        if (!currentLibraryPath) {
+          return libraryUpdateFailure(
+            dirName,
+            "Invalid update metadata: libraryPath escapes library skills directory",
+          );
+        }
+        if (
+          !(await libraryPathRealpathIsContained(skillsDir, currentLibraryPath))
+        ) {
+          return libraryUpdateFailure(
+            dirName,
+            "Invalid update metadata: libraryPath escapes library skills directory",
+          );
+        }
+
+        if (currentEntry.commitHash === nextCommitHash) {
+          return {
+            name: currentEntry.name,
+            status: "skipped" as const,
+            oldVersion: currentEntry.version,
+            newVersion: versionFromSource,
+            oldCommit: currentEntry.commitHash,
+            newCommit: nextCommitHash,
+          };
+        }
+
+        const updatedLock = {
+          ...currentLock,
+          skills: {
+            ...currentLock.skills,
+            [dirName]: {
+              ...currentEntry,
+              name: nameFromSource,
+              version: versionFromSource,
+              commitHash: nextCommitHash,
+              installedAt: new Date().toISOString(),
+            },
+          },
+        };
+
+        const swapResult = await replaceDirectoryAtomically({
+          stagedDir,
+          targetDir: currentLibraryPath,
+          writeLock: () => persistLibraryLockFn(updatedLock, lockPath),
+        });
+        if (swapResult) {
+          return libraryUpdateFailure(
+            dirName,
+            swapResult.reason ?? "Failed to update library skill",
+          );
+        }
+
+        return {
+          name: nameFromSource,
+          status: "updated" as const,
+          oldVersion: currentEntry.version,
+          newVersion: versionFromSource,
+          oldCommit: currentEntry.commitHash,
+          newCommit: nextCommitHash,
+        };
+      });
+    } finally {
+      await rm(stagedDir, { recursive: true, force: true });
+    }
   } finally {
     if (cleanupSourceRoot) {
       await rm(cleanupSourceRoot, { recursive: true, force: true });
@@ -861,19 +931,20 @@ export async function installLibrarySkill(
   const name = fm.name || libraryName;
   const version = resolveVersion(fm);
 
-  const lock = await readLibraryLock(lockPath);
-  lock.skills[libraryName] = {
-    name,
-    version,
-    source: plan.source,
-    sourceType: plan.sourceType,
-    commitHash: plan.commitHash,
-    ref: plan.ref,
-    skillPath: plan.skillPath,
-    libraryPath,
-    installedAt: new Date().toISOString(),
-  };
-  await writeLibraryLock(lock, lockPath);
+  await mutateLibraryLock(lockPath, (lock) => {
+    lock.skills[libraryName] = {
+      name,
+      version,
+      source: plan.source,
+      sourceType: plan.sourceType,
+      commitHash: plan.commitHash,
+      ref: plan.ref,
+      skillPath: plan.skillPath,
+      libraryPath,
+      installedAt: new Date().toISOString(),
+    };
+    return { changed: true };
+  });
 
   return { name, version, libraryPath };
 }

--- a/src/library.ts
+++ b/src/library.ts
@@ -913,38 +913,53 @@ export async function installLibrarySkill(
   const libraryName = validateSkillDirectoryName(plan.libraryName);
   const libraryPath = join(skillsDir, libraryName);
 
-  if (await pathExists(libraryPath)) {
-    if (!plan.force) {
-      throw new Error(
-        `Library skill already exists: ${libraryPath}. Use --force to overwrite.`,
-      );
-    }
-    await rm(libraryPath, { recursive: true, force: true });
-  }
-
   await mkdir(skillsDir, { recursive: true });
-  await cp(plan.sourceDir, libraryPath, { recursive: true });
-  await rm(join(libraryPath, ".git"), { recursive: true, force: true });
+  const stagedDir = await stageLibraryDirectory(plan.sourceDir, libraryPath);
 
-  const skillMarkdown = await readFile(join(libraryPath, "SKILL.md"), "utf-8");
-  const fm = parseFrontmatter(skillMarkdown);
-  const name = fm.name || libraryName;
-  const version = resolveVersion(fm);
+  try {
+    const skillMarkdown = await readFile(join(stagedDir, "SKILL.md"), "utf-8");
+    const fm = parseFrontmatter(skillMarkdown);
+    const name = fm.name || libraryName;
+    const version = resolveVersion(fm);
 
-  await mutateLibraryLock(lockPath, (lock) => {
-    lock.skills[libraryName] = {
-      name,
-      version,
-      source: plan.source,
-      sourceType: plan.sourceType,
-      commitHash: plan.commitHash,
-      ref: plan.ref,
-      skillPath: plan.skillPath,
-      libraryPath,
-      installedAt: new Date().toISOString(),
-    };
-    return { changed: true };
-  });
+    await withFileMutationLock(lockPath, async () => {
+      const currentLock = await readLibraryLockFile(lockPath);
+      if ((await pathExists(libraryPath)) && !plan.force) {
+        throw new Error(
+          `Library skill already exists: ${libraryPath}. Use --force to overwrite.`,
+        );
+      }
 
-  return { name, version, libraryPath };
+      const updatedLock = {
+        ...currentLock,
+        skills: {
+          ...currentLock.skills,
+          [libraryName]: {
+            name,
+            version,
+            source: plan.source,
+            sourceType: plan.sourceType,
+            commitHash: plan.commitHash,
+            ref: plan.ref,
+            skillPath: plan.skillPath,
+            libraryPath,
+            installedAt: new Date().toISOString(),
+          },
+        },
+      };
+
+      const swapResult = await replaceDirectoryAtomically({
+        stagedDir,
+        targetDir: libraryPath,
+        writeLock: () => persistLibraryLock(updatedLock, lockPath),
+      });
+      if (swapResult) {
+        throw new Error(swapResult.reason ?? "Failed to install library skill");
+      }
+    });
+
+    return { name, version, libraryPath };
+  } finally {
+    await rm(stagedDir, { recursive: true, force: true });
+  }
 }

--- a/src/library.ts
+++ b/src/library.ts
@@ -135,16 +135,30 @@ function libraryUpdateFailure(
   return { name, status: "failed", reason };
 }
 
-function libraryEntryMatchesUpdateSource(
+async function libraryEntryMatchesUpdateSource(
   currentEntry: LibrarySkillEntry,
   expectedEntry: LibrarySkillEntry,
-): boolean {
+  expectedLocalSourceIdentity: string | null,
+): Promise<boolean> {
+  if (currentEntry.sourceType !== expectedEntry.sourceType) {
+    return false;
+  }
+  if (resolve(currentEntry.libraryPath) !== resolve(expectedEntry.libraryPath)) {
+    return false;
+  }
+  if (currentEntry.sourceType === "local") {
+    if (!expectedLocalSourceIdentity) {
+      return false;
+    }
+    return (
+      (await resolveLocalSourceIdentity(currentEntry)) ===
+      expectedLocalSourceIdentity
+    );
+  }
   return (
     currentEntry.source === expectedEntry.source &&
-    currentEntry.sourceType === expectedEntry.sourceType &&
     currentEntry.ref === expectedEntry.ref &&
-    currentEntry.skillPath === expectedEntry.skillPath &&
-    currentEntry.libraryPath === expectedEntry.libraryPath
+    currentEntry.skillPath === expectedEntry.skillPath
   );
 }
 
@@ -166,6 +180,33 @@ function librarySourceRoot(entry: LibrarySkillEntry): string | null {
     return null;
   }
   return resolve(basePath);
+}
+
+async function resolveLocalSourceIdentity(
+  entry: LibrarySkillEntry,
+): Promise<string> {
+  const sourceRoot = librarySourceRoot(entry);
+  if (!sourceRoot) {
+    throw new Error("Unsupported library source for update");
+  }
+
+  const sourceDir = resolveContainedPath(
+    sourceRoot,
+    join(sourceRoot, entry.skillPath),
+  );
+  if (!sourceDir) {
+    throw new Error("Invalid update metadata: skillPath escapes source root");
+  }
+
+  const [realSourceRoot, realSourceDir] = await Promise.all([
+    realpath(sourceRoot),
+    realpath(sourceDir),
+  ]);
+  if (!isContainedPath(realSourceRoot, realSourceDir)) {
+    throw new Error("Invalid update metadata: skillPath escapes source root");
+  }
+
+  return realSourceDir;
 }
 
 async function readLibraryLockFile(path: string): Promise<LibraryLockFile> {
@@ -537,6 +578,7 @@ export async function updateLibrarySkill(
   }
 
   let cleanupSourceRoot: string | null = null;
+  let expectedLocalSourceIdentity: string | null = null;
   try {
     let sourceRoot: string;
     let nextCommitHash: string | null = null;
@@ -608,6 +650,9 @@ export async function updateLibrarySkill(
         "Invalid update metadata: skillPath escapes source root",
       );
     }
+    if (entry.sourceType === "local") {
+      expectedLocalSourceIdentity = realSourceDir;
+    }
 
     let sourceMarkdown: string;
     try {
@@ -671,10 +716,16 @@ export async function updateLibrarySkill(
           );
         }
 
-        const updateSourceStillMatches = libraryEntryMatchesUpdateSource(
-          currentEntry,
-          expectedEntry,
-        );
+        let updateSourceStillMatches: boolean;
+        try {
+          updateSourceStillMatches = await libraryEntryMatchesUpdateSource(
+            currentEntry,
+            expectedEntry,
+            expectedLocalSourceIdentity,
+          );
+        } catch {
+          return libraryEntryChangedDuringUpdate(dirName);
+        }
         if (updateSourceStillMatches && currentEntry.commitHash === nextCommitHash) {
           return {
             name: currentEntry.name,

--- a/src/library.ts
+++ b/src/library.ts
@@ -20,7 +20,10 @@ import { getLibraryLockPath, getLibrarySkillsDir } from "./config";
 import { debug } from "./logger";
 import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
 import { createDirSymlink } from "./utils/fs";
-import { withFileMutationLock, writeTextFileAtomically } from "./utils/atomic-file";
+import {
+  withFileMutationLock,
+  writeTextFileAtomically,
+} from "./utils/atomic-file";
 import { sourceToCloneUrl } from "./updater";
 import type { LibraryLockFile, LibrarySkillEntry } from "./utils/types";
 
@@ -143,7 +146,9 @@ async function libraryEntryMatchesUpdateSource(
   if (currentEntry.sourceType !== expectedEntry.sourceType) {
     return false;
   }
-  if (resolve(currentEntry.libraryPath) !== resolve(expectedEntry.libraryPath)) {
+  if (
+    resolve(currentEntry.libraryPath) !== resolve(expectedEntry.libraryPath)
+  ) {
     return false;
   }
   if (currentEntry.sourceType === "local") {
@@ -162,9 +167,7 @@ async function libraryEntryMatchesUpdateSource(
   );
 }
 
-function libraryEntryChangedDuringUpdate(
-  name: string,
-): LibraryUpdateResult {
+function libraryEntryChangedDuringUpdate(name: string): LibraryUpdateResult {
   return libraryUpdateFailure(
     name,
     `Library skill "${name}" changed while update was in progress. Run "asm library update ${name}" again.`,
@@ -726,7 +729,10 @@ export async function updateLibrarySkill(
         } catch {
           return libraryEntryChangedDuringUpdate(dirName);
         }
-        if (updateSourceStillMatches && currentEntry.commitHash === nextCommitHash) {
+        if (
+          updateSourceStillMatches &&
+          currentEntry.commitHash === nextCommitHash
+        ) {
           return {
             name: currentEntry.name,
             status: "skipped" as const,

--- a/src/library.ts
+++ b/src/library.ts
@@ -175,6 +175,12 @@ function libraryEntryChangedDuringUpdate(name: string): LibraryUpdateResult {
   );
 }
 
+function nextInstalledAt(previousInstalledAt?: string): string {
+  const installedAt = new Date().toISOString();
+  if (installedAt !== previousInstalledAt) return installedAt;
+  return new Date(Date.parse(installedAt) + 1).toISOString();
+}
+
 function librarySourceRoot(entry: LibrarySkillEntry): string | null {
   if (!entry.source.startsWith("local:")) {
     return null;
@@ -740,7 +746,10 @@ export async function updateLibrarySkill(
         } catch {
           return libraryEntryChangedDuringUpdate(dirName);
         }
+        const installedGenerationStillMatches =
+          currentEntry.installedAt === expectedEntry.installedAt;
         if (
+          installedGenerationStillMatches &&
           updateSourceStillMatches &&
           currentEntry.commitHash === nextCommitHash
         ) {
@@ -755,6 +764,7 @@ export async function updateLibrarySkill(
         }
 
         if (
+          !installedGenerationStillMatches ||
           !updateSourceStillMatches ||
           currentEntry.commitHash !== expectedEntry.commitHash
         ) {
@@ -770,7 +780,7 @@ export async function updateLibrarySkill(
               name: nameFromSource,
               version: versionFromSource,
               commitHash: nextCommitHash,
-              installedAt: new Date().toISOString(),
+              installedAt: nextInstalledAt(currentEntry.installedAt),
             },
           },
         };
@@ -1045,7 +1055,9 @@ export async function installLibrarySkill(
             ref: plan.ref,
             skillPath: plan.skillPath,
             libraryPath,
-            installedAt: new Date().toISOString(),
+            installedAt: nextInstalledAt(
+              currentLock.skills[libraryName]?.installedAt,
+            ),
           },
         },
       };

--- a/src/utils/atomic-file.test.ts
+++ b/src/utils/atomic-file.test.ts
@@ -59,7 +59,10 @@ vi.mock("fs/promises", async (importOriginal) => {
 import { mkdtemp, rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
-import { writeTextFileAtomically } from "./atomic-file";
+import {
+  AtomicWritePostRenameError,
+  writeTextFileAtomically,
+} from "./atomic-file";
 
 function fsError(code: string, message = code): NodeJS.ErrnoException {
   return Object.assign(new Error(message), { code });
@@ -134,14 +137,50 @@ describe("writeTextFileAtomically", () => {
     ]);
   });
 
-  test("propagates directory sync failures without cleaning up after rename", async () => {
+  test.each([
+    ["open", "directoryOpenError"],
+    ["sync", "directorySyncError"],
+    ["close", "directoryCloseError"],
+  ] as const)(
+    "classifies a directory %s failure as post-rename",
+    async (phase, errorField) => {
+      const cause = fsError("EIO", `directory ${phase} failed`);
+      fspMocks[errorField] = cause;
+
+      const failure = await writeTextFileAtomically(
+        destinationPath,
+        "contents",
+      ).then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+      expect(failure).toBeInstanceOf(AtomicWritePostRenameError);
+      expect(failure).toMatchObject({
+        committed: true,
+        path: destinationPath,
+        cause,
+      });
+      expect(fspMocks.events.indexOf("rename")).toBeGreaterThanOrEqual(0);
+      expect(fspMocks.events.indexOf(`directory-${phase}`)).toBeGreaterThan(
+        fspMocks.events.indexOf("rename"),
+      );
+      expect(fspMocks.events).not.toContain("temp-remove");
+    },
+  );
+
+  test("preserves the directory sync failure when closing also fails", async () => {
     const syncError = fsError("EIO", "directory sync failed");
     fspMocks.directorySyncError = syncError;
     fspMocks.directoryCloseError = fsError("EIO", "directory close failed");
 
-    await expect(
-      writeTextFileAtomically(destinationPath, "contents"),
-    ).rejects.toBe(syncError);
+    const failure = await writeTextFileAtomically(
+      destinationPath,
+      "contents",
+    ).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(AtomicWritePostRenameError);
+    expect(failure).toMatchObject({ cause: syncError });
     expect(fspMocks.events).toEqual([
       "temp-open",
       "temp-write",
@@ -171,21 +210,5 @@ describe("writeTextFileAtomically", () => {
       writeTextFileAtomically(destinationPath, "contents"),
     ).resolves.toBeUndefined();
     expect(fspMocks.events.slice(-2)).toEqual(["rename", "directory-open"]);
-  });
-
-  test("does not swallow unexpected directory open or close failures", async () => {
-    const openError = fsError("EACCES", "directory open failed");
-    fspMocks.directoryOpenError = openError;
-    await expect(
-      writeTextFileAtomically(destinationPath, "contents"),
-    ).rejects.toBe(openError);
-
-    fspMocks.events = [];
-    fspMocks.directoryOpenError = null;
-    const closeError = fsError("EINVAL", "directory close failed");
-    fspMocks.directoryCloseError = closeError;
-    await expect(
-      writeTextFileAtomically(destinationPath, "contents"),
-    ).rejects.toBe(closeError);
   });
 });

--- a/src/utils/atomic-file.test.ts
+++ b/src/utils/atomic-file.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const fspMocks = vi.hoisted(() => ({
+  events: [] as string[],
+  tempSyncError: null as Error | null,
+  tempCloseError: null as Error | null,
+  directoryOpenError: null as Error | null,
+  directorySyncError: null as Error | null,
+  directoryCloseError: null as Error | null,
+}));
+
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+  return {
+    ...actual,
+    open: async (...args: Parameters<typeof actual.open>) => {
+      if (args[1] === "wx") {
+        fspMocks.events.push("temp-open");
+        return {
+          writeFile: async () => {
+            fspMocks.events.push("temp-write");
+          },
+          sync: async () => {
+            fspMocks.events.push("temp-sync");
+            if (fspMocks.tempSyncError) throw fspMocks.tempSyncError;
+          },
+          close: async () => {
+            fspMocks.events.push("temp-close");
+            if (fspMocks.tempCloseError) throw fspMocks.tempCloseError;
+          },
+        } as unknown as Awaited<ReturnType<typeof actual.open>>;
+      }
+
+      fspMocks.events.push("directory-open");
+      if (fspMocks.directoryOpenError) throw fspMocks.directoryOpenError;
+      return {
+        sync: async () => {
+          fspMocks.events.push("directory-sync");
+          if (fspMocks.directorySyncError) throw fspMocks.directorySyncError;
+        },
+        close: async () => {
+          fspMocks.events.push("directory-close");
+          if (fspMocks.directoryCloseError) {
+            throw fspMocks.directoryCloseError;
+          }
+        },
+      } as unknown as Awaited<ReturnType<typeof actual.open>>;
+    },
+    rename: async () => {
+      fspMocks.events.push("rename");
+    },
+    rm: async (...args: Parameters<typeof actual.rm>) => {
+      fspMocks.events.push("temp-remove");
+      await actual.rm(...args);
+    },
+  };
+});
+
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { writeTextFileAtomically } from "./atomic-file";
+
+function fsError(code: string, message = code): NodeJS.ErrnoException {
+  return Object.assign(new Error(message), { code });
+}
+
+let tempDir: string;
+let destinationPath: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "atomic-file-test-"));
+  destinationPath = join(tempDir, "lock.json");
+  fspMocks.events = [];
+  fspMocks.tempSyncError = null;
+  fspMocks.tempCloseError = null;
+  fspMocks.directoryOpenError = null;
+  fspMocks.directorySyncError = null;
+  fspMocks.directoryCloseError = null;
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("writeTextFileAtomically", () => {
+  test("syncs the temporary file before rename and the directory afterward", async () => {
+    await writeTextFileAtomically(destinationPath, "contents");
+
+    expect(fspMocks.events).toEqual([
+      "temp-open",
+      "temp-write",
+      "temp-sync",
+      "temp-close",
+      "rename",
+      "directory-open",
+      "directory-sync",
+      "directory-close",
+    ]);
+  });
+
+  test("preserves a temporary sync failure while closing and cleaning up", async () => {
+    const syncError = fsError("EIO", "temp sync failed");
+    fspMocks.tempSyncError = syncError;
+    fspMocks.tempCloseError = fsError("EIO", "cleanup close failed");
+
+    await expect(
+      writeTextFileAtomically(destinationPath, "contents"),
+    ).rejects.toBe(syncError);
+    expect(fspMocks.events).toEqual([
+      "temp-open",
+      "temp-write",
+      "temp-sync",
+      "temp-close",
+      "temp-remove",
+    ]);
+  });
+
+  test("does not rename when closing the temporary file fails", async () => {
+    const closeError = fsError("EIO", "temp close failed");
+    fspMocks.tempCloseError = closeError;
+
+    await expect(
+      writeTextFileAtomically(destinationPath, "contents"),
+    ).rejects.toBe(closeError);
+    expect(fspMocks.events).toEqual([
+      "temp-open",
+      "temp-write",
+      "temp-sync",
+      "temp-close",
+      "temp-close",
+      "temp-remove",
+    ]);
+  });
+
+  test("propagates directory sync failures without cleaning up after rename", async () => {
+    const syncError = fsError("EIO", "directory sync failed");
+    fspMocks.directorySyncError = syncError;
+    fspMocks.directoryCloseError = fsError("EIO", "directory close failed");
+
+    await expect(
+      writeTextFileAtomically(destinationPath, "contents"),
+    ).rejects.toBe(syncError);
+    expect(fspMocks.events).toEqual([
+      "temp-open",
+      "temp-write",
+      "temp-sync",
+      "temp-close",
+      "rename",
+      "directory-open",
+      "directory-sync",
+      "directory-close",
+    ]);
+  });
+
+  test("tolerates filesystems that do not support directory sync", async () => {
+    fspMocks.directorySyncError = fsError("ENOTSUP");
+
+    await expect(
+      writeTextFileAtomically(destinationPath, "contents"),
+    ).resolves.toBeUndefined();
+    expect(fspMocks.events.at(-1)).toBe("directory-close");
+  });
+
+  test("tolerates unsupported directory opens on Windows", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    fspMocks.directoryOpenError = fsError("EISDIR");
+
+    await expect(
+      writeTextFileAtomically(destinationPath, "contents"),
+    ).resolves.toBeUndefined();
+    expect(fspMocks.events.slice(-2)).toEqual(["rename", "directory-open"]);
+  });
+
+  test("does not swallow unexpected directory open or close failures", async () => {
+    const openError = fsError("EACCES", "directory open failed");
+    fspMocks.directoryOpenError = openError;
+    await expect(
+      writeTextFileAtomically(destinationPath, "contents"),
+    ).rejects.toBe(openError);
+
+    fspMocks.events = [];
+    fspMocks.directoryOpenError = null;
+    const closeError = fsError("EINVAL", "directory close failed");
+    fspMocks.directoryCloseError = closeError;
+    await expect(
+      writeTextFileAtomically(destinationPath, "contents"),
+    ).rejects.toBe(closeError);
+  });
+});

--- a/src/utils/atomic-file.ts
+++ b/src/utils/atomic-file.ts
@@ -19,6 +19,21 @@ function isUnsupportedDirectorySyncError(error: unknown): boolean {
   );
 }
 
+export class AtomicWritePostRenameError extends Error {
+  readonly committed = true as const;
+
+  constructor(
+    readonly path: string,
+    readonly cause: unknown,
+  ) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    super(
+      `Atomic write to ${path} was renamed into place, but parent-directory durability could not be confirmed: ${detail}`,
+    );
+    this.name = "AtomicWritePostRenameError";
+  }
+}
+
 async function syncDirectory(path: string): Promise<void> {
   let handle: Awaited<ReturnType<typeof open>>;
   try {
@@ -110,8 +125,12 @@ export async function writeTextFileAtomically(
     throw err;
   }
 
-  // Renaming persists the file contents but not necessarily the directory entry.
-  // Some platforms/filesystems do not support opening or syncing directories;
-  // syncDirectory tolerates only known unsupported-operation errors.
-  await syncDirectory(destinationDir);
+  // Renaming publishes the file contents but does not necessarily make the
+  // directory entry crash-durable. Failures after this commit point must remain
+  // distinguishable from failures that definitely left the destination intact.
+  try {
+    await syncDirectory(destinationDir);
+  } catch (cause) {
+    throw new AtomicWritePostRenameError(destinationPath, cause);
+  }
 }

--- a/src/utils/atomic-file.ts
+++ b/src/utils/atomic-file.ts
@@ -4,6 +4,50 @@ import { basename, dirname, join, resolve } from "path";
 
 const fileMutationQueues = new Map<string, Promise<void>>();
 
+const unsupportedDirectorySyncCodes = new Set([
+  "EINVAL",
+  "ENOSYS",
+  "ENOTSUP",
+  "EOPNOTSUPP",
+]);
+
+function isUnsupportedDirectorySyncError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null)?.code;
+  return (
+    (typeof code === "string" && unsupportedDirectorySyncCodes.has(code)) ||
+    (process.platform === "win32" && (code === "EISDIR" || code === "EPERM"))
+  );
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  let handle: Awaited<ReturnType<typeof open>>;
+  try {
+    handle = await open(path, "r");
+  } catch (error) {
+    if (isUnsupportedDirectorySyncError(error)) return;
+    throw error;
+  }
+
+  let syncFailed = false;
+  let syncError: unknown;
+  try {
+    await handle.sync();
+  } catch (error) {
+    if (!isUnsupportedDirectorySyncError(error)) {
+      syncFailed = true;
+      syncError = error;
+    }
+  }
+
+  try {
+    await handle.close();
+  } catch (error) {
+    if (!syncFailed) throw error;
+  }
+
+  if (syncFailed) throw syncError;
+}
+
 export async function withFileMutationLock<T>(
   path: string,
   operation: () => Promise<T>,
@@ -44,6 +88,7 @@ export async function writeTextFileAtomically(
   try {
     handle = await open(tempPath, "wx");
     await handle.writeFile(content, "utf-8");
+    await handle.sync();
     await handle.close();
     handle = null;
     await rename(tempPath, destinationPath);
@@ -64,4 +109,9 @@ export async function writeTextFileAtomically(
 
     throw err;
   }
+
+  // Renaming persists the file contents but not necessarily the directory entry.
+  // Some platforms/filesystems do not support opening or syncing directories;
+  // syncDirectory tolerates only known unsupported-operation errors.
+  await syncDirectory(destinationDir);
 }

--- a/src/utils/atomic-file.ts
+++ b/src/utils/atomic-file.ts
@@ -1,0 +1,67 @@
+import { mkdir, open, rename, rm } from "fs/promises";
+import { randomUUID } from "crypto";
+import { basename, dirname, join, resolve } from "path";
+
+const fileMutationQueues = new Map<string, Promise<void>>();
+
+export async function withFileMutationLock<T>(
+  path: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const key = resolve(path);
+  const tail = fileMutationQueues.get(key) ?? Promise.resolve();
+  const run = tail.then(operation, operation);
+  const settled = run.then(
+    () => undefined,
+    () => undefined,
+  );
+
+  fileMutationQueues.set(key, settled);
+
+  try {
+    return await run;
+  } finally {
+    if (fileMutationQueues.get(key) === settled) {
+      fileMutationQueues.delete(key);
+    }
+  }
+}
+
+export async function writeTextFileAtomically(
+  path: string,
+  content: string,
+): Promise<void> {
+  const destinationPath = resolve(path);
+  const destinationDir = dirname(destinationPath);
+  const tempPath = join(
+    destinationDir,
+    `.${basename(destinationPath)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`,
+  );
+
+  await mkdir(destinationDir, { recursive: true });
+
+  let handle: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    handle = await open(tempPath, "wx");
+    await handle.writeFile(content, "utf-8");
+    await handle.close();
+    handle = null;
+    await rename(tempPath, destinationPath);
+  } catch (err) {
+    if (handle) {
+      try {
+        await handle.close();
+      } catch {
+        // best effort close before cleanup
+      }
+    }
+
+    try {
+      await rm(tempPath, { force: true });
+    } catch {
+      // best effort cleanup of owned temp artifact only
+    }
+
+    throw err;
+  }
+}

--- a/src/utils/lock.test.ts
+++ b/src/utils/lock.test.ts
@@ -1,10 +1,12 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 
 const fspMocks = vi.hoisted(() => ({
-  renameOverride: null as null | ((
-    realRename: typeof import("fs/promises").rename,
-    ...args: Parameters<typeof import("fs/promises").rename>
-  ) => Promise<void>),
+  renameOverride: null as
+    | null
+    | ((
+        realRename: typeof import("fs/promises").rename,
+        ...args: Parameters<typeof import("fs/promises").rename>
+      ) => Promise<void>),
 }));
 vi.mock("fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("fs/promises")>();
@@ -17,14 +19,7 @@ vi.mock("fs/promises", async (importOriginal) => {
   };
 });
 
-import {
-  mkdtemp,
-  writeFile,
-  rm,
-  readFile,
-  mkdir,
-  readdir,
-} from "fs/promises";
+import { mkdtemp, writeFile, rm, readFile, mkdir, readdir } from "fs/promises";
 import { execSync } from "child_process";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -208,22 +203,23 @@ describe("writeLockEntry", () => {
   });
 
   test("preserves the previous lock file when atomic rename fails", async () => {
-    const original = JSON.stringify(
-      {
-        version: 1,
-        skills: {
-          existing: {
-            source: "github:bob/existing",
-            commitHash: "111",
-            ref: "main",
-            installedAt: "2026-03-19T10:00:00Z",
-            provider: "claude",
+    const original =
+      JSON.stringify(
+        {
+          version: 1,
+          skills: {
+            existing: {
+              source: "github:bob/existing",
+              commitHash: "111",
+              ref: "main",
+              installedAt: "2026-03-19T10:00:00Z",
+              provider: "claude",
+            },
           },
         },
-      },
-      null,
-      2,
-    ) + "\n";
+        null,
+        2,
+      ) + "\n";
     await writeFile(mockState.lockPath, original, "utf-8");
 
     fspMocks.renameOverride = async (_realRename, _from, to) => {

--- a/src/utils/lock.test.ts
+++ b/src/utils/lock.test.ts
@@ -1,11 +1,29 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+
+const fspMocks = vi.hoisted(() => ({
+  renameOverride: null as null | ((
+    realRename: typeof import("fs/promises").rename,
+    ...args: Parameters<typeof import("fs/promises").rename>
+  ) => Promise<void>),
+}));
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+  return {
+    ...actual,
+    rename: (...args: Parameters<typeof actual.rename>) =>
+      fspMocks.renameOverride
+        ? fspMocks.renameOverride(actual.rename, ...args)
+        : actual.rename(...args),
+  };
+});
+
 import {
   mkdtemp,
   writeFile,
   rm,
   readFile,
   mkdir,
-  appendFile,
+  readdir,
 } from "fs/promises";
 import { execSync } from "child_process";
 import { join } from "path";
@@ -27,12 +45,24 @@ vi.mock("../config", () => ({
 
 let tempDir: string;
 
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 beforeEach(async () => {
   tempDir = await mkdtemp(join(tmpdir(), "lock-test-"));
   mockState.lockPath = join(tempDir, ".skill-lock.json");
+  fspMocks.renameOverride = null;
 });
 
 afterEach(async () => {
+  fspMocks.renameOverride = null;
   await rm(tempDir, { recursive: true, force: true });
 });
 
@@ -175,6 +205,114 @@ describe("writeLockEntry", () => {
     const lock = await readLock();
     expect(lock.skills["my-skill"].commitHash).toBe("new-hash");
     expect(lock.skills["my-skill"].ref).toBe("v2.0");
+  });
+
+  test("preserves the previous lock file when atomic rename fails", async () => {
+    const original = JSON.stringify(
+      {
+        version: 1,
+        skills: {
+          existing: {
+            source: "github:bob/existing",
+            commitHash: "111",
+            ref: "main",
+            installedAt: "2026-03-19T10:00:00Z",
+            provider: "claude",
+          },
+        },
+      },
+      null,
+      2,
+    ) + "\n";
+    await writeFile(mockState.lockPath, original, "utf-8");
+
+    fspMocks.renameOverride = async (_realRename, _from, to) => {
+      if (to === mockState.lockPath) {
+        throw new Error("rename boom");
+      }
+    };
+
+    await expect(
+      writeLockEntry("new-skill", {
+        source: "github:alice/new-skill",
+        commitHash: "222",
+        ref: "v1.0",
+        installedAt: "2026-03-20T12:00:00Z",
+        provider: "codex",
+      }),
+    ).rejects.toThrow("rename boom");
+
+    await expect(readFile(mockState.lockPath, "utf-8")).resolves.toBe(original);
+    await expect(readdir(tempDir)).resolves.toEqual([".skill-lock.json"]);
+  });
+
+  test("serializes overlapping mutations and keeps queued writes recoverable", async () => {
+    const firstRenameStarted = deferred<void>();
+    const releaseFirstRename = deferred<void>();
+    let blockedFirstRename = false;
+
+    fspMocks.renameOverride = async (realRename, from, to) => {
+      if (to === mockState.lockPath && !blockedFirstRename) {
+        blockedFirstRename = true;
+        firstRenameStarted.resolve();
+        await releaseFirstRename.promise;
+      }
+      await realRename(from, to);
+    };
+
+    const firstWrite = writeLockEntry("skill-a", {
+      source: "github:owner/a",
+      commitHash: "aaa",
+      ref: "main",
+      installedAt: "2026-03-20T12:00:00Z",
+      provider: "claude",
+    });
+    await firstRenameStarted.promise;
+
+    const secondWrite = writeLockEntry("skill-b", {
+      source: "github:owner/b",
+      commitHash: "bbb",
+      ref: "main",
+      installedAt: "2026-03-20T12:00:00Z",
+      provider: "codex",
+    });
+
+    releaseFirstRename.resolve();
+    await Promise.all([firstWrite, secondWrite]);
+
+    fspMocks.renameOverride = async (_realRename, _from, to) => {
+      if (to === mockState.lockPath) {
+        throw new Error("rename boom");
+      }
+    };
+    await expect(
+      writeLockEntry("broken", {
+        source: "github:owner/broken",
+        commitHash: "ccc",
+        ref: "main",
+        installedAt: "2026-03-20T12:00:00Z",
+        provider: "claude",
+      }),
+    ).rejects.toThrow("rename boom");
+
+    fspMocks.renameOverride = null;
+    await writeLockEntry("skill-c", {
+      source: "github:owner/c",
+      commitHash: "ddd",
+      ref: "main",
+      installedAt: "2026-03-20T12:00:00Z",
+      provider: "claude",
+    });
+
+    const lock = await readLock();
+    expect(Object.keys(lock.skills).sort()).toEqual([
+      "skill-a",
+      "skill-b",
+      "skill-c",
+    ]);
+    expect(lock.skills["skill-a"].commitHash).toBe("aaa");
+    expect(lock.skills["skill-b"].commitHash).toBe("bbb");
+    expect(lock.skills["skill-c"].commitHash).toBe("ddd");
   });
 });
 

--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -1,9 +1,9 @@
-import { readFile, writeFile, mkdir, copyFile } from "fs/promises";
+import { readFile, copyFile } from "fs/promises";
 import { execFile } from "child_process";
 import { promisify } from "util";
-import { dirname } from "path";
 import { getLockPath } from "../config";
 import { debug } from "../logger";
+import { withFileMutationLock, writeTextFileAtomically } from "./atomic-file";
 import type { LockFile, LockEntry } from "./types";
 
 const execFileAsync = promisify(execFile);
@@ -13,7 +13,73 @@ function createEmptyLock(): LockFile {
 }
 
 export async function readLock(): Promise<LockFile> {
-  const lockPath = getLockPath();
+  return readLockFile(getLockPath());
+}
+
+export async function writeLockEntry(
+  name: string,
+  entry: LockEntry,
+): Promise<void> {
+  await mutateLock((lock) => {
+    lock.skills[name] = entry;
+    return { changed: true };
+  });
+  debug(`lock: wrote entry for "${name}"`);
+}
+
+export async function removeLockEntry(name: string): Promise<void> {
+  const removed = await mutateLock((lock) => {
+    if (!(name in lock.skills)) {
+      return { changed: false, result: false };
+    }
+    delete lock.skills[name];
+    return { changed: true, result: true };
+  });
+
+  if (!removed) {
+    debug(`lock: no entry for "${name}", nothing to remove`);
+    return;
+  }
+
+  debug(`lock: removed entry for "${name}"`);
+}
+
+/**
+ * Rewrite an existing entry's provider field while preserving every other
+ * field (source, commitHash, ref, installedAt, sourceType, registryName).
+ * No-op when the entry doesn't exist. Used by partial-uninstall (`-t`) when
+ * a real-folder relocation moves the canonical home from one provider to
+ * another and source-tracking metadata must follow the surviving instance.
+ */
+export async function setLockEntryProvider(
+  name: string,
+  provider: string,
+): Promise<void> {
+  const outcome = await mutateLock((lock) => {
+    const entry = lock.skills[name];
+    if (!entry) {
+      return { changed: false, result: "missing" as const };
+    }
+    if (entry.provider === provider) {
+      return { changed: false, result: "unchanged" as const };
+    }
+    lock.skills[name] = { ...entry, provider };
+    return { changed: true, result: "updated" as const };
+  });
+
+  if (outcome === "missing") {
+    debug(`lock: no entry for "${name}", cannot update provider`);
+    return;
+  }
+  if (outcome === "unchanged") {
+    debug(`lock: entry for "${name}" already points at "${provider}"`);
+    return;
+  }
+
+  debug(`lock: updated provider for "${name}" -> "${provider}"`);
+}
+
+async function readLockFile(lockPath: string): Promise<LockFile> {
   let raw: string;
   try {
     raw = await readFile(lockPath, "utf-8");
@@ -37,7 +103,6 @@ export async function readLock(): Promise<LockFile> {
     debug(`lock: loaded ${Object.keys(parsed.skills).length} entries`);
     return parsed as LockFile;
   } catch {
-    // Corrupted lock file — back up and rebuild
     const backupPath = lockPath + ".bak";
     debug(`lock: parse error, backing up to ${backupPath}`);
     try {
@@ -52,57 +117,29 @@ export async function readLock(): Promise<LockFile> {
   }
 }
 
-export async function writeLockEntry(
-  name: string,
-  entry: LockEntry,
-): Promise<void> {
-  const lock = await readLock();
-  lock.skills[name] = entry;
-  await writeLock(lock);
-  debug(`lock: wrote entry for "${name}"`);
-}
-
-export async function removeLockEntry(name: string): Promise<void> {
-  const lock = await readLock();
-  if (!(name in lock.skills)) {
-    debug(`lock: no entry for "${name}", nothing to remove`);
-    return;
-  }
-  delete lock.skills[name];
-  await writeLock(lock);
-  debug(`lock: removed entry for "${name}"`);
-}
-
-/**
- * Rewrite an existing entry's provider field while preserving every other
- * field (source, commitHash, ref, installedAt, sourceType, registryName).
- * No-op when the entry doesn't exist. Used by partial-uninstall (`-t`) when
- * a real-folder relocation moves the canonical home from one provider to
- * another and source-tracking metadata must follow the surviving instance.
- */
-export async function setLockEntryProvider(
-  name: string,
-  provider: string,
-): Promise<void> {
-  const lock = await readLock();
-  const entry = lock.skills[name];
-  if (!entry) {
-    debug(`lock: no entry for "${name}", cannot update provider`);
-    return;
-  }
-  if (entry.provider === provider) {
-    debug(`lock: entry for "${name}" already points at "${provider}"`);
-    return;
-  }
-  lock.skills[name] = { ...entry, provider };
-  await writeLock(lock);
-  debug(`lock: updated provider for "${name}" -> "${provider}"`);
-}
-
-async function writeLock(lock: LockFile): Promise<void> {
+async function mutateLock<T>(
+  mutate: (
+    lock: LockFile,
+  ) =>
+    | Promise<{ changed: boolean; result?: T }>
+    | { changed: boolean; result?: T },
+): Promise<T | undefined> {
   const lockPath = getLockPath();
-  await mkdir(dirname(lockPath), { recursive: true });
-  await writeFile(lockPath, JSON.stringify(lock, null, 2) + "\n", "utf-8");
+  return withFileMutationLock(lockPath, async () => {
+    const lock = await readLockFile(lockPath);
+    const { changed, result } = await mutate(lock);
+    if (changed) {
+      await writeLock(lock, lockPath);
+    }
+    return result;
+  });
+}
+
+async function writeLock(lock: LockFile, lockPath: string): Promise<void> {
+  await writeTextFileAtomically(
+    lockPath,
+    JSON.stringify(lock, null, 2) + "\n",
+  );
 }
 
 export async function getCommitHash(repoDir: string): Promise<string | null> {

--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -136,10 +136,7 @@ async function mutateLock<T>(
 }
 
 async function writeLock(lock: LockFile, lockPath: string): Promise<void> {
-  await writeTextFileAtomically(
-    lockPath,
-    JSON.stringify(lock, null, 2) + "\n",
-  );
+  await writeTextFileAtomically(lockPath, JSON.stringify(lock, null, 2) + "\n");
 }
 
 export async function getCommitHash(repoDir: string): Promise<string | null> {


### PR DESCRIPTION
Closes #369

## Summary

Make skill and library lock-file mutations crash-safe and concurrency-safe within one asm process. Lock updates now serialize complete read-modify-write operations, replace files atomically from same-directory temporary files, and preserve fresh library state when install and update work overlaps.

## Approach

**Option 2 — Balanced atomic write plus in-process serialization.** Add a reusable atomic writer and per-path mutation queue, then route skill and library lock mutations through fresh-state critical sections. Long library preparation remains outside the lock; publication revalidates source identity and merges only the prepared per-skill delta under the lock.

## Decision Record

- **Root cause:** Skill and library state were persisted by reading a whole JSON snapshot, mutating it, and writing the destination in place. A crash could truncate the destination, while overlapping async operations could publish stale snapshots and erase newer entries; library clone/copy work widened that race window.
- **Options considered:** Option 1 — atomic writes only; Option 2 — atomic writes plus in-process serialization; Option 3 — comprehensive lock coordination with advisory cross-process locking.
- **Options rejected:** Option 1 — atomic durability alone does not prevent stale-snapshot lost updates; Option 3 — cross-process coordination and broader CLI/config refactoring exceed the acceptance criteria and add regression risk.
- **Selected option:** Option 2 — Balanced atomic write plus in-process serialization.
- **Residual risk:** Cross-process read-modify-write operations are not serialized; atomic replacement still prevents truncated files, but two separate asm processes can retain last-writer-wins behavior. Advisory cross-process locking was explicitly optional for this issue.

Analyzed at: `refactor/369-make-lock-file-writes-atomic-and @ 6b83c60` (2026-08-09)

## Changes

| File | Change |
|------|--------|
| `src/utils/atomic-file.ts` | Add same-directory atomic replacement and a rejection-safe per-path mutation queue. |
| `src/utils/lock.ts` | Serialize complete skill-lock mutations and persist fresh state atomically. |
| `src/library.ts` | Serialize library publication, merge fresh per-skill deltas, coordinate rollback/install/update, and reject genuinely stale staged updates. |
| `src/utils/lock.test.ts` | Cover failed atomic replacement, overlapping mutations, and queue recovery. |
| `src/library.test.ts` | Cover atomic failure preservation and deterministic install/update concurrency interleavings. |

## Test Results

- Unit/integration tests: 1,981 passed (`src/` + `website-src/`)
- E2e tests: 141 passed, 3 skipped
- New regression tests: 8 passed
- Typecheck: passed (`npm run typecheck`)
- Build: passed (`npm run build`, included in `npm run test:all`)
- QA cycles: 4

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| An interrupted lock write never leaves a truncated/corrupt lock file | pass | `src/utils/atomic-file.ts`; `preserves the previous lock file when atomic rename fails`; `writeLibraryLock preserves the previous lock when atomic rename fails` |
| Concurrent lock mutations within one process cannot lose entries | pass | `serializes overlapping mutations and keeps queued writes recoverable`; library overlap/reinstall/stale-update regressions in `src/library.test.ts` |
| Existing lock/library/updater test suites pass | pass | `npm run test:all` — 2,122 passed, 3 skipped; `src/utils/lock.test.ts` 23 passed, `src/library.test.ts` 51 passed, `src/updater.test.ts` 51 passed |
