### PR TITLE
perf(ingester): parallelize skill ingest pipeline (#372)

### DIFF
--- a/src/evaluator.test.ts
+++ b/src/evaluator.test.ts
@@ -962,9 +962,9 @@ describe("runWithConcurrency", () => {
 
     const mapper = vi.fn(async (n: number): Promise<number> => {
       started.add(n);
-      if (n === 0) {
+      if (n === 1) {
         await new Promise((r) => setTimeout(r, 50));
-        throw new Error("boom from 0");
+        throw new Error("boom from 1");
       }
       await gate.promise;
       return n * 2;
@@ -980,7 +980,7 @@ describe("runWithConcurrency", () => {
     gate.resolve();
 
     // Should reject with the original error
-    await expect(promise).rejects.toThrow("boom from 0");
+    await expect(promise).rejects.toThrow("boom from 1");
 
     // Only the initial batch of 3 started — no queued work after failure
     expect(started.size).toBeLessThanOrEqual(3);

--- a/src/evaluator.test.ts
+++ b/src/evaluator.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import {
   buildFixPlan,
   evaluateSkillContent,
@@ -943,6 +943,47 @@ describe("runWithConcurrency", () => {
   it("treats limit < 1 as 1", async () => {
     const r = await runWithConcurrency([1, 2, 3], 0, async (x) => x);
     expect(r).toEqual([1, 2, 3]);
+  });
+
+  it("rejects on mapper error, waits for already-started blocked mappers, and does not start queued work", async () => {
+    // Regression guard: runWithConcurrency must re-throw the original error
+    // (not swallow it) and must not start queued work after the first
+    // failure.  Already-started mappers that are blocked on external
+    // synchronisation must still be awaited.
+    function deferred(): { promise: Promise<void>; resolve: () => void } {
+      let resolve!: () => void;
+      const promise = new Promise<void>((done) => {
+        resolve = done;
+      });
+      return { promise, resolve };
+    }
+    const gate = deferred();
+    const started = new Set<number>();
+
+    const mapper = vi.fn(async (n: number): Promise<number> => {
+      started.add(n);
+      if (n === 0) {
+        await new Promise((r) => setTimeout(r, 50));
+        throw new Error("boom from 0");
+      }
+      await gate.promise;
+      return n * 2;
+    });
+
+    const promise = runWithConcurrency([1, 2, 3, 4, 5], 3, mapper);
+
+    // Let worker 0 throw
+    await new Promise((r) => setTimeout(r, 60));
+    expect(started.size).toBeLessThanOrEqual(3);
+
+    // Release blocked mappers
+    gate.resolve();
+
+    // Should reject with the original error
+    await expect(promise).rejects.toThrow("boom from 0");
+
+    // Only the initial batch of 3 started — no queued work after failure
+    expect(started.size).toBeLessThanOrEqual(3);
   });
 });
 

--- a/src/evaluator.test.ts
+++ b/src/evaluator.test.ts
@@ -957,33 +957,78 @@ describe("runWithConcurrency", () => {
       });
       return { promise, resolve };
     }
-    const gate = deferred();
+
+    // Three independent gates for deterministic synchronisation:
+    //   progressGate  — released when the initial 3 workers have all started
+    //   rejectionGate — triggers n=1 to throw (and signals the mapper to fail)
+    //   inFlightGate  — releases the blocked n=2/n=3 mappers
+    const progressGate = deferred();
+    const rejectionGate = deferred();
+    const inFlightGate = deferred();
     const started = new Set<number>();
+    let startedCount = 0;
 
     const mapper = vi.fn(async (n: number): Promise<number> => {
       started.add(n);
+      if (++startedCount === 3) {
+        progressGate.resolve();
+      }
       if (n === 1) {
-        await new Promise((r) => setTimeout(r, 50));
+        // Wait until the test triggers the rejection, then signal and throw.
+        await rejectionGate.promise;
         throw new Error("boom from 1");
       }
-      await gate.promise;
+      // n=2 and n=3 are blocked until the test releases them.
+      await inFlightGate.promise;
       return n * 2;
     });
 
     const promise = runWithConcurrency([1, 2, 3, 4, 5], 3, mapper);
 
-    // Let worker 0 throw
-    await new Promise((r) => setTimeout(r, 60));
-    expect(started.size).toBeLessThanOrEqual(3);
+    // Settlement observer attached immediately so a rejection is captured
+    // synchronously.  Using .then(onSuccess, onFailure) avoids creating a
+    // new rejecting promise (unlike .finally) so the original promise can
+    // still be asserted with expect(...).rejects.
+    let settleObserved = false;
+    let settleError: unknown = undefined;
+    promise.then(
+      () => {},
+      (err) => {
+        settleObserved = true;
+        settleError = err;
+      },
+    );
 
-    // Release blocked mappers
-    gate.resolve();
+    // Wait until all three initial workers have started.
+    await progressGate.promise;
 
-    // Should reject with the original error
+    // Trigger n=1's rejection.
+    rejectionGate.resolve();
+
+    // At this point n=2/n=3 are still blocked on inFlightGate and the
+    // promise is unsettled.
+    expect(started.size).toBe(3);
+    expect(started).toEqual(new Set([1, 2, 3]));
+    expect(settleObserved).toBe(false);
+
+    // Release the blocked mappers.
+    inFlightGate.resolve();
+
+    // Workers n=2/n=3 complete; Promise.all(workers) settles; the function
+    // re-throws the original error.  The settlement observer fires as a
+    // microtask — flush until it has run.
+    await inFlightGate.promise;
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    expect(settleObserved).toBe(true);
+    expect(settleError).toBeInstanceOf(Error);
+    expect((settleError as Error).message).toBe("boom from 1");
+
+    // Only the initial batch of 3 started — no queued work after failure.
+    expect(started.size).toBe(3);
+    expect(started).toEqual(new Set([1, 2, 3]));
+
+    // The original promise still rejects with the exact error.
     await expect(promise).rejects.toThrow("boom from 1");
-
-    // Only the initial batch of 3 started — no queued work after failure
-    expect(started.size).toBeLessThanOrEqual(3);
   });
 });
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1951,44 +1951,26 @@ export function summariseBatch(items: EvalBatchItem[]): EvalBatchAggregate {
 }
 
 /**
- * Tagged result from a single worker — captures success or failure so that
- * one worker's rejection does not abort the entire batch.  The caller
- * (e.g. ingestRepo) inspects the tag to decide whether to surface the
- * error or treat it as a known fail-soft outcome.
- */
-export interface TaggedResult<T> {
-  /** "ok" when the worker returned a value; "err" when it threw. */
-  readonly tag: "ok" | "err";
-  /** Populated when tag is "ok". */
-  readonly value?: T;
-  /** Populated when tag is "err". */
-  readonly error?: unknown;
-}
-
-function taggedOk<T>(value: T): TaggedResult<T> {
-  return { tag: "ok", value };
-}
-
-function taggedErr<T>(error: unknown): TaggedResult<T> {
-  return { tag: "err", error };
-}
-
-/**
  * Run an async task for each input with a bounded concurrency window.
  * Preserves output order (index-indexed results array).
  *
- * Each worker is wrapped in a tagged-result so that one worker's
- * rejection does not abort the entire batch — all workers settle
- * regardless of individual failures.  The caller receives an array of
- * TaggedResult<T> and can decide how to handle per-skill errors.
+ * On the first mapper rejection a boolean failure flag is set and the
+ * original error is remembered.  Workers stop claiming new indexes once
+ * failure is observed.  All already-started mapper calls are awaited
+ * (because every worker promise is awaited).  After Promise.all the first
+ * error is re-thrown; otherwise the ordered results are returned.
+ *
+ * Empty input always returns an empty array.
  */
 export async function runWithConcurrency<T, R>(
   inputs: T[],
   limit: number,
   fn: (input: T, index: number) => Promise<R>,
 ): Promise<R[]> {
-  const results: TaggedResult<R>[] = new Array(inputs.length);
+  const results: R[] = new Array(inputs.length);
   let next = 0;
+  let failure = false;
+  let firstError: unknown;
   const boundedLimit = Math.max(1, Math.floor(limit));
   const workers: Promise<void>[] = [];
   const size = Math.min(boundedLimit, inputs.length);
@@ -1996,12 +1978,17 @@ export async function runWithConcurrency<T, R>(
     workers.push(
       (async () => {
         while (true) {
+          if (failure) break;
           const idx = next++;
           if (idx >= inputs.length) break;
           try {
-            results[idx] = taggedOk(await fn(inputs[idx], idx));
+            results[idx] = await fn(inputs[idx], idx);
           } catch (err: unknown) {
-            results[idx] = taggedErr(err);
+            if (!failure) {
+              failure = true;
+              firstError = err;
+            }
+            break;
           }
         }
       })(),
@@ -2009,31 +1996,10 @@ export async function runWithConcurrency<T, R>(
   }
   await Promise.all(workers);
 
-  // Re-throw only when ALL workers failed — preserves the existing
-  // "first failure wins" behaviour for the common case where every
-  // worker succeeds.  When one or more succeed, return the values
-  // that are available (fail-soft) so that callers like ingestRepo
-  // can still write a partial index instead of losing the entire
-  // clone during cleanup.
-  const errors: unknown[] = [];
-  const values: R[] = new Array(inputs.length);
-  for (let i = 0; i < inputs.length; i++) {
-    const entry = results[i]!;
-    if (entry.tag === "ok") {
-      values[i] = entry.value!;
-    } else {
-      errors.push(entry.error);
-    }
+  if (failure) {
+    throw firstError;
   }
-
-  if (inputs.length === 0) {
-    return [];
-  }
-  if (errors.length === inputs.length) {
-    // All failed — surface the first error (matches old behaviour).
-    throw errors[0];
-  }
-  return values;
+  return results;
 }
 
 /**

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1951,15 +1951,43 @@ export function summariseBatch(items: EvalBatchItem[]): EvalBatchAggregate {
 }
 
 /**
+ * Tagged result from a single worker — captures success or failure so that
+ * one worker's rejection does not abort the entire batch.  The caller
+ * (e.g. ingestRepo) inspects the tag to decide whether to surface the
+ * error or treat it as a known fail-soft outcome.
+ */
+export interface TaggedResult<T> {
+  /** "ok" when the worker returned a value; "err" when it threw. */
+  readonly tag: "ok" | "err";
+  /** Populated when tag is "ok". */
+  readonly value?: T;
+  /** Populated when tag is "err". */
+  readonly error?: unknown;
+}
+
+function taggedOk<T>(value: T): TaggedResult<T> {
+  return { tag: "ok", value };
+}
+
+function taggedErr<T>(error: unknown): TaggedResult<T> {
+  return { tag: "err", error };
+}
+
+/**
  * Run an async task for each input with a bounded concurrency window.
  * Preserves output order (index-indexed results array).
+ *
+ * Each worker is wrapped in a tagged-result so that one worker's
+ * rejection does not abort the entire batch — all workers settle
+ * regardless of individual failures.  The caller receives an array of
+ * TaggedResult<T> and can decide how to handle per-skill errors.
  */
 export async function runWithConcurrency<T, R>(
   inputs: T[],
   limit: number,
   fn: (input: T, index: number) => Promise<R>,
 ): Promise<R[]> {
-  const results: R[] = new Array(inputs.length);
+  const results: TaggedResult<R>[] = new Array(inputs.length);
   let next = 0;
   const boundedLimit = Math.max(1, Math.floor(limit));
   const workers: Promise<void>[] = [];
@@ -1970,13 +1998,42 @@ export async function runWithConcurrency<T, R>(
         while (true) {
           const idx = next++;
           if (idx >= inputs.length) break;
-          results[idx] = await fn(inputs[idx], idx);
+          try {
+            results[idx] = taggedOk(await fn(inputs[idx], idx));
+          } catch (err: unknown) {
+            results[idx] = taggedErr(err);
+          }
         }
       })(),
     );
   }
   await Promise.all(workers);
-  return results;
+
+  // Re-throw only when ALL workers failed — preserves the existing
+  // "first failure wins" behaviour for the common case where every
+  // worker succeeds.  When one or more succeed, return the values
+  // that are available (fail-soft) so that callers like ingestRepo
+  // can still write a partial index instead of losing the entire
+  // clone during cleanup.
+  const errors: unknown[] = [];
+  const values: R[] = new Array(inputs.length);
+  for (let i = 0; i < inputs.length; i++) {
+    const entry = results[i]!;
+    if (entry.tag === "ok") {
+      values[i] = entry.value!;
+    } else {
+      errors.push(entry.error);
+    }
+  }
+
+  if (inputs.length === 0) {
+    return [];
+  }
+  if (errors.length === inputs.length) {
+    // All failed — surface the first error (matches old behaviour).
+    throw errors[0];
+  }
+  return values;
 }
 
 /**

--- a/src/ingester.test.ts
+++ b/src/ingester.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { mkdtemp, writeFile, mkdir, rm, readFile, readdir } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
 import {
   buildSkillInstallUrl,
   ensureIndexDir,
+  ingestRepo,
   listIndexedRepos,
   removeRepoIndex,
 } from "./ingester";
@@ -12,6 +13,144 @@ import { getIndexDir } from "./config";
 import { discoverSkills } from "./installer";
 import { dedupeSkillsByName } from "./skill-dedupe";
 import { verifySkill } from "./verifier";
+import type { EvalProvider } from "./eval/types";
+import type { IndexedSkill } from "./utils/types";
+
+const ingestMocks = vi.hoisted(() => ({
+  checkGitAvailable: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+  cloneToTemp: vi.fn<() => Promise<string>>(),
+  cleanupTemp: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+  getEvalProviders: vi.fn<() => EvalProvider[]>(() => []),
+}));
+
+vi.mock("./installer", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./installer")>();
+  return {
+    ...actual,
+    checkGitAvailable: ingestMocks.checkGitAvailable,
+    cloneToTemp: ingestMocks.cloneToTemp,
+    cleanupTemp: ingestMocks.cleanupTemp,
+  };
+});
+
+vi.mock("./eval/builtins", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./eval/builtins")>();
+  return {
+    ...actual,
+    getEvalProviders: ingestMocks.getEvalProviders,
+  };
+});
+
+interface Deferred {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+function deferred(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function progressTracker() {
+  let value = 0;
+  const waiters: Array<{ target: number; resolve: () => void }> = [];
+  return {
+    advance() {
+      value++;
+      for (const waiter of waiters) {
+        if (value >= waiter.target) waiter.resolve();
+      }
+    },
+    waitFor(target: number): Promise<void> {
+      if (value >= target) return Promise.resolve();
+      return new Promise((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error(`Timed out waiting for progress ${target}`)),
+          5_000,
+        );
+        waiters.push({
+          target,
+          resolve: () => {
+            clearTimeout(timeout);
+            resolve();
+          },
+        });
+      });
+    },
+  };
+}
+
+async function writeIngestSkill(
+  root: string,
+  relPath: string,
+  name: string,
+): Promise<void> {
+  const skillDir = join(root, relPath);
+  await mkdir(skillDir, { recursive: true });
+  await writeFile(
+    join(skillDir, "SKILL.md"),
+    `---
+name: ${name}
+description: Evaluate deterministic indexing behavior for concurrency tests
+version: 1.0.0
+license: MIT
+creator: Test Author
+---
+
+# ${name}
+
+## Instructions
+
+Use this skill to validate deterministic indexing output and provider summaries.
+`,
+    "utf-8",
+  );
+}
+
+function createTestProvider(
+  applicable: EvalProvider["applicable"] = async () => ({ ok: true }),
+): EvalProvider {
+  return {
+    id: "test-provider",
+    version: "1.0.0",
+    schemaVersion: 1,
+    description: "Deterministic ingester test provider",
+    applicable,
+    async run(ctx) {
+      const index = Number(ctx.skillPath.match(/(\d+)$/)?.[1] ?? 0);
+      return {
+        providerId: "test-provider",
+        providerVersion: "1.0.0",
+        schemaVersion: 1,
+        score: 80 + index,
+        passed: true,
+        categories: [
+          {
+            id: "determinism",
+            name: "Determinism",
+            score: 1,
+            max: 1,
+          },
+        ],
+        findings: [],
+        startedAt: "",
+        durationMs: 0,
+      };
+    },
+  };
+}
+
+function withoutEvaluationTimes(skill: IndexedSkill): IndexedSkill {
+  const normalized = structuredClone(skill);
+  if (normalized.evalSummary) normalized.evalSummary.evaluatedAt = "<time>";
+  for (const summary of Object.values(normalized.evalSummaries ?? {})) {
+    summary.evaluatedAt = "<time>";
+  }
+  return normalized;
+}
 
 describe("ensureIndexDir", () => {
   it("creates and returns the index directory path", async () => {
@@ -124,6 +263,156 @@ describe("buildSkillInstallUrl", () => {
         "skills/example",
       ),
     ).toBe("github:owner/repo#main:skills/example");
+  });
+});
+
+describe("parallel skill ingestion (issue #372)", () => {
+  let tempDir: string;
+  let repoName: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-ingest-parallel-"));
+    repoName = `parallel-skills-${tempDir.split("-").at(-1)!.toLowerCase()}`;
+    ingestMocks.checkGitAvailable.mockReset();
+    ingestMocks.checkGitAvailable.mockResolvedValue(undefined);
+    ingestMocks.cloneToTemp.mockReset();
+    ingestMocks.cleanupTemp.mockReset();
+    ingestMocks.cleanupTemp.mockResolvedValue(undefined);
+    ingestMocks.getEvalProviders.mockReset();
+    ingestMocks.getEvalProviders.mockReturnValue([]);
+  });
+
+  afterEach(async () => {
+    ingestMocks.getEvalProviders.mockReturnValue([]);
+    await removeRepoIndex("issue-372-tests", repoName);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("bounds overlapping work and preserves sequential content in input order", async () => {
+    const batchRoot = join(tempDir, "batch");
+    const skillNames = Array.from(
+      { length: 10 },
+      (_, index) => `skill-${String(index).padStart(2, "0")}`,
+    );
+    for (const name of skillNames) {
+      await writeIngestSkill(batchRoot, join("skills", name), name);
+    }
+
+    const discovered = await discoverSkills(batchRoot);
+    const { kept: deduped } = dedupeSkillsByName(discovered);
+    const inputOrder = deduped.map((skill) => skill.name);
+
+    ingestMocks.getEvalProviders.mockReturnValue([createTestProvider()]);
+    const sequentialSkills: IndexedSkill[] = [];
+    for (const name of inputOrder) {
+      const singleRoot = join(tempDir, "sequential", name);
+      await writeIngestSkill(singleRoot, join("skills", name), name);
+      ingestMocks.cloneToTemp.mockResolvedValueOnce(singleRoot);
+      const result = await ingestRepo(`github:issue-372-tests/${repoName}`);
+      expect(result.success).toBe(true);
+      sequentialSkills.push(...result.repoIndex!.skills);
+    }
+
+    const gates = new Map(inputOrder.map((name) => [name, deferred()]));
+    const started: string[] = [];
+    const applicabilityCompleted: string[] = [];
+    const startedProgress = progressTracker();
+    const completedProgress = progressTracker();
+    let active = 0;
+    let maxActive = 0;
+    const provider = createTestProvider(async (ctx) => {
+      const name = ctx.skillPath.split(/[\\/]/).at(-1)!;
+      active++;
+      maxActive = Math.max(maxActive, active);
+      started.push(name);
+      startedProgress.advance();
+      try {
+        await gates.get(name)!.promise;
+        return { ok: true };
+      } finally {
+        active--;
+        applicabilityCompleted.push(name);
+        completedProgress.advance();
+      }
+    });
+    ingestMocks.getEvalProviders.mockReturnValue([provider]);
+    ingestMocks.cloneToTemp.mockResolvedValueOnce(batchRoot);
+
+    const concurrentResultPromise = ingestRepo(
+      `github:issue-372-tests/${repoName}`,
+    );
+    let concurrentResult!: Awaited<ReturnType<typeof ingestRepo>>;
+    try {
+      await startedProgress.waitFor(8);
+      expect(active).toBe(8);
+      expect(maxActive).toBeLessThanOrEqual(8);
+
+      const releaseOrder = [
+        ...inputOrder.slice(0, 8).reverse(),
+        ...inputOrder.slice(8).reverse(),
+      ];
+      for (const [index, name] of releaseOrder.entries()) {
+        gates.get(name)!.resolve();
+        await completedProgress.waitFor(index + 1);
+      }
+      expect(applicabilityCompleted).toEqual(releaseOrder);
+      expect(applicabilityCompleted).not.toEqual(inputOrder);
+    } finally {
+      for (const gate of gates.values()) gate.resolve();
+      concurrentResult = await concurrentResultPromise;
+    }
+
+    expect(concurrentResult.success).toBe(true);
+    expect(started).toHaveLength(inputOrder.length);
+    expect(maxActive).toBe(8);
+    expect(
+      concurrentResult.repoIndex!.skills.map((skill) => skill.name),
+    ).toEqual(inputOrder);
+    expect(
+      concurrentResult.repoIndex!.skills.map(withoutEvaluationTimes),
+    ).toEqual(sequentialSkills.map(withoutEvaluationTimes));
+  });
+
+  it("isolates a provider failure to its skill", async () => {
+    const batchRoot = join(tempDir, "fail-soft");
+    const skillNames = ["skill-00", "skill-01", "skill-02"];
+    for (const name of skillNames) {
+      await writeIngestSkill(batchRoot, join("skills", name), name);
+    }
+    const discovered = await discoverSkills(batchRoot);
+    const { kept: deduped } = dedupeSkillsByName(discovered);
+    const inputOrder = deduped.map((skill) => skill.name);
+    const failedName = inputOrder[1];
+    const visited: string[] = [];
+
+    ingestMocks.getEvalProviders.mockReturnValue([
+      createTestProvider(async (ctx) => {
+        const name = ctx.skillPath.split(/[\\/]/).at(-1)!;
+        visited.push(name);
+        if (name === failedName) throw new Error("provider unavailable");
+        return { ok: true };
+      }),
+    ]);
+    ingestMocks.cloneToTemp.mockResolvedValueOnce(batchRoot);
+
+    const result = await ingestRepo(`github:issue-372-tests/${repoName}`);
+
+    expect(result.success).toBe(true);
+    expect(result.repoIndex!.skills.map((skill) => skill.name)).toEqual(
+      inputOrder,
+    );
+    const failedSkill = result.repoIndex!.skills[1];
+    const laterSkill = result.repoIndex!.skills[2];
+    expect(failedSkill.name).toBe(failedName);
+    expect(failedSkill.verified).toBe(true);
+    expect(failedSkill.evalSummary).toBeDefined();
+    expect(failedSkill.evalSummaries).toBeUndefined();
+    expect(laterSkill.evalSummaries?.["test-provider"]).toMatchObject({
+      providerId: "test-provider",
+      passed: true,
+      overallScore: 82,
+    });
+    expect(visited.sort()).toEqual([...inputOrder].sort());
   });
 });
 

--- a/src/ingester.test.ts
+++ b/src/ingester.test.ts
@@ -16,6 +16,22 @@ import { verifySkill } from "./verifier";
 import type { EvalProvider } from "./eval/types";
 import type { IndexedSkill } from "./utils/types";
 
+// ─── Config sandbox for production-ingest tests ─────────────────────────────
+// Production-ingest tests must never write to the real getIndexDir user
+// config.  We intercept getIndexDir at module-load time so that
+// ensureIndexDir / removeRepoIndex / listIndexedRepos all operate under a
+// tempDir that is cleaned up in afterEach.
+
+let sandboxIndexDir: string | null = null;
+
+vi.mock("./config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./config")>();
+  return {
+    ...actual,
+    getIndexDir: () => sandboxIndexDir ?? actual.getIndexDir(),
+  };
+});
+
 const ingestMocks = vi.hoisted(() => ({
   checkGitAvailable: vi.fn<() => Promise<void>>(() => Promise.resolve()),
   cloneToTemp: vi.fn<() => Promise<string>>(),
@@ -153,6 +169,17 @@ function withoutEvaluationTimes(skill: IndexedSkill): IndexedSkill {
 }
 
 describe("ensureIndexDir", () => {
+  beforeEach(async () => {
+    sandboxIndexDir = await mkdtemp(join(tmpdir(), "asm-index-sandbox-"));
+  });
+
+  afterEach(async () => {
+    if (sandboxIndexDir) {
+      await rm(sandboxIndexDir, { recursive: true, force: true });
+      sandboxIndexDir = null;
+    }
+  });
+
   it("creates and returns the index directory path", async () => {
     const dir = await ensureIndexDir();
     expect(typeof dir).toBe("string");
@@ -175,6 +202,17 @@ describe("ensureIndexDir", () => {
 });
 
 describe("listIndexedRepos", () => {
+  beforeEach(async () => {
+    sandboxIndexDir = await mkdtemp(join(tmpdir(), "asm-index-sandbox-"));
+  });
+
+  afterEach(async () => {
+    if (sandboxIndexDir) {
+      await rm(sandboxIndexDir, { recursive: true, force: true });
+      sandboxIndexDir = null;
+    }
+  });
+
   it("returns an array", async () => {
     const repos = await listIndexedRepos();
     expect(Array.isArray(repos)).toBe(true);
@@ -199,6 +237,17 @@ describe("listIndexedRepos", () => {
 });
 
 describe("removeRepoIndex", () => {
+  beforeEach(async () => {
+    sandboxIndexDir = await mkdtemp(join(tmpdir(), "asm-index-sandbox-"));
+  });
+
+  afterEach(async () => {
+    if (sandboxIndexDir) {
+      await rm(sandboxIndexDir, { recursive: true, force: true });
+      sandboxIndexDir = null;
+    }
+  });
+
   it("returns false for non-existent index", async () => {
     const result = await removeRepoIndex(
       "nonexistent-owner-xyz",
@@ -271,6 +320,7 @@ describe("parallel skill ingestion (issue #372)", () => {
   let repoName: string;
 
   beforeEach(async () => {
+    sandboxIndexDir = await mkdtemp(join(tmpdir(), "asm-index-sandbox-"));
     tempDir = await mkdtemp(join(tmpdir(), "asm-ingest-parallel-"));
     repoName = `parallel-skills-${tempDir.split("-").at(-1)!.toLowerCase()}`;
     ingestMocks.checkGitAvailable.mockReset();
@@ -286,6 +336,10 @@ describe("parallel skill ingestion (issue #372)", () => {
     ingestMocks.getEvalProviders.mockReturnValue([]);
     await removeRepoIndex("issue-372-tests", repoName);
     await rm(tempDir, { recursive: true, force: true });
+    if (sandboxIndexDir) {
+      await rm(sandboxIndexDir, { recursive: true, force: true });
+      sandboxIndexDir = null;
+    }
   });
 
   it("bounds overlapping work and preserves sequential content in input order", async () => {
@@ -371,6 +425,41 @@ describe("parallel skill ingestion (issue #372)", () => {
     expect(
       concurrentResult.repoIndex!.skills.map(withoutEvaluationTimes),
     ).toEqual(sequentialSkills.map(withoutEvaluationTimes));
+  });
+
+  it("does not abort sibling workers when one mapper throws (regression)", async () => {
+    // Regression for issue #372: runWithConcurrency must not let a single
+    // worker rejection abort the entire batch.  All workers must settle so
+    // that ingestRepo's finally-block cleanup waits for the shared clone.
+    const batchRoot = join(tempDir, "abort-regression");
+    const skillNames = ["skill-abort-a", "skill-abort-b", "skill-abort-c"];
+    for (const name of skillNames) {
+      await writeIngestSkill(batchRoot, join("skills", name), name);
+    }
+
+    ingestMocks.getEvalProviders.mockReturnValue([]);
+    ingestMocks.cloneToTemp.mockResolvedValueOnce(batchRoot);
+
+    // Inject a mapper that throws on the second skill.  The tagged-result
+    // pattern in runWithConcurrency must catch this so that the other two
+    // workers still finish and the finally-block cleanup runs after all
+    // workers complete.
+    const originalEval = (await import("./evaluator")).runWithConcurrency;
+    // We rely on the existing runWithConcurrency implementation — the test
+    // validates behaviour by checking that ingestRepo resolves successfully
+    // even though one of the three skills has a provider that throws.
+
+    const result = await ingestRepo(`github:issue-372-tests/${repoName}`);
+
+    // ingestRepo should succeed because the mapper catches errors internally
+    // (the provider throw is wrapped).  The important invariant is that
+    // cleanupTemp runs AFTER all workers settle, which is guaranteed by the
+    // tagged-result pattern.
+    expect(result.success).toBe(true);
+    expect(result.repoIndex).not.toBeNull();
+    // All three skills should be present (fail-soft).
+    const names = result.repoIndex!.skills.map((s) => s.name).sort();
+    expect(names).toEqual(skillNames.sort());
   });
 
   it("isolates a provider failure to its skill", async () => {

--- a/src/ingester.test.ts
+++ b/src/ingester.test.ts
@@ -427,41 +427,6 @@ describe("parallel skill ingestion (issue #372)", () => {
     ).toEqual(sequentialSkills.map(withoutEvaluationTimes));
   });
 
-  it("does not abort sibling workers when one mapper throws (regression)", async () => {
-    // Regression for issue #372: runWithConcurrency must not let a single
-    // worker rejection abort the entire batch.  All workers must settle so
-    // that ingestRepo's finally-block cleanup waits for the shared clone.
-    const batchRoot = join(tempDir, "abort-regression");
-    const skillNames = ["skill-abort-a", "skill-abort-b", "skill-abort-c"];
-    for (const name of skillNames) {
-      await writeIngestSkill(batchRoot, join("skills", name), name);
-    }
-
-    ingestMocks.getEvalProviders.mockReturnValue([]);
-    ingestMocks.cloneToTemp.mockResolvedValueOnce(batchRoot);
-
-    // Inject a mapper that throws on the second skill.  The tagged-result
-    // pattern in runWithConcurrency must catch this so that the other two
-    // workers still finish and the finally-block cleanup runs after all
-    // workers complete.
-    const originalEval = (await import("./evaluator")).runWithConcurrency;
-    // We rely on the existing runWithConcurrency implementation — the test
-    // validates behaviour by checking that ingestRepo resolves successfully
-    // even though one of the three skills has a provider that throws.
-
-    const result = await ingestRepo(`github:issue-372-tests/${repoName}`);
-
-    // ingestRepo should succeed because the mapper catches errors internally
-    // (the provider throw is wrapped).  The important invariant is that
-    // cleanupTemp runs AFTER all workers settle, which is guaranteed by the
-    // tagged-result pattern.
-    expect(result.success).toBe(true);
-    expect(result.repoIndex).not.toBeNull();
-    // All three skills should be present (fail-soft).
-    const names = result.repoIndex!.skills.map((s) => s.name).sort();
-    expect(names).toEqual(skillNames.sort());
-  });
-
   it("isolates a provider failure to its skill", async () => {
     const batchRoot = join(tempDir, "fail-soft");
     const skillNames = ["skill-00", "skill-01", "skill-02"];

--- a/src/ingester.ts
+++ b/src/ingester.ts
@@ -18,7 +18,7 @@ import {
   mergeRepoBundles,
 } from "./repo-bundles";
 import { estimateTokenCount } from "./utils/token-count";
-import { evaluateSkillContent } from "./evaluator";
+import { evaluateSkillContent, runWithConcurrency } from "./evaluator";
 import { getEvalProviders } from "./eval/builtins";
 import { runProvider } from "./eval/runner";
 import { sortProviderReports, toSkillEvalSummary } from "./eval/summary";
@@ -34,6 +34,8 @@ export interface IngestResult {
   repoIndex: RepoIndex | null;
   error?: string;
 }
+
+const INGEST_SKILL_CONCURRENCY = 8;
 
 export async function ensureIndexDir(): Promise<string> {
   const indexDir = getIndexDir();
@@ -93,121 +95,126 @@ export async function ingestRepo(sourceInput: string): Promise<IngestResult> {
       );
     }
 
-    const skills: IndexedSkill[] = [];
-    for (const skill of deduped) {
-      // Read SKILL.md content for verification
-      const skillMdPath = join(tempDir, skill.relPath, "SKILL.md");
-      let skillMdContent = "";
-      try {
-        skillMdContent = await readFile(skillMdPath, "utf-8");
-      } catch {
-        // If we can't read SKILL.md, the skill won't pass verification
-        debug(`ingester: could not read SKILL.md at ${skillMdPath}`);
-      }
-
-      const verification = verifySkill(skill, skillMdContent);
-      if (!verification.verified) {
-        debug(
-          `ingester: ${skill.name} not verified: ${verification.reasons.join(", ")}`,
-        );
-      }
-
-      // Token count: prefer the value populated during discovery; recompute
-      // here as a safe fallback when discovery did not set it (e.g., older
-      // discovery code paths in tests).
-      const tokenCount =
-        typeof skill.tokenCount === "number"
-          ? skill.tokenCount
-          : skillMdContent
-            ? estimateTokenCount(skillMdContent)
-            : undefined;
-
-      // Eval summary — captured at index time so the website + TUI + CLI
-      // inspect surfaces can show "what would I be installing" before the
-      // user runs `asm install`. We intentionally drop findings/suggestions
-      // from the catalog payload to keep catalog.json small.
-      let evalSummary: SkillEvalSummary | undefined;
-      let evalSummaries: IndexedSkill["evalSummaries"] | undefined;
-      if (skillMdContent) {
-        let rootEntries: string[] | undefined;
+    const skillRoot = tempDir;
+    const skills = await runWithConcurrency(
+      deduped,
+      INGEST_SKILL_CONCURRENCY,
+      async (skill): Promise<IndexedSkill> => {
+        // Read SKILL.md content for verification
+        const skillMdPath = join(skillRoot, skill.relPath, "SKILL.md");
+        let skillMdContent = "";
         try {
-          rootEntries = await readdir(join(tempDir, skill.relPath));
+          skillMdContent = await readFile(skillMdPath, "utf-8");
         } catch {
-          rootEntries = undefined;
+          // If we can't read SKILL.md, the skill won't pass verification
+          debug(`ingester: could not read SKILL.md at ${skillMdPath}`);
         }
 
-        try {
-          const report = evaluateSkillContent({
-            content: skillMdContent,
-            skillPath: skill.relPath || skill.name,
-            skillMdPath,
-            rootEntries,
-          });
-          evalSummary = {
-            overallScore: report.overallScore,
-            grade: report.grade,
-            categories: report.categories.map((c) => ({
-              id: c.id,
-              name: c.name,
-              score: c.score,
-              max: c.max,
-            })),
-            evaluatedAt: report.evaluatedAt,
-            evaluatedVersion: skill.version || undefined,
-          };
-        } catch (err) {
-          // Eval is best-effort during indexing — never fail the whole
-          // ingest because one skill produced a malformed evaluator result.
-          debug(`ingester: eval failed for ${skill.name}: ${err}`);
-        }
-
-        try {
-          const ctx = {
-            skillPath: join(tempDir, skill.relPath),
-            skillMdPath,
-          };
-          const providerResults = await Promise.all(
-            sortProviderReports(getEvalProviders()).map(async (provider) => {
-              const applicable = await provider.applicable(ctx, {});
-              if (!applicable.ok) return null;
-              return runProvider(provider, ctx);
-            }),
+        const verification = verifySkill(skill, skillMdContent);
+        if (!verification.verified) {
+          debug(
+            `ingester: ${skill.name} not verified: ${verification.reasons.join(", ")}`,
           );
-          const summaries = providerResults
-            .filter(
-              (result): result is NonNullable<typeof result> => result !== null,
-            )
-            .map((result) =>
-              toSkillEvalSummary(result, skill.version || undefined),
-            );
-          if (summaries.length > 0) {
-            evalSummaries = Object.fromEntries(
-              summaries
-                .filter((summary) => summary.providerId)
-                .map((summary) => [summary.providerId!, summary]),
-            );
-          }
-        } catch (err) {
-          debug(`ingester: provider eval failed for ${skill.name}: ${err}`);
         }
-      }
 
-      skills.push({
-        name: skill.name,
-        description: skill.description,
-        version: skill.version,
-        license: skill.license,
-        creator: skill.creator,
-        compatibility: skill.compatibility,
-        allowedTools: skill.allowedTools,
-        installUrl: buildSkillInstallUrl(source, skill.relPath),
-        relPath: skill.relPath,
-        verified: verification.verified,
-        tokenCount,
-        evalSummary,
-        evalSummaries,
-      });
-    }
+        // Token count: prefer the value populated during discovery; recompute
+        // here as a safe fallback when discovery did not set it (e.g., older
+        // discovery code paths in tests).
+        const tokenCount =
+          typeof skill.tokenCount === "number"
+            ? skill.tokenCount
+            : skillMdContent
+              ? estimateTokenCount(skillMdContent)
+              : undefined;
+
+        // Eval summary — captured at index time so the website + TUI + CLI
+        // inspect surfaces can show "what would I be installing" before the
+        // user runs `asm install`. We intentionally drop findings/suggestions
+        // from the catalog payload to keep catalog.json small.
+        let evalSummary: SkillEvalSummary | undefined;
+        let evalSummaries: IndexedSkill["evalSummaries"] | undefined;
+        if (skillMdContent) {
+          let rootEntries: string[] | undefined;
+          try {
+            rootEntries = await readdir(join(skillRoot, skill.relPath));
+          } catch {
+            rootEntries = undefined;
+          }
+
+          try {
+            const report = evaluateSkillContent({
+              content: skillMdContent,
+              skillPath: skill.relPath || skill.name,
+              skillMdPath,
+              rootEntries,
+            });
+            evalSummary = {
+              overallScore: report.overallScore,
+              grade: report.grade,
+              categories: report.categories.map((c) => ({
+                id: c.id,
+                name: c.name,
+                score: c.score,
+                max: c.max,
+              })),
+              evaluatedAt: report.evaluatedAt,
+              evaluatedVersion: skill.version || undefined,
+            };
+          } catch (err) {
+            // Eval is best-effort during indexing — never fail the whole
+            // ingest because one skill produced a malformed evaluator result.
+            debug(`ingester: eval failed for ${skill.name}: ${err}`);
+          }
+
+          try {
+            const ctx = {
+              skillPath: join(skillRoot, skill.relPath),
+              skillMdPath,
+            };
+            const providerResults = await Promise.all(
+              sortProviderReports(getEvalProviders()).map(async (provider) => {
+                const applicable = await provider.applicable(ctx, {});
+                if (!applicable.ok) return null;
+                return runProvider(provider, ctx);
+              }),
+            );
+            const summaries = providerResults
+              .filter(
+                (result): result is NonNullable<typeof result> =>
+                  result !== null,
+              )
+              .map((result) =>
+                toSkillEvalSummary(result, skill.version || undefined),
+              );
+            if (summaries.length > 0) {
+              evalSummaries = Object.fromEntries(
+                summaries
+                  .filter((summary) => summary.providerId)
+                  .map((summary) => [summary.providerId!, summary]),
+              );
+            }
+          } catch (err) {
+            debug(`ingester: provider eval failed for ${skill.name}: ${err}`);
+          }
+        }
+
+        return {
+          name: skill.name,
+          description: skill.description,
+          version: skill.version,
+          license: skill.license,
+          creator: skill.creator,
+          compatibility: skill.compatibility,
+          allowedTools: skill.allowedTools,
+          installUrl: buildSkillInstallUrl(source, skill.relPath),
+          relPath: skill.relPath,
+          verified: verification.verified,
+          tokenCount,
+          evalSummary,
+          evalSummaries,
+        };
+      },
+    );
 
     const repoIndex: RepoIndex = {
       repoUrl: source.cloneUrl,


### PR DESCRIPTION
Closes #372

## Summary

Parallelizes independent per-skill ingest evaluation through the existing bounded worker pool while preserving deduplicated input order, indexed content, and fail-soft provider behavior. Ten or more skills now execute with at most eight active pipelines instead of waiting for each skill to finish before starting the next.

## Approach

**Option 1 — Reuse `runWithConcurrency` for per-skill ingestion.** Convert the sequential enrichment loop into an ordered async mapper with a fixed concurrency limit of eight, retain index writing and bundle construction after the pool settles, and strengthen the shared helper so unexpected mapper failures stop new scheduling, await in-flight work, and rethrow before clone cleanup.

## Decision Record

- **Root cause:** `src/ingester.ts` awaited every deduplicated skill's file reads, verification, quality evaluation, and provider evaluation in a sequential loop even though each pipeline reads an independent skill path from the shared read-only clone.
- **Options considered:** Option 1 — Reuse `runWithConcurrency` with a fixed ingest limit; Option 2 — Implement a dedicated ingester worker pool; Option 3 — Introduce a configurable shared concurrency framework.
- **Options rejected:** Option 2 — duplicates an existing tested concurrency primitive and increases scheduling risk; Option 3 — expands into configuration and repo-level pooling concerns outside this issue.
- **Selected option:** Option 1 — Reuse `runWithConcurrency` for per-skill ingestion.
- **Residual risk:** The concurrency limit is a fixed value of eight rather than runtime-configurable; unexpected mapper failures wait for already-started work to settle before surfacing, which favors safe cleanup over immediate rejection.

Analyzed at: `refactor/372-parallelize-the-skill-ingest @ 6b83c60` (2026-08-10)

## Changes

| File | Change |
|------|--------|
| `src/ingester.ts` | Run per-skill enrichment through an eight-worker, input-order-preserving pool. |
| `src/ingester.test.ts` | Add sandboxed deterministic coverage for overlap, the concurrency cap, reverse completion order, sequential content parity, and provider failure isolation. |
| `src/evaluator.ts` | Stop scheduling after the first unexpected mapper rejection, await already-started workers, then rethrow the original error. |
| `src/evaluator.test.ts` | Add deterministic rejection, drain, and no-new-work regression coverage. |

## Test Results

- Unit/source tests: 1,906 passed
- Integration/website tests: 70 passed
- E2e tests: 141 passed, 3 skipped
- Typecheck: passed
- Build: passed
- QA cycles: 3

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Indexing a multi-skill repo runs skill evaluations concurrently with a bounded limit | pass | `src/ingester.ts:38,99-102`; `src/ingester.test.ts:345` proves eight tasks overlap and active work never exceeds eight. |
| Index output (content and order) is identical to the sequential implementation | pass | `src/ingester.test.ts:345` completes work out of order, then compares the complete normalized result array with a sequential baseline in input order. |
| ingester test suite passes | pass | `src/ingester.test.ts`: 25 passed; final `npm run test:all` passed 1,906 source, 70 website, and 141 e2e tests (3 skipped), including the new failure-isolation test at `src/ingester.test.ts:430`. |
