### PR TITLE
perf(website): parse search index once on load (#370)

### DIFF
--- a/website-src/src/__tests__/app-smoke.test.jsx
+++ b/website-src/src/__tests__/app-smoke.test.jsx
@@ -187,6 +187,79 @@ describe("App smoke", () => {
     expect(screen.getByText(/Select a skill/i)).toBeTruthy();
   });
 
+  it("parses the search index once and preserves search results", async () => {
+    window.history.replaceState(null, "", "/#/skills");
+    const indexText = buildIndexJson();
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).endsWith("search.idx.json")) {
+        return new Response(indexText);
+      }
+      for (const [suffix, fn] of Object.entries(FETCH_MAP)) {
+        if (String(url).endsWith(suffix)) return fn();
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const parseSpy = vi.spyOn(JSON, "parse");
+
+    render(
+      <HashRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <App />
+      </HashRouter>,
+    );
+    await waitFor(() => expect(screen.getByText("hello-world")).toBeTruthy());
+
+    expect(
+      parseSpy.mock.calls.filter(([value]) => value === indexText),
+    ).toHaveLength(1);
+
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search skills" }), {
+      target: { value: "friendly" },
+    });
+    fireEvent.keyDown(
+      screen.getByRole("searchbox", { name: "Search skills" }),
+      { key: "Enter" },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("hello-world")).toBeTruthy();
+      expect(screen.queryByText("readme-generator")).toBeNull();
+    });
+  });
+
+  it("reports a catalog and search-index build mismatch", async () => {
+    window.history.replaceState(null, "", "/#/skills");
+    const mismatchedCatalog = {
+      ...catalog,
+      generatedAt: "2026-04-23T00:00:00.000Z",
+    };
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).endsWith("skills.min.json")) {
+        return new Response(JSON.stringify(mismatchedCatalog));
+      }
+      for (const [suffix, fn] of Object.entries(FETCH_MAP)) {
+        if (String(url).endsWith(suffix)) return fn();
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    render(
+      <HashRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <App />
+      </HashRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Catalog failed to load")).toBeTruthy();
+      expect(
+        screen.getByText("catalog build mismatch — reload the page"),
+      ).toBeTruthy();
+    });
+  });
+
   it("selecting a sidebar row updates the URL and renders detail", async () => {
     window.history.replaceState(null, "", "/#/skills");
     const { container } = render(

--- a/website-src/src/hooks/useCatalog.jsx
+++ b/website-src/src/hooks/useCatalog.jsx
@@ -44,15 +44,15 @@ export function CatalogProvider({ children }) {
           skillsRes.json(),
           idxRes.text(),
         ]);
-        const idxMeta = JSON.parse(idxText);
+        const parsedIndex = JSON.parse(idxText);
         if (
           catalog.generatedAt &&
-          idxMeta.generatedAt &&
-          catalog.generatedAt !== idxMeta.generatedAt
+          parsedIndex.generatedAt &&
+          catalog.generatedAt !== parsedIndex.generatedAt
         ) {
           throw new Error("catalog build mismatch — reload the page");
         }
-        const miniSearch = MiniSearch.loadJSON(idxText, MINISEARCH_OPTIONS);
+        const miniSearch = MiniSearch.loadJS(parsedIndex, MINISEARCH_OPTIONS);
         if (cancelled) return;
         setState({ loading: false, error: null, catalog, miniSearch });
       } catch (err) {


### PR DESCRIPTION
Closes #370

## Summary

Parses the website search index JSON once during catalog loading and hydrates MiniSearch from the resulting object. This removes the duplicate multi-megabyte parse from the first-paint path while preserving build-skew detection and search behavior.

## Approach

**Single parsed-object hydration (light profile):** parse `search.idx.json` once, reuse that object for the `generatedAt` consistency check, and pass it to `MiniSearch.loadJS` with the existing runtime options. Add focused integration coverage for parse count, real search results, and the mismatch error.

## Decision Record

- **Root cause:** `CatalogProvider` parsed `idxText` to read `generatedAt`, then passed the same text to `MiniSearch.loadJSON`, which parsed it again internally before hydration.
- **Options considered:** Single parsed-object hydration — reuse the already-parsed index with `MiniSearch.loadJS`.
- **Options rejected:** n/a — small, focused change with a direct plan (light profile)
- **Selected option:** Single parsed-object hydration
- **Residual risk:** The regression test spies on `JSON.parse` for the exact fetched index string; a future transport change may require updating that test seam even if single-parse behavior remains intact.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `refactor/370-parse-the-website-search-index-json @ 6b83c60` (2026-08-10)

## Changes

| File | Change |
|------|--------|
| `website-src/src/hooks/useCatalog.jsx` | Reuse one parsed index object for build validation and MiniSearch hydration. |
| `website-src/src/__tests__/app-smoke.test.jsx` | Verify one parse, unchanged search results, and preserved build-mismatch errors. |

## Test Results

- Unit/source tests: 1,905 passed
- Website integration tests: 72 passed, including 2 added tests
- E2e tests: 141 passed, 3 skipped
- Build: passed
- Lint: passed for changed website files
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| The search index text is parsed exactly once during catalog load | pass | `website-src/src/hooks/useCatalog.jsx:47`; `website-src/src/__tests__/app-smoke.test.jsx:190` |
| Build-mismatch detection behavior is preserved | pass | `website-src/src/hooks/useCatalog.jsx:48-53`; `website-src/src/__tests__/app-smoke.test.jsx:231` |
| Website test suite passes; search results unchanged | pass | `npm run test:site` — 72 passed; `parses the search index once and preserves search results` exercises real MiniSearch hydration and filtering |
